### PR TITLE
Removes old pieces of importlib notice

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -89,15 +89,6 @@ Based on your Python version, there are different ways to install this:
 .. _Tulip project: https://code.google.com/p/tulip/
 .. _trollius: http://trollius.readthedocs.org/
 
-importlib
----------
-
-To run with Python <=2.6 you will need to install importlib from PyPI:
-
-.. code-block:: bash
-
-   pip install importlib
-
 dbus/gobject
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,6 @@ elif sys.version_info >= (3, 3):
 else:
     dependencies.append('trollius')
 
-if (3, 0) <= sys.version_info <= (3, 1):
-    dependencies.append('importlib')
-
 setup(
     name="qtile",
     version="0.10.1",


### PR DESCRIPTION
Removes old information from docs because 2.6 is not more supported
Removes dependency from the setup.py about importlib because there is no
support anymore for 3.0 to 3.1