### PR TITLE
#355: open 1st window after closing win in treeLayout

### DIFF
--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -297,6 +297,9 @@ class TreeTab(SingleWindow):
         del self._nodes[win]
         self.draw_panel()
 
+        # select 1st window in the list
+        self.cmd_down()
+
     def _create_panel(self):
         self._panel = window.Internal.create(
             self.group.qtile,


### PR DESCRIPTION
if I close window with lazy.window.kill() I suposed to get next open window, but it didn't happen
https://github.com/qtile/qtile/issues/355
