### PR TITLE
set_position & set_size distributed from window.py to layout files

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -292,15 +292,24 @@ class Columns(Layout):
     def find(self,client):        
         for s in self.columns:
             if s.__contains__(client):
-                return [self.columns.index(s),s.clients.index(client)]
+                return s
 
     def set_position(self, sw, dw):        
-        sidx = self.find(sw)
-        didx = self.find(dw)        
-       
-        self.columns[sidx[0]].clients[sidx[1]],self.columns[didx[0]].clients[didx[1]] = self.columns[didx[0]].clients[didx[1]], self.columns[sidx[0]].clients[sidx[1]]
-        self.focus(self.columns[sidx[0]].clients[sidx[1]])
-        self.group.layoutAll() 
+        sc = self.find(sw)
+        dc = self.find(dw)
+        si = sc.index(sw)
+        di = dc.index(dw)
+
+        sc.heights[dw], \
+        dc.heights[sw], \
+        sc.clients[si], \
+        dc.clients[di] = dc.heights.pop(dw), \
+                         sc.heights.pop(sw), \
+                         dc.clients[di], \
+                         sc.clients[si]
+     
+        self.focus(dc.clients[dc.index(sw)])
+        self.group.layoutAll()
 
     def set_size(self,sw,w,h):
         pass

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -289,29 +289,24 @@ class Columns(Layout):
             if win in col:
                 return col.focus_previous(win)
 
-    def find(self,client):        
+    def find(self, client):
         for s in self.columns:
             if s.__contains__(client):
                 return s
 
-    def set_position(self, sw, dw):        
+    def set_position(self, sw, dw):
         sc = self.find(sw)
         dc = self.find(dw)
         si = sc.index(sw)
         di = dc.index(dw)
 
-        sc.heights[dw], \
-        dc.heights[sw], \
-        sc.clients[si], \
-        dc.clients[di] = dc.heights.pop(dw), \
-                         sc.heights.pop(sw), \
-                         dc.clients[di], \
-                         sc.clients[si]
-     
+        sc.heights[dw], dc.heights[sw], sc.clients[si], dc.clients[di] = \
+            dc.heights.pop(dw), sc.heights.pop(sw), dc.clients[di], sc.clients[si]
+
         self.focus(dc.clients[dc.index(sw)])
         self.group.layoutAll()
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_toggle_split(self):

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -289,6 +289,22 @@ class Columns(Layout):
             if win in col:
                 return col.focus_previous(win)
 
+    def find(self,client):        
+        for s in self.columns:
+            if s.__contains__(client):
+                return [self.columns.index(s),s.clients.index(client)]
+
+    def set_position(self, sw, dw):        
+        sidx = self.find(sw)
+        didx = self.find(dw)        
+       
+        self.columns[sidx[0]].clients[sidx[1]],self.columns[didx[0]].clients[didx[1]] = self.columns[didx[0]].clients[didx[1]], self.columns[sidx[0]].clients[sidx[1]]
+        self.focus(self.columns[sidx[0]].clients[sidx[1]])
+        self.group.layoutAll() 
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_toggle_split(self):
         self.cc.toggleSplit()
         self.group.layoutAll()

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -154,15 +154,15 @@ class Matrix(Layout):
         )
         client.unhide()
 
-    def set_position(self, sw, dw):        
+    def set_position(self, sw, dw):
         sidx = self.clients.index(sw)
         didx = self.clients.index(dw)
 
         self.clients[sidx], self.clients[didx] = self.clients[didx], self.clients[sidx]
-        self.focus(clients[sidx])
-        self.group.layoutAll()   
+        self.focus(self.clients[sidx])
+        self.group.layoutAll()
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_next(self):

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -154,6 +154,17 @@ class Matrix(Layout):
         )
         client.unhide()
 
