### PR TITLE
Adding support for CPU graph in FreeBSD

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -222,7 +222,7 @@ class CPUGraph(_Graph):
             if platform.system() == 'FreeBSD':
                 name, user, nice, sys, idle = line.split(None, 4)
             else:
-	        name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
+                name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
 
             return (int(user), int(nice), int(sys), int(idle))
 
@@ -440,4 +440,3 @@ class HDDBusyGraph(_Graph):
 
     def update_graph(self):
         self.push(self._getActivity())
-

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -201,7 +201,11 @@ class CPUGraph(_Graph):
         self.oldvalues = self._getvalues()
 
     def _getvalues(self):
-        with open('/proc/stat') as file:
+        proc = '/proc/stat'
+        if platform.system() == "FreeBSD":
+            proc = '/compat/linux' + proc
+
+        with open(proc) as file:
             lines = file.readlines()
 
             # default to all cores (first line)
@@ -215,61 +219,10 @@ class CPUGraph(_Graph):
 
                 if not line.startswith("cpu%s" % self.core):
                     raise ValueError("No such core: %s" % self.core)
-
-            name, user, sys, nice, sys, idle = line.split()[:5]
-
-            return (int(user), int(nice), int(sys), int(idle))
-
-    def update_graph(self):
-        nval = self._getvalues()
-        oval = self.oldvalues
-        busy = nval[0] + nval[1] + nval[2] - oval[0] - oval[1] - oval[2]
-        total = busy + nval[3] - oval[3]
-        # sometimes this value is zero for unknown reason (time shift?)
-        # we just sent the previous value, because it gives us no info about
-        # cpu load, if it's zero.
-
-        if total:
-            push_value = busy * 100.0 / total
-            self.push(push_value)
-        else:
-            self.push(self.values[0])
-        self.oldvalues = nval
-
-
-class CPUGraphFreeBSD(_Graph):
-    """
-        Display CPU usage graph.
-    """
-    orientations = base.ORIENTATION_HORIZONTAL
-    defaults = [
-        ("core", "all", "Which core to show (all/0/1/2/...)"),
-    ]
-
-    fixed_upper_bound = True
-
-    def __init__(self, **config):
-        _Graph.__init__(self, **config)
-        self.add_defaults(CPUGraphFreeBSD.defaults)
-        self.maxvalue = 100
-        self.oldvalues = self._getvalues()
-
-    def _getvalues(self):
-        with open('/compat/linux/proc/stat') as file:
-            lines = file.readlines()
-
-            # default to all cores (first line)
-            line = lines.pop(0)
-
-            # core specified, grab the corresponding line
-            if isinstance(self.core, int):
-                # we already removed the first line from the list,
-                # so it's 0 indexed now :D
-                line = lines[self.core]
-
-                if not line.startswith("cpu%s" % self.core):
-                    raise ValueError("No such core: %s" % self.core)
-            name, user, nice, sys, idle = line.split(None, 4)
+            if platform.system() == 'FreeBSD':
+                name, user, nice, sys, idle = line.split(None, 4)
+            else:
+                name, user, sys, nice, sys, idle = line.split(None, 6)
 
             return (int(user), int(nice), int(sys), int(idle))
 
@@ -291,13 +244,21 @@ class CPUGraphFreeBSD(_Graph):
 
 
 def get_meminfo():
-    with open('/proc/meminfo') as file:
-        val = {}
+    val = {}
+    proc = '/proc/meminfo'
+    if platform.system() == "FreeBSD":
+        proc = "/compat/linux" + proc
+    with open(proc) as file:
         for line in file:
-            key, tail = line.split(':')
-            uv = tail.split()
-            val[key] = int(uv[0])
+            if line.lstrip().startswith("total"):
+                pass
+            else:
+                key, tail = line.strip().split(':')
+                uv = tail.split()
+                val[key] = int(uv[0]) // 1000
+    val['MemUsed'] = val['MemTotal'] - val['MemFree']
     return val
