### PR TITLE
Max layout: insert new windows after the currently focused one

### DIFF
--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -86,7 +86,12 @@ class Max(SingleWindow):
         return c
 
     def add(self, client):
-        self.clients.insert(0, client)
+        try:
+            idx = self.clients.index(self._get_window())
+        except ValueError:
+            self.clients.append(client)
+        else:
+            self.clients.insert(idx + 1, client)
 
     def remove(self, client):
         if client not in self.clients:

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -161,7 +161,7 @@ def test_max_simple(self):
     self.testWindow("one")
     assert self.c.layout.info()["clients"] == ["one"]
     self.testWindow("two")
-    assert self.c.layout.info()["clients"] == ["two", "one"]
+    assert self.c.layout.info()["clients"] == ["one", "two"]
 
 
 @Xephyr(False, MaxConfig())
@@ -169,10 +169,10 @@ def test_max_updown(self):
     self.testWindow("one")
     self.testWindow("two")
     self.testWindow("three")
-    assert self.c.layout.info()["clients"] == ["three", "two", "one"]
-    self.c.layout.down()
-    assert self.c.groups()["a"]["focus"] == "two"
+    assert self.c.layout.info()["clients"] == ["one", "two", "three"]
     self.c.layout.up()
+    assert self.c.groups()["a"]["focus"] == "two"
+    self.c.layout.down()
     assert self.c.groups()["a"]["focus"] == "three"
 
 
@@ -180,7 +180,7 @@ def test_max_updown(self):
 def test_max_remove(self):
     self.testWindow("one")
     two = self.testWindow("two")
-    assert self.c.layout.info()["clients"] == ["two", "one"]
+    assert self.c.layout.info()["clients"] == ["one", "two"]
     self.kill(two)
     assert self.c.layout.info()["clients"] == ["one"]
 
@@ -194,8 +194,8 @@ def test_closing_dialog(self):
     dialog1 = self.testWindow("dialog1")
     self.testWindow("one")
     self.testWindow("two")
-    self.testWindow("three")
-    self.c.layout.up()
+    three = self.testWindow("three")
+    self.c.layout.down()
     assert self.c.window.info()['name'] == "dialog1", self.c.window.info()[
                                                                         'name']
     self.c.window.toggle_floating()
@@ -204,25 +204,25 @@ def test_closing_dialog(self):
                                                                         'name']
 
     # Now test a dialog that is the last open window in the group
-    self.c.layout.down()
     dialog2 = self.testWindow("dialog2")
     self.c.window.toggle_floating()
     self.kill(dialog2)
-    assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
+    assert self.c.window.info()['name'] == "three", self.c.window.info()[
+                                                                        'name']
 
     # Now test a dialog that is neither the first nor the last open window in
     # the group
     dialog3 = self.testWindow("dialog3")
-    self.testWindow("four")
-    five = self.testWindow("five")
-    six = self.testWindow("six")
+    four = self.testWindow("four")
+    self.testWindow("five")
+    self.testWindow("six")
     # TODO: for a more generic test, find a way to focus 'five', then focus
     #  'dialog3' skipping 'four', so that then, after closing 'dialog3', the
     #  focus must be returned to 'five', which better represents a generic
     #  window that wasn't necessarily opened immediately after the dialog
-    self.c.layout.down()
-    self.c.layout.down()
-    self.c.layout.down()
+    self.c.layout.up()
+    self.c.layout.up()
+    self.c.layout.up()
     assert self.c.window.info()['name'] == "dialog3", self.c.window.info()[
                                                                         'name']
     self.c.window.toggle_floating()
@@ -233,24 +233,20 @@ def test_closing_dialog(self):
     # closed without stealing focus from the dialog, thus requiring to find the
     # window that had focus even before that (this tests the history of focus)
     dialog4 = self.testWindow("dialog4")
-    self.testWindow("seven")
-    self.testWindow("eight")
-    self.c.layout.down()
-    self.c.layout.down()
-    self.c.layout.down()
-    self.c.layout.down()
-    self.c.layout.down()
-    assert self.c.window.info()['name'] == "four", self.c.window.info()['name']
     self.c.layout.up()
     self.c.layout.up()
     self.c.layout.up()
+    assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
+    self.c.layout.down()
+    self.c.layout.down()
+    self.c.layout.down()
     assert self.c.window.info()['name'] == "dialog4", self.c.window.info()[
                                                                         'name']
     self.c.window.toggle_floating()
-    self.kill(five)
-    self.kill(six)
+    self.kill(three)
+    self.kill(four)
     self.kill(dialog4)
-    assert self.c.window.info()['name'] == "four", self.c.window.info()['name']
+    assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
 
 
 @Xephyr(False, MaxConfig())
@@ -268,7 +264,7 @@ def test_closing_notification(self):
     self.testWindow("one")
     self.testWindow("two")
     self.testWindow("three")
-    self.c.layout.down()
+    self.c.layout.up()
     assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
     self.kill(notification1)
     assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
@@ -278,8 +274,8 @@ def test_closing_notification(self):
     self.c.window.toggle_floating()
     # Create and kill 'temp', otherwise self.c.layout.down() won't work
     temp = self.testWindow("temp")
-    self.c.layout.down()
-    self.c.layout.down()
+    self.c.layout.up()
+    self.c.layout.up()
     self.kill(temp)
     assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
     self.kill(notification2)
@@ -291,9 +287,9 @@ def test_closing_notification(self):
     self.c.window.toggle_floating()
     four = self.testWindow("four")
     five = self.testWindow("five")
-    self.c.layout.down()
-    self.c.layout.down()
-    self.c.layout.down()
+    self.c.layout.up()
+    self.c.layout.up()
+    self.c.layout.up()
     assert self.c.window.info()['name'] == "two", self.c.window.info()['name']
     self.kill(notification3)
     assert self.c.window.info()['name'] == "two", self.c.window.info()['name']


### PR DESCRIPTION
Before this patch, the Max layout was always prepending new windows to its internal list, but this was making it behave in an innatural way. Suppose to have opened 3 windows, `A`, `B` and `C`, in that order: at the current state, the internal list will be `[C, B, A]`. Now suppose that `B`, a browser window, has focus: if you open a new window now, `D`, for example a text editor to take a quick note, the list will be `[D, C, B, A]`. If you now try to go back to `B`, maybe to select some text for pasting it in `D`, you won't find it as the previous window in the stack, i.e. pressing the key for "up" will go to `A`, which is unexpected.
This patch makes Max insert new windows right after the currently focused one. If you opened 3 windows, `A`, `B` and `C`, in that order, the internal list will be `[A, B, C]`; if you focus `B` and open `D`, the list will now be `[A, B, D, C]`, which properly allows going back to `B` with "up", and again to `D` with "down", which is more natural, since in lists "up" is usually associated with "previous", and "down" with "next".

Before this change, because of how new windows were inserted, going "up" meant "next", in practice, and "down" meant "previous": this has made it necessary to also update the tests accordingly.