### PR TITLE
Fix: Lenght is unfixed for Net widget's output

### DIFF
--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -75,8 +75,8 @@ class Net(base.ThreadedPollText):
         if len(up) > 5:
             up = up[:5]
 
-        down = "  " * (5 - len(down)) + down
-        up = "  " * (5 - len(up)) + up
+        down = " " * (5 - len(down)) + down
+        up = " " * (5 - len(up)) + up
         return down, up
 
     def poll(self):


### PR DESCRIPTION
The length of the output of Net Widget is unfixed. For example:

`1.12` -> `__1.12` (two space, 6 characters in total)
while `12.12` -> `12.12` (5 characters in total)

unfixed length of output will cause the widget' length to change every interval.