### PR TITLE
update deps for debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,15 +10,15 @@ Build-Depends: debhelper (>= 9)
     , python3-all-dev
     , python-setuptools
     , python3-setuptools
-    , python-cffi (>= 0.8.2)
-    , python3-cffi (>= 0.8.2)
+    , python-cffi (>= 1.1.0)
+    , python3-cffi (>= 1.1.0)
     , python-trollius
     , python3-trollius
 # testing
-    , python-xcffib (>= 0.1.5)
-    , python3-xcffib (>= 0.1.5)
-    , python-cairocffi (>= 0.6)
-    , python3-cairocffi (>= 0.6)
+    , python-xcffib (>= 0.3.4)
+    , python3-xcffib (>= 0.3.4)
+    , python-cairocffi (>= 0.7)
+    , python3-cairocffi (>= 0.7)
     , python-trollius
     , python3-trollius
     , libglib2.0-0
@@ -44,9 +44,9 @@ XB-Description: Full-featured, pure-Python tiling window manager.
 
 Package: python-qtile
 Architecture: all
-Depends: python-cffi (>= 0.8.2)
-    , python-xcffib (>= 0.1.5)
-    , python-cairocffi (>= 0.6)
+Depends: python-cffi (>= 1.1.0)
+    , python-xcffib (>= 0.3.4)
+    , python-cairocffi (>= 0.7)
     , python-trollius
     , libglib2.0-0
     , libpango1.0-0
@@ -57,9 +57,9 @@ Provides: ${python:Provides}
 
 Package: python3-qtile
 Architecture: all
-Depends: python-cffi (>= 0.8.2)
-    , python-xcffib (>= 0.1.5)
-    , python-cairocffi (>= 0.6)
+Depends: python-cffi (>= 1.1.0)
+    , python-xcffib (>= 0.3.4)
+    , python-cairocffi (>= 0.7)
     , libglib2.0-0
     , libpango1.0-0
     , libpangocairo-1.0-0


### PR DESCRIPTION
At some point it would be best for us to tag a point release; but let's wait
until cairocffi 0.7 is in debian unstable, and then we can tag a point release
and do a debian upload. For now, anyway, these are the right dependencies.