### PR TITLE
Fix handling of messages and the systray

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -575,10 +575,6 @@ class Qtile(command.CommandObject):
                 e = self.conn.conn.poll_for_event()
                 if not e:
                     break
-                # This should be done in xpyb
-                # client mesages start at 128
-                if e.response_type >= 128:
-                    e = xcb.xproto.ClientMessageEvent(e)
 
                 ename = e.__class__.__name__
 


### PR DESCRIPTION
- Properly handles incoming messages
- systray parses ClientMessageEvents "properly"
- systray only tries to set icon for `SYSTEM_TRAY_REQUEST_DOCK` messages (see http://standards.freedesktop.org/systemtray-spec/systemtray-spec-latest.html)
