### PR TITLE
clear windowname if group has no window

### DIFF
--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -42,6 +42,12 @@ class WindowName(base._TextBox):
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
         hook.subscribe.float_change(self.update)
+        # Clear the widget if group has no window
+        @hook.subscribe.client_killed
+        def on_client_killed(window):
+            if window == self.bar.screen.group.currentWindow:
+                self.text = ""
+                self.bar.draw()
 
     def update(self):
         w = self.bar.screen.group.currentWindow


### PR DESCRIPTION
If I close all the windows in a group the widget still displays the name of the latest opened window (I don't understand why looking at the code...), while it should display nothing