### PR TITLE
Add coveralls support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ qtile.egg-info/
 *.swo
 /doc
 /docs/_build
+.coverage
 # some people hack on macs? :-)
 .DS_Store
 # debian stuff

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,8 @@ install:
   - if [[ ${EVENTLOOP} == "trollius" ]]; then pip install trollius; fi
   - if [[ ${EVENTLOOP} == "tulip" ]]; then pip install asyncio; fi
 
+after_success:
+  - coveralls
+
 notifications:
   - email: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default:
 
 .PHONY: check
 check:
-	nosetests -v -d
+	nosetests -v -d --with-coverage --cover-package=libqtile
 
 .PHONY: lint
 lint:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==============
-Qtile |travis|
-==============
+==========================
+Qtile |travis| |coveralls|
+==========================
 
 A full-featured, pure-Python tiling window manager
 ==================================================
@@ -48,6 +48,10 @@ the Github `issue tracker`_. There are also a few `tips, tricks, and guidelines
 documentation.
 
 .. _`issue tracker`: https://github.com/qtile/qtile/issues
+
 .. |travis| image:: https://travis-ci.org/qtile/qtile.svg?branch=develop
     :alt: Build Status
     :target: https://travis-ci.org/qtile/qtile
+.. |coveralls| image:: https://coveralls.io/repos/qtile/qtile/badge.png?branch=develop
+    :alt: Build Coverage
+    :target: https://coveralls.io/r/qtile/qtile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e git://github.com/flacjacket/cairocffi.git@xcb#egg=cairocffi
 cffi
 flake8
+python-coveralls
 six
 xcffib


### PR DESCRIPTION
It would need someone to sign up at https://coveralls.io/ and enable the repo, but this would give us nice coverage data on the tests.
