### PR TITLE
do not set the file log handlers's log level.

### DIFF
--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -43,7 +43,6 @@ class ColorFormatter(logging.Formatter):
 def init_log(log_level=logging.WARNING, logger='qtile'):
     handler = logging.FileHandler(
         os.path.expanduser('~/.%s.log' % logger))
-    handler.setLevel(logging.WARNING)
     handler.setFormatter(
         logging.Formatter(
             "%(asctime)s %(levelname)s %(funcName)s:%(lineno)d %(message)s"))


### PR DESCRIPTION
The handler now inherits the log level from the logger, which can be changed by qtile.
Should fix #179
