### PR TITLE
Comply with XDG Base Directory specification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ qtile x.x.x, released xxxx-xx-xx:
         - the default log file path changed from ~/.qtile.log to
           ~/.local/share/qtile/qtile.log
         - the cache directory changed from ~/.cache to ~/.cache/qtile
+        - the prompt widget's history file changed from ~/.qtile_history to
+          ~/.cache/qtile/prompt_history
     * features
         - wlan widget shows when you are disconnected and uses a configurable
           format

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 qtile x.x.x, released xxxx-xx-xx:
     * file path changes (XDG Base Directory specification)
+        - the default log file path changed from ~/.qtile.log to
+          ~/.local/share/qtile/qtile.log
         - the cache directory changed from ~/.cache to ~/.cache/qtile
     * features
         - wlan widget shows when you are disconnected and uses a configurable

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 qtile x.x.x, released xxxx-xx-xx:
+    * file path changes (XDG Base Directory specification)
+        - the cache directory changed from ~/.cache to ~/.cache/qtile
     * features
         - wlan widget shows when you are disconnected and uses a configurable
           format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@ has two qualities:
    Do not combine multiple problems even they seem to be similar. Write
    different reports for each problem.
 
-To give more information about your bug you can append logs from `~/.qtile.log`
-or on occasionally events you can capture bugs with `xtrace` for this have a deeper 
-look on the documentation about [capturing an xtrace](http://qtile.readthedocs.org/en/latest/manual/hacking.html#capturing-an-xtrace)
+To give more information about your bug you can append logs from
+`~/.local/share/qtile/qtile.log` or on occasionally events you can capture bugs
+with `xtrace` for this have a deeper look on the documentation about
+[capturing an xtrace](http://qtile.readthedocs.org/en/latest/manual/hacking.html#capturing-an-xtrace)
 
 Writing code
 ============

--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -10,7 +10,7 @@ install them from your package manager.
 
 * `Nose <http://nose.readthedocs.org/en/latest/>`_
 * `Xephyr <http://www.freedesktop.org/wiki/Software/Xephyr>`_
-* ``xeyes`` and ``xclock``
+* ``xrandr``, ``xterm``, ``xeyes`` and ``xclock`` (``x11-apps`` on ubuntu)
 
 On ubuntu, this can be done with ``sudo apt-get install python-nose
 xserver-xephyr x11-apps``.

--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -89,7 +89,7 @@ Qtile's conversations with the X server. To capture one of these, create an
 
 .. code-block:: bash
 
-  exec xtrace qtile >> ~/.qtile.log
+  exec xtrace qtile >> ~/qtile.log
 
 This will put the xtrace output in Qtile's logfile as well. You can then
 demonstrate the bug, and paste the contents of this file into the bug report.

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -66,7 +66,7 @@ class ColorFormatter(Formatter):
         return message + self.reset_seq
 
 
-def init_log(log_level=WARNING, log_path='~/.%s.log', log_truncate=False,
+def init_log(log_level=WARNING, log_path=True, log_truncate=False,
              log_size=10000000, log_numbackups=1, log_color=True):
     formatter = Formatter(
         "%(asctime)s %(levelname)s %(name)s %(filename)s:%(funcName)s():L%(lineno)d %(message)s"
@@ -85,6 +85,15 @@ def init_log(log_level=WARNING, log_path='~/.%s.log', log_truncate=False,
 
     # If we have a log path, we'll also setup a log file
     if log_path:
+        if not isinstance(log_path, str):
+            data_directory = os.path.expandvars('$XDG_DATA_HOME')
+            if data_directory == '$XDG_DATA_HOME':
+                # if variable wasn't set
+                data_directory = os.path.expanduser("~/.local/share")
+            data_directory = os.path.join(data_directory, 'qtile')
+            if not os.path.exists(data_directory):
+                os.makedirs(data_directory)
+            log_path = os.path.join(data_directory, '%s.log')
         try:
             log_path %= 'qtile'
         except TypeError:  # Happens if log_path doesn't contain formatters.

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -213,6 +213,7 @@ def get_cache_dir():
     if cache_directory == '$XDG_CACHE_HOME':
         # if variable wasn't set
         cache_directory = os.path.expanduser("~/.cache")
+    cache_directory = os.path.join(cache_directory, 'qtile')
     if not os.path.exists(cache_directory):
         os.makedirs(cache_directory)
     return cache_directory

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -362,7 +362,8 @@ class Prompt(base._TextBox):
             self.original_background = self.background
         # If history record is on, get saved history or create history record
         if self.record_history:
-            self.history_path = os.path.expanduser('~/.qtile_history')
+            self.history_path = os.path.join(utils.get_cache_dir(),
+                                             'prompt_history')
             if os.path.exists(self.history_path):
                 with open(self.history_path, 'rb') as f:
                     try:


### PR DESCRIPTION
I think by default the file paths used by Qtile should respect the [XDG Base Directory specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

The specification was only partially followed, and this series of commits tries to complete the implementation.

The optional dependency on PyXDG has been made a requirement, so packagers should be informed and accordingly update their scripts.

As noted in `CHANGELOG`, some files' default paths have changed. Users may be instructed to move `.qtile_history` to `~/.cache/qtile/prompt_history` in order to preserve the history of commands typed in the prompt. They may also be advised to delete the old `~/.qtile.log` file and refer to `~/.local/share/qtile/qtile.log`, or define `log_path` in their `config.py`.

The GoogleCalendar widget seems to be still using a `~/.credentials` folder, but I don't use it and I haven't tried to update it because I wouldn't be able to test it.

Last thing, I'm not sure if `%changelog` in `rpm/qtile.spec` should be updated too.