### PR TITLE
add window border to single client xmonad layout

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -303,9 +303,9 @@ class MonadTall(SingleWindow):
             client.place(
                 self.group.screen.dx,
                 self.group.screen.dy,
-                self.group.screen.dwidth,
-                self.group.screen.dheight,
-                0,
+                self.group.screen.dwidth - self.margin,
+                self.group.screen.dheight - self.margin,
+                self.border_width,
                 px,
                 margin=self.margin,
             )


### PR DESCRIPTION
not having the window border can be tedious sometimes, for example if you have a completely transparent terminal window it's difficult to quickly detect if the window is opened or not.
Also xmonad'sdefault layout has window border for single client too