### PR TITLE
Config is not used in qsh and Client

### DIFF
--- a/bin/qsh
+++ b/bin/qsh
@@ -20,38 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os, os.path
-from libqtile import confreader, sh, command
+from libqtile import sh, command
 
 def main():
-    from optparse import OptionParser, OptionGroup
+
+    from optparse import OptionParser
+
     parser = OptionParser(version="%prog 0.2")
-    parser.add_option(
-                        "-c", "--config",
-                        action="store", type="string",
-                        default=None,
-                        dest="configfile",
-                        help='Use specified configuration file.'
-                    )
-    parser.add_option(
-                        "-s", "--socket",
-                        action="store", type="string",
-                        default=None,
-                        dest="socket",
-                        help='Use specified comms socket.'
-                    )
+    parser.add_option("-s", "--socket",
+                      action="store", type="string",
+                      default=None,
+                      dest="socket",
+                      help='Use specified socket to connect to qtile.')
     options, args = parser.parse_args()
 
-    try:
-        c = confreader.File(options.configfile)
-    except confreader.ConfigError, v:
-        parser.error(v.message)
-    client = command.Client(options.socket, c)
+    client = command.Client(options.socket)
     qsh = sh.QSh(client)
     qsh.loop()
 
 
 if __name__ == "__main__":
     main()
-
-

--- a/libqtile/command.py
+++ b/libqtile/command.py
@@ -233,7 +233,7 @@ class Client(_CommandRoot):
         Exposes a command tree used to communicate with a running instance of
         Qtile.
     """
-    def __init__(self, fname=None, conf=None):
+    def __init__(self, fname=None):
         if not fname:
             fname = find_sockfile()
         self.client = ipc.Client(fname)

--- a/test/utils.py
+++ b/test/utils.py
@@ -149,7 +149,7 @@ class Xephyr(object):
             sys.exit(0)
         else:
             self.qtilepid = pid
-            self.c = libqtile.command.Client(self.fname, config)
+            self.c = libqtile.command.Client(self.fname)
             self._waitForQtile()
 
     def stopQtile(self):


### PR DESCRIPTION
Currently qsh fails to start if there are errors in user config file, or if it is missing. This commit fixes that.
