### PR TITLE
df widget: always use the integer division operator in py2 and py3

### DIFF
--- a/libqtile/widget/df.py
+++ b/libqtile/widget/df.py
@@ -60,9 +60,9 @@ class DF(base.ThreadedPollText):
     def poll(self):
         statvfs = os.statvfs(self.partition)
 
-        size = statvfs.f_frsize * statvfs.f_blocks / self.calc
-        free = statvfs.f_frsize * statvfs.f_bfree / self.calc
-        self.user_free = statvfs.f_frsize * statvfs.f_bavail / self.calc
+        size = statvfs.f_frsize * statvfs.f_blocks // self.calc
+        free = statvfs.f_frsize * statvfs.f_bfree // self.calc
+        self.user_free = statvfs.f_frsize * statvfs.f_bavail // self.calc
 
         if self.visible_on_warn and self.user_free >= self.warn_space:
             text = ""


### PR DESCRIPTION
When I started using python3 for qtile this widget started showing sizes
as floating point numbers with more digits than it would have if it
showed bytes. Given how old this widget is, the intended behavior was
clearly integer division.