### PR TITLE
added screen affinity to Group

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -300,7 +300,7 @@ class Group(object):
     """
     def __init__(self, name, matches=None, exclusive=False,
                  spawn=None, layout=None, persist=True, init=True,
-                 layout_opts=None):
+                 layout_opts=None, screen_affinity=None):
         """
         :param name: the name of this group
         :type name: string
@@ -328,6 +328,8 @@ class Group(object):
             matches = []
         self.matches = matches
         self.layout_opts = layout_opts or {}
+
+        self.screen_affinity = screen_affinity
 
 class Match(object):
     """

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -117,6 +117,9 @@ class DGroups(object):
                                     v(group_obj.layout)
                                 else:
                                     setattr(group_obj.layout, k, v)
+                            affinity = group.screen_affinity
+                            if affinity and len(self.qtile.screens) > affinity:
+                                self.qtile.screens[affinity].setGroup(group_obj)
 
                 if rule.float:
                     client.enablefloating()


### PR DESCRIPTION
screen affinity, makes a group starts in some screen, if exists, it's useful for example, to start mplayer in the second screen.

ie:
Group("Mplayer", persist=False, init=False, screen_affinity=1,
     matches=[Match(wm_class=["MPlayer"])]
)
