### PR TITLE
Fix division by zero in battery widget.

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -193,7 +193,7 @@ class BatteryIcon(_Battery):
     def _get_icon_key(self):
         key = 'battery'
         info = self._get_info()
-        if info == False:
+        if info == False or not info.get('full'):
             key += '-missing'
         else:
             percent = info['now'] / info['full']


### PR DESCRIPTION
After resuming some laptop batteries report capacity of 0 just for a second or two, but it's enough to raise a division by zero in the battery widget.
