### PR TITLE
Enables arguments in user functions

### DIFF
--- a/libqtile/command.py
+++ b/libqtile/command.py
@@ -430,10 +430,10 @@ class CommandObject(object):
             error = traceback.format_exc().strip().split("\n")[-1]
             return (False, error)
 
-    def cmd_function(self, function):
+    def cmd_function(self, function, *args):
         """Call a function with current object as argument"""
         try:
-            function(self)
+            function(self, *args)
         except Exception:
             error = traceback.format_exc()
             self.log.error('Exception calling "%s":\n%s' % (function, error))


### PR DESCRIPTION
This change allows the use an arguments in the functions of the user.

Example:

```
def switchGroup(qtile, *args):
    nextGroup = args[0]
    nextName = args[1]
    currentGroup = qtile.currentGroup.name
    if currentGroup != nextName:
        qtile.groups[nextGroup].cmd_toscreen(0)
    else:
        qtile.screens[0].cmd_togglegroup()

for index, grp in enumerate(groups):
     keys.extend([
         Key([mod], str(index+1), lazy.function(switchGroup, index, grp.name)),
    ])
```
(In this example in case of switch to current group will switch to the previous group.)