### PR TITLE
catch IndexError when restoring screens

### DIFF
--- a/libqtile/state.py
+++ b/libqtile/state.py
@@ -56,5 +56,5 @@ class QtileState(object):
             try:
                 g = qtile.groupMap[group]
                 qtile.screens[screen].setGroup(g)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass # group or screen missing


### PR DESCRIPTION
Currently only KeyErrors are caught when restoring screens, but qtile.screens is a list so it will throw an IndexError.
