### PR TITLE
Add forgotten return to get_main_iface()

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -347,7 +347,7 @@ class NetGraph(_Graph):
     def get_main_iface():
         filename = "/proc/net/route"
         def make_route(line):
-            dict(zip(['iface', 'dest'], line.split()))
+            return dict(zip(['iface', 'dest'], line.split()))
         routes = [make_route(line) for line in list(open(filename))[1:]]
         try:
             return next(


### PR DESCRIPTION
This fixes the following backtrace I get when I switch to develop:

```
2015-02-13 11:34:42,521 qtile init_log:93  Starting Qtile
2015-02-13 11:34:42,979 qtile safe_import:49  Can't Import Widget: '.launchbar.LaunchBar', No module named xdg.IconTheme
2015-02-13 11:34:42,981 qtile safe_import:49  Can't Import Widget: '.mpriswidget.Mpris', No module named dbus
2015-02-13 11:34:42,982 qtile safe_import:49  Can't Import Widget: '.mpris2widget.Mpris2', No module named dbus
2015-02-13 11:34:42,983 qtile safe_import:49  Can't Import Widget: '.mpdwidget.Mpd', No module named mpd
2015-02-13 11:34:42,994 qtile safe_import:49  Can't Import Widget: '.wlan.Wlan', No module named pythonwifi.iwlibs
2015-02-13 11:34:43,007 qtile safe_import:49  Can't Import Widget: '.google_calendar.GoogleCalendar', ado/nobackup/virtualenvs/qtile/lib/python2.7/site-packages (from qtile==0.9.0)
No module named dateutil.parser
2015-02-13 11:34:43,008 qtile safe_import:49  Can't Import Widget: '.imapwidget.ImapWidget', No module named keyring
2015-02-13 11:34:43,013 qtile make_qtile:109  Error while reading config file
Traceback (most recent call last):
  File "./bin/qtile", line 107, in make_qtile
    c = confreader.File(options.configfile, is_restart=options.no_spawn)
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/confreader.py", line 63, in __init__
    raise ConfigError(str(v) + "\n\n" + tb)
ConfigError: 'NoneType' object has no attribute '__getitem__'

Traceback (most recent call last):
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/confreader.py", line 53, in __init__
    config = __import__(os.path.basename(fname)[:-3])
  File "/afs/dfn-cert.de/user/delgado/.config/qtile/config.py", line 357, in <module>
    ] + _barend(),
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 318, in __init__
    self.interface = self.get_main_iface()
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 355, in get_main_iface
    routes[0]
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 354, in <genexpr>
    (r for r in routes if not int(r['dest'], 16)),
TypeError: 'NoneType' object has no attribute '__getitem__'

Traceback (most recent call last):
  File "./bin/qtile", line 130, in <module>
    q = make_qtile()
  File "./bin/qtile", line 107, in make_qtile
    c = confreader.File(options.configfile, is_restart=options.no_spawn)
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/confreader.py", line 63, in __init__
    raise ConfigError(str(v) + "\n\n" + tb)
ConfigError: 'NoneType' object has no attribute '__getitem__'

Traceback (most recent call last):
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/confreader.py", line 53, in __init__
    config = __import__(os.path.basename(fname)[:-3])
  File "/afs/dfn-cert.de/user/delgado/.config/qtile/config.py", line 357, in <module>
    ] + _barend(),
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 318, in __init__
    self.interface = self.get_main_iface()
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 355, in get_main_iface
    routes[0]
  File "/afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/widget/graph.py", line 354, in <genexpr>
    (r for r in routes if not int(r['dest'], 16)),
TypeError: 'NoneType' object has no attribute '__getitem__'


> /afs/dfn-cert.de/user/delgado/nobackup/anon-vc/qtile/bin/libqtile/confreader.py(63)__init__()
-> raise ConfigError(str(v) + "\n\n" + tb)
(Pdb)
```
