### PR TITLE
Improved the battery widget's handeling of a power value of zero.

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -108,9 +108,6 @@ class Battery(_Battery):
     def __init__(self, low_percentage=0.10, width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, "BAT", **config)
         self.low_percentage = low_percentage
-        if not self.calc_time_left and \
-                self.format == '{char}·{percent:2.0%}·{hour:d}:{min:02d}':
-            self.format='{char} {percent:2.0%}'
 
     def _configure(self, qtile, bar):
         base._TextBox._configure(self, qtile, bar)


### PR DESCRIPTION
Instead of setting the whole text to "Inf", both, hour and min, will be set to -1.
This way the widget still displays some useful information but it is also obvious that something is wrong.
