### PR TITLE
Inline command edition and a few errors corrected (prompt widget).

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -618,8 +618,9 @@ class Prompt(base._TextBox):
         state = e.state & ~(self.qtile.numlockMask)
         keysym = self.qtile.conn.keycode_to_keysym(e.detail, state)
         handle_key = self._get_keyhandler(keysym)
-        handle_key()
-        del self.key
+        if handle_key:
+            handle_key()
+            del self.key
         self._update()
 
     def cmd_fake_keypress(self, key):

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -335,8 +335,8 @@ class Prompt(base._TextBox):
                  "Alert at the begin/end of the command history. " +
                  "Posible values: 'audible', 'visual' and None."),
                 ("visual_bell_color", "ff0000",
-                 "Color for the visual bell (changes text prompt color)."),
-                ("visual_bell_time", 0.4,
+                 "Color for the visual bell (changes prompt background)."),
+                ("visual_bell_time", 0.2,
                  "Visual bell duration (in seconds).")]
 
     def __init__(self, name="prompt", **config):
@@ -367,6 +367,8 @@ class Prompt(base._TextBox):
         printables = {x: self._write_char for x in printables if
                       chr(x) in string.printable}
         self.keyhandlers.update(printables)
+        if self.bell_style == "visual":
+            self.original_background = self.background
         # If history record is on, get saved history or create history record
         if self.record_history:
             self.history_path = os.path.expanduser('~/.qtile_history')
@@ -545,11 +547,11 @@ class Prompt(base._TextBox):
         if self.bell_style == "audible":
             self.qtile.conn.conn.core.Bell(0)
         elif self.bell_style == "visual":
-            self.layout.colour = self.visual_bell_color
+            self.background = self.visual_bell_color
             self.timeout_add(self.visual_bell_time, self._stop_visual_alert)
 
     def _stop_visual_alert(self):
-        self.layout.colour = self.foreground
+        self.background = self.original_background
         self._update()
 
     def _get_prev_cmd(self):


### PR DESCRIPTION
Added support for cursor movement across the input text,
edition in place (add/delete text before the cursor, and
delete in cursor position with *Delete* key).

Added options for show or not the text cursor and for
choose their color. Cursor position is noticeable by
the text cursor and by the character above it in the same
color than the cursor (even if you choose to not show the
text cursor).

Corrected a few errors in previous code:
- When `cursorblink` was set to zero, the cursor simply
dissapear. If this is a feature, is deceiving: If
`cursorblink` is zero it should, you know, just not
blink. That's what it do now.
- The widget didn't clear the text (*"hide the widget"*) in focus change with
`cursorblink` equal to zero. This also happened when you 
choose to not show the cursor. Now it behaves ok in both cases.

Also, function in charge of return the appropiate action to one
key (`_key_handler`) was renamed (`_get_keyhandler`) and simplified,
creating a dictionary on `__init__` (for no rebuilt it every time a new
key is handled), with pairs (keycode, function to execute).

I still want to review this and the rest of this widget code, for check if I can improve/simplify something, but this already works for me.