### PR TITLE
debian: update packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
-qtile (0.9.1-1) unstable; urgency=low
+qtile (0.10.3-1) unstable; urgency=low
 
   * Initial release.
+  * Closes: #762637
 
- -- Tycho Andersen <tycho@tycho.ws>  Tue, 20 Jan 2015 18:10:02 +1300
+ -- Tycho Andersen <tycho@tycho.ws>  Thu, 24 Dec 2015 04:03:11 +0000

--- a/debian/control
+++ b/debian/control
@@ -10,13 +10,13 @@ Build-Depends: debhelper (>= 9)
     , python3-all-dev
     , python-setuptools
     , python3-setuptools
-    , python-cffi (>= 1.1.0)
-    , python3-cffi (>= 1.1.0)
+    , python-cffi (>= 1.3.0)
+    , python3-cffi (>= 1.3.0)
     , python-trollius
     , python3-trollius
 # testing
-    , python-xcffib (>= 0.3.4)
-    , python3-xcffib (>= 0.3.4)
+    , python-xcffib (>= 0.4.0)
+    , python3-xcffib (>= 0.4.0)
     , python-cairocffi (>= 0.7)
     , python3-cairocffi (>= 0.7)
     , python-trollius
@@ -26,7 +26,7 @@ Build-Depends: debhelper (>= 9)
     , libpangocairo-1.0-0
 X-Python-Version: >= 2.6
 X-Python3-Version: >= 3.2
-Standards-Version: 3.9.5
+Standards-Version: 3.9.6
 Homepage: http://qtile.org
 Vcs-Git: https://github.com/qtile/qtile
 Vcs-Browser: https://github.com/qtile/qtile
@@ -44,8 +44,8 @@ XB-Description: Full-featured, pure-Python tiling window manager.
 
 Package: python-qtile
 Architecture: all
-Depends: python-cffi (>= 1.1.0)
-    , python-xcffib (>= 0.3.4)
+Depends: python-cffi (>= 1.3.0)
+    , python-xcffib (>= 0.4.0)
     , python-cairocffi (>= 0.7)
     , python-trollius
     , libglib2.0-0
@@ -53,12 +53,17 @@ Depends: python-cffi (>= 1.1.0)
     , libpangocairo-1.0-0
     , ${misc:Depends}
     , ${python:Depends}
+# extras for widgets
+    , python-dbus
+    , python-mpd
+    , python-keyring
+    , python-xdg
 Provides: ${python:Provides}
 
 Package: python3-qtile
 Architecture: all
-Depends: python-cffi (>= 1.1.0)
-    , python-xcffib (>= 0.3.4)
+Depends: python-cffi (>= 1.3.0)
+    , python-xcffib (>= 0.4.0)
     , python-cairocffi (>= 0.7)
     , libglib2.0-0
     , libpango1.0-0
@@ -67,6 +72,10 @@ Depends: python-cffi (>= 1.1.0)
     , python3-trollius
     , ${misc:Depends}
     , ${python3:Depends}
+# extras for widgets
+    , python3-dbus
+    , python3-keyring
+    , python3-xdg
 Provides: ${python3:Provides}
 
 Package: qtile

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,28 +3,7 @@ Upstream-Name: qtile
 Source: http://github.com/qtile/qtile
 
 Files: *
-Copyright: 2008-2011 Aldo Cortesi
-License: MIT
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- SOFTWARE.
-
-Files: debian/*
-Copyright: 2012 Tycho Andersen <tycho@tycho.ws>
+Copyright: 2008-2015 Aldo Cortesi and commmitters
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* add debian WNPP bug number
* bump versions for dependencies
* bump version number for release (this may need to be corrected)
* bump debian standards version (lintian)
* get rid of separate licensing for debian/ (lintian)
* add extra dependencies for widgets (still missing are google calendar's deps,
  iwlib, and mpd in python3 which aren't in the debian archives; if users
  install these manually they should work)

Note that there is still one (set of) lintian warning(s, for all the images),
which would require code changes to fix:

W: python-qtile: image-file-in-usr-lib usr/lib/python2.7/dist-packages/libqtile/resources/battery-icons/battery-good.png

I've also bumped the version number to 0.10.3, but that may not be the next
version of qtile that is tagged. We should bump this version number to whatever
that next version is when it is tagged. (And it would be handy to tag soon, so
I can start the process of getting a debian upload :)