### PR TITLE
Changes error text if no battery is available

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -151,26 +151,22 @@ class Battery(_Battery):
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ('low_foreground', 'FF0000', 'font color when battery is low'),
-        (
-            'format',
-            '{char} {percent:2.0%} {hour:d}:{min:02d}',
-            'Display format'
-        ),
         ('charge_char', '^', 'Character to indicate the battery is charging'),
-        (
-            'discharge_char',
-            'V',
-            'Character to indicate the battery'
-            ' is discharging'
-        ),
-        (
-            'low_percentage',
-            0.10,
-            "0 < x < 1 at which to indicate battery is low with low_foreground"
-        ),
-        ('hide_threshold', None, 'Hide the text when there is enough energy'),
+        ('discharge_char',
+         'V',
+         'Character to indicate the battery is discharging'
+         ),
         ('error_message', 'Error', 'Error message if something is wrong'),
+        ('format',
+         '{char} {percent:2.0%} {hour:d}:{min:02d}',
+         'Display format'
+         ),
+        ('hide_threshold', None, 'Hide the text when there is enough energy'),
+        ('low_percentage',
+         0.10,
+         "Indicates when to use the low_foreground color 0 < x < 1"
+         ),
+        ('low_foreground', 'FF0000', 'Font color on low battery'),
     ]
 
     def __init__(self, **config):

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -170,6 +170,7 @@ class Battery(_Battery):
             "0 < x < 1 at which to indicate battery is low with low_foreground"
         ),
         ('hide_threshold', None, 'Hide the text when there is enough energy'),
+        ('error_message', 'Error', 'Error message if something is wrong'),
     ]
 
     def __init__(self, **config):
@@ -191,7 +192,7 @@ class Battery(_Battery):
     def _get_text(self):
         info = self._get_info()
         if info is False:
-            return 'Error'
+            return self.error_message
 
         # Set the charging character
         try:

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -57,7 +57,7 @@ def default_icon_path():
 
 
 class _Battery(base._TextBox):
-    ''' Base battery class '''
+    """Base battery class"""
 
     filenames = {}
 
@@ -242,9 +242,8 @@ class Battery(_Battery):
 
 
 class BatteryIcon(_Battery):
-    '''
-        Battery life indicator widget.
-    '''
+    """Battery life indicator widget."""
+
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ('theme_path', default_icon_path(), 'Path of the icons'),


### PR DESCRIPTION
I think this is not an error if no a battery is available because if you a work on desktop pc or a laptop where you removed the battery you don't need this kind of info. That will be more like plug and play. :)