### PR TITLE
added missing call to self.drawer.draw in the spacer widget's draw method

### DIFF
--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -15,3 +15,4 @@ class Spacer(base._Widget):
 
     def draw(self):
         self.clear()
+        self.drawer.draw(self.offset, self.width)


### PR DESCRIPTION
Probably fixes Issue #162
