### PR TITLE
Change the implementation of cmd_next and cmd_previous to cycle through visible windows

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -315,9 +315,23 @@ class Columns(Layout):
             col.current = (col.current + 1) % len(col)
             self.group.focus(col.cw, True)
 
-    cmd_next = cmd_down
+    def cmd_next(self):
+        if self.cc.split and self.cc.current < len(self.cc)-1:
+            self.cc.current = self.cc.current + 1
+        elif len(self.columns) > 0:
+            self.current = (self.current + 1) % len(self.columns)
+            if self.cc.split:
+                self.cc.current = 0
+        self.group.focus(self.cc.cw, True)
 
-    cmd_previous = cmd_up
+    def cmd_previous(self):
+        if self.cc.split and self.cc.current > 0:
+            self.cc.current = self.cc.current - 1
+        elif len(self.columns) > 0:
+            self.current = (self.current - 1) % len(self.columns)
+            if self.cc.split:
+                self.cc.current = len(self.cc) - 1
+        self.group.focus(self.cc.cw, True)
 
     def cmd_shuffle_left(self):
         cur = self.cc


### PR DESCRIPTION
This patch changes the behaviour of cmd_next and cmd_previous in the columns layout to allow cycling through all the visible windows.