### PR TITLE
Fix assertFocus. This surfaces broken tests using assertFocusPath.

### DIFF
--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -8,7 +8,8 @@ from utils import Xephyr
 def assertFocused(self, name):
     """Asserts that window with specified name is currently focused"""
     info = self.c.window.info()
-    assert info['name']
+    assert info['name'] == name, 'Got {0!r}, expected {1!r}'.format(
+        info['name'], name)
 
 
 def assertDimensions(self, x, y, w, h, win=None):


### PR DESCRIPTION
This is the PR I promised in #369. It fails a couple of tests that need fixing.

`assertFocus` was just asserting the current window has *a* name instead of
comparing it to the expected `name`.

Now that assertFocus really asserts, tests using assertFocusPath break:

 - test_slice_focus
 - test_zoomy_one

Ironically assertFocusPath makes the impression it asserts very thoroughly, by 
assertFocus twice in forward direction and twice backwards.