### PR TITLE
Automagical focus switching between screens

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -374,7 +374,7 @@ class Group(command.CommandObject):
                     self.layout.layout(normal, screen)
                 if floating:
                     self.floating_layout.layout(floating, screen)
-                if self.currentWindow:
+                if self.currentWindow and self.screen == self.qtile.currentScreen:
                     self.currentWindow.focus(warp)
 
     def _setScreen(self, screen):


### PR DESCRIPTION
Hi!

I had an issue with my dual screen setup: It was impossible to switch screens (with lazy.to_screen()) with Firefox as the currentWindow on one of the screens.

It seems that Firefox sends a WM_HINTS every time it loses focus (there might be other applications that do something like that, too). This causes the group to be re-layouted and focused again, switching back to that screen. I believe that layoutAll should only focus its current window if the group is on the current screen.
