### PR TITLE
Make spawncmd and togroups' prompt spacing consistent.

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -1669,7 +1669,7 @@ class Qtile(command.CommandObject):
 
         mb.startInput(prompt, self.moveToGroup, "group")
 
-    def cmd_spawncmd(self, prompt="spawn:", widget="prompt"):
+    def cmd_spawncmd(self, prompt="spawn: ", widget="prompt"):
         """
             Spawn a command using a prompt widget, with tab-completion.
 


### PR DESCRIPTION
Minor fix to make the UI consistent.
