### PR TITLE
Python3 needs a string from pangocffi.markup_escape_text

### DIFF
--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -256,4 +256,6 @@ def parse_markup(value, accel_marker=0):
 
 def markup_escape_text(text):
     ret = gobject.g_markup_escape_text(text.encode(), -1)
+    if six.PY3:
+        return ffi.string(ret).decode()
     return ffi.string(ret)


### PR DESCRIPTION
This fixes issue #570. 