### PR TITLE
MonadTall margin fix

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -308,8 +308,9 @@ class MonadTall(SingleWindow):
             client.place(
                 self.group.screen.dx,
                 self.group.screen.dy,
-                self.group.screen.dwidth - 2 * self.single_border_width - self.margin,
-                self.group.screen.dheight - 2 * self.single_border_width - self.margin,
+                # Edited to even the Margin
+                self.group.screen.dwidth - 2 * self.single_border_width,
+                self.group.screen.dheight - 2 * self.single_border_width,
                 self.single_border_width,
                 px,
                 margin=self.margin,

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -308,7 +308,6 @@ class MonadTall(SingleWindow):
             client.place(
                 self.group.screen.dx,
                 self.group.screen.dy,
-                # Edited to even the Margin
                 self.group.screen.dwidth - 2 * self.single_border_width,
                 self.group.screen.dheight - 2 * self.single_border_width,
                 self.single_border_width,


### PR DESCRIPTION
When MonadTall is used with a single window, the margin on the righte side and the bottom is too big. This should fix it.