### PR TITLE
Use some new xcffib api

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -316,7 +316,7 @@ class _Window(command.CommandObject):
 
     def getOpacity(self):
         opacity = self.window.get_property(
-            "_NET_WM_WINDOW_OPACITY", unpack="I"
+            "_NET_WM_WINDOW_OPACITY", unpack=int
         )
         if not opacity:
             return 1.0
@@ -655,11 +655,11 @@ class Static(_Window):
     def update_strut(self):
         strut = self.window.get_property(
             "_NET_WM_STRUT_PARTIAL",
-            unpack="I" * 12
+            unpack=int
         )
         strut = strut or self.window.get_property(
             "_NET_WM_STRUT",
-            unpack="I" * 4
+            unpack=int
         )
         strut = strut or (0, 0, 0, 0)
         self.qtile.update_gaps(strut, self.strut)
@@ -1028,10 +1028,9 @@ class Window(_Window):
             Set a dict with the icons of the window
         """
 
-        ret = self.window.get_property('_NET_WM_ICON', 'CARDINAL')
-        if not ret:
+        icon = self.window.get_property('_NET_WM_ICON', 'CARDINAL', unpack=int)
+        if not icon:
             return
-        icon = list(map(ord, ret.value))
 
         icons = {}
         while True:
@@ -1072,7 +1071,7 @@ class Window(_Window):
             prev_state = self.window.get_property(
                 '_NET_WM_STATE',
                 'ATOM',
-                unpack='I'
+                unpack=int
             )
             if not prev_state:
                 prev_state = []


### PR DESCRIPTION
This uses some of the new stuff available in xcffib not in xpyb, namely `.to_atoms()` and `.to_strings()` to parse returned values and using synthetic events. Using the git xcffib, the tests pass fine for me, however, Travis seems to have some problems with the synthetic events. Not even sending them, but just packing them. Using only 7e7cab282da2e6e6a20401bcccd2da11e81214e1, which just tries to pack the data and compare it to the struct packed data causes Travis to hang https://travis-ci.org/flacjacket/qtile/builds/39116342. I have no way of saying where this is coming from.
