### PR TITLE
[stack layout] Update win order to mimic xmonad

### DIFF
--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -83,7 +83,7 @@ class _WinStack(object):
 
     def add(self, client):
         self.lst.insert(self.current+1, client)
-        self.focus(client)
+        self.group.focus(client, False)
 
     def remove(self, client):
         if client not in self.lst:


### PR DESCRIPTION
 Stack layout now use the same order as monadtall or treetab.
 They can now be used in conjonction using the same keybindings.
