### PR TITLE
Fix #282: focus on next window on kill in TreeTab

### DIFF
--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -282,13 +282,12 @@ class TreeTab(SingleWindow):
         self._nodes[win] = node
 
     def remove(self, win):
-        res = self.focus_next(win)
         if self._focused is win:
             self._focused = None
         self._nodes[win].remove()
         del self._nodes[win]
+        self.cmd_up()
         self.draw_panel()
-        return res
 
     def _create_panel(self):
         self._panel = window.Internal.create(self.group.qtile,


### PR DESCRIPTION
focus_next() was called, but it is not implemented. This patch replaces focus_next() call by a cmd_up() call which works just as well.
