### PR TITLE
Fix make check command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 default:
 	@echo "'make check'" for tests
+	@echo "'make check-cov'" for tests with converage
 	@echo "'make lint'" for source code checks
 	@echo "'make ckpatch'" to check a patch
 	@echo "'make clean'" to clean generated files
@@ -9,11 +10,11 @@ default:
 
 .PHONY: check
 check:
-	nosetests -v -d libqtile
+	nosetests --verbose --detailed-errors
 
 .PHONY: check-cov
 check-cov:
-	nosetests -v -d --with-cov --cover-package libqtile
+	nosetests --verbose --detailed-errors --with-cov --cover-package libqtile
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
'make check' don't find tests. This was introuced in
728fafdc937b56319d24d87bb21bf2f254dda92a

The problem is that the 'libqtile' was the argument of --cov.
That one restricted the coverage output. After this parameter was
removed nosetests was thinking it should search in the folder libqtile for
tests.

I remove 'libqtile' as argument and now it runs smoothly again.
Also, I expand the command line parameter to see what they
actually mean and the 'make check-cov' call has now an echo output.