### PR TITLE
Gap: fix calculation of y property

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -64,10 +64,9 @@ class Gap(command.CommandObject):
             return screen.y
         elif screen.bottom is self:
             return screen.dy + screen.dheight
-        elif screen.left is self:
+        else:
+            # Screen corners are reserved to horizontal gaps, if present
             return screen.dy
-        elif screen.right is self:
-            return screen.y + screen.dy
 
     @property
     def width(self):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -227,7 +227,7 @@ class Screen(command.CommandObject):
     def __init__(self, top=None, bottom=None, left=None, right=None,
                  x=None, y=None, width=None, height=None):
         """
-            - top, bottom, left, right: Instances of bar objects, or None.
+            - top, bottom, left, right: Instances of Gap/Bar objects, or None.
 
             Note that bar.Bar objects can only be placed at the top or the
             bottom of the screen (bar.Gap objects can be placed anywhere).

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -166,7 +166,8 @@ class _Widget(command.CommandObject, configurable.Configurable):
         """
             This method calls either ``.call_later`` with given arguments.
         """
-        return self.qtile.call_later(seconds, self._wrapper, method, *method_args)
+        return self.qtile.call_later(seconds, self._wrapper, method,
+                                     *method_args)
 
     def call_process(self, command, **kwargs):
         """
@@ -333,7 +334,8 @@ class InLoopPollText(_TextBox):
 
     def timer_setup(self):
         update_interval = self.tick()
-        # If self.update_interval is defined and .tick() returns None, re-call after self.update_interval
+        # If self.update_interval is defined and .tick() returns None, re-call
+        # after self.update_interval
         if update_interval is None and self.update_interval is not None:
             self.timeout_add(self.update_interval, self.timer_setup)
         # We can change the update interval by returning something from .tick()
@@ -381,7 +383,8 @@ class ThreadedPollText(InLoopPollText):
         def worker():
             text = self.poll()
             self.qtile.call_soon_threadsafe(self.update, text)
-        # TODO: There are nice asyncio constructs for this sort of thing, I think...
+        # TODO: There are nice asyncio constructs for this sort of thing, I
+        # think...
         threading.Thread(target=worker).start()
 
 
@@ -398,14 +401,16 @@ class ThreadPoolText(_TextBox):
     param: text - Initial text to display.
     """
     def __init__(self, text, **config):
-        super(ThreadPoolText, self).__init__(text, width=bar.CALCULATED, **config)
+        super(ThreadPoolText, self).__init__(text, width=bar.CALCULATED,
+                                             **config)
 
     def timer_setup(self):
         def on_done(future):
             try:
                 result = future.result()
             except Exception:
-                self.log.exception('poll() raised exceptions, not rescheduling')
+                self.log.exception('poll() raised exceptions, not '
+                                   'rescheduling')
 
             if result is not None:
                 try:

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -36,9 +36,6 @@ import logging
 import threading
 import warnings
 
-LEFT = object()
-CENTER = object()
-
 
 class _Widget(command.CommandObject, configurable.Configurable):
     """

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -53,8 +53,8 @@ GRAPH_KW = dict(line_width=1,
 #     500     |--------|
 #                 400
 #
-# Notice there is hole in the middle
-# also that D goes down below the others
+# Notice there is a hole in the middle
+# also D goes down below the others
 
 
 class FakeScreenConfig:
@@ -99,6 +99,8 @@ class FakeScreenConfig:
                 24,
                 background="#555555"
             ),
+            left=bar.Gap(16),
+            right=bar.Gap(20),
             x=0, y=0, width=600, height=480
         ),
         Screen(
@@ -110,6 +112,8 @@ class FakeScreenConfig:
                 ],
                 30,
             ),
+            bottom=bar.Gap(24),
+            left=bar.Gap(12),
             x=600, y=0, width=300, height=580
         ),
         Screen(
@@ -121,10 +125,12 @@ class FakeScreenConfig:
                 ],
                 30,
             ),
+            bottom=bar.Gap(16),
+            right=bar.Gap(40),
             x=0, y=480, width=500, height=400
         ),
         Screen(
-            bottom=bar.Bar(
+            top=bar.Bar(
                 [
                     widget.GroupBox(),
                     widget.WindowName(),
@@ -132,6 +138,8 @@ class FakeScreenConfig:
                 ],
                 30,
             ),
+            left=bar.Gap(20),
+            right=bar.Gap(24),
             x=500, y=580, width=400, height=400
         ),
     ]
