### PR TITLE
pacman widget doesn't work

### DIFF
--- a/libqtile/widget/pacman.py
+++ b/libqtile/widget/pacman.py
@@ -45,7 +45,7 @@ class Pacman(base.ThreadedPollText):
 
     def poll(self):
         pacman = self.call_process(['checkupdates'])
-        return str(len(pacman.stdout.readlines()))
+        return str(len(pacman.splitlines()))
 
     def button_press(self, x, y, button):
         base.ThreadedPollText.button_press(self, x, y, button)


### PR DESCRIPTION
call_process returns string with \n. Before it returned PIPE (list). Simple splitlines() helped. Checked on py3 and py2