### PR TITLE
The systray icon's minium width may be 0

### DIFF
--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -29,6 +29,9 @@ class Icon(window._Window):
             new_width = width / height * icon_size
             height = icon_size
             width = new_width
+        if height <= 0:
+            width, height = icon_size, icon_size
+
         self.width, self.height = width, height
         self.window.set_attribute(backpixmap=self.systray.drawer.pixmap)
         self.systray.draw()


### PR DESCRIPTION
I found some systray icons minium width and height are 0, and cannot be placed in right position.

It seems that the exception in [handle_ConfigureNotify](https://github.com/qtile/qtile/blob/develop/libqtile/widget/systray.py#L23) may not be triggered.
