### PR TITLE
Change default log named ".%s.log" to ".qtile.log"

### DIFF
--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -40,7 +40,7 @@ class ColorFormatter(logging.Formatter):
         return message + self.reset_seq
 
 
-def init_log(log_level=logging.ERROR, logger='qtile', log_path='~/.%s.log'):
+def init_log(log_level=logging.ERROR, logger='qtile', log_path='~/.qtile.log'):
     log = getLogger(logger)
     log.setLevel(log_level)
 


### PR DESCRIPTION
I freshly reinstalled qtile on my new laptop and I found a `.%s.log` file in my current directory.

A quick `git grep` shows that the culprit is https://github.com/qtile/qtile/blob/develop/libqtile/log_utils.py#L43 as pasted below:

``` python
def init_log(log_level=logging.ERROR, logger='qtile', log_path='~/.%s.log'):
```

I propose to change the `log_path` default value to `.qtile.log`.
