### PR TITLE
Hide bar when Flash is fullscreen

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1103,6 +1103,11 @@ class Window(_Window):
 
             # add support for additional flags here
             self.fullscreen = (fullscreen_atom in current_state)
+            # remove the bar if the window is fullscreen
+            screen = self.group.screen
+            for bar in [screen.top, screen.bottom, screen.left, screen.right]:
+                if bar:
+                    bar.show(not self.fullscreen)
 
             self.window.set_property('_NET_WM_STATE', list(current_state))
 


### PR DESCRIPTION
I just started using Qtile tonight so please I need your feedback on this PR even if it is small. In particular, I'd like to know what happen behind the scenes.

Setting: I am currently using Qtile as window manager for KDE.
Problem: in Firefox, when I set a flash video fullscreen, the bar remains visible and hide the bottom part of the video (very annoying when there are subtitles)

I have fixed that by hiding the bar when the state _NET_WM_STATE_FULLSCREEN is chenged. However, I am not sure if I've put the snippet of code at the right place. Also, I don't understand why the bar become visible again I quit the fullscreen mode (this is the desired behavior but since I have added no code to make it visible again, I'm a bit puzzled).

Thanks for your feedback.