### PR TITLE
Update hints["input"] during updateHints

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -262,6 +262,8 @@ class _Window(command.CommandObject):
         if getattr(self, 'group', None):
             self.group.layoutAll()
 
+        if h:
+            self.hints["input"] = h["input"]
         return
 
     def updateState(self):


### PR DESCRIPTION
The hints["input"] is never updated after initialized to True. This will cause problems for some non-focusable windows that set this hint to false. For example: xfce4-notifyd will set this.
