### PR TITLE
pangocffi: add FontDescription.from_string() to parse styles too

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -46,8 +46,7 @@ class TextLayout(object):
         layout.set_alignment(pangocffi.ALIGN_CENTER)
         if not wrap:  # pango wraps by default
             layout.set_ellipsize(pangocffi.ELLIPSIZE_END)
-        desc = pangocffi.FontDescription()
-        desc.set_family(font_family)
+        desc = pangocffi.FontDescription.from_string(font_family)
         desc.set_absolute_size(pangocffi.units_from_double(font_size))
         layout.set_font_description(desc)
         self.font_shadow = font_shadow

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -145,6 +145,9 @@ ffi.cdef("""
     PangoFontDescription *pango_font_description_new (void);
     void pango_font_description_free (PangoFontDescription *desc);
 
+    PangoFontDescription *
+    pango_font_description_from_string (const char *str);
+
     void
     pango_font_description_set_family (PangoFontDescription *desc,
                                        const char *family);
@@ -251,6 +254,12 @@ class FontDescription(object):
             self._pointer = ffi.gc(self._pointer, pango.pango_font_description_free)
         else:
             self._pointer = pointer
+
+    @classmethod
+    def from_string(cls, string):
+        pointer = pango.pango_font_description_from_string(string.encode())
+        pointer = ffi.gc(pointer, pango.pango_font_description_free)
+        return cls(pointer)
 
     def set_family(self, family):
         pango.pango_font_description_set_family(self._pointer, family.encode())


### PR DESCRIPTION
This allows specifying the font name as "DejaVu Sans Bold Italic", for example.