### PR TITLE
Include python-xcffib warning for arch install

### DIFF
--- a/docs/manual/install/arch.rst
+++ b/docs/manual/install/arch.rst
@@ -20,6 +20,8 @@ if you use `yaourt`_:
     # or for develop
     yaourt -S qtile-python3-git
 
+**note:** you may have to add the `community-testing` mirror to your mirrors list in /etc/pacman.conf to install the correct version of python-xcffib.
+
 Using pacman
 ============
 


### PR DESCRIPTION
to build qtile-python3-git on arch linux with pacman i had to add community-testing to my mirrors list, (which contains the correct version of python-xcffib).