### PR TITLE
Fix battery widget when battery status cannot be read

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -90,8 +90,8 @@ class _Battery(base._TextBox):
                     self.filenames[name] = file
                     return value
 
-        ## If we made it this far, we don't have a valid file. Just return 0.
-        return 0
+        ## If we made it this far, we don't have a valid file. Just return None.
+        return None
 
     def _get_info(self):
         try:


### PR DESCRIPTION
Currently the battery widget will display 'Full' if it is not able to get the status of the battery (for example, if it tries to read the wrong file in sysfs).
The code was already trying to handle this case, by casting 0 to a float, and catching TypeError but casting an int to a float does not raise an exception.
This patch makes _get_info() returns None in case of error, allowing the widget to display an error message.
