### PR TITLE
SI prefix for kilo is k

### DIFF
--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -44,7 +44,7 @@ class Net(base.ThreadedPollText):
         letter = 'B'
         if b // 1000 > 0:
             b /= 1000.0
-            letter = 'K'
+            letter = 'k'
         if b // 1000 > 0:
             b /= 1000.0
             letter = 'M'


### PR DESCRIPTION
The SI unit K means Kelvin.  The SI prefix for kilo is k.  Although a lowercase k is slightly less typographically neat in this context, I suggest we stick to the corect prefixes.

Merging this pull-request will close #717.

Cheers.