### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# How to contribute
+
+Reporting bugs
+--------------
+
+Perhaps the easiest way to contribute to Qtile is to report any bugs you
+run into on the [github issue tracker](https://github.com/qtile/qtile/issues).
+
+Useful bug reports are ones that get bugs fixed. A useful bug report normally
+has two qualities:
+
+1. **Reproducible.** If your bug is not reproducible it will never get fixed.
+   You should clearly mention the steps to reproduce the bug. Do not assume or
+   skip any reproducing step. Described the issue, step-by-step, so that it is
+   easy to reproduce and fix.
+
+2. **Specific.** Do not write a essay about the problem. Be Specific and to the
+   point. Try to summarize the problem in minimum words yet in effective way.
+   Do not combine multiple problems even they seem to be similar. Write
+   different reports for each problem.
+
+To give more information about your bug you can append logs from `~/.qtile.log`
+or on occasionally events you can capture bugs with `xtrace` for this have a deeper 
+look on the documentation about [capturing an xtrace](http://qtile.readthedocs.org/en/latest/manual/hacking.html#capturing-an-xtrace)
+
+Writing code
+============
+
+To get started writing code for Qtile, check out our guide to [hacking](http://qtile.readthedocs.org/en/latest/manual/hacking.html).
+
+Submit a pull request
+---------------------
+
+You've done your hacking and are ready to submit your patch to Qtile. Great!
+Now it's time to submit a [pull request](https://help.github.com/articles/using-pull-requests)
+to our [issue tracker](https://github.com/qtile/qtile/issues) on Github.
+
+Pull requests are not considered complete until they include all of the
+following:
+
+1. Code: Should conform PEP8 and should pass `make lint`.
+2. Unit tests: Should pass on travis
+3. Documentation: Should get updated if it needed
+
+**Feel free to add your contribution (no matter how small) to the appropriate
+place in the CHANGELOG as well!**
+
+Thanks

--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,12 @@ Contributing
 ============
 
 Please report any suggestions, feature requests, bug reports, or annoyances to
-the Github `issue tracker`_. There are also a few `tips, tricks, and guidelines
-<http://docs.qtile.org/en/latest/manual/hacking.html>`_ for contributing in the
-documentation.
+the Github `issue tracker`_. There are also a few `tips & tricks`_,
+and `guidelines`_ for contributing in the documentation.
 
 .. _`issue tracker`: https://github.com/qtile/qtile/issues
+.. _`tips & tricks`: http://docs.qtile.org/en/latest/manual/hacking.html
+.. _`guidelines`: http://docs.qtile.org/en/latest/manual/contributing.html
 
 .. |travis| image:: https://travis-ci.org/qtile/qtile.svg?branch=develop
     :alt: Build Status


### PR DESCRIPTION
In the README was the direct link missing to the contributing section in
the docs.

I add the Link to the docs about contributing.
Also to improve contributions I include the CONTRIBUTING.md this is file what
provides on github a yellow box what links contributor to the CONTRIBUTING.md.

https://help.github.com/articles/setting-guidelines-for-repository-contributors/

Closes #804