+
 
 class MemoryGraph(_Graph):
     """
@@ -480,7 +441,3 @@ class HDDBusyGraph(_Graph):
     def update_graph(self):
         self.push(self._getActivity())
 
-if platform.system() == 'FreeBSD':
-    CPUGraph = CPUGraphFreeBSD
-else:
-    CPUGraph = CPUGraph

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -222,7 +222,7 @@ class CPUGraph(_Graph):
             if platform.system() == 'FreeBSD':
                 name, user, nice, sys, idle = line.split(None, 4)
             else:
-		name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
+	        name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
 
             return (int(user), int(nice), int(sys), int(idle))
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -485,3 +485,5 @@ class HDDBusyGraph(_Graph):
 
 if platform.system() == 'FreeBSD':
     CPUGraph = CPUGraphFreeBSD
+else:
+    CPUGraph = CPUGraph

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -200,7 +200,10 @@ class CPUGraph(_Graph):
         self.oldvalues = self._getvalues()
 
     def _getvalues(self):
-        with open('/proc/stat') as file:
+        proc = '/proc/stat'
+        if platform.system() == 'FreeBSD':
+            proc = '/compat/linux'+proc
+        with open(proc) as file:
             lines = file.readlines()
 
             # default to all cores (first line)
@@ -211,11 +214,14 @@ class CPUGraph(_Graph):
                 # we already removed the first line from the list,
                 # so it's 0 indexed now :D
                 line = lines[self.core]
+                print line
 
                 if not line.startswith("cpu%s" % self.core):
                     raise ValueError("No such core: %s" % self.core)
-
-            name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
+            if platform.system() == 'FreeBSD':
+                name, user, nice, sys, idle = line.split(None, 6)
+            else:
+                name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
 
             return (int(user), int(nice), int(sys), int(idle))
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -36,6 +36,7 @@ import cairocffi
 from . import base
 from os import statvfs
 import time
+import platform
 
 __all__ = [
     'CPUGraph',
@@ -202,7 +203,7 @@ class CPUGraph(_Graph):
     def _getvalues(self):
         proc = '/proc/stat'
         if platform.system() == 'FreeBSD':
-            proc = '/compat/linux'+proc
+            proc = '/compat/linux' + proc
         with open(proc) as file:
             lines = file.readlines()
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -215,7 +215,6 @@ class CPUGraph(_Graph):
                 # we already removed the first line from the list,
                 # so it's 0 indexed now :D
                 line = lines[self.core]
-                print line
 
                 if not line.startswith("cpu%s" % self.core):
                     raise ValueError("No such core: %s" % self.core)

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -48,9 +48,6 @@ __all__ = [
 ]
 
 
-
-
-
 class _Graph(base._Widget):
     fixed_upper_bound = False
     defaults = [
@@ -272,7 +269,7 @@ class CPUGraphFreeBSD(_Graph):
 
                 if not line.startswith("cpu%s" % self.core):
                     raise ValueError("No such core: %s" % self.core)
-            name, user,  sys, idle = line.split(None, 4)
+            name, user, nice, sys, idle = line.split(None, 4)
 
             return (int(user), int(nice), int(sys), int(idle))
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -255,7 +255,7 @@ def get_meminfo():
             else:
                 key, tail = line.strip().split(':')
                 uv = tail.split()
-                val[key] = int(uv[0]) // 1000
+                val[key] = int(uv[0])
     val['MemUsed'] = val['MemTotal'] - val['MemFree']
     return val
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -222,7 +222,7 @@ class CPUGraph(_Graph):
             if platform.system() == 'FreeBSD':
                 name, user, nice, sys, idle = line.split(None, 4)
             else:
-                name, user, sys, nice, sys, idle = line.split(None, 6)
+		name, user, nice, sys, idle, iowait, tail = line.split(None, 6)
 
             return (int(user), int(nice), int(sys), int(idle))
 


### PR DESCRIPTION
This commit adds support for CPU graph in FreeBSD.

For this to work in FreeBSD linprocfs needs to be mounted.

Since linprocfs uses an older model of the kernel not all
fields are available, hence removing some of the fields
for FreeBSD.

In FreeBSD /proc stuff is located in
/compat/linux/proc , but it lacks some of the features
of a modern linux kernel. Hence the platform.system(checks).

This should maintain compatibility with Linux, but please test
it so I don't break anything.

Cheers!