### PR TITLE
groupbox/tasklist: Better X/Y margin/padding settings

### DIFF
--- a/libqtile/configurable.py
+++ b/libqtile/configurable.py
@@ -44,3 +44,23 @@ class Configurable(object):
                     return self._widget_defaults[name]
                 except KeyError:
                     raise AttributeError("no attribute: %s" % name)
+
+class ExtraFallback(object):
+    """
+        Adds another layer of fallback to attributes - to look up
+        a different attribute name
+    """
+
+    def __init__(self, name, fallback):
+        self.name = name
+        self.fallback = fallback
+
+    def __get__(self, instance, owner=None):
+        try:
+            retval = Configurable.__getattr__(instance, self.name)
+        except AttributeError:
+            retval = None
+
+        if retval is None:
+            retval = Configurable.__getattr__(instance, self.fallback)
+        return retval

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -251,3 +251,43 @@ class _TextBox(_Widget):
         if fontshadow is not UNSPECIFIED:
             self.fontshadow = fontshadow
         self.bar.draw()
+
+
+# these two classes below look SUSPICIOUSLY similar
+
+class PaddingMixin(object):
+    """
+        Mixin that provides padding(_x|_y|)
+
+        To use it, subclass and add this to __init__:
+
+            self.add_defaults(base.PaddingMixin.defaults)
+    """
+
+    defaults = [
+        ("padding", 3, "Padding inside the box"),
+        ("padding_x", None, "X Padding. Overrides 'padding' if set"),
+        ("padding_y", None, "Y Padding. Overrides 'padding' if set"),
+    ]
+
+    padding_x = configurable.ExtraFallback('padding_x', 'padding')
+    padding_y = configurable.ExtraFallback('padding_y', 'padding')
+
+
+class MarginMixin(object):
+    """
+        Mixin that provides margin(_x|_y|)
+
+        To use it, subclass and add this to __init__:
+
+            self.add_defaults(base.MarginMixin.defaults)
+    """
+
+    defaults = [
+        ("margin", 3, "Margin inside the box"),
+        ("margin_x", None, "X Margin. Overrides 'margin' if set"),
+        ("margin_y", None, "Y Margin. Overrides 'margin' if set"),
+    ]
+
+    margin_x = configurable.ExtraFallback('margin_x', 'margin')
+    margin_y = configurable.ExtraFallback('margin_y', 'margin')

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -2,20 +2,16 @@ from .. import bar, hook, utils
 import base
 
 
-class _GroupBase(base._TextBox):
+class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
     defaults = [
-        ("padding", 5, "Padding inside the box"),
-        ("padding_x", None, "X Padding. Overrides 'padding' if set"),
-        ("padding_y", None, "Y Padding. Overrides 'padding' if set"),
-        ("margin", 3, "Margin outside the box"),
-        ("margin_x", None, "X margin. Overrides 'margin' if set"),
-        ("margin_y", None, "Y margin. Overrides 'margin' if set"),
         ("borderwidth", 3, "Current group border width"),
     ]
 
     def __init__(self, **config):
         base._TextBox.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(_GroupBase.defaults)
+        self.add_defaults(base.PaddingMixin.defaults)
+        self.add_defaults(base.MarginMixin.defaults)
 
     def box_width(self, groups):
         width, height = self.drawer.max_layout_size(
@@ -28,11 +24,6 @@ class _GroupBase(base._TextBox):
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
-
-        # handle margin/padding overrides
-        for key in ('padding_x', 'padding_y', 'margin_x', 'margin_y'):
-            if getattr(self, key) is None:
-                setattr(self, key, getattr(self, key.split("_")[0]))
 
         if self.fontsize is None:
             calc = self.bar.height - self.margin_y * 2 - \

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -3,7 +3,7 @@ from .. import bar, hook
 import base
 
 
-class TaskList(base._Widget):
+class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
     defaults = [
         ("font", "Arial", "Default font"),
         ("fontsize", None, "Font size. Calculated if None."),
@@ -13,12 +13,6 @@ class TaskList(base._Widget):
             None,
             "font shadow color, default is None(no shadow)"
         ),
-        ("padding", 0, "Padding inside the box"),
-        ("padding_x", None, "X Padding. Overrides 'padding' if set"),
-        ("padding_y", None, "Y Padding. Overrides 'padding' if set"),
-        ("margin", 3, "Margin outside the box"),
-        ("margin_x", None, "X margin. Overrides 'margin' if set"),
-        ("margin_y", None, "Y margin. Overrides 'margin' if set"),
         ("borderwidth", 2, "Current group border width"),
         ("border", "215578", "Border colour"),
         ("rounded", True, "To round or not to round borders"),
@@ -40,6 +34,8 @@ class TaskList(base._Widget):
     def __init__(self, **config):
         base._Widget.__init__(self, bar.STRETCH, **config)
         self.add_defaults(TaskList.defaults)
+        self.add_defaults(base.PaddingMixin.defaults)
+        self.add_defaults(base.MarginMixin.defaults)
         self._icons_cache = {}
 
     def box_width(self, text):
@@ -54,11 +50,6 @@ class TaskList(base._Widget):
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
         self.icon_size = self.bar.height - (self.borderwidth + 2) * 2
-
-        # handle margin/padding overrides
-        for key in ('padding_x', 'padding_y', 'margin_x', 'margin_y'):
-            if getattr(self, key) is None:
-                setattr(self, key, getattr(self, key.split("_")[0]))
 
         if self.fontsize is None:
             calc = self.bar.height - self.margin_y * 2 - \


### PR DESCRIPTION
Paddings can now be specified as X and Y separately, and margins can be specified as just "margin" too.

Specifying `(margin|padding)_(x|y)` overrides `(margin|padding)`.

(Doing this because personally I like to set padding_x to be wider than padding_y. It creates a nice effect with the background color)

Example:

![](http://dump.dequis.org/3_yu5.png)

(Note the wider horizontal padding in the selected ones)
