### PR TITLE
Change wait process from xterm to qtile on xephyr script

### DIFF
--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -5,8 +5,12 @@ SCREEN_SIZE=${SCREEN_SIZE:-800x600}
 XDISPLAY=:1
 
 Xephyr +extension RANDR -screen ${SCREEN_SIZE} ${XDISPLAY} -ac &
+XEPHYR_PID=$!
 (
   sleep 1
   env DISPLAY=${XDISPLAY} "${HERE}"/../bin/qtile -l INFO $@ &
-  env DISPLAY=${XDISPLAY} xterm
+  QTILE_PID=$!
+  env DISPLAY=${XDISPLAY} xterm &
+  wait $QTILE_PID
+  kill $XEPHYR_PID
 )


### PR DESCRIPTION
In current verison, xephyr start script waits xterm. Exiting xterm, the script will end. It should wait qtile one. When qtile shutdown, i consider xephyr also should shutdown just like xorg. i have fixed the xephyr startup script.