### PR TITLE
Preventing NotificationService from registering if unused

### DIFF
--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -57,18 +57,25 @@ class NotificationManager(object):
     def __init__(self):
         self.notifications = []
         self.callbacks = []
+        self._service = None
 
-        if dbus:
+    @property
+    def service(self):
+        if dbus and self._service is None:
             try:
                 DBusGMainLoop(set_as_default=True)
-                self.service = NotificationService(self)
+                self._service = NotificationService(self)
             except Exception:
-                logging.getLogger('qtile').exception('Dbus init failed')
-                self.service = None
-        else:
-            self.service = None
+                logging.getLogger('qtile').exception('Dbus connection failed')
+                self._service = None
+        return self._service
 
     def register(self, callback):
+        if not self.service:
+            logging.getLogger('qtile').warning(
+                'Registering %s without any dbus connection existing',
+                callback.__name__,
+            )
         self.callbacks.append(callback)
 
     def add(self, notif):


### PR DESCRIPTION
Until now, once `libqtile.widget` was imported, a new `NotificationService` was
created and registered as a DBus Notification daemon, and thus making impossible for any other notification daemon to register.

This patch prevents `NotificationManager.service` (a `NotificationService` instance) to be initialized until further call of `register()` method, which basically avoid registering as a notification daemon when the configuration does not uses any notification widget.
