### PR TITLE
[RFC] Ability to enable/disable automatic focus change when mouse pointer moves to another screen.

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -62,6 +62,7 @@ class File(object):
             "mouse",
             "groups",
             "follow_mouse_focus",
+            "follow_mouse_focus_on_other_screen",
             "cursor_warp",
             "layouts",
             "floating_layout",

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -80,6 +80,7 @@ screens = [
 
 main = None
 follow_mouse_focus = True
+follow_mouse_focus_on_other_screen = True
 cursor_warp = False
 floating_layout = layout.Floating()
 mouse = ()

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -857,7 +857,7 @@ class Window(_Window):
         if self.qtile.config.follow_mouse_focus and \
                         self.group.currentWindow != self:
             self.group.focus(self, False)
-        if self.group.screen and self.qtile.currentScreen != self.group.screen:
+        if self.group.screen and self.qtile.currentScreen != self.group.screen and self.qtile.config.follow_mouse_focus_on_other_screen:
             self.qtile.toScreen(self.group.screen.index)
         return True
 


### PR DESCRIPTION
Hi,

working with multiple monitors and having "follow_mouse_focus = False" I noticed that every time the pointer moves to another screen the focus changes to the underlying window on the new screen.

I imagined that this behavior (do not change focus on windows on the same screen but change when the mouse moves to another screen when "follow_mouse_focus = False") was wanted and happily used but, at least for me, this is very annoying much of the time (for example when you scroll a window bar that is at the right edge of the left screen).

So I added an option called "follow_mouse_focus_on_other_screen" to enable/disable the automatic focus when the pointer moves to another screen.

The new option was added (and defaulted to True) to maintain the actual behavior.

Let me know what you think about it.

Thanks!
