### PR TITLE
Have Slice proxy cmd_ calls to the fallback layout.

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -265,8 +265,12 @@ class Delegate(Layout):
                 focus = layouts[idx].focus_last()
         return focus
 
-    def cmd_up(self):
-        self._get_active_layout().cmd_up()
+    def __getattr__(self, name):
+        """Delegate unimplemented command calls to active layout.
 
-    def cmd_down(self):
-        self._get_active_layout().cmd_down()
+        For `cmd_`-methods that don't exist on the Delegate subclass, this
+        looks for an implementation on the active layout.
+        """
+        if name.startswith('cmd_'):
+            return getattr(self._get_active_layout(), name)
+        return super(Delegate, self).__getattr__(name)

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -65,12 +65,6 @@ class Slice(Delegate):
         self._slice = Single()
         self._fallback = fallback
 
-    def __getattr__(self, name):
-        "Proxy command calls to fallback layout"
-        if name.startswith('cmd_'):
-            return getattr(self._fallback, name)
-        return super(Slice, self).__getattr__(name)
-
     def clone(self, group):
         res = Layout.clone(self, group)
         res._slice = self._slice.clone(group)


### PR DESCRIPTION
I use Slice to create a fixed with browser window with a Stack of (depending on
screen width) one or more stacks next to it. This changeset helps getting
shuffle and split commands to the Stack.

It could probably use a test.
