### PR TITLE
Warp cursor support

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -33,6 +33,7 @@ class Config:
     screens = ()
     main = None
     follow_mouse_focus = True
+    cursor_warp = False
 
 
 class File(Config):
@@ -61,6 +62,7 @@ class File(Config):
         self.mouse = globs.get("mouse", [])
         self.groups = globs.get("groups")
         self.follow_mouse_focus = globs.get("follow_mouse_focus", True)
+        self.cursor_warp = globs.get("cursor_warp", False)
         self.layouts = globs.get("layouts")
         self.floating_layout = globs.get('floating_layout', None)
         if self.floating_layout is None:

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -96,12 +96,12 @@ class Tile(Layout):
     def shuffle(self, function):
         if self.clients:
             function(self.clients)
-            self.group.layoutAll()
+            self.group.layoutAll(True)
 
     def shift(self, idx1, idx2):
         if self.clients:
             self.clients[idx1], self.clients[idx2] = self.clients[idx2], self.clients[idx1]
-            self.group.layoutAll()
+            self.group.layoutAll(True)
 
     def clone(self, group):
         c = Layout.clone(self, group)

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -438,7 +438,7 @@ class Group(command.CommandObject):
             self.currentWindow = None
         hook.fire("focus_change")
         # !!! note that warp isn't hooked up now
-        self.layoutAll()
+        self.layoutAll(warp)
 
     def info(self):
         return dict(

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -385,8 +385,8 @@ class _Window(command.CommandObject):
     def focus(self, warp):
         if not self.hidden and self.hints['input']:
             self.window.set_input_focus()
-            if warp:
-                self.window.warp_pointer(0, 0)
+            if warp and self.qtile.config.cursor_warp:
+                self.window.warp_pointer(self.width//2, self.height//2)
         hook.fire("client_focus", self)
 
     def _items(self, name, sel):

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -305,6 +305,18 @@ class Window:
             xcb.xproto.Time.CurrentTime
         )
 
+    def warp_pointer(self, x, y):
+        self.conn.conn.core.WarpPointer(
+                0
+                ,self.wid
+                ,0
+                ,0
+                ,0
+                ,0
+                ,x
+                ,y
+        )
+
     def get_name(self):
         """
             Tries to retrieve a canonical window name. We test the following


### PR DESCRIPTION
Added warp_cursor support in xcbq.py using this as reference: http://cpan.uwinnipeg.ca/htdocs/X11-XCB/X11/XCB/Window.pm.html#warp_pointer-

A lot of the code to support warp cursor was already there, I added warp on shift and shuffle in tile() as I think that fits best, as I don't use the other layouts myself I think it's up to other people to make the decision on where to implement warp. I've also added the config option to enable warp. 
It's off by default.
