### PR TITLE
Allow subprocess.Popen-style argument list in cmd_spawn

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -1345,11 +1345,19 @@ class Qtile(command.CommandObject):
         """
             Run cmd in a shell.
 
+            cmd may be a string, which is parsed by shlex.split, or
+            a list (similar to subprocess.Popen).
+
             Example:
 
                 spawn("firefox")
+
+                spawn(["xterm", "-T", "Temporary terminal"])
         """
-        args = shlex.split(cmd)
+        if isinstance(cmd, six.string_types):
+            args = shlex.split(cmd)
+        else:
+            args = list(cmd)
 
         r, w = os.pipe()
         pid = os.fork()

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -236,6 +236,12 @@ def test_spawn(self):
 
 
 @Xephyr(False, TestConfig())
+def test_spawn_list(self):
+    # Spawn something with a pid greater than init's
+    assert int(self.c.spawn(["echo", "true"])) > 1
+
+
+@Xephyr(False, TestConfig())
 def test_kill(self):
     self.testWindow("one")
     self.testwindows = []


### PR DESCRIPTION
This is more convenient when an argument might contain
spaces, since the caller can avoid having to escape that
arg (which would be un-escaped by shlex.split straight away).