### PR TITLE
Report more accurate memory usage in MemoryGraph

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -174,7 +174,7 @@ class MemoryGraph(_Graph):
         val = self._getvalues()
         self.maxvalue = val['MemTotal']
 
-        mem = val['MemTotal'] - val['MemFree'] - val['Inactive']
+        mem = val['MemTotal'] - val['MemFree'] - val['Buffers'] - val['Cached']
         self.fullfill(mem)
 
     def _getvalues(self):
@@ -182,7 +182,7 @@ class MemoryGraph(_Graph):
 
     def update_graph(self):
         val = self._getvalues()
-        self.push(val['MemTotal'] - val['MemFree'] - val['Inactive'])
+        self.push(val['MemTotal'] - val['MemFree'] - val['Buffers'] - val['Cached'])
 
 
 class SwapGraph(_Graph):


### PR DESCRIPTION
Previously, the memory usage reported by the MemoryGraph widget was way
too high. This fixes it to use the same algorithm as the "free" tool.
