### PR TITLE
Prevent UnicodeEncodeError in the __repr__ of windows in python2

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -622,7 +622,7 @@ class Internal(_Window):
         return i
 
     def __repr__(self):
-        return "Internal(%s, %s)" % (self.name, self.window.wid)
+        return "Internal(%r, %s)" % (self.name, self.window.wid)
 
     def kill(self):
         self.qtile.conn.conn.core.DestroyWindow(self.window.wid)
@@ -698,7 +698,7 @@ class Static(_Window):
             self.update_strut()
 
     def __repr__(self):
-        return "Static(%s)" % self.name
+        return "Static(%r)" % self.name
 
 
 class Window(_Window):
@@ -1196,7 +1196,7 @@ class Window(_Window):
             return self.group.screen
 
     def __repr__(self):
-        return "Window(%s)" % self.name
+        return "Window(%r)" % self.name
 
     def cmd_static(self, screen, x, y, width, height):
         self.static(screen, x, y, width, height)


### PR DESCRIPTION
These would appear in other places, such as the focus function of layouts, which indirectly call `__repr__` somehow.