### PR TITLE
fix exception in xcbq.get_wm_protocls()

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -494,7 +494,9 @@ class Window(object):
 
     def get_wm_protocols(self):
         l = self.get_property("WM_PROTOCOLS", "ATOM", unpack=int)
-        return set(self.conn.atoms.get_name(i) for i in l)
+        if l is not None:
+            return set(self.conn.atoms.get_name(i) for i in l)
+        return set()
 
     def get_wm_state(self):
         return self.get_property("WM_STATE", xcffib.xproto.GetPropertyType.Any, unpack=int)


### PR DESCRIPTION
Now that this can return none, let's switch it to the empty set to avoid
crashing. (It's likely none because there was a WindowError, so this window
will die soon; let's just return the empty set so that no extra work is
done and we can move onto the next event gracefully.)

2015-10-05 02:55:19,154 ERROR _xpoll:758 Got an exception in poll loop
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/manager.py", line 735, in _xpoll
    r = h(e)
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/manager.py", line 1057, in handle_MapRequest
    c = self.manage(w)
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/manager.py", line 627, in manage
    self.currentScreen.group.add(c, focus=c.can_steal_focus())
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/group.py", line 273, in add
    self.focus(win, True)
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/group.py", line 227, in focus
    self.layoutAll(warp)
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/group.py", line 162, in layoutAll
    self.currentWindow.focus(warp)
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/window.py", line 511, in focus
    "WM_TAKE_FOCUS" in self.window.get_wm_protocols():
  File "/usr/local/lib/python3.4/dist-packages/qtile-0.10.1-py3.4.egg/libqtile/xcbq.py", line 497, in get_wm_protocols
    return set(self.conn.atoms.get_name(i) for i in l)
TypeError: 'NoneType' object is not iterable