### PR TITLE
Py3 thermalsensor regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 MANIFEST
 /build
 /dist
+/env
 # complied cffi output
 libqtile/_ffi_pango.py
 libqtile/_ffi_xcursors.py

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -20,6 +20,7 @@
 
 import operator
 import functools
+import warnings
 
 import six
 from six.moves import reduce
@@ -152,3 +153,43 @@ def scrub_to_utf8(text):
         return text
     else:
         return text.decode("utf-8", "ignore")
+
+
+# WARNINGS
+class UnixCommandNotFound(Warning):
+    pass
+
+
+def catch_exception_and_warn(warning=Warning, return_on_exception=None,
+                             excepts=Exception):
+    """
+    .. function:: warn_on_exception(func, [warning_class, return_on_failure,
+            excepts])
+        attemps to call func. catches exception or exception tuple and issues
+        a warning instead. returns value of return_on_failure when the
+        specified exception is raised.
+
+        :param func: a callable to be wrapped
+        :param warning: the warning class to issue if an exception is
+            raised
+        :param return_on_exception: the default return value of the function
+            if an exception is raised
+        :param excepts: an exception class (or tuple of exception classes) to
+            catch during the execution of func
+        :type excepts: Exception or tuple of Exception classes
+        :type warning: Warning
+        :rtype: a callable
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return_value = return_on_exception
+            try:
+                return_value = func(*args, **kwargs)
+                print(return_value)
+            except excepts as err:
+                print(err.strerror)
+                warnings.warn(err.strerror, warning)
+            return return_value
+        return wrapper
+    return decorator

--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -27,7 +27,7 @@
 # coding: utf-8
 
 from . import base
-from six import u
+from six import u, PY2
 
 import re
 
@@ -59,12 +59,12 @@ class ThermalSensor(base.InLoopPollText):
         self.add_defaults(ThermalSensor.defaults)
         self.sensors_temp = re.compile(
             u(r"""
-            ([a-zA-Z0-9\s]+): #Tag
-            \s+[+-]           #Temp signed
-            ([0-9]+\.[0-9]+)  #Temp value
-            (\xc2\xb0         #° match
-            [CF])             #Celsius or Fahrenheit
-            """),
+            ([\w ]+):   #Tag
+            \s+[+|-]    #Temp signed
+            (\d+\.\d+)  #Temp value
+            ({degrees}  #° match
+            [C|F])      #Celsius or Fahrenheit
+            """.format(degrees="\xc2\xb0" if PY2 else "\xb0")),
             re.UNICODE | re.VERBOSE
         )
         self.value_temp = re.compile("[0-9]+\.[0-9]+")


### PR DESCRIPTION
ThermalSensor widget was not python3 complient in its regex for
capturing the degree symbol. try the following in the python shell to
confirm.
```python
>>> assert re.match(r"\xc2\xb0", "°") == None
>>> assert re.match(r"\xb0", "°")
```
- includes some general cleaning up on the ThermalSensor class
- includes a unittest for ThermalSensor widget
- includes a util `catch_exception_and_warn` that can be used as a
decorator to catch an exeption and issue a warning in its place if a
method raises an exception.
