### PR TITLE
Drop Xlib from tests, use xcb

### DIFF
--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -8,12 +8,11 @@ Any reasonably recent version of these should work, so you can probably just
 install them from your package manager.
 
 * `Nose <http://nose.readthedocs.org/en/latest/>`_
-* `Python X Library <http://python-xlib.sourceforge.net/>`_
 * `Xephyr <http://www.freedesktop.org/wiki/Software/Xephyr>`_
 * ``xeyes`` and ``xclock``
 
 On ubuntu, this can be done with ``sudo apt-get install python-nose
-python-xlib xserver-xephyr x11-apps``.
+xserver-xephyr x11-apps``.
 
 Running the test suite
 ----------------------

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,8 +7,8 @@ import subprocess
 import sys
 import time
 import traceback
-import Xlib.X
-import Xlib.display
+import xcb
+import xcb.xproto
 from nose.tools import with_setup, assert_raises
 from nose.plugins.attrib import attr
 from functools import wraps
@@ -115,15 +115,14 @@ class Xephyr(object):
         # Try until Xephyr is up
         for i in range(50):
             try:
-                d = Xlib.display.Display(self.display)
+                conn = xcb.xcb.connect(self.display)
                 break
-            except (Xlib.error.DisplayConnectionError,
-                    Xlib.error.ConnectionClosedError):
+            except xcb.ConnectException:
                 time.sleep(0.1)
         else:
             raise AssertionError("Could not connect to display.")
-        d.close()
-        del d
+        conn.disconnect()
+        del conn
 
     def _waitForQtile(self):
         for i in range(20):


### PR DESCRIPTION
Uses xpyb in place of Xlib for the test suite. This was inspired by work to get qtile with xcffib to run on Python 3 (tych0/qtile#2), while python-xlib is 2 only, and python3-xlib is poorly maintained, even by python-xlib standards. Running the full test suite, I get a couple RuntimeErrors printing to the console, like:

```
Exception RuntimeError: 'maximum recursion depth exceeded while calling a Python object' in <bound method Popen.__del__ of <subprocess.Popen object at 0x298a5d0>> ignored
```

but I can't track it down. However, all the tests show as passing.
