### PR TITLE
Set locale to current system locale

### DIFF
--- a/bin/qtile
+++ b/bin/qtile
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import locale
 import logging
 from libqtile import confreader, manager
 
@@ -72,6 +73,7 @@ def make_qtile():
 
 
 if __name__ == "__main__":
+    locale.setlocale(locale.LC_ALL, locale.getdefaultlocale())
     q = make_qtile()
     try:
         q.loop()


### PR DESCRIPTION
It is needed to '%c' datetime format string to work correctly in Clock widget,
for example.
