### PR TITLE
Drop Encoding from the desktop file

### DIFF
--- a/resources/qtile.desktop
+++ b/resources/qtile.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Qtile
 Comment=Qtile Session
 Exec=qtile


### PR DESCRIPTION
Deprecated, see:

http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
