### PR TITLE
fix fullscreen problems with programs like firefox

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1126,9 +1126,6 @@ class Window(_Window):
                 elif action == _NET_WM_STATE_TOGGLE:
                     current_state ^= set([prop])  # toggle :D
 
-            # add support for additional flags here
-            self.fullscreen = (fullscreen_atom in current_state)
-
             self.window.set_property('_NET_WM_STATE', list(current_state))
 
     def handle_PropertyNotify(self, e):


### PR DESCRIPTION
Don't toggle fullscreen on handle_ClientMessage it's handled on handle_PropertyNotify, when updateState is called.