### PR TITLE
Decode window property strings manually instead of relying on xcffib.

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -370,7 +370,7 @@ class Window:
         """
             Extract a string from a window property reply message.
         """
-        return r.value.to_string()
+        return b''.join(r.value).decode('utf-8')
 
     def send_event(self, synthevent, mask=EventMask.NoEvent):
         self.conn.conn.core.SendEvent(False, self.wid, mask, synthevent.pack())


### PR DESCRIPTION
See issue #548. Should work with Python 2 and 3 but I haven't tested with 2.