### PR TITLE
Fix missing non-ascii symbols in window titles in  windowname widget

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -191,12 +191,7 @@ def scrub_to_utf8(text):
     elif isinstance(text, unicode):
         return text
     else:
-        try:
-            return text.decode("utf-8")
-        except UnicodeDecodeError:
-            # We don't know the provenance of this string
-            # - so we scrub it to ASCII.
-            return "".join(i for i in text if 31 < ord(i) < 127)
+        return text.decode("utf-8", "ignore")
 
 
 def escape(text):


### PR DESCRIPTION
It seems that sometimes, when window title contains ascii and non-ascii chars, GetProperty returns truncated window title with half of non-ascii symbol on the end, like here:

``` python
In [7]: print "фуу"[:5]
фуÑ
```

And when it occurs function scrub_to_utf8 remove ALL non-ascii chars in title and it looks weird. I suggest just preserve all symbols except symbols with problems.
