### PR TITLE
Only create a single Drawer object for a given TreeTab instance.

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -194,6 +194,10 @@ class Drawer:
         self.ctx = self.new_ctx()
         self.clear((0, 0, 1))
 
+    def __del__(self):
+        self.qtile.conn.conn.core.FreeGC(self.gc)
+        self.qtile.conn.conn.core.FreePixmap(self.pixmap)
+
     def _rounded_rect(self, x, y, width, height, linewidth):
         aspect = 1.0
         corner_radius = height / 10.0

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -262,6 +262,7 @@ class TreeTab(SingleWindow):
         self.add_defaults(TreeTab.defaults)
         self._focused = None
         self._panel = None
+        self._drawer = None
         self._tree = Root(self.sections)
         self._nodes = {}
 
@@ -545,12 +546,13 @@ class TreeTab(SingleWindow):
         self.group.layoutAll()
 
     def _create_drawer(self):
-        self._drawer = drawer.Drawer(
-            self.group.qtile,
-            self._panel.window.wid,
-            self.panel_width,
-            self.group.screen.dheight
-        )
+        if self._drawer is None:
+            self._drawer = drawer.Drawer(
+                self.group.qtile,
+                self._panel.window.wid,
+                self.panel_width,
+                self.group.screen.dheight
+            )
         self._drawer.clear(self.bg_color)
         self._layout = self._drawer.textlayout(
             "",


### PR DESCRIPTION
This, on top of the ugly **del** for Drawer, ensures that qtile doesn't
leak pixmap and graphic context objects in Xorg.bin.

fixes #520.

I haven't added any tests for this, though. I feel bad! If you have a preferred way of testing something like this, let me know.
