### PR TITLE
clicking on a task in the tasklist now show/hide the window.

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -138,6 +138,10 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             window.group.focus(window, False)
             if window.floating:
                 window.cmd_bring_to_front()
+            if window.minimized:
+                window.toggleminimize()
+        elif window:
+            window.toggleminimize()
 
     def get_window_icon(self, window):
         cache = self._icons_cache.get(window.window.wid)


### PR DESCRIPTION
added the ability to show/hide a window when clicking on the tasklist:
- when we click on a non current task, it only select (and unhide it).
- when we click on the already current task, it hide it.
