### PR TITLE
layout.Tile() changes to further fit XMonad styled tiling

### DIFF
--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -9,7 +9,7 @@ class Tile(Layout):
         ("border_width", 1, "Border width.")
     )
     def __init__(self, ratio=0.618, masterWindows=1, expand=True,
-        ratio_increment=0.05, **config):
+        ratio_increment=0.05, add_on_top=True, **config):
         Layout.__init__(self, **config)
         self.clients = []
         self.ratio = ratio
@@ -17,6 +17,7 @@ class Tile(Layout):
         self.focused = None
         self.expand = expand
         self.ratio_increment = ratio_increment
+        self.add_on_top = add_on_top
 
     @property
     def master_windows(self):
@@ -114,8 +115,12 @@ class Tile(Layout):
         self.focused = None
 
     def add(self, c):
-        self.clients.insert(0, c) #TODO: maybe make this configurable
-                                  # Should new clients go to top?
+        if not self.add_on_top and self.clients:
+            currentindex = self.clients.index(self.focused)
+            self.clients.insert(currentindex, c)
+
+        else:
+            self.clients.insert(0, c) 
 
     def remove(self, c):
         if self.focused is c:


### PR DESCRIPTION
I've added support for the XMonad window switching behavior and the XMonad way of adding windows other than placing them ontop.

I've made the changes so that they don't break the current workflow of layout.Tile()
