### PR TITLE
add possibility to not show window state on windowname widget

### DIFF
--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2008, 2010 Aldo Cortesi
 # Copyright (c) 2010 matt
 # Copyright (c) 2011 Mounier Florian
@@ -33,17 +34,19 @@ class WindowName(base._TextBox):
         Displays the name of the window that currently has focus.
     """
     orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [
+        ('show_state', True, 'show window status before window name')
+    ]
 
-    def __init__(self, width=bar.STRETCH, show_state=True, **config):
+    def __init__(self, width=bar.STRETCH, **config):
         base._TextBox.__init__(self, width=width, **config)
-        self.show_state = show_state
+        self.add_defaults(WindowName.defaults)
 
     def _configure(self, qtile, bar):
         base._TextBox._configure(self, qtile, bar)
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
-        if self.show_state:
-            hook.subscribe.float_change(self.update)
+        hook.subscribe.float_change(self.update)
         # Clear the widget if group has no window
         @hook.subscribe.client_killed
         def on_client_killed(window):

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -34,8 +34,9 @@ class WindowName(base._TextBox):
     """
     orientations = base.ORIENTATION_HORIZONTAL
 
-    def __init__(self, width=bar.STRETCH, **config):
+    def __init__(self, width=bar.STRETCH, show_state=True, **config):
         base._TextBox.__init__(self, width=width, **config)
+        self.show_state = show_state
 
     def _configure(self, qtile, bar):
         base._TextBox._configure(self, qtile, bar)

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -41,7 +41,8 @@ class WindowName(base._TextBox):
         base._TextBox._configure(self, qtile, bar)
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
-        hook.subscribe.float_change(self.update)
+        if self.show_state:
+            hook.subscribe.float_change(self.update)
         # Clear the widget if group has no window
         @hook.subscribe.client_killed
         def on_client_killed(window):
@@ -52,13 +53,12 @@ class WindowName(base._TextBox):
     def update(self):
         w = self.bar.screen.group.currentWindow
         state = ''
-        if w is None:
-            pass
-        elif w.maximized:
-            state = '[] '
-        elif w.minimized:
-            state = '_ '
-        elif w.floating:
-            state = 'V '
+        if self.show_state and w is not None:
+            if w.maximized:
+                state = '[] '
+            elif w.minimized:
+                state = '_ '
+            elif w.floating:
+                state = 'V '
         self.text = "%s%s" % (state, w.name if w and w.name else " ")
         self.bar.draw()

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2008, 2010 Aldo Cortesi
 # Copyright (c) 2010 matt
 # Copyright (c) 2011 Mounier Florian


### PR DESCRIPTION
I find this feature a bit confusing and also useless since I can see the state of a window by just looking at it =)