### PR TITLE
rework the focus model a bit

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -195,13 +195,17 @@ class _Group(command.CommandObject):
         for i in self.windows:
             i._resetMask()
 
-    def focus(self, win, warp):
+    def focus(self, win, warp=True):
         """
             if win is in the group, blur any windows and call
             ``focus`` on the layout (in case it wants to track
             anything), fire focus_change hook and invoke layoutAll.
 
-            warp - warp pointer to win
+            warp - warp pointer to win. This should basically always be True,
+            unless the focus event is coming from something like EnterNotify,
+            where the user is actively using the mouse or on full screen
+            layouts where only one window is "maximized" at a time, and it
+            doesn't make sense for the mouse to automatically move.
         """
         if self.qtile._drag:
             # don't change focus while dragging windows

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -198,9 +198,9 @@ class Floating(Layout):
     def cmd_next(self):
         client = self.focus_next(self.focused) or \
             self.focus_first()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_previous(self):
         client = self.focus_previous(self.focused) or \
             self.focus_last()
-        self.group.focus(client, False)
+        self.group.focus(client)

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -159,12 +159,12 @@ class Matrix(Layout):
     def cmd_next(self):
         client = self.focus_next(self.get_current_window()) or \
             self.focus_first()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_previous(self):
         client = self.focus_previous(self.get_current_window()) or \
             self.focus_last()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_left(self):
         """
@@ -172,7 +172,7 @@ class Matrix(Layout):
         """
         column, row = self.current_window
         self.current_window = ((column - 1) % len(self.get_row(row)), row)
-        self.group.focus(self.get_current_window(), False)
+        self.group.focus(self.get_current_window())
 
     def cmd_right(self):
         """
@@ -180,7 +180,7 @@ class Matrix(Layout):
         """
         column, row = self.current_window
         self.current_window = ((column + 1) % len(self.get_row(row)), row)
-        self.group.focus(self.get_current_window(), False)
+        self.group.focus(self.get_current_window())
 
     def cmd_down(self):
         """
@@ -191,7 +191,7 @@ class Matrix(Layout):
             column,
             (row + 1) % len(self.get_column(column))
         )
-        self.group.focus(self.get_current_window(), False)
+        self.group.focus(self.get_current_window())
 
     def cmd_up(self):
         """
@@ -202,7 +202,7 @@ class Matrix(Layout):
             column,
             (row - 1) % len(self.get_column(column))
         )
-        self.group.focus(self.get_current_window(), False)
+        self.group.focus(self.get_current_window())
 
     def cmd_delete(self):
         """

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -363,11 +363,11 @@ class RatioTile(Layout):
 
     def next(self):
         n = self.getPreviousClient()
-        self.group.focus(n, True)
+        self.group.focus(n)
 
     def previous(self):
         n = self.getNextClient()
-        self.group.focus(n, True)
+        self.group.focus(n)
 
     def shuffle(self, function):
         if self.clients:

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -218,11 +218,11 @@ class Tile(Layout):
 
     def cmd_next(self):
         client = self.focus_next(self.focused) or self.focus_first()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_previous(self):
         client = self.focus_previous(self.focused) or self.focus_last()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_decrease_ratio(self):
         self.ratio -= self.ratio_increment

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -254,19 +254,19 @@ class VerticalTile(Layout):
 
     def cmd_next(self):
         self.focus_next(self.focused)
-        self.group.focus(self.focused, False)
+        self.group.focus(self.focused)
 
     def cmd_previous(self):
         self.focus_previous(self.focused)
-        self.group.focus(self.focused, False)
+        self.group.focus(self.focused)
 
     def cmd_down(self):
         self.focus_next(self.focused)
-        self.group.focus(self.focused, False)
+        self.group.focus(self.focused)
 
     def cmd_up(self):
         self.focus_previous(self.focused)
-        self.group.focus(self.focused, False)
+        self.group.focus(self.focused)
 
     def cmd_shuffle_up(self):
         index = self.clients.index(self.focused)

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -683,12 +683,12 @@ class MonadTall(SingleWindow):
     def cmd_next(self):
         client = self.focus_next(self.clients[self.focused]) or \
             self.focus_first()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_previous(self):
         client = self.focus_previous(self.clients[self.focused]) or \
             self.focus_last()
-        self.group.focus(client, False)
+        self.group.focus(client)
 
     def cmd_shrink(self):
         """
@@ -708,12 +708,12 @@ class MonadTall(SingleWindow):
     def cmd_up(self):
         "Focus on the next more prominent client on the stack"
         self.focused -= 1
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])
 
     def cmd_down(self):
         "Focus on the less prominent client on the stack"
         self.focused += 1
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])
 
     def cmd_shuffle_up(self):
         "Shuffle the client up the stack."
@@ -722,7 +722,7 @@ class MonadTall(SingleWindow):
         self.clients[_oldf], self.clients[self.focused] = \
             self.clients[self.focused], self.clients[_oldf]
         self.group.layoutAll()
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])
 
     def cmd_shuffle_down(self):
         "Shuffle the client down the stack."
@@ -731,7 +731,7 @@ class MonadTall(SingleWindow):
         self.clients[_oldf], self.clients[self.focused] = \
             self.clients[self.focused], self.clients[_oldf]
         self.group.layoutAll()
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])
 
     def cmd_flip(self):
         "Flip the layout horizontally."
@@ -754,7 +754,7 @@ class MonadTall(SingleWindow):
             self.clients[index2], self.clients[index1]
         self.group.layoutAll()
         self.focused = index1
-        self.group.focus(window1, False)
+        self.group.focus(window1)
 
     def cmd_swap_left(self):
         "Swap current window with closest window to the left."
@@ -786,7 +786,7 @@ class MonadTall(SingleWindow):
         candidates = [c for c in self.clients if c.info()['x'] < x]
         target = self._get_closest(x, y, candidates)
         self.focused = self.clients.index(target)
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])
 
     def cmd_right(self):
         "Focus on the closest window to the right of the current window."
@@ -795,4 +795,4 @@ class MonadTall(SingleWindow):
         candidates = [c for c in self.clients if c.info()['x'] > x]
         target = self._get_closest(x, y, candidates)
         self.focused = self.clients.index(target)
-        self.group.focus(self.clients[self.focused], False)
+        self.group.focus(self.clients[self.focused])

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -873,7 +873,7 @@ class Qtile(command.CommandObject):
             return True
         s = self.find_screen(e.root_x, e.root_y)
         if s:
-            self.toScreen(s.index)
+            self.toScreen(s.index, warp=False)
 
     def handle_ClientMessage(self, event):
         atoms = self.conn.atoms
@@ -1527,7 +1527,7 @@ class Qtile(command.CommandObject):
         try:
             nxt = [w for w in self.windowMap.values() if w.urgent][0]
             nxt.group.cmd_toscreen()
-            nxt.group.focus(nxt, False)
+            nxt.group.focus(nxt, True)
         except IndexError:
             pass  # no window had urgent set
 


### PR DESCRIPTION
Several issues here:

1. most layouts were passing warp=False in a lot of places, so people who
   used cursor_warp effectively couldn't use those layouts. Instead, let's
   only pass warp=False where it makes sense

2. toScreen defaulted warp=True, which happened on EnterNotify, so the
   mouse would move around if you were switching screens with it, which was
   annoying.

Instead, let's make warp optional, and explicitly pass False when we know
we don't want to warp. This patch leaves max (and similar layouts) as they
were, not ever moving the pointer on behalf of the user, since is no real
"movement" when switching windows in these layouts.

Closes #760