### PR TITLE
Handle the _NET_ACTIVE_WINDOW message

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -116,6 +116,15 @@ configuration variables that control specific aspects of Qtile's behavior:
       - If a window requests to be fullscreen, it is automatically
         fullscreened. Set this to false if you only want windows to be
         fullscreen if you ask them to be.
+    * - focus_on_window_activation
+      - urgent
+      - Behavior of the _NET_ACTIVATE_WINDOW message sent by applications
+
+        - urgent: urgent flag is set for the window
+
+        - focus: automatically focus the window
+
+        - smart: automatically focus if the window is in the current group
 
 Testing your configuration
 ==========================

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -80,6 +80,7 @@ class File(object):
             "dgroups_key_binder",
             "dgroups_app_rules",
             "follow_mouse_focus",
+            "focus_on_window_activation",
             "cursor_warp",
             "layouts",
             "floating_layout",

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -139,6 +139,7 @@ bring_front_click = False
 cursor_warp = False
 floating_layout = layout.Floating()
 auto_fullscreen = True
+focus_on_window_activation = "urgent"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1152,6 +1152,23 @@ class Window(_Window):
                     current_state ^= set([prop])  # toggle :D
 
             self.window.set_property('_NET_WM_STATE', list(current_state))
+        elif atoms["_NET_ACTIVE_WINDOW"] == opcode:
+            source = data.data32[0]
+            if source == 2:  # XCB_EWMH_CLIENT_SOURCE_TYPE_NORMAL
+                logger.info("Focusing window by pager")
+                self.group.focus(self)
+                self.qtile.currentScreen.setGroup(self.group)
+            else:  # XCB_EWMH_CLIENT_SOURCE_TYPE_OTHER
+                focus_behavior = self.qtile.config.focus_on_window_activation
+                if focus_behavior == "focus" or (focus_behavior == "smart" and self.group.screen):
+                    logger.info("Focusing window")
+                    self.group.focus(self)
+                    self.qtile.currentScreen.setGroup(self.group)
+                elif focus_behavior == "urgent" or (focus_behavior == "smart" and not self.group.screen):
+                    logger.info("Setting urgent flag for window")
+                    self.urgent = True
+                else:
+                    logger.info("Ignoring focus request")
 
     def handle_PropertyNotify(self, e):
         name = self.qtile.conn.atoms.get_name(e.atom)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1156,14 +1156,14 @@ class Window(_Window):
             source = data.data32[0]
             if source == 2:  # XCB_EWMH_CLIENT_SOURCE_TYPE_NORMAL
                 logger.info("Focusing window by pager")
-                self.group.focus(self)
                 self.qtile.currentScreen.setGroup(self.group)
+                self.group.focus(self)
             else:  # XCB_EWMH_CLIENT_SOURCE_TYPE_OTHER
                 focus_behavior = self.qtile.config.focus_on_window_activation
                 if focus_behavior == "focus" or (focus_behavior == "smart" and self.group.screen):
                     logger.info("Focusing window")
-                    self.group.focus(self)
                     self.qtile.currentScreen.setGroup(self.group)
+                    self.group.focus(self)
                 elif focus_behavior == "urgent" or (focus_behavior == "smart" and not self.group.screen):
                     logger.info("Setting urgent flag for window")
                     self.urgent = True


### PR DESCRIPTION
Fixes #848 and #455 
Mirrors I3's behavior.

There are multiple client_focus events after focusing the window, but I'm not familiar with the code, not sure if it's correct.
