### PR TITLE
when qtile can't found key, self.conn.get_modifire return None.

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -111,7 +111,7 @@ class Qtile(command.CommandObject):
 
         # Find the modifier mask for the numlock key, if there is one:
         nc = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])
-        self.numlockMask = xcbq.ModMasks[self.conn.get_modifier(nc)]
+        self.numlockMask = xcbq.ModMasks.get(self.conn.get_modifier(nc), 0)
         self.validMask = ~(self.numlockMask | xcbq.ModMasks["lock"])
 
         # Because we only do Xinerama multi-screening,


### PR DESCRIPTION
When I remove caps_lock key from keyboard by xmodmap command, I couldn't restart qtile.
So I fixed that ModMasks allow to receive None.