### PR TITLE
Try to keep tests running

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -190,11 +190,12 @@ class Xephyr(object):
                       config, self.display, self.fname)
 
     def testWindow(self, name):
+        python = sys.executable
         d = os.path.dirname(os.path.realpath(__file__))
         path = os.path.join(d, "scripts", "window.py")
         return self._testProc(
-                    path,
-                    [path, self.display, name]
+                    python,
+                    [python, path, self.display, name]
                 )
 
     def testXclock(self):


### PR DESCRIPTION
- Make sure children of forks exit so we (hopefully) don't get fork bombs.
- Use a temporary file for the qtile socket, so if things don't shutdown nicely in one test, the following tests won't also fail.
- Run `scripts/window.py` with current executable
