### PR TITLE
Multimedia keys not grabbed

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -702,7 +702,8 @@ class Connection:
 
         first_sym_to_code = {}
         for k, s in self.code_to_syms.items():
-            first_sym_to_code[s[0]] = k
+            if s[0] and not s[0] in first_sym_to_code:
+                first_sym_to_code[s[0]] = k
 
         self.first_sym_to_code = first_sym_to_code
 


### PR DESCRIPTION
I could not grab multimedia keys like XF86AudioPlay (keysyms are present of course). I tracked the problem down to Connection.refresh_keymap(). It looks like it doesn't take the first but the last keysym (215 instead of 172 in case of XF86AudioPlay). This modification works for me but it's kind of trial-and-error.
