### PR TITLE
Fixed RTD build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
+-r ../requirements.in
+
 mock # for python <= 3.2
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
The docs didn't build because the order of the packages was wrong
Related to #802 (qtile#802 (comment))

I test it on my own rtd instance and I got it to run if the setting is disabled
`python setup.py install` for this case we have to load the general project
requirements file inside the docs requirements file