### PR TITLE
don't crash when loading history

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -36,6 +36,7 @@ import glob
 import os
 import pickle
 import string
+import logging
 from collections import deque
 
 from . import base
@@ -374,7 +375,15 @@ class Prompt(base._TextBox):
             self.history_path = os.path.expanduser('~/.qtile_history')
             if os.path.exists(self.history_path):
                 with open(self.history_path, 'rb') as f:
-                    self.history = pickle.load(f)
+                    try:
+                        self.history = pickle.load(f)
+                    except:
+                        # unfortunately, pickle doesn't wrap its errors, so we
+                        # can't detect what's a pickle error and what's not.
+                        log = logging.getLogger('qtile')
+                        log.exception("failed to load prompt history")
+                        self.history = {x: deque(maxlen=self.max_history)
+                                        for x in self.completers if x}
                     if self.max_history != \
                        self.history[list(self.history)[0]].maxlen:
                         self.history = {x: deque(copy.copy(self.history[x]),


### PR DESCRIPTION
For whatever reason, my qtile history couldn't be loaded across restarts,
which causes this code to fail, which then causes me to lose my session.
Instead, let's just log an error (which, unfortuantely only goes to stderr
because this likely happens in the user's config before qtile's logging is
initialized) and continue on.