### PR TITLE
widget: graph: NetGraph: fix unhandled exception

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -320,7 +320,7 @@ class NetGraph(_Graph):
                 (r for r in routes if not int(r['dest'], 16)),
                 routes[0]
             )['iface']
-        except (KeyError, ValueError):
+        except (KeyError, IndexError, ValueError):
             raise RuntimeError('No valid interfaces available')
 
 


### PR DESCRIPTION
If Qtile trys to come up without default route, this TraceBack appears:

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/qtile-0.8.0-py2.7.egg/libqtile/confreader.py", line 54, in **init**
    config = **import**(os.path.basename(fname)[:-3])
  File "/home/fsc/.config/qtile/config.py", line 139, in <module>
    widget.NetGraph(**widget_graph_defaults),
  File "/usr/local/lib/python2.7/dist-packages/qtile-0.8.0-py2.7.egg/libqtile/widget/graph.py", line 285, in **init**
    self.interface = self.get_main_iface()
  File "/usr/local/lib/python2.7/dist-packages/qtile-0.8.0-py2.7.egg/libqtile/widget/graph.py", line 321, in get_main_iface
    routes[0]
IndexError: list index out of range

Signed-off-by: Florian Scherf fscherf@gmx.net
