### PR TITLE
fix arch docs, qtile-git and qtile-python3-git were swapped

### DIFF
--- a/docs/manual/install/arch.rst
+++ b/docs/manual/install/arch.rst
@@ -38,13 +38,13 @@ Also you need these packages from AUR:
 
 **For python3:**
 
-- `qtile-git`_
+- `qtile-python3-git`_
 - `python-xcffib`_
 - `python-cairocffi-xcffib-git`_
 
 **For python2:**
 
-- `qtile-python3-git`_
+- `qtile-git`_
 - `python2-xcffib`_
 - `python2-cairocffi-xcffib-git`_
 - `trollius`_


### PR DESCRIPTION
whoops, i think now everything it's ok, if some other arch users want to take a look before merge..
