### PR TITLE
delete argument

### DIFF
--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -104,8 +104,8 @@ class Slice(Delegate):
         ("fallback", Max(), "Fallback layout"),
     ]
 
-    def __init__(self, side, width, **config):
-        Delegate.__init__(self, width=width, side=side, **config)
+    def __init__(self, **config):
+        Delegate.__init__(self, **config)
         self.add_defaults(Slice.defaults)
         self.match = {
             'wname': self.wname,


### PR DESCRIPTION
I deleted argument of __init__ for dealing same way with other layouts __init__.

And slice layout have default size and width value, so I am thinking these don't need.