### PR TITLE
Don't let notifications steal focus

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -176,7 +176,7 @@ class _Group(command.CommandObject):
             screen=self.screen.index if self.screen else None
         )
 
-    def add(self, win):
+    def add(self, win, focus=True):
         hook.fire("group_window_add")
         self.windows.add(win)
         win.group = self
@@ -196,7 +196,8 @@ class _Group(command.CommandObject):
         else:
             for i in self.layouts:
                 i.add(win)
-        self.focus(win, True)
+        if focus:
+            self.focus(win, True)
 
     def remove(self, win):
         self.windows.remove(win)

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -546,7 +546,7 @@ class Qtile(command.CommandObject):
                 self.windowMap[w.wid] = c
                 # Window may have been bound to a group in the hook.
                 if not c.group:
-                    self.currentScreen.group.add(c)
+                    self.currentScreen.group.add(c, focus=c.can_steal_focus())
                 self.update_client_list()
                 hook.fire("client_managed", c)
             return c

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -460,6 +460,9 @@ class _Window(command.CommandObject):
 
         self.window.send_event(event, mask=EventMask.StructureNotify)
 
+    def can_steal_focus(self):
+        return self.window.get_wm_type() != 'notification'
+
     def focus(self, warp):
 
         # Workaround for misbehaving java applications (actually it might be


### PR DESCRIPTION
Currently notification windows are stealing the focus, but they shouldn't: this patch fixes it for me.

This may also be useful as a starting point for fixing #122 and #537.