### PR TITLE
Fix click to focus across screens when follow_mouse_focus is off

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1017,6 +1017,10 @@ class Window(_Window):
             if not self.qtile.config.follow_mouse_focus and \
                             self.group.currentWindow != self:
                 self.group.focus(self, False)
+            if self.group.screen and \
+                self.qtile.currentScreen != self.group.screen:
+                self.qtile.toScreen(self.group.screen.index)
+
         else:
             self.qtile.log.info("Unknown window property: %s" % name)
         return False


### PR DESCRIPTION
When follow_mouse_focus is set to False, clicking a window on another screen makes the border of the clicked window blue, but does not move the keyboard focus. Clicking a window on the same screen works as expected.

This is related to issue #125, although it now seems to happen only across screens.

This patch fixes the problem for applications that register _NET_WM_USER_TIME. This means most applications will work, but xterm will not. As suggested in issue #125 by tych0 I have attempted to get this working using ButtonRelease instead, but using the exact same code in a handle_ButtonRelease function produced the same symptoms as I was originally seeing.

I suggest merging this until a better solution can be found, to make click to focus usable for more than one screen.
