### PR TITLE
xcbq: return [] instead of None in get_property if unpack is set

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -671,6 +671,8 @@ class Window(object):
             logging.getLogger('qtile').warning(
                 'X error in GetProperty (wid=%r, prop=%r), ignoring',
                 self.wid, prop)
+            if unpack:
+                return []
             return None
 
         if not r.value_len:


### PR DESCRIPTION
Follow up to d19d5517, fixes more a few more exceptions on X errors