### PR TITLE
Fixed logging, when error occurred at reading config file.

### DIFF
--- a/bin/qtile
+++ b/bin/qtile
@@ -105,8 +105,8 @@ def make_qtile():
 
     try:
         c = confreader.File(options.configfile, is_restart=options.no_spawn)
-    except:
-        log.exception('Error while reading config file')
+    except Exception as e:
+        log.exception(str(e) + '\n\nError while reading config file')
         raise
 
     # XXX: the import is here becouse we need to call init_log

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -26,6 +26,7 @@
 import os
 import sys
 import traceback
+import logging
 
 
 class ConfigError(Exception):
@@ -52,15 +53,17 @@ class File(object):
                 sys.path.insert(0, os.path.dirname(fname))
                 config = __import__(os.path.basename(fname)[:-3])
             except Exception as v:
+
+                tb = traceback.format_exc()
+
                 # On restart, user potentially has some windows open, but they
                 # screwed up their config. So as not to lose their apps, we
                 # just load the default config here.
                 if is_restart:
-                    traceback.print_exc()
+                    logging.getLogger('qtile').warning(tb + '\nQtile restarted by default config')
                     config = None
                 else:
-                    tb = traceback.format_exc()
-                    raise ConfigError(str(v) + "\n\n" + tb)
+                    raise ConfigError(tb)
         else:
             config = None
 


### PR DESCRIPTION
I missed error log at ".qtile.log", when config file have syntax error. So, I added code for log message about that.
