### PR TITLE
Specify bracketed versions for dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-cairocffi
-cffi
+cairocffi >=0.6, <7.0
+cffi >=0.8.2, <0.9
+xcffib >=0.1.11, <0.2
 flake8
 nose-cov
 python-coveralls
 six
-xcffib

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ Features
       unit-tested window mangers around.
 """
 
-dependencies = ['cairocffi>=0.6', 'cffi>=0.8.2', 'six>=1.4.1', 'xcffib>=0.1.11']
+dependencies = ['cairocffi>=0.6, <0.7', 'cffi>=0.8.2, <0.9', 'six>=1.4.1, <1.9', 'xcffib>=0.1.11, <0.2']
 
 if sys.version_info >= (3, 4):
     pass


### PR DESCRIPTION
This PR brackets dependency versions that are known to work. After making this change I was able to `python setup.py install` in a fresh virtualenv!

Newer versions of these packages may work, but these versions are verified. As a general rule future point releases are allowed for dependencies, but version changes are not. This strikes a good balance between allowing updated deps and documenting what is known to work.

This, hopefully, resolves issues like #680, #683, #687.

I had trouble on arch too, python-xcffib 0.3.2-1 did not work for me, nor did downgrading cairocffi.

However, after much fiddling, I managed to get qtile on master running from source in a virtualenv with the following package versions:

``` sh
$ pip install cairocffi==0.6
$ pip install cffi==0.8.2
$ pip install xcffib==0.1.11
$ python setup.py install  # qtile:master
$ pip freeze
cairocffi==0.6
cffi==0.8.2
pycparser==2.14
qtile==0.9.1
six==1.9.0
xcffib==0.1.11
```
note: Python 3.4.3, master branch

I tried many combinations of the above library versions. Needless to say, the current versions on these packages do not work for me.

It might be good to specify the max package versions in `requirements.txt` when a qtile version is tagged. Thereby freezing the packages with the version. This way master will always build.

I usually bracket to allow point releases, e.g.

``` sh
$ cat requirements.txt
cairocffi >=0.6, <7.0
cffi >=0.8.2, <0.9
xcffib >=0.1.11, <0.2
```
