### PR TITLE
Add parameter to Groups to allow for custom titles

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -329,8 +329,9 @@ class Group(command.CommandObject):
         in other window managers. Each client window managed by the window
         manager belongs to exactly one group.
     """
-    def __init__(self, name, layout=None):
+    def __init__(self, name, layout=None, title=None):
         self.name = name
+        self.title = name if title == None else title
         self.customLayout = layout  # will be set on _configure
         self.windows = set()
         self.qtile = None

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -21,7 +21,7 @@ class _GroupBase(base._Widget):
 
     def box_width(self, groups):
         width, height = self.drawer.max_layout_size(
-            [i.name for i in groups],
+            [i.title for i in groups],
             self.font,
             self.fontsize
         )
@@ -87,7 +87,7 @@ class AGroupBox(_GroupBase):
         self.drawer.clear(self.background or self.bar.background)
         e = (i for i in self.qtile.groups
              if i.name == self.bar.screen.group.name).next()
-        self.drawbox(self.margin_x, e.name, self.border, self.foreground)
+        self.drawbox(self.margin_x, e.title, self.border, self.foreground)
         self.drawer.draw(self.offset, self.width)
 
 
@@ -207,7 +207,7 @@ class GroupBox(_GroupBase):
 
             self.drawbox(
                 self.margin_x + offset,
-                g.name,
+                g.title,
                 border,
                 text,
                 self.rounded,


### PR DESCRIPTION
This patch adds a "title" parameter to the Group constructor to allow for custom display titles to be set (used in the GroupBox widget).

Is there anywhere else I should update to use "title" rather than "name"?