+    def set_position(self, sw, dw):        
+        sidx = self.clients.index(sw)
+        didx = self.clients.index(dw)
+
+        self.clients[sidx], self.clients[didx] = self.clients[didx], self.clients[sidx]
+        self.focus(clients[sidx])
+        self.group.layoutAll()   
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_next(self):
         client = self.focus_next(self.get_current_window()) or \
             self.focus_first()

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -132,7 +132,7 @@ class Max(SingleWindow):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_down(self):

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -129,6 +129,12 @@ class Max(SingleWindow):
         d["clients"] = [x.name for x in self.clients]
         return d
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_down(self):
         """Switch down in the window list"""
         self.down()

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -366,6 +366,12 @@ class RatioTile(Layout):
             function(self.clients)
             self.group.layoutAll()
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_down(self):
         self.previous()
 

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -369,7 +369,7 @@ class RatioTile(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_down(self):

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -160,7 +160,7 @@ class Slice(Delegate):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_next(self):

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -157,6 +157,12 @@ class Slice(Delegate):
             self.fallback.add(win)
             self.layouts[win] = self.fallback
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_next(self):
         self.fallback.cmd_next()
 

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -336,25 +336,24 @@ class Stack(Layout):
         d["clients"] = [c.name for c in self.clients]
         return d
 
-    def find(self,client):        
+    def find(self, client):
         for s in self.columns:
             if s.__contains__(client):
                 return s
 
-    def set_position(self, sw, dw):        
+    def set_position(self, sw, dw):
         sc = self.find(sw)
         dc = self.find(dw)
         si = sc.index(sw)
         di = dc.index(dw)
 
-        sc.clients[si], \
-        dc.clients[di] = dc.clients[di], \
-                         sc.clients[si]
+        sc.clients[si], dc.clients[di] = \
+            dc.clients[di], sc.clients[si]
 
         self.focus(dc.clients[dc.index(sw)])
         self.group.layoutAll()
-    
-    def set_size(self,sw,w,h):
+
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_toggle_split(self):

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -337,16 +337,21 @@ class Stack(Layout):
         return d
 
     def find(self,client):        
-        for s in self.stacks:
+        for s in self.columns:
             if s.__contains__(client):
-                return [self.stacks.index(s),s.lst.index(client)]
+                return s
 
     def set_position(self, sw, dw):        
-        sidx = self.find(sw)
-        didx = self.find(dw)        
-       
-        self.stacks[sidx[0]].lst[sidx[1]],self.stacks[didx[0]].lst[didx[1]] = self.stacks[didx[0]].lst[didx[1]], self.stacks[sidx[0]].lst[sidx[1]]
-        self.focus(self.stacks[sidx[0]].lst[sidx[1]])
+        sc = self.find(sw)
+        dc = self.find(dw)
+        si = sc.index(sw)
+        di = dc.index(dw)
+
+        sc.clients[si], \
+        dc.clients[di] = dc.clients[di], \
+                         sc.clients[si]
+
+        self.focus(dc.clients[dc.index(sw)])
         self.group.layoutAll()
     
     def set_size(self,sw,w,h):

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -336,6 +336,22 @@ class Stack(Layout):
         d["clients"] = [c.name for c in self.clients]
         return d
 
+    def find(self,client):        
+        for s in self.stacks:
+            if s.__contains__(client):
+                return [self.stacks.index(s),s.lst.index(client)]
+
+    def set_position(self, sw, dw):        
+        sidx = self.find(sw)
+        didx = self.find(dw)        
+       
+        self.stacks[sidx[0]].lst[sidx[1]],self.stacks[didx[0]].lst[didx[1]] = self.stacks[didx[0]].lst[didx[1]], self.stacks[sidx[0]].lst[sidx[1]]
+        self.focus(self.stacks[sidx[0]].lst[sidx[1]])
+        self.group.layoutAll()
+    
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_toggle_split(self):
         """Toggle vertical split on the current stack"""
         self.currentStack.toggleSplit()

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -210,6 +210,17 @@ class Tile(Layout):
             slave=[c.name for c in self.slave_windows],
         )
 
+    def set_position(self, sw, dw):        
+        sidx = self.clients.index(sw)
+        didx = self.clients.index(dw)
+
+        self.clients[sidx], self.clients[didx] = self.clients[didx], self.clients[sidx]
+        self.focus(clients[sidx])
+        self.group.layoutAll()
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_down(self):
         self.down()
 

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -210,15 +210,15 @@ class Tile(Layout):
             slave=[c.name for c in self.slave_windows],
         )
 
-    def set_position(self, sw, dw):        
+    def set_position(self, sw, dw):
         sidx = self.clients.index(sw)
         didx = self.clients.index(dw)
 
         self.clients[sidx], self.clients[didx] = self.clients[didx], self.clients[sidx]
