### PR TITLE
Fix having long unicode characters in properties

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -588,8 +588,11 @@ class Window:
 
         try:
             if isinstance(value, six.string_types):
-                # xcffib will pack the strings
-                pass
+                # xcffib will pack the bytes, but we should encode them properly
+                if six.PY3:
+                    value = value.encode()
+                elif isinstance(value, unicode):
+                    value = value.encode('utf-8')
             else:
                 # if this runs without error, the value is already a list, don't wrap it
                 six.next(iter(value))

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -591,7 +591,10 @@ class Window:
                 # xcffib will pack the bytes, but we should encode them properly
                 if six.PY3:
                     value = value.encode()
-                elif isinstance(value, unicode):
+                elif not isinstance(value, str):
+                    # This will only run for Python 2 unicode strings, can't
+                    # use 'isinstance(value, unicode)' because Py 3 does not
+                    # have unicode and pyflakes complains
                     value = value.encode('utf-8')
             else:
                 # if this runs without error, the value is already a list, don't wrap it


### PR DESCRIPTION
The real problem here is that for long unicode characters in a string, the number of bytes needed is more than the number of characters in the string.  By encoding unicode before taking the length, we mitigate this problem.

When we have things that are unicode (PY3 string or PY2 unicode), we really _should_ encode them properly before sending them over the wire.  xcffib does have code that could deal with strings if we were able to properly get the length, but we should play nice and send it bytes.