### PR TITLE
Update qtile.session for recent versions of gnome

### DIFF
--- a/docs/manual/config/gnome.rst
+++ b/docs/manual/config/gnome.rst
@@ -43,10 +43,7 @@ The custom session for gnome-session.
     $ cat /usr/share/gnome-session/sessions/qtile.session
     [GNOME Session]
     Name=Qtile session
-    RequiredComponents=gnome-settings-daemon;
-    RequiredProviders=windowmanager;notifications;
-    DefaultProvider-windowmanager=qtile
-    DefaultProvider-notifications=notification-daemon
+    RequiredComponents=qtile;gnome-settings-daemon;
 
 So that Qtile starts automatically on login.
 


### PR DESCRIPTION
RequiredProviders support was removed from gnome in https://bugzilla.gnome.org/show_bug.cgi?id=691663. Now you just list everything in RequiredComponents.
