### PR TITLE
Ensure that WindowGroupHint is set in get_wm_hints

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -471,7 +471,7 @@ class Window(object):
                 icon_x=l[5],
                 icon_y=l[6],
                 icon_mask=l[7],
-                window_group=l[8]
+                window_group=l[8] if 'WindowGroupHint' in flags else None,
             )
 
     def get_wm_normal_hints(self):


### PR DESCRIPTION
This is a fix for #920.
I wonder if the other properties are always there also (I don't know anything about X). I also don't know if None is the right default value but it works for me.