### PR TITLE
Changed window.Internal.create to window.Internal.__init__

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -153,7 +153,7 @@ class Bar(Gap):
             raise confreader.ConfigError("Only one STRETCH widget allowed!")
 
         Gap._configure(self, qtile, screen)
-        self.window = window.Internal.create(
+        self.window = window.Internal(
                         self.qtile,
                         self.x, self.y, self.width, self.height,
                         self.opacity

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -288,9 +288,11 @@ class TreeTab(SingleWindow):
         return res
 
     def _create_panel(self):
-        self._panel = window.Internal.create(self.group.qtile,
+        self._panel = window.Internal(
+            self.group.qtile,
             0, 0,
-            self.panel_width, 100)
+            self.panel_width, 100
+        )
         self._create_drawer()
         self._panel.handle_Expose = self._panel_Expose
         self._panel.handle_ButtonPress = self._panel_ButtonPress

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -528,16 +528,13 @@ class Internal(_Window):
                   EventMask.ButtonPress |\
                   EventMask.KeyPress
 
-    @classmethod
-    def create(klass, qtile, x, y, width, height, opacity=1.0):
-        win = qtile.conn.create_window(
-                    x, y, width, height
-              )
+    def __init__(self, qtile, x, y, width, height, opacity=1.0):
+        win = qtile.conn.create_window(x, y, width, height)
         win.set_property("QTILE_INTERNAL", 1)
-        i = Internal(win, qtile)
-        i.place(x, y, width, height, 0, None)
-        i.opacity = opacity
-        return i
+        super(Internal, self).__init__(win, qtile)
+
+        self.place(x, y, width, height, 0, None)
+        self.opacity = opacity
 
     def __repr__(self):
         return "Internal(%s, %s)" % (self.name, self.window.wid)


### PR DESCRIPTION
No other class is instantiated by a classmethod like Internal was. 
