### PR TITLE
Fix multiple matching for dynamic groups

### DIFF
--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -134,6 +134,8 @@ class DGroups(object):
                 if rule.intrusive:
                     intrusive = rule.intrusive
 
+                break
+
         # If app doesn't have a group
         if not group_set:
             current_group = self.qtile.currentGroup.name
@@ -166,7 +168,7 @@ class DGroups(object):
                     len(group.windows) <= 0:
                 self.qtile.delGroup(group.name)
 
-        # wait the delay until really delete the group
+        # Wait the delay until really delete the group
         self.qtile.log.info('Add dgroup timer')
         self.timeout[client] = gobject.timeout_add_seconds(
             self.delay,

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -856,7 +856,7 @@ class Qtile(command.CommandObject):
 
     def moveToGroup(self, group):
         """
-            Create a group if it dosn't exist and move a windows there
+            Create a group if it doesn't exist and move a windows there
         """
         if self.currentWindow and group:
             self.addGroup(group)


### PR DESCRIPTION
Initial problem:
    Qtile proceeded matching rules until the end.
Example:
    When matching weechat in a first group and xterm in a second one,
    weechat will be setup into the second group.

New behaviour:
    Qtile stops matching after first result.
Example:
    Weechat matchs the first group and the matching process stops.
