### PR TITLE
Fix build of docs on python3

### DIFF
--- a/docs/BUILDING
+++ b/docs/BUILDING
@@ -1,15 +1,10 @@
-NOTE that the doc build scripts require Python 2, and will *not* work with
-Python 3!!!
-
-===============================================================================
-
-To build in a virtual environment (requires the 'virtualenv' and 'pip' tools
+To build in a virtual environment (requires the 'virtualenv', 'pip' and 'graphiz' tools
 installed in your distro):
 
 $ cd ./docs
-$ virtualenv2 qtile
+$ virtualenv qtile
 $ source qtile/bin/activate
-$ pip2 install -r requirements.txt
+$ pip install -r requirements.txt
 $ make html
 $ deactivate
 
@@ -17,7 +12,7 @@ $ deactivate
 
 To build on Ubuntu:
 
-$ sudo apt-get install python-sphinxcontrib.seqdiag python-sphinxcontrib.blockdiag
+$ sudo apt-get install python-sphinxcontrib.seqdiag graphiz
 
 Install: https://github.com/:snide/sphinx_rtd_theme
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext coverage
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -37,6 +37,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 
 clean:
 	-rm -rf $(BUILDDIR)/*
@@ -151,3 +152,8 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+coverage:
+	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
+	@echo "Testing of coverage in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/coverage/python.txt."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ sys.path.insert(0, os.path.abspath('../'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.coverage',
     'sphinx.ext.graphviz',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
@@ -123,8 +124,11 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
 
-# -- Options for HTML output ---------------------------------------------------
+
+# -- Options for HTML output --------fautod-------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,6 @@ extensions = [
     'sphinx.ext.graphviz',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.blockdiag',
     'sphinxcontrib.seqdiag',
     'sphinx_qtile',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,14 +13,14 @@
 
 import os
 import sys
-from mock import MagicMock
+try:
+    # Python >=3.3
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
 
 
 class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-            return Mock()
-
     # xcbq does a dir() on objects and pull stuff out of them and tries to sort
     # the result. MagicMock has a bunch of stuff that can't be sorted, so let's
     # like about dir().
@@ -28,6 +28,8 @@ class Mock(MagicMock):
         return []
 
 MOCK_MODULES = [
+    'libqtile._ffi_pango',
+    'libqtile._ffi_xcursors',
     'cairocffi',
     'cffi',
     'trollius',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,4 @@
-jinja2
-mock
-six
+mock # for python <= 3.2
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-blockdiag
 sphinxcontrib-seqdiag
-watchdog

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 jinja2
-#TODO: find out why newer version raise an runtimeerror
-mock==0.8
+mock
 six
 sphinx
 sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 jinja2
-mock
+#TODO: find out why newer version raise an runtimeerror
+mock==0.8
 six
 sphinx
 sphinx_rtd_theme

--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -24,7 +24,7 @@ from docutils.statemachine import ViewList
 from jinja2 import Template
 from libqtile import command, configurable, widget
 from six import class_types
-from six.moves import builtins
+from six.moves import builtins, reduce
 from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 

--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -25,9 +25,10 @@ class Cmus(base.ThreadPoolText):
 
     Show the artist and album of now listening song and allow basic mouse
     control from the bar:
-        - toggle pause (or play if stopped) on left click;
-        - skip forward in playlist on scroll up;
-        - skip backward in playlist on scroll down.
+
+    - toggle pause (or play if stopped) on left click;
+    - skip forward in playlist on scroll up;
+    - skip backward in playlist on scroll down.
 
     Cmus (https://cmus.github.io) should be installed.
     """

--- a/libqtile/widget/moc.py
+++ b/libqtile/widget/moc.py
@@ -26,9 +26,10 @@ class Moc(base.ThreadPoolText):
 
     Show the artist and album of now listening song and allow basic mouse
     control from the bar:
-        - toggle pause (or play if stopped) on left click;
-        - skip forward in playlist on scroll up;
-        - skip backward in playlist on scroll down.
+
+    - toggle pause (or play if stopped) on left click;
+    - skip forward in playlist on scroll up;
+    - skip backward in playlist on scroll down.
 
     MOC (http://moc.daper.net) should be installed.
     """


### PR DESCRIPTION
mock has to be pinned to version 0.8 because otherwise there is a
RuntimeError (Maximum recursion depth) with in newer versions