### PR TITLE
Emacs-style configuration helper for keys and buttons.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,12 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
             return Mock()
 
+    # xcbq does a dir() on objects and pull stuff out of them and tries to sort
+    # the result. MagicMock has a bunch of stuff that can't be sorted, so let's
+    # like about dir().
+    def __dir__(self):
+        return []
+
 MOCK_MODULES = [
     'cairocffi',
     'cffi',

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -11,7 +11,7 @@ Configuration lookup order
 
 Qtile looks in the following places for a configuration file, in order:
 
-* The location specified by the ``-f`` argument.
+* The location specified by the ``-c`` argument.
 * ``$XDG_CONFIG_HOME/qtile/config.py``, if it is set
 * ``~/.config/qtile/config.py``
 * It reads the module ``libqtile.resources.default_config``, included by

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -2,7 +2,48 @@
 Keys
 ====
 
-The ``keys`` variable defines Qtile's key bindings.
+The ``keys`` variable defines Qtile's key bindings. Individual key
+bindings are defined with ``libqtile.config.Key`` as demonstrated in
+the following example. Note that you may specify more than one
+callback functions.
+
+::
+
+   from libqtile.config import Key
+
+   keys = [
+      # Pressing "Meta + Shift + a".
+      Key(["mod4", "shift"], "a", callback, ...),
+
+      # Pressing "Control + p".
+      Key(["control"], "p", callback, ...),
+
+      # Pressing "Meta + Tab".
+      Key(["mod4", "mod1"], "Tab", callback, ...),
+   ]
+
+The above may also be written more concisely with the help of the
+``EzKey`` helper class. The following example is functionally
+equivalent to the above::
+
+    from libqtile.config import EzKey as Key
+
+    keys = [
+       Key("M-S-a", callback, ...),
+       Key("C-p",   callback, ...),
+       Key("M-A-<Tab>", callback, ...),
+    ]
+
+The ``EzKey`` modifier keys (i.e. ``MASC``) can be overwritten through
+the ``EzKey.modifier_keys`` dictionary. The defaults are::
+
+    modifier_keys = {
+       'M': 'mod4',
+       'A': 'mod1',
+       'S': 'shift',
+       'C': 'control',
+    }
+
 
 The command.lazy object
 =======================
@@ -19,6 +60,7 @@ Example
 
     from libqtile.config import Key
     from libqtile.command import lazy
+
     keys = [
         Key(
             ["mod1"], "k",

--- a/docs/manual/config/mouse.rst
+++ b/docs/manual/config/mouse.rst
@@ -20,3 +20,16 @@ Example
             start=lazy.window.get_size()),
         Click([mod], "Button2", lazy.window.bring_to_front())
     ]
+
+The above example can also be written more concisely with the help of
+the ``EzClick`` and ``EzDrag`` helpers::
+
+    from libqtile.config import EzClick as EzClick, EzDrag as Drag
+
+    mouse = [
+        Drag("M-1", lazy.window.set_position_floating(),
+            start=lazy.window.get_position()),
+        Drag("M-3", lazy.window.set_size_floating(),
+            start=lazy.window.get_size()),
+        Click("M-2", lazy.window.bring_to_front())
+    ]

--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -24,7 +24,7 @@ from docutils.statemachine import ViewList
 from jinja2 import Template
 from libqtile import command, configurable
 from six import class_types
-from six.moves import builtins
+from six.moves import builtins, reduce
 from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -34,6 +34,7 @@ from six import MAXSIZE
 
 from .widget.base import deprecated
 
+
 class Key:
     """
         Defines a keybinding.
@@ -112,6 +113,73 @@ class Click(object):
 
     def __repr__(self):
         return "Click(%s, %s)" % (self.modifiers, self.button)
+
+
+class EzConfig:
+    '''
+    Helper class for defining key and button bindings in an emacs-like format.
+    Inspired by Xmonad's XMonad.Util.EZConfig.
+    '''
+
+    modifier_keys = {
+        'M': 'mod4',
+        'A': 'mod1',
+        'S': 'shift',
+        'C': 'control',
+    }
+
+    def parse(self, spec):
+        '''
+        Splits an emacs keydef into modifiers and keys. For example:
+          "M-S-a"     -> ['mod4', 'shift'], 'a'
+          "A-<minus>" -> ['mod1'], 'minus'
+          "C-<Tab>"   -> ['control'], 'Tab'
+        '''
+        mods = []
+        keys = []
+
+        for key in spec.split('-'):
+            if not key:
+                break
+            if key in self.modifier_keys:
+                if keys:
+                    msg = 'Modifiers must always come before key/btn: %s'
+                    raise utils.QtileError(msg % spec)
+                mods.append(self.modifier_keys[key])
+                continue
+            if len(key) == 1:
+                keys.append(key)
+                continue
+            if len(key) > 3 and key[0] == '<' and key[-1] == '>':
+                keys.append(key[1:-1])
+                continue
+
+        if not keys:
+            msg = 'Invalid key/btn specifier: %s'
+            raise utils.QtileError(msg % spec)
+
+        if len(keys) > 1:
+            msg = 'Key chains are not supported: %s' % spec
+            raise utils.QtileError(msg)
+
+        return mods, keys[0]
+
+class EzKey(EzConfig, Key):
+    def __init__(self, keydef, *commands):
+        modkeys, key = self.parse(keydef)
+        super(EzKey, self).__init__(modkeys, key, *commands)
+
+class EzClick(EzConfig, Click):
+    def __init__(self, btndef, *commands, **kwargs):
+        modkeys, button = self.parse(btndef)
+        button = 'Button%s' % button
+        super(EzClick, self).__init__(modkeys, button, *commands, **kwargs)
+
+class EzDrag(EzConfig, Drag):
+    def __init__(self, btndef, *commands, **kwargs):
+        modkeys, button = self.parse(btndef)
+        button = 'Button%s' % button
+        super(EzDrag, self).__init__(modkeys, button, *commands, **kwargs)
 
 
 class ScreenRect(object):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -35,7 +35,7 @@ from six import MAXSIZE
 from .widget.base import deprecated
 
 
-class Key:
+class Key(object):
     """
         Defines a keybinding.
     """
@@ -115,7 +115,7 @@ class Click(object):
         return "Click(%s, %s)" % (self.modifiers, self.button)
 
 
-class EzConfig:
+class EzConfig(object):
     '''
     Helper class for defining key and button bindings in an emacs-like format.
     Inspired by Xmonad's XMonad.Util.EZConfig.

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -212,7 +212,10 @@ class MaskMap:
         for i in dir(obj):
             if not i.startswith("_"):
                 self.mmap.append((getattr(obj, i), i.lower()))
-        self.mmap.sort()
+        try:
+            self.mmap.sort()
+        except TypeError:
+            pass
 
     def __call__(self, **kwargs):
         """

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -212,10 +212,7 @@ class MaskMap:
         for i in dir(obj):
             if not i.startswith("_"):
                 self.mmap.append((getattr(obj, i), i.lower()))
-        try:
-            self.mmap.sort()
-        except TypeError:
-            pass
+        self.mmap.sort()
 
     def __call__(self, **kwargs):
         """

--- a/scripts/genkeysyms
+++ b/scripts/genkeysyms
@@ -6,24 +6,26 @@
 import os, os.path, sys
 import re
 
+
+template = '''\
+keysyms = {
+%s
+}\
+'''
+
 def genkeysyms(path):
     XRE = r"#define\s+XK_(\S+)\s+(\S+)"
     ks = []
     for i in file(path):
         m = re.match(XRE, i)
         if m:
-            ks.append(
-                (m.group(1), m.group(2))
-            )
-    print "keysyms = {"
-    for i in ks:
-        print "    '%s': %s,"%i
-    print "}"
+            ks.append(m.groups())
+
+    lines = ["    '%s': %s," % i for i in ks]
+    print(template % '\n'.join(lines))
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print >> sys.stderr, "Usage: genkeysyms path/to/keysymdef.h"
+        sys.stderr.write("Usage: genkeysyms path/to/keysymdef.h\n")
         sys.exit(1)
     genkeysyms(sys.argv[1])
-
-

--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -1,2 +1,12 @@
 #!/bin/sh
-Xephyr +extension RANDR -screen ${SCREEN_SIZE:-800x600} :1 -ac & (sleep 1; env DISPLAY=:1 ./bin/qtile -l INFO $@ & env DISPLAY=:1 xterm)
+
+HERE=$(dirname $(readlink -f $0))
+SCREEN_SIZE=${SCREEN_SIZE:-800x600}
+XDISPLAY=:1
+
+Xephyr +extension RANDR -screen ${SCREEN_SIZE} ${XDISPLAY} -ac &
+(
+  sleep 1
+  env DISPLAY=${XDISPLAY} "${HERE}"/../bin/qtile -l INFO $@ &
+  env DISPLAY=${XDISPLAY} xterm
+)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -21,7 +21,8 @@
 # SOFTWARE.
 
 from libqtile import confreader
-from nose.tools import raises
+from libqtile import config, utils
+from nose.tools import raises, assert_raises
 
 import os
 tests_dir = os.path.dirname(os.path.realpath(__file__))
@@ -29,7 +30,6 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 @raises(confreader.ConfigError)
 def test_syntaxerr():
     confreader.File(os.path.join(tests_dir, "configs", "syntaxerr.py"))
-
 
 def test_basic():
     f = confreader.File(os.path.join(tests_dir, "configs", "basic.py"))
@@ -42,3 +42,40 @@ def test_falls_back():
     # default is; don't assert anything at all about the default in case
     # someone changes it down the road.
     assert hasattr(f, "follow_mouse_focus")
+
+def test_ezkey():
+    cmd = lambda x: None
+
+    key = config.EzKey('M-A-S-a', cmd, cmd)
+    modkey, altkey = (config.EzConfig.modifier_keys[i] for i in 'MA')
+    assert key.modifiers == [modkey, altkey, 'shift']
+    assert key.key == 'a'
+    assert key.commands == (cmd, cmd)
+
+    key = config.EzKey('M-<Tab>', cmd)
+    assert key.modifiers == [modkey]
+    assert key.key == 'Tab'
+    assert key.commands == (cmd,)
+
+    with assert_raises(utils.QtileError):
+        config.EzKey('M--', cmd)
+
+    with assert_raises(utils.QtileError):
+        config.EzKey('Z-Z-z', cmd)
+
+    with assert_raises(utils.QtileError):
+        config.EzKey('asdf', cmd)
+
+    with assert_raises(utils.QtileError):
+        config.EzKey('M-a-A', cmd)
+
+def test_ezclick_ezdrag():
+    cmd = lambda x: None
+
+    btn = config.EzClick('M-1', cmd)
+    assert btn.button == 'Button1'
+    assert btn.modifiers == [config.EzClick.modifier_keys['M']]
+
+    btn = config.EzDrag('A-2', cmd)
+    assert btn.button == 'Button2'
+    assert btn.modifiers == [config.EzClick.modifier_keys['A']]


### PR DESCRIPTION
Hello,

This PR adds convenience wrappers around `Key`, `Drag` and `Click` that make key and button bindings a bit more straighforward in my opinion. I hope the following example, adapted from `default_config.py`, serves well in demonstrating the change.

```python
from libqtile.config import EzKey as Key, EzDrag as Drag, EzClick as Click

keys = [
    # Switch between windows in current stack pane
    Key('M-k', lazy.layout.down()),
    Key('M-j', lazy.layout.up()),

    # Move windows up or down in current stack
    Key('M-C-k', lazy.layout.shuffle_down()),
    Key('M-C-j', lazy.layout.shuffle_up()),

    # Switch window focus to other pane(s) of stack
    Key('M-<space>', lazy.layout.next()),

    # Swap panes of split stack
    Key('M-S-<space>', lazy.layout.rotate()),

    # Toggle between different layouts as defined below
    Key('M-<Tab>', lazy.nextlayout()),
    Key('M-w',     lazy.window.kill()),
]

mouse = [
    Drag('M-1',  lazy.window.set_position_floating()),
    Drag('M-3',  lazy.window.set_size_floating()),
    Click('M-2', lazy.window.bring_to_front())
]
```

In other words:

```python
EzKey('M-A-z', ...)   == Key(['mod4', 'mod1'], 'z', ...)
EzKey('M-<Tab>', ...) == Key(['mod4'], 'Tab', ...)
```


Xmonad users will likely recognize the `EZConfig` name from the handy [XMonad.Util.EZConfig](http://xmonad.org/xmonad-docs/xmonad-contrib/XMonad-Util-EZConfig.html) module. On a side note, I've also implemented this for Awesome WM ([ezconfig.lua](https://github.com/gvalkov/awesome-ezconfig) if curious).

Please consider this as a request for comments more than a final PR. 

Kind regards,
Georgi
