### PR TITLE
Make layout.Max answer to _Group.cmd_{prev,next}_window()

### DIFF
--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -106,3 +106,13 @@ class Max(SingleWindow):
         self.up()
 
     cmd_previous = cmd_up
+
+    def focus_next(self, window):
+        if window != self._get_window():
+            self.focus(window)
+        self.down()
+
+    def focus_prev(self, window):
+        if window != self._get_window():
+            self.focus(window)
+        self.up()


### PR DESCRIPTION
Without this, `lazy.group.prev_window()` and `lazy.group.next_window()` does not work when using `layout.Max`.
