### PR TITLE
Add 'line' highlighting method for GroupBox widget

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -132,7 +132,7 @@ class TextLayout(object):
         self.drawer.ctx.show_layout(self.layout)
 
     def framed(self, border_width, border_color, pad_x, pad_y,
-               highlight_color, line_thickness):
+               highlight_color=None, line_thickness=None):
         return TextFrame(self, border_width, border_color, pad_x, pad_y,
                          highlight_color, line_thickness)
 

--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -131,16 +131,21 @@ class TextLayout(object):
         self.drawer.ctx.move_to(x, y)
         self.drawer.ctx.show_layout(self.layout)
 
-    def framed(self, border_width, border_color, pad_x, pad_y):
-        return TextFrame(self, border_width, border_color, pad_x, pad_y)
+    def framed(self, border_width, border_color, pad_x, pad_y,
+               highlight_color, line_thickness):
+        return TextFrame(self, border_width, border_color, pad_x, pad_y,
+                         highlight_color, line_thickness)
 
 
 class TextFrame(object):
-    def __init__(self, layout, border_width, border_color, pad_x, pad_y):
+    def __init__(self, layout, border_width, border_color, pad_x, pad_y,
+                 highlight_color, line_thickness):
         self.layout = layout
         self.border_width = border_width
         self.border_color = border_color
         self.drawer = self.layout.drawer
+        self.highlight_color = highlight_color
+        self.line_thickness = line_thickness
 
         if isinstance(pad_x, collections.Iterable):
             self.pad_left = pad_x[0]
@@ -154,7 +159,8 @@ class TextFrame(object):
         else:
             self.pad_top = self.pad_bottom = pad_y
 
-    def draw(self, x, y, rounded=True, fill=False):
+    def draw(self, x, y, bar_height=None, rounded=True, fill=False,
+             line=False):
         self.drawer.set_source_rgb(self.border_color)
         opts = [
             x, y,
@@ -162,7 +168,27 @@ class TextFrame(object):
             self.layout.height + self.pad_top + self.pad_bottom,
             self.border_width
         ]
-        if fill:
+        if line:
+            highlight_opts = [
+                x, 0,
+                self.layout.width + self.pad_left + self.pad_right,
+                bar_height,
+                self.border_width
+            ]
+            self.drawer.set_source_rgb(self.highlight_color)
+            self.drawer.fillrect(*highlight_opts)
+
+            lineopts = [
+                x,
+                bar_height - self.line_thickness,
+                self.layout.width + self.pad_left + self.pad_right,
+                self.line_thickness,
+                self.border_width
+            ]
+
+            self.drawer.set_source_rgb(self.border_color)
+            self.drawer.fillrect(*lineopts)
+        elif fill:
             if rounded:
                 self.drawer.rounded_fillrect(*opts)
             else:
@@ -180,6 +206,9 @@ class TextFrame(object):
 
     def draw_fill(self, x, y, rounded=True):
         self.draw(x, y, rounded, fill=True)
+
+    def draw_line(self, x, y, bar_height, rounded=False):
+        self.draw(x, y, bar_height, rounded, line=True)
 
     @property
     def height(self):

--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -169,6 +169,8 @@ class TextFrame(object):
             self.border_width
         ]
         if line:
+            if not bar_height:
+                bar_height = self.layout.height + self.pad_top + self.pad_bottom
             highlight_opts = [
                 x, 0,
                 self.layout.width + self.pad_left + self.pad_right,

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -155,7 +155,7 @@ class GroupBox(_GroupBase):
         (
             "highlight_method",
             "border",
-            "Method of highlighting ('border', 'block', 'text' or 'line')"
+            "Method of highlighting ('border', 'block', 'text', or 'line')"
             "Uses \*_border color settings"
         ),
         ("rounded", True, "To round or not to round borders"),


### PR DESCRIPTION
Adds a new highlighting method called **line** for the GroupBox widget. Here are some screenshots:

![gradients](https://cloud.githubusercontent.com/assets/6579510/10443757/72ce649e-712c-11e5-8c2f-07e3a98884da.png)
![material_dark](https://cloud.githubusercontent.com/assets/6579510/10443756/72cd8088-712c-11e5-9d44-24d0a3ae4dbc.png)

The thickness of the line is configurable with the **line_thickness** variable, its color is customizable with **this_current_screen_border** and the color of the block on top of the line is also modifiable with **highlight_color**.