### PR TITLE
Fixes Log File Size (MAX : 2 GB) 

### DIFF
--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -74,11 +74,11 @@ def init_log(log_level=logging.WARNING, logger='qtile', log_path='~/.%s.log'):
         except TypeError:  # Happens if log_path doesn't contain formatters.
             pass
         log_path = os.path.expanduser(log_path)
-        with open(log_path, "a"):
+        with open(log_path, "w"):
             pass
         handler = logging.handlers.RotatingFileHandler(
             log_path,
-            maxBytes=1000000000,
+            maxBytes=10000000,
             backupCount=1
         )
         handler.setFormatter(

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -74,7 +74,7 @@ def init_log(log_level=logging.WARNING, logger='qtile', log_path='~/.%s.log'):
         except TypeError:  # Happens if log_path doesn't contain formatters.
             pass
         log_path = os.path.expanduser(log_path)
-        with open(log_path, "aw"):
+        with open(log_path, "a"):
             pass
         handler = logging.handlers.RotatingFileHandler(
             log_path,

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 
 import logging
+import logging.handlers
 import os
 import sys
 from logging import getLogger, StreamHandler
@@ -73,9 +74,10 @@ def init_log(log_level=logging.WARNING, logger='qtile', log_path='~/.%s.log'):
         except TypeError:  # Happens if log_path doesn't contain formatters.
             pass
         log_path = os.path.expanduser(log_path)
-        with open(log_path, "w"):
+        with open(log_path, "aw"):
             pass
-        handler = logging.FileHandler(log_path)
+        handler = logging.handlers.RotatingFileHandler(
+              log_path, maxBytes=1073741824)
         handler.setFormatter(
             logging.Formatter(
                 "%(asctime)s %(levelname)s %(funcName)s:%(lineno)d %(message)s"

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -77,7 +77,7 @@ def init_log(log_level=logging.WARNING, logger='qtile', log_path='~/.%s.log'):
         with open(log_path, "aw"):
             pass
         handler = logging.handlers.RotatingFileHandler(
-              log_path, maxBytes=1073741824)
+              log_path, maxBytes=1000000000, backupCount=1)
         handler.setFormatter(
             logging.Formatter(
                 "%(asctime)s %(levelname)s %(funcName)s:%(lineno)d %(message)s"

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -77,7 +77,10 @@ def init_log(log_level=logging.WARNING, logger='qtile', log_path='~/.%s.log'):
         with open(log_path, "aw"):
             pass
         handler = logging.handlers.RotatingFileHandler(
-              log_path, maxBytes=1000000000, backupCount=1)
+            log_path,
+            maxBytes=1000000000,
+            backupCount=1
+        )
         handler.setFormatter(
             logging.Formatter(
                 "%(asctime)s %(levelname)s %(funcName)s:%(lineno)d %(message)s"


### PR DESCRIPTION
I recently faced issues with log file size.
I remember someone in IRC mention it also , even after the patch dfa26b0f0c8bad5a558b54021af6f020e419a6b6

This fixes #648 

Also now we don't need to truncate log file at restarts.