### PR TITLE
Hook unsubscribe

### DIFF
--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -144,6 +144,21 @@ class Subscribe:
 
 subscribe = Subscribe()
 
+class Unsubscribe(Subscribe):
+    """
+        This class mirrors subscribe, except the _subscribe member has been
+        overridden to removed calls from hooks.
+    """
+    def _subscribe(self, event, func):
+        lst = subscriptions.setdefault(event, [])
+        try:
+            lst.remove(func)
+        except ValueError:
+            raise manager.QtileError("Tried to unsubscribe a hook that was not currently subscribed")
+
+
+unsubscribe = Unsubscribe()
+
 def fire(event, *args, **kwargs):
     if event not in subscribe.hooks:
         raise manager.QtileError("Unknown event: %s"%event)

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -8,15 +8,17 @@ class uHook(libpry.AutoTree):
     def tearDown(self):
         libqtile.hook.clear()
         
-    def test_basic(self):
-        self.testVal = None
-        def test(x):
-            self.testVal = x
+    def setUpAll(self):
         class Dummy: pass
         dummy = Dummy()
         io = cStringIO.StringIO()
         dummy.log = libqtile.manager.Log(5, io)
         libqtile.hook.init(dummy)
+        
+    def test_basic(self):
+        self.testVal = None
+        def test(x):
+            self.testVal = x
 
         libpry.raises("unknown event", libqtile.hook.fire, "unkown")
         libqtile.manager.hook.subscribe.group_window_add(test)
@@ -27,6 +29,21 @@ class uHook(libpry.AutoTree):
         libqtile.manager.hook.clear()
         assert not libqtile.manager.hook.subscriptions
 
+    def test_unsubscribe(self):
+        self.testVal = None
+        def test(x):
+            self.testVal = x
+
+        libqtile.manager.hook.subscribe.group_window_add(test)
+        libqtile.manager.hook.fire("group_window_add", 3)
+        assert self.testVal == 3
+
+        libqtile.manager.hook.unsubscribe.group_window_add(test)
+        libqtile.manager.hook.fire("group_window_add", 4)
+        assert self.testVal == 3
+
+        libqtile.manager.hook.clear()
+        assert not libqtile.manager.hook.subscriptions
 
 
 


### PR DESCRIPTION
small patch to add hook unsubscriptions. I just added a class derived from Subscribe and hijacked _subscribe to do the opposite.
