### PR TITLE
Make Max layout drawing all windows by default

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -142,7 +142,8 @@ class Floating(Layout):
             client.width,
             client.height,
             bw,
-            bc
+            bc,
+            client is self.focused
         )
         client.unhide()
 

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -106,7 +106,7 @@ class Max(SingleWindow):
                 screen.height,
                 0,
                 None,
-                client is self.focused
+                client is self.group.currentWindow
             )
             client.unhide()
 


### PR DESCRIPTION
Make Max layout drawing all windows by default, but still acting like before with `only_focused=True`.

See #415.
