### PR TITLE
Don't save `.previous_group` when deleting visible group

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -203,14 +203,15 @@ class Screen(command.CommandObject):
     def get_rect(self):
         return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
 
-    def setGroup(self, new_group):
+    def setGroup(self, new_group, save_prev=True):
         """
         Put group on this screen
         """
         if new_group.screen == self:
             return
 
-        self.previous_group = self.group
+        if save_prev:
+            self.previous_group = self.group
 
         if new_group is None:
             return

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -374,7 +374,7 @@ class Qtile(command.CommandObject):
             for i in list(group.windows):
                 i.togroup(target.name)
             if self.currentGroup.name == name:
-                self.currentScreen.setGroup(target)
+                self.currentScreen.setGroup(target, save_prev=False)
             self.groups.remove(group)
             del(self.groupMap[name])
             hook.fire("delgroup", self, name)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -254,11 +254,19 @@ def test_adddelgroup(self):
     self.c.delgroup("testgroup")
     assert not "testgroup" in self.c.groups().keys()
     # Assert that the test window is still a member of some group.
-    assert sum([len(i["windows"]) for i in self.c.groups().values()])
-    for i in self.c.groups().keys()[:len(self.c.groups())-1]:
+    assert sum(len(i["windows"]) for i in self.c.groups().values())
+    for i in self.c.groups().keys()[:-1]:
         self.c.delgroup(i)
     assert_raises(libqtile.command.CommandException,
                   self.c.delgroup, self.c.groups().keys()[0])
+
+
+@Xephyr(False, TestConfig())
+def test_delgroup(self):
+    self.testWindow("one")
+    for i in ['a', 'd', 'c']:
+        self.c.delgroup(i)
+    assert_raises(libqtile.command.CommandException, self.c.delgroup, 'b')
 
 
 @Xephyr(False, TestConfig())


### PR DESCRIPTION
This fixes a problem I've been noticing on Travis in `test_adddelgroup()`, particularly with Python 3 tests (e.g. [1]). Since hash randomization is used, the iteration in https://github.com/qtile/qtile/blob/develop/test/test_manager.py#L258 is not always in the same order. I broke it down and found when the initial screen (`a`) is deleted, then the screen that is switched to (`dummygroup`) is deleted, it tries to switch back to the previous screen, but since `a` had been deleted, it throws an error. This fixes this error by not storing `.previous_group` in this case. The test, since it iterates using a list, would always fail in the current branch, but will pass with this change.

[1] https://travis-ci.org/tych0/qtile/jobs/31510161
