### PR TITLE
Patch to allow gradent drawing

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -245,10 +245,34 @@ class Drawer:
         return pangocairo.CairoContext(cairo.Context(self.surface))
 
     def set_source_rgb(self, colour):
-        self.ctx.set_source_rgba(*utils.rgb(colour))
+        if type(colour) == list:
+            linear = cairo.LinearGradient(0.0, 0.0, 0.0, self.height)
+            c1 = utils.rgb(colour[0])
+            c2 = utils.rgb(colour[1])
+            if len(c1) < 4:
+                c1[3] = 1
+            if len(c2) < 4:
+                c2[3] = 1
+            linear.add_color_stop_rgba(0.0, c1[0], c1[1], c1[2], c1[3])
+            linear.add_color_stop_rgba(1.0, c2[0], c2[1], c2[2], c2[3])
+            self.ctx.set_source(linear)
+        else:
+            self.ctx.set_source_rgba(*utils.rgb(colour))
 
     def clear(self, colour):
-        self.set_source_rgb(colour)
+        if type(colour) == list:
+            linear = cairo.LinearGradient(0.0, 0.0, 0.0, self.height)
+            c1 = utils.rgb(colour[0])
+            c2 = utils.rgb(colour[1])
+            if len(c1) < 4:
+                c1[3] = 1
+            if len(c2) < 4:
+                c2[3] = 1
+            linear.add_color_stop_rgba(0.0, c1[0], c1[1], c1[2], c1[3])
+            linear.add_color_stop_rgba(1.0, c2[0], c2[1], c2[2], c2[3])
+            self.ctx.set_source(linear)
+        else:
+            self.set_source_rgb(colour)
         self.ctx.rectangle(0, 0, self.width, self.height)
         self.ctx.fill()
         self.ctx.stroke()


### PR DESCRIPTION
This patch allows gradient drawing for both background and foreground. Colors are set in config file as list.

Example:

``` python
background=["#F8F8F8","#BBBBBB"], foreground=["#9E242E.1","#000000"]
```
