### PR TITLE
use the .0 soname

### DIFF
--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -54,9 +54,9 @@ try:
 except ImportError:
     from libqtile.ffi_build import pango_ffi as ffi
 
-gobject = ffi.dlopen('libgobject-2.0.so')
-pango = ffi.dlopen('libpango-1.0.so')
-pangocairo = ffi.dlopen('libpangocairo-1.0.so')
+gobject = ffi.dlopen('libgobject-2.0.so.0')
+pango = ffi.dlopen('libpango-1.0.so.0')
+pangocairo = ffi.dlopen('libpangocairo-1.0.so.0')
 
 
 def CairoContext(cairo_t):


### PR DESCRIPTION
On rpm and deb based distros, these libraries (symlinks) are provided by
the -dev version of the packages, where the .0 name is provided by the
actual library package. Let's use the .0 name instead so we don't have an
undocumented dependency on -dev packages.

Closes #734

Signed-off-by: Tycho Andersen <tycho@tycho.ws>