@@ -161,15 +169,35 @@ def test_basic(self):
 
 
 @Xephyr(False, FakeScreenConfig(), two_screens=False, width=900, height=980)
+def test_gaps(self):
+    g = self.c.screens()[0]["gaps"]
+    assert g["bottom"] == (0, 456, 600, 24)
+    assert g["left"] == (0, 0, 16, 456)
+    assert g["right"] == (580, 0, 20, 456)
+    g = self.c.screens()[1]["gaps"]
+    assert g["top"] == (600, 0, 300, 30)
+    assert g["bottom"] == (600, 556, 300, 24)
+    assert g["left"] == (600, 30, 12, 526)
+    g = self.c.screens()[2]["gaps"]
+    assert g["top"] == (0, 480, 500, 30)
+    assert g["bottom"] == (0, 864, 500, 16)
+    assert g["right"] == (460, 510, 40, 354)
+    g = self.c.screens()[3]["gaps"]
+    assert g["top"] == (500, 580, 400, 30)
+    assert g["left"] == (500, 610, 20, 370)
+    assert g["right"] == (876, 610, 24, 370)
+
+
+@Xephyr(False, FakeScreenConfig(), two_screens=False, width=900, height=980)
 def test_maximize_with_move_to_screen(self):
     """
     Ensure that maximize respects bars
     """
     self.testXclock()
     self.c.window.toggle_maximize()
-    assert self.c.window.info()['width'] == 600
+    assert self.c.window.info()['width'] == 564
     assert self.c.window.info()['height'] == 456
-    assert self.c.window.info()['x'] == 0
+    assert self.c.window.info()['x'] == 16
     assert self.c.window.info()['y'] == 0
     assert self.c.window.info()['group'] == 'a'
 
@@ -180,9 +208,9 @@ def test_maximize_with_move_to_screen(self):
     assert self.c.group.info()['name'] == 'b'
     self.c.group['a'].toscreen()
 
-    assert self.c.window.info()['width'] == 300
-    assert self.c.window.info()['height'] == 550
-    assert self.c.window.info()['x'] == 600
+    assert self.c.window.info()['width'] == 288
+    assert self.c.window.info()['height'] == 526
+    assert self.c.window.info()['x'] == 612
     assert self.c.window.info()['y'] == 30
     assert self.c.window.info()['group'] == 'a'
 
@@ -214,7 +242,8 @@ def test_float_change_screens(self):
     assert self.c.group.info()['floating_info']['clients'] == ['xclock']
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 0
+    # 16 is given by the left gap width
+    assert self.c.window.info()['x'] == 16
     assert self.c.window.info()['y'] == 0
     assert self.c.window.info()['group'] == 'a'
 
@@ -232,7 +261,7 @@ def test_float_change_screens(self):
     assert self.c.window.info()['name'] == 'xclock'
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 600
+    assert self.c.window.info()['x'] == 616
     assert self.c.window.info()['y'] == 0
     assert self.c.window.info()['group'] == 'a'
     assert self.c.group.info()['floating_info']['clients'] == ['xclock']
@@ -248,7 +277,7 @@ def test_float_change_screens(self):
     assert self.c.window.info()['name'] == 'xclock'
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 0
+    assert self.c.window.info()['x'] == 16
     assert self.c.window.info()['y'] == 480
 
     # now screen 4 for fun
@@ -262,7 +291,7 @@ def test_float_change_screens(self):
     assert self.c.window.info()['name'] == 'xclock'
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 500
+    assert self.c.window.info()['x'] == 516
     assert self.c.window.info()['y'] == 580
 
     # and back to one
@@ -276,7 +305,7 @@ def test_float_change_screens(self):
     assert self.c.window.info()['name'] == 'xclock'
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 0
+    assert self.c.window.info()['x'] == 16
     assert self.c.window.info()['y'] == 0
 
 
@@ -286,17 +315,18 @@ def test_float_outside_edges(self):
     self.c.window.toggle_floating()
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 0
+    # 16 is given by the left gap width
+    assert self.c.window.info()['x'] == 16
     assert self.c.window.info()['y'] == 0
     # empty because window is floating
     assert self.c.layout.info() == {
         'clients': [], 'group': 'a', 'name': 'max'}
 
     # move left, but some still on screen 0
