### PR TITLE
add name of widget to error about orientation support missing

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -153,12 +153,13 @@ class _Widget(command.CommandObject, configurable.Configurable):
         if horizontal:
             if not self.orientations & ORIENTATION_HORIZONTAL:
                 raise confreader.ConfigError(
-                    "The widget is not compatible with the orientation of the "
-                    "bar."
+                    self.__class__.__name__ +
+                    " is not compatible with the orientation of the bar."
                 )
         elif not self.orientations & ORIENTATION_VERTICAL:
             raise confreader.ConfigError(
-                "The widget is not compatible with the orientation of the bar."
+                self.__class__.__name__ +
+                " is not compatible with the orientation of the bar."
             )
 
     def timer_setup(self):


### PR DESCRIPTION
this makes the error easier to apply in a configuration fix.