### PR TITLE
Ignore mouse wheel in GroupBox if desired

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -193,7 +193,7 @@ class GroupBox(_GroupBase):
             "Disable dragging and dropping of group names on widget"
         ),
         ("invert_mouse_wheel", False, "Whether to invert mouse wheel group movement"),
-        ("ignore_mouse_wheel", False, "Whether to ignore mouse wheel events"),
+        ("use_mouse_wheel", True, "Whether to use mouse wheel events"),
         (
             "visible_groups",
             None,
@@ -230,14 +230,14 @@ class GroupBox(_GroupBase):
         curGroup = self.qtile.currentGroup
 
         if button == (5 if not self.invert_mouse_wheel else 4):
-            if not self.ignore_mouse_wheel:
+            if self.use_mouse_wheel:
                 i = itertools.cycle(self.qtile.groups)
                 while next(i) != curGroup:
                     pass
                 while group is None or group not in self.groups:
                     group = next(i)
         elif button == (4 if not self.invert_mouse_wheel else 5):
-            if not self.ignore_mouse_wheel:
+            if self.use_mouse_wheel:
                 i = itertools.cycle(reversed(self.qtile.groups))
                 while next(i) != curGroup:
                     pass

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -193,6 +193,7 @@ class GroupBox(_GroupBase):
             "Disable dragging and dropping of group names on widget"
         ),
         ("invert_mouse_wheel", False, "Whether to invert mouse wheel group movement"),
+        ("ignore_mouse_wheel", False, "Whether to ignore mouse wheel events"),
         (
             "visible_groups",
             None,
@@ -229,17 +230,19 @@ class GroupBox(_GroupBase):
         curGroup = self.qtile.currentGroup
 
         if button == (5 if not self.invert_mouse_wheel else 4):
-            i = itertools.cycle(self.qtile.groups)
-            while next(i) != curGroup:
-                pass
-            while group is None or group not in self.groups:
-                group = next(i)
+            if not self.ignore_mouse_wheel:
+                i = itertools.cycle(self.qtile.groups)
+                while next(i) != curGroup:
+                    pass
+                while group is None or group not in self.groups:
+                    group = next(i)
         elif button == (4 if not self.invert_mouse_wheel else 5):
-            i = itertools.cycle(reversed(self.qtile.groups))
-            while next(i) != curGroup:
-                pass
-            while group is None or group not in self.groups:
-                group = next(i)
+            if not self.ignore_mouse_wheel:
+                i = itertools.cycle(reversed(self.qtile.groups))
+                while next(i) != curGroup:
+                    pass
+                while group is None or group not in self.groups:
+                    group = next(i)
         else:
             group = self.get_clicked_group(x, y)
             if not self.disable_drag:


### PR DESCRIPTION
This PR adds the ability to disable wheel scrolling in GroupBox if desired via the flag ignore_mouse_wheel. This feature can be handy when scrolling with two fingers on a touchpad.
