### PR TITLE
Make user pathes work with the prompt widget

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -289,6 +289,7 @@ class CommandCompleter(object):
                     dirs = os.environ.get("PATH", self.DEFAULTPATH).split(":")
                     for didx, d in enumerate(dirs):
                         try:
+                            d = os.path.expanduser(d)
                             for cmd in glob.glob(os.path.join(d, "%s*" % txt)):
                                 if self.executable(cmd):
                                     self.lookup.append(


### PR DESCRIPTION
As for now, the prompt widget can't complete binaries if there's `~` in the PATH environment variable.
This commit should resolve this.