### PR TITLE
Handle _NET_WM_STATE_DEMANDS_ATTENTION 

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -239,7 +239,7 @@ class _Group(command.CommandObject):
         self.windows.add(win)
         win.group = self
         try:
-            if win.window.get_net_wm_state() == 'fullscreen' and \
+            if 'fullscreen' in win.window.get_net_wm_state() and \
                     self.qtile.config.auto_fullscreen:
                 win._float_state = window.FULLSCREEN
             elif self.floating_layout.match(win):

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -290,7 +290,7 @@ class _Window(command.CommandObject):
 
     @property
     def urgent(self):
-        return self.hints['urgent'] | self._demands_attention
+        return self.hints['urgent'] or self._demands_attention
 
     @urgent.setter
     def urgent(self, val):

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -142,6 +142,7 @@ class _Window(command.CommandObject):
         self.state = NormalState
         self.window_type = "normal"
         self._float_state = NOT_FLOATING
+        self._demands_attention = False
 
         self.hints = {
             'input': True,
@@ -275,18 +276,28 @@ class _Window(command.CommandObject):
         return
 
     def updateState(self):
-        if not self.qtile.config.auto_fullscreen:
-            return
+        triggered = ['urgent']
+
+        if self.qtile.config.auto_fullscreen:
+            triggered.append('fullscreen')
+
         state = self.window.get_net_wm_state()
-        self.qtile.log.debug('_NET_WM_STATE: %s' % state)
-        if state == 'fullscreen':
-            self.fullscreen = True
-        else:
-            self.fullscreen = False
+
+        if state:
+            self.qtile.log.debug('_NET_WM_STATE: %s' % ','.join(state))
+            for s in triggered:
+                setattr(self, s, (s in state))
 
     @property
     def urgent(self):
-        return self.hints['urgent']
+        return self.hints['urgent'] | self._demands_attention
+
+    @urgent.setter
+    def urgent(self, val):
+        self._demands_attention = val
+        # TODO unset window hint as well?
+        if not val:
+            self.hints['urgent'] = False
 
     def info(self):
         if self.group:
@@ -521,6 +532,7 @@ class _Window(command.CommandObject):
                     self.window.warp_pointer(self.width // 2, self.height // 2)
             except AttributeError:
                 pass
+        self.urgent = False
         self.qtile.root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
         hook.fire("client_focus", self)
 

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -124,6 +124,7 @@ WindowTypes = {
 WindowStates = {
     None: 'normal',
     '_NET_WM_STATE_FULLSCREEN': 'fullscreen',
+    '_NET_WM_STATE_DEMANDS_ATTENTION': 'urgent'
 }
 
 # Maps property names to types and formats.
@@ -549,14 +550,11 @@ class Window:
             return WindowTypes.get(name, name)
 
     def get_net_wm_state(self):
-        # TODO: _NET_WM_STATE is a *list* of atoms
-        # We're returning only the first one, but we don't need anything
-        # other than _NET_WM_STATE_FULLSCREEN (at least for now)
-        # Fixing this requires refactoring each call to use a list instead
         r = self.get_property('_NET_WM_STATE', "ATOM", unpack=int)
         if r:
-            name = self.conn.atoms.get_name(r[0])
-            return WindowStates.get(name, name)
+            names = [self.conn.atoms.get_name(p) for p in r]
+            return [WindowStates.get(n, n) for n in names]
+        return []
 
     def get_net_wm_pid(self):
         r = self.get_property("_NET_WM_PID", unpack=int)


### PR DESCRIPTION
Hi there,
I've added handling of the _NET_WM_STATE_DEMANDS_ATTENTION for setting window urgency state.
It is considered weaker than flag in WM_HINTS, but many applications (I believe all the Qt applications) will use it instead.