### PR TITLE
Remove trollius tests for py3k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ matrix:
         - python: 2.7  # these are just to make travis's UI a bit prettier
           env: TOXENV=py27-trollius
         - python: 3.3
-          env: TOXENV=py33-trollius
-        - python: 3.3
-          env: TOXENV=py33-tulip
+          env: TOXENV=py33-asyncio
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5
@@ -18,8 +16,6 @@ matrix:
 
         - python: pypy
           env: TOXENV=pypy-trollius
-        - python: pypy3
-          env: TOXENV=pypy3-trollius
 
         - python: 3.5
           env: TOXENV=packaging
@@ -35,8 +31,6 @@ matrix:
           env: TOXENV=py-nightly
         - python: pypy
           env: TOXENV=pypy-trollius
-        - python: pypy3
-          env: TOXENV=pypy3-trollius
 
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ skipsdist=True
 minversion = 1.8
 envlist =
     py27-trollius,
-    py33-trollius,
-    py33-tulip,
+    py33-asyncio,
     py34,
     py35,
     pypy-trollius,
-    pypy3-trollius,
     py2-pep8,
     py3-pep8,
     py-nightly
@@ -30,7 +28,7 @@ deps =
     coveralls
 
     trollius: trollius
-    tulip: asyncio
+    asyncio: asyncio
 commands =
     # xcffib has to be installed before cairo
     pip install xcffib


### PR DESCRIPTION
Trollius is deprecated and should be not more not more tested for the
python3 branch but this keeps trollius for python2 because there is no
replacment for.

pypy3 is not more tested because is currently based on python3.2
