### PR TITLE
Patch to fix the volume widget on Python 2.6

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -85,9 +85,15 @@ class Volume(base._TextBox):
             self.surfaces[img_name] = imgpat
 
     def get_volume(self):
-        from subprocess import check_output
-        mixer_out = check_output(['amixer', '-c', str(self.cardid),
-                                         'sget', self.channel])
+        import subprocess
+        mixerprocess = subprocess.Popen(['amixer', '-c', str(self.cardid),
+                                         'sget', self.channel],
+                                        stdout=subprocess.PIPE)
+        mixer_out = mixerprocess.communicate()[0]
+        if mixerprocess.returncode:
+            raise subprocess.CalledProcessError(mixerprocess.returncode,
+                                                'amixer')
+        
         if '[off]' in mixer_out:
             return -1
 


### PR DESCRIPTION
widget/volume.py used subprocess.check_output in get_volume to call the
amixer program. That call was introduced in Python 2.7. This changes
get_volume to use subprocess.Popen, while retaining the same semantics
(namely raising subprocess.CalledProcessError if amixer fails for some
reason).
