### PR TITLE
mashed clipboard notify for utf8

### DIFF
--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -69,7 +69,7 @@ class Clipboard(base._TextBox):
 
             if six.PY3:
                 text = six.b(text).decode('utf-8')
-                
+
             self.text = text
 
             if self.timeout_id:

--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -1,3 +1,5 @@
+import six
+
 from . import base
 from .. import bar, hook, xcbq
 
@@ -65,7 +67,7 @@ class Clipboard(base._TextBox):
                 if self.max_width is not None and len(text) > self.max_width:
                     text = text[:self.max_width] + "..."
 
-            self.text = text
+            self.text = six.b(text).decode('utf-8')
 
             if self.timeout_id:
                 self.timeout_id.cancel()

--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -67,7 +67,10 @@ class Clipboard(base._TextBox):
                 if self.max_width is not None and len(text) > self.max_width:
                     text = text[:self.max_width] + "..."
 
-            self.text = six.b(text).decode('utf-8')
+            if six.PY3:
+                text = six.b(text).decode('utf-8')
+                
+            self.text = text
 
             if self.timeout_id:
                 self.timeout_id.cancel()


### PR DESCRIPTION
same thing as windows title. Try to copy "ĄČĘĖ" - should show same in clipboard widget.

I don't know is it good place to fix