### PR TITLE
Maildir now supports labels

### DIFF
--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -40,7 +40,7 @@ class Maildir(base._TextBox):
         # if it looks like a list of strings then we just convert them
         # and use the name as the label
         if isinstance(subFolders[0], basestring):
-            self._subFolders = [{"path": folder} for folder in subFolders]
+            self._subFolders = [{"path": folder, "label": folder } for folder in subFolders]
         else:
             self._subFolders = subFolders
 
@@ -65,9 +65,6 @@ class Maildir(base._TextBox):
                 yield path.rsplit(":")[0]
 
         for subFolder in self._subFolders:
-            # if there's no label just use the path name
-            subFolder.setdefault("label", subFolder["path"])
-
             path = os.path.join(self._maildirPath, subFolder["path"])
             maildir = mailbox.Maildir(path)
             state[subFolder["label"]] = 0


### PR DESCRIPTION
You can now use the following configuration:

```
    widget.Maildir(maildirPath="~/Mail/skimlinks",
                  subFolders=[{"path": "INBOX", "label": "skim"}]),
```

Which will apply a label to your box.

It's backwardly-compatible - the old configuration style will still work.
