### PR TITLE
Improove multiple keyboard layout support

### DIFF
--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -104,9 +104,6 @@ class KeyboardLayout(base.InLoopPollText):
     def cmd_next_keyboard(self):
         self.next_keyboard()
 
-    def check(self,q):
-        return True
-
 class _Keyboard(object):
 
     def __init__(self):

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -101,6 +101,11 @@ class KeyboardLayout(base.InLoopPollText):
             self.log.error('Please, check that setxkbmap is available: {0}'
                            .format(e))
 
+    def cmd_next_keyboard(self):
+        self.next_keyboard()
+
+    def check(self,q):
+        return True
 
 class _Keyboard(object):
 


### PR DESCRIPTION
Hi!

Now, keyboardlayout widget determinates current layout from the setxkbmap verbose output, so  it possible to use 3+ layouts, if needed.
Also:
Fixes [#650](https://github.com/qtile/qtile/issues/650).