### PR TITLE
Fix xcbq.Window.query_tree return value

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -777,7 +777,7 @@ class Window(object):
         if q.root:
             root = Window(self.conn, q.root)
         if q.parent:
-            parent = Window(self.conn, q.root)
+            parent = Window(self.conn, q.parent)
         return root, parent, [Window(self.conn, i) for i in q.children]
 
 


### PR DESCRIPTION
xcbq.Window.query_tree currently returns the root window where it should return the parent window