### PR TITLE
Fix typos in doc (manual/commands)

### DIFF
--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -73,7 +73,7 @@ currently displaying group "b", we can do this:
 
 Be aware, however, that group "b" might not currently be displayed. In that
 case, it has no associated screen, the path resolves to a non-existent
-node, and we get an exeption:
+node, and we get an exception:
 
 .. code-block:: python
 
@@ -100,7 +100,7 @@ The key specifier for the various object types are as follows:
       - Key
       - Optional?
       - Example
-    * - Bar
+    * - bar
       - "top", "bottom"
       - No
       - | c.screen.bar["bottom"]


### PR DESCRIPTION
exeption -> exception
Bar -> bar : other object types are not capitalized.