### PR TITLE
Allow custom column widths in Stack layout

### DIFF
--- a/examples/config/roger-config.py
+++ b/examples/config/roger-config.py
@@ -89,7 +89,7 @@ for i in groups:
 
 layouts = [
     layout.Max(),
-    layout.Stack(stacks=2),
+    layout.Stack(stacks=[50, 50]),
     layout.Tile(ratio=0.25),
 ]
 

--- a/examples/config/tailhook-config.py
+++ b/examples/config/tailhook-config.py
@@ -135,10 +135,10 @@ layouts = [
     layout.TreeTab(sections=['Surfing', 'E-mail', 'Docs', 'Incognito']),
     layout.Slice('left', 320, wmclass='pino',
         fallback=layout.Slice('right', 320, role='roster',
-        fallback=layout.Stack(1, **border))),
+        fallback=layout.Stack([100], **border))),
     layout.Slice('left', 192, role='gimp-toolbox',
         fallback=layout.Slice('right', 256, role='gimp-dock',
-        fallback=layout.Stack(1, **border))),
+        fallback=layout.Stack([100], **border))),
     ]
 floating_layout = layout.Floating(**border)
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -60,7 +60,10 @@ for i in groups:
 
 layouts = [
     layout.Max(),
-    layout.Stack(stacks=2)
+    layout.Stack(stacks=[50, 50]),
+    layout.Stack(stacks=[30, 70]),
+    layout.Stack(stacks=[70, 30]),
+
 ]
 
 screens = [

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -13,7 +13,7 @@ class GBConfig:
         libqtile.manager.Group("dddd"),
         libqtile.manager.Group("Pppy")
     ]
-    layouts = [libqtile.layout.stack.Stack(stacks=1)]
+    layouts = [libqtile.layout.stack.Stack(stacks=[100])]
     floating_layout = libqtile.layout.floating.Floating()
     screens = [
         libqtile.manager.Screen(
@@ -134,7 +134,7 @@ class GeomConf:
         libqtile.manager.Group("c"),
         libqtile.manager.Group("d")
     ]
-    layouts = [libqtile.layout.stack.Stack(stacks=1)]
+    layouts = [libqtile.layout.stack.Stack(stacks=[100])]
     floating_layout = libqtile.layout.floating.Floating()
     screens = [
         libqtile.manager.Screen(

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -23,7 +23,7 @@ class CallConfig(object):
         libqtile.manager.Group("b"),
     ]
     layouts = [
-        libqtile.layout.Stack(stacks=1),
+        libqtile.layout.Stack(stacks=[100]),
         libqtile.layout.Max(),
     ]
     floating_layout = libqtile.layout.floating.Floating()
@@ -122,9 +122,9 @@ class ServerConfig(object):
         libqtile.manager.Group("c"),
     ]
     layouts = [
-        libqtile.layout.Stack(stacks=1),
-        libqtile.layout.Stack(stacks=2),
-        libqtile.layout.Stack(stacks=3),
+        libqtile.layout.Stack(stacks=[100]),
+        libqtile.layout.Stack(stacks=[50, 50]),
+        libqtile.layout.Stack(stacks=[33, 33, 33]),
     ]
     floating_layout = libqtile.layout.floating.Floating()
     screens = [

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -56,8 +56,8 @@ class StackConfig:
         libqtile.manager.Group("d")
     ]
     layouts = [
-        layout.Stack(stacks=2),
-        layout.Stack(stacks=1),
+        layout.Stack(stacks=[50, 50]),
+        layout.Stack(stacks=[100]),
     ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = []
@@ -425,13 +425,13 @@ class SliceConfig:
     ]
     layouts = [
         layout.Slice('left', 200, wname='slice',
-            fallback=layout.Stack(stacks=1, border_width=0)),
+            fallback=layout.Stack(stacks=[100], border_width=0)),
         layout.Slice('right', 200, wname='slice',
-            fallback=layout.Stack(stacks=1, border_width=0)),
+            fallback=layout.Stack(stacks=[100], border_width=0)),
         layout.Slice('top', 200, wname='slice',
-            fallback=layout.Stack(stacks=1, border_width=0)),
+            fallback=layout.Stack(stacks=[100], border_width=0)),
         layout.Slice('bottom', 200, wname='slice',
-            fallback=layout.Stack(stacks=1, border_width=0)),
+            fallback=layout.Stack(stacks=[100], border_width=0)),
         ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = []

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -14,8 +14,8 @@ class TestConfig:
         libqtile.manager.Group("d")
     ]
     layouts = [
-                libqtile.layout.stack.Stack(stacks=1),
-                libqtile.layout.stack.Stack(2),
+                libqtile.layout.stack.Stack(stacks=[100]),
+                libqtile.layout.stack.Stack([50, 50]),
                 libqtile.layout.max.Max()
             ]
     floating_layout = libqtile.layout.floating.Floating(float_rules=[dict(wmclass="xclock")])
@@ -52,8 +52,8 @@ class BareConfig:
         libqtile.manager.Group("d")
     ]
     layouts = [
-                libqtile.layout.stack.Stack(stacks=1),
-                libqtile.layout.stack.Stack(2)
+                libqtile.layout.stack.Stack(stacks=[100]),
+                libqtile.layout.stack.Stack([50, 50])
             ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = [
@@ -785,8 +785,8 @@ class _Config:
         libqtile.manager.Group("d")
     ]
     layouts = [
-                libqtile.layout.stack.Stack(stacks=1),
-                libqtile.layout.stack.Stack(2)
+                libqtile.layout.stack.Stack(stacks=[100]),
+                libqtile.layout.stack.Stack([50, 50])
             ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = [


### PR DESCRIPTION
This allows you to set the percentage of the screen you want to use for each column in the Stack layout instead of using equal widths for each stack.

Example config:

```
layouts = [
    layout.Max(),
    layout.Stack(stacks=[50, 50]),
    layout.Stack(stacks=[30, 70]),
    layout.Stack(stacks=[70, 30]),
]
```

I updated the tests and they all passed when I ran them. I didn't add any documentation though sorry.
