### PR TITLE
Prevent 'Go' search button from overflowing

### DIFF
--- a/docs/_themes/qtile/static/qtile.css_t
+++ b/docs/_themes/qtile/static/qtile.css_t
@@ -78,8 +78,8 @@ div.sphinxsidebar .logo a:active {
     color: #036;
 }
 
-div.sphinxsidebar input[type="submit"] {
-    padding: 2px 5px;
+div.sphinxsidebar input {
+    margin: 2px 0;
 }
 
 div.sphinxsidebar ul {


### PR DESCRIPTION
I prevented the overflow on Firefox and ensured both input (text and submit) had same height.

[See the change with this gif](http://i.imgur.com/yR1j4Gi.gifv)
