### PR TITLE
create new windows in the parent's group

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -213,10 +213,16 @@ def get_cache_dir():
 try:
     import psutil
     def parent_pid(pid):
-        return psutil.Process(pid).ppid()
+        try:
+            return psutil.Process(pid).ppid()
+        except:
+            return None
 
 except ImportError:
     import subprocess
     def parent_pid(pid):
         cmd = 'ps -o ppid= -p {}'.format(pid)
-        return int(subprocess.check_output(cmd.split()))
+        try:
+            return int(subprocess.check_output(cmd.split()))
+        except:
+            return None

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -208,3 +208,15 @@ def get_cache_dir():
     if not os.path.exists(cache_directory):
         os.makedirs(cache_directory)
     return cache_directory
+
+
+try:
+    import psutil
+    def parent_pid(pid):
+        return psutil.Process(pid).ppid()
+
+except ImportError:
+    import subprocess
+    def parent_pid(pid):
+        cmd = 'ps -o ppid= -p {}'.format(pid)
+        return int(subprocess.check_output(cmd.split()))

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1054,7 +1054,7 @@ class Window(_Window):
             return
 
         parent = utils.parent_pid(pid)
-        while parent != 1:
+        while parent is not None:
             parentWindow = processMap.get(parent, None)
             if parentWindow:
                 return parentWindow


### PR DESCRIPTION
This partly fixes #775 (the case where a process forks and creates a new window).
Handling execution from the prompt needs a different approach.