### PR TITLE
If a client is moved to a group that doesn't exist, that group will not ...

### DIFF
--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -160,6 +160,9 @@ class DGroups(object):
         self.sort_groups()
 
     def sort_groups(self):
+        for g in self.qtile.groups:
+            if not g.name in self.groupMap:
+                self.add_dgroup(Group(g.name, persist=False))
         self.qtile.groups.sort(key=lambda g: self.groupMap[g.name].position)
         libqtile.hook.fire("setgroup")
 


### PR DESCRIPTION
...be added to the group map causing the following error:

```
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 565, in _xpoll
    r = h(e)
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 833, in handle_MapRequest
    c = self.manage(w)
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 450, in manage
    hook.fire("client_new", c)
  File "/usr/lib/python2.7/site-packages/libqtile/hook.py", line 216, in fire
    i(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 165, in _add
    self.sort_groups()
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 172, in sort_groups
    self.qtile.groups.sort(key=lambda g: self.groupMap[g.name].position)
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 172, in <lambda>
    self.qtile.groups.sort(key=lambda g: self.groupMap[g.name].position)
KeyError: 'foo'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 565, in _xpoll
    r = h(e)
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 833, in handle_MapRequest
    c = self.manage(w)
  File "/usr/lib/python2.7/site-packages/libqtile/manager.py", line 450, in manage
    hook.fire("client_new", c)
  File "/usr/lib/python2.7/site-packages/libqtile/hook.py", line 216, in fire
    i(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 165, in _add
    self.sort_groups()
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 172, in sort_groups
    self.qtile.groups.sort(key=lambda g: self.groupMap[g.name].position)
  File "/usr/lib/python2.7/site-packages/libqtile/dgroups.py", line 172, in <lambda>
    self.qtile.groups.sort(key=lambda g: self.groupMap[g.name].position)
KeyError: 'foo'
```

This patch fixes that bug.
