### PR TITLE
Allow internal windows to be destroyed if needed

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -539,6 +539,11 @@ class Internal(_Window):
     def __repr__(self):
         return "Internal(%s, %s)" % (self.name, self.window.wid)
 
+    def kill(self):
+        self.qtile.conn.conn.core.DestroyWindow(self.window.wid)
+
+    def cmd_kill(self):
+        self.kill()
 
 class Static(_Window):
     """


### PR DESCRIPTION
This patch gives ability to destroy internal windows both via function call and qsh. Useful if we are using internal windows for pop-ups or similar.