-    self.c.window.move_floating(-10, 20, 42, 42)
+    self.c.window.move_floating(-30, 20, 42, 42)
     assert self.c.window.info()['width'] == 164
     assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == -10
+    assert self.c.window.info()['x'] == -14
     assert self.c.window.info()['y'] == 20
     assert self.c.window.info()['group'] == 'a'
 

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -74,64 +74,66 @@ class FakeScreenConfig:
     floating_layout = libqtile.layout.floating.Floating()
     keys = []
     mouse = []
-    fake_screens = [Screen(
-        bottom=bar.Bar(
-            [
-                widget.GroupBox(this_screen_border=CHAM3,
-                                borderwidth=1,
-                                fontsize=FONTSIZE,
-                                padding=1, margin_x=1, margin_y=1),
-                widget.AGroupBox(),
-                widget.Prompt(),
-                widget.Sep(),
-                widget.WindowName(
-                    fontsize=FONTSIZE, margin_x=6),
-                widget.Sep(),
-                widget.CPUGraph(**GRAPH_KW),
-                widget.MemoryGraph(**GRAPH_KW),
-                widget.SwapGraph(foreground='20C020', **GRAPH_KW),
-                widget.Sep(),
-                widget.Systray(),
-                widget.Sep(),
-                widget.Clock(format='%H:%M:%S %d.%m.%Y',
-                             fontsize=FONTSIZE, padding=6),
-            ],
-                    24,
-            background="#555555"
+    fake_screens = [
+        Screen(
+            bottom=bar.Bar(
+                [
+                    widget.GroupBox(this_screen_border=CHAM3,
+                                    borderwidth=1,
+                                    fontsize=FONTSIZE,
+                                    padding=1, margin_x=1, margin_y=1),
+                    widget.AGroupBox(),
+                    widget.Prompt(),
+                    widget.Sep(),
+                    widget.WindowName(fontsize=FONTSIZE, margin_x=6),
+                    widget.Sep(),
+                    widget.CPUGraph(**GRAPH_KW),
+                    widget.MemoryGraph(**GRAPH_KW),
+                    widget.SwapGraph(foreground='20C020', **GRAPH_KW),
+                    widget.Sep(),
+                    widget.Systray(),
+                    widget.Sep(),
+                    widget.Clock(format='%H:%M:%S %d.%m.%Y',
+                                 fontsize=FONTSIZE, padding=6),
+                ],
+                24,
+                background="#555555"
+            ),
+            x=0, y=0, width=600, height=480
         ),
-        x=0, y=0, width=600, height=480
-    ),
-    Screen(
-        top=bar.Bar(
-            [
-                        widget.GroupBox(),
-                widget.WindowName(),
-                widget.Clock()
-            ],
-                    30,
+        Screen(
+            top=bar.Bar(
+                [
+                    widget.GroupBox(),
+                    widget.WindowName(),
+                    widget.Clock()
+                ],
+                30,
+            ),
+            x=600, y=0, width=300, height=580
         ),
-        x=600, y=0, width=300, height=580
-    ),
-    Screen(
-        top=bar.Bar(
-            [
-                        widget.GroupBox(),
-                widget.WindowName(),
-                widget.Clock()
-            ],
-                    30,
+        Screen(
+            top=bar.Bar(
+                [
+                    widget.GroupBox(),
+                    widget.WindowName(),
+                    widget.Clock()
+                ],
+                30,
+            ),
+            x=0, y=480, width=500, height=400
         ),
-           x=0, y=480, width=500, height=400),
-                    Screen(
-                        bottom=bar.Bar(
-                            [
-                        widget.GroupBox(),
-                                widget.WindowName(),
-                                widget.Clock()
-                            ],
-                    30,
-                        ),
-           x=500, y=580, width=400, height=400),
+        Screen(
+            bottom=bar.Bar(
+                [
+                    widget.GroupBox(),
+                    widget.WindowName(),
+                    widget.Clock()
+                ],
+                30,
+            ),
+            x=500, y=580, width=400, height=400
+        ),
     ]
 
     screens = fake_screens


### PR DESCRIPTION
While working on #573 I've accumulated these fixes that I'd like to stop rebasing every time I fetch :) They should be all trivial ones, except for 9f687657bae381c43dcb50f6e19a0b0a0cab5efc, which I'd like to discuss here, because I don't think it's tested, and by just looking at the code I can't understand why `y` was calculated differently whether the Gap was on the left or right side of the screen.