### PR TITLE
Move cmd_(eval|function) to all objects of the ipc tree

### DIFF
--- a/libqtile/command.py
+++ b/libqtile/command.py
@@ -411,3 +411,28 @@ class CommandObject(object):
             return self.doc(name)
         else:
             raise CommandError("No such command: %s" % name)
+
+    def cmd_eval(self, code):
+        """
+            Evaluates code in the same context as this function.
+            Return value is (success, result), success being a boolean and
+            result being a string representing the return value of eval, or
+            None if exec was used instead.
+        """
+        try:
+            try:
+                return (True, str(eval(code)))
+            except SyntaxError:
+                exec code
+                return (True, None)
+        except:
+            error = traceback.format_exc().strip().split("\n")[-1]
+            return (False, error)
+
+    def cmd_function(self, function):
+        """Call a function with current object as argument"""
+        try:
+            function(self)
+        except Exception:
+            error = traceback.format_exc()
+            self.log.error('Exception calling "%s":\n%s' % (function, error))

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -1343,31 +1343,6 @@ class Qtile(command.CommandObject):
     def cmd_delgroup(self, group):
         return self.delGroup(group)
 
-    def cmd_eval(self, code):
-        """
-            Evaluates code in the same context as this function.
-            Return value is (success, result), success being a boolean and
-            result being a string representing the return value of eval, or
-            None if exec was used instead.
-        """
-        try:
-            try:
-                return (True, str(eval(code)))
-            except SyntaxError:
-                exec code
-                return (True, None)
-        except:
-            error = traceback.format_exc().strip().split("\n")[-1]
-            return (False, error)
-
-    def cmd_function(self, function):
-        """ Call a function with qtile instance as argument """
-        try:
-            function(self)
-        except Exception:
-            error = traceback.format_exc()
-            self.log.error('Exception calling "%s":\n%s' % (function, error))
-
     def cmd_add_rule(self, match_args, rule_args, min_priorty=False):
         """
             Add a dgroup rule, returns rule_id needed to remove it


### PR DESCRIPTION
They were in the manager object only previously, now they are in CommandObject, which means all subclasses have it (including manager)

Now it's possible to use eval() from any part of qsh, for example:

```
group['term']> eval("self.windows")
(True, 'set([Window(st)])')
```

Or have keybindings that work on a specific kind of object:

```
Key([mod], "x", lazy.window.function(lambda w: w.setOpacity(0.5))),
```

Figuring out any useful things to do with these is left as an exercise for the reader.
