### PR TITLE
Removes deprecated functions from default config and documentation

### DIFF
--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -122,13 +122,13 @@ Group functions
 
     * - function
       - description
-    * - ``lazy.nextlayout())``
+    * - ``lazy.next_layout())``
       - Use next layout on the actual group
-    * - ``lazy.prevlayout())``
+    * - ``lazy.prev_layout())``
       - Use previous layout on the actual group
-    * - ``lazy.screen.nextgroup())``
+    * - ``lazy.screen.next_group())``
       - Move to the group on the right
-    * - ``lazy.screen.prevgroup())``
+    * - ``lazy.screen.prev_group())``
       - Move to the group on the left
     * - ``lazy.screen.togglegroup())``
       - Move to the last visited group

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -74,7 +74,7 @@ keys = [
     Key([mod], "Return", lazy.spawn("xterm")),
 
     # Toggle between different layouts as defined below
-    Key([mod], "Tab", lazy.nextlayout()),
+    Key([mod], "Tab", lazy.next_layout()),
     Key([mod], "w", lazy.window.kill()),
 
     Key([mod, "control"], "r", lazy.restart()),


### PR DESCRIPTION
Removes deprecated functions from documentation and default configuration

Caused `command error nextlayout: No such command`

in default configuration