### PR TITLE
Add the pulse device to the volume widget

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -68,6 +68,8 @@ class Volume(base._TextBox):
             subprocess.call([
                 'amixer',
                 '-q',
+                '-D',
+                'pulse',
                 '-c',
                 str(self.cardid),
                 'sset',


### PR DESCRIPTION
When muting with amixer with the default device (no -D), amixer mutes the Master channel, but also the headphone channel. Unfortunately, unmuting (by toogling) works fine, hence unmutes only Master, leaving the headphone channel muted.
Open to discussion, because we make the assumption the user uses pulseaudio.
