### PR TITLE
Added cmd_swap_groups

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -670,6 +670,9 @@ class Group(command.CommandObject):
         # for item in from_group:
         #     item[0].togroup(self.name)
         
+        # swap names
+        self.name, other_group.name = other_group.name, self.name
+
         [windows_.append([ours]) for ours in self.windows]
         [from_group.append([other]) for other in other_group.windows]
         [item[0].togroup(group) for item in windows_]


### PR DESCRIPTION
New function which will allow for two groups on the same screen to be swapped around. I don't have multiple screens so I can't test this (someone can send me a monitor, kthx).

Usage is in the docstring but I'll put it here for the lazy:

Key([sup, "shift"], NUMBER, lazy.group.swap_groups(grp.name))

I've found this to be an extremely useful addition to my commands. A useful update to this would be to get the layouts from both the target and the source and swap them around too, shouldn't be too hard.
