### PR TITLE
Unquote query parameter to aptitude for CheckUpdates widget

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -45,7 +45,7 @@ class CheckUpdates(base.ThreadedPollText):
                          "Arch_checkupdates": ("checkupdates", 0),
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Ubuntu": ("aptitude search '~U'", 0),
+                         "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("yum list updates", 3),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),
                          "Mandriva": ("urpmq --auto-select", 0)


### PR DESCRIPTION
This check returns an empty string for me on Ubuntu 15.10 if I don't unquote the query parameter

The current command would be equal to running ```aptitude search \'~U\'``` in the console which also yields empty output.