### PR TITLE
zoomy layout: don't set property if it is None

### DIFF
--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -138,11 +138,14 @@ class Zoomy(SingleWindow):
         return d
 
     def focus(self, win):
-        if self.focused and self.property_name:
+        if self.focused and self.property_name and self.focused.window.get_property(
+                self.property_name,
+                "UTF8_STRING"
+                ):
             self.focused.window.set_property(
                 self.property_name,
                 self.property_small,
-                "STRING",
+                "UTF8_STRING",
                 format=8
             )
         SingleWindow.focus(self, win)
@@ -151,7 +154,7 @@ class Zoomy(SingleWindow):
             win.window.set_property(
                 self.property_name,
                 self.property_big,
-                "STRING",
+                "UTF8_STRING",
                 format=8
             )
 

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -141,7 +141,7 @@ class Zoomy(SingleWindow):
         if self.focused and self.property_name and self.focused.window.get_property(
                 self.property_name,
                 "UTF8_STRING"
-                ):
+                ) is not None:
             self.focused.window.set_property(
                 self.property_name,
                 self.property_small,

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -139,9 +139,9 @@ class Zoomy(SingleWindow):
 
     def focus(self, win):
         if self.focused and self.property_name and self.focused.window.get_property(
-                    self.property_name,
-                    "UTF8_STRING"
-                ) is not None:
+            self.property_name,
+            "UTF8_STRING"
+        ) is not None:
             self.focused.window.set_property(
                 self.property_name,
                 self.property_small,

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -139,8 +139,8 @@ class Zoomy(SingleWindow):
 
     def focus(self, win):
         if self.focused and self.property_name and self.focused.window.get_property(
-                self.property_name,
-                "UTF8_STRING"
+                    self.property_name,
+                    "UTF8_STRING"
                 ) is not None:
             self.focused.window.set_property(
                 self.property_name,


### PR DESCRIPTION
avoid setting property if it doesn't exist. In this case property_small for ZOOM property will not exist untill it will be set with property_big. In zoomy layout there creates big window and if new window appears it can be „iconified“.
This should fix https://github.com/qtile/qtile/issues/561