### PR TITLE
Put overvview first

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,8 +20,8 @@ Configuration
 -------------
 
 * **The basics**:
-  :doc:`Default Configuration </manual/config/default>` |
   :doc:`Overview </manual/config/index>` |
+  :doc:`Default Configuration </manual/config/default>` |
   :doc:`Hooks </manual/config/hooks>` |
   :doc:`Running inside Gnome </manual/config/gnome>`
 


### PR DESCRIPTION
The overview section is listed second in the config section. In every other section overview is first--becaue overviews should be first.