-        self.focus(clients[sidx])
+        self.focus(self.clients[sidx])
         self.group.layoutAll()
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_down(self):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -482,7 +482,7 @@ class TreeTab(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_down(self):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -479,6 +479,12 @@ class TreeTab(Layout):
         if self._panel:
             self._panel.hide()
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_down(self):
         """Switch down in the window list"""
         win = None

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -250,7 +250,7 @@ class VerticalTile(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_next(self):

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -247,6 +247,12 @@ class VerticalTile(Layout):
             self.ratio -= self.steps
             self.group.layoutAll()
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_next(self):
         self.focus_next(self.focused)
         self.group.focus(self.focused)

--- a/libqtile/layout/wmii.py
+++ b/libqtile/layout/wmii.py
@@ -262,7 +262,7 @@ class Wmii(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_left(self):

--- a/libqtile/layout/wmii.py
+++ b/libqtile/layout/wmii.py
@@ -259,6 +259,12 @@ class Wmii(Layout):
         if len(c['rows']) != 0:
             return c['rows'][len(c['rows']) - 1]
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_left(self):
         """Switch to the first window on prev column"""
         c = self.current_column()

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -670,6 +670,12 @@ class MonadTall(Layout):
         if self.focused > 0:
             return self.clients[self.focused - 1]
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_next(self):
         client = self.focus_next(self.clients[self.focused]) or \
             self.focus_first()

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -673,7 +673,7 @@ class MonadTall(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_next(self):

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -157,6 +157,12 @@ class Zoomy(Layout):
                 format=8
             )
 
+    def set_position(self, sw, dw):
+        pass
+
+    def set_size(self,sw,w,h):
+        pass
+
     def cmd_next(self):
         client = self.focus_next(self.focused) or self.focus_first()
         self.group.focus(client, False)

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -160,7 +160,7 @@ class Zoomy(Layout):
     def set_position(self, sw, dw):
         pass
 
-    def set_size(self,sw,w,h):
+    def set_size(self, sw, w, h):
         pass
 
     def cmd_next(self):

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1365,20 +1365,20 @@ class Window(_Window):
         else:
             self.opacity = 1
 
-    def cmd_set_position(self, dx, dy, curx, cury):        
+    def cmd_set_position(self, dx, dy, curx, cury):
         if self.floating:
             self.tweak_float(dx, dy)
             return
-        
+
         for window in self.group.windows:
             if window == self or window.floating:
                 continue
             if self._is_in_window(curx, cury, window):
-                self.group.layout.set_position(sw=self,dw=window)
+                self.group.layout.set_position(sw=self, dw=window)
 
     def cmd_set_size(self, w, h, curx, cury):
         if self.floating:
             self.tweak_float(w, h)
             return
 
-        self.group.layout.set_size(sw,w,h)
+        self.group.layout.set_size(sw=self, w, h)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1381,4 +1381,4 @@ class Window(_Window):
             self.tweak_float(w, h)
             return
 
-        self.group.layout.set_size(sw=self, w, h)
+        self.group.layout.set_size(w, h, sw=self)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1241,6 +1241,10 @@ class Window(_Window):
         elif name == "screen":
             return self.group.screen
 
+    def _is_in_window(self, x, y, window):
+        return (window.edges[0] <= x <= window.edges[2] and
+                window.edges[1] <= y <= window.edges[3])
+
     def __repr__(self):
         return "Window(%r)" % self.name
 
@@ -1361,22 +1365,20 @@ class Window(_Window):
         else:
             self.opacity = 1
 
-    def _is_in_window(self, x, y, window):
-        return (window.edges[0] <= x <= window.edges[2] and
-                window.edges[1] <= y <= window.edges[3])
-
-    def cmd_set_position(self, dx, dy, curx, cury):
+    def cmd_set_position(self, dx, dy, curx, cury):        
         if self.floating:
             self.tweak_float(dx, dy)
             return
+        
         for window in self.group.windows:
             if window == self or window.floating:
                 continue
             if self._is_in_window(curx, cury, window):
-                clients = self.group.layout.clients
-                index1 = clients.index(self)
-                index2 = clients.index(window)
-                clients[index1], clients[index2] = clients[index2], clients[index1]
-                self.group.layout.focused = index2
-                self.group.layoutAll()
-                break
+                self.group.layout.set_position(sw=self,dw=window)
+
+    def cmd_set_size(self, w, h, curx, cury):
+        if self.floating:
+            self.tweak_float(w, h)
+            return
+
+        self.group.layout.set_size(sw,w,h)


### PR DESCRIPTION
Hello,
This is my little edit which is all about `set_position` and `set_size` ,
- currently those functions `cmd_set_size` and `cmd_set_position` are located in `window.py`,
  swapping algorithm included. 

I believe as long as `window.py` can't swap directly and need cooperate with `layout` class,
swapping algorithm shouldn't be located in `window.py`, while it can and will differ base on `layout` itself. For example there is different algorithm to switch `tile` and `stack` layout.

With this edit, swapping windows should be possible with Tile, Stack, Columns, Floating, Matrix.
Next step will be to implement resizing, which is dependent on layout istelf (again) and by naming someone gave it to it, it should be done through function `set_size`.

Hope this will be accepted edit :), while i didn't consult it with anybody from you folks :).
Next thing i have in my mind is to bit unify layouts and give them some kind of interface,
for example documentation says Columns layout it's inherited from Stack,
but technically it not inherited and even uses different terminology (stacks/columns , lst/clients).

Love this, wish have more time to invest.
