### PR TITLE
Robustifying default widgets

### DIFF
--- a/libqtile/widget/khal_calendar.py
+++ b/libqtile/widget/khal_calendar.py
@@ -82,7 +82,7 @@ class KhalCalendar(base.ThreadedPollText):
         # and get the next event
         args = ['khal', 'agenda', '--days', str(self.lookahead)]
         cal = subprocess.Popen(args, stdout=subprocess.PIPE)
-        output = unicode(cal.communicate()[0], 'utf-8')
+        output = cal.communicate()[0].decode('utf-8')
         output = output.split('\n')
         if len(output) < 2:
             return 'No appointments scheduled'
@@ -100,7 +100,7 @@ class KhalCalendar(base.ThreadedPollText):
                 try:
                     if output[i] == 'Today:':
                         date = str(now.month) + '/' + str(now.day) + '/' + \
-                                str(now.year)
+                            str(now.year)
                     elif output[i] == 'Tomorrow:':
                         date = str(tomorrow.month) + '/' + str(tomorrow.day) + \
                             '/' + str(tomorrow.year)

--- a/libqtile/widget/khal_calendar.py
+++ b/libqtile/widget/khal_calendar.py
@@ -75,7 +75,6 @@ class KhalCalendar(base.ThreadedPollText):
         # get today and tomorrow
         now = datetime.datetime.now()
         tomorrow = now + datetime.timedelta(days=1)
-        dbg = open('/home/christoph/dbgout.txt', 'w')
         # get reminder time in datetime format
         remtime = datetime.timedelta(minutes=self.remindertime)
 
@@ -120,7 +119,6 @@ class KhalCalendar(base.ThreadedPollText):
 
         # get rid of any garbage in appointment added by khal
         data = ''.join(filter(lambda x: x in string.printable, data))
-        dbg.write('check1')
         # colorize the event if it is within reminder time
         if (starttime - remtime <= now) and (endtime > now):
             self.foreground = utils.hex(self.reminder_color)

--- a/libqtile/widget/khal_calendar.py
+++ b/libqtile/widget/khal_calendar.py
@@ -16,6 +16,7 @@
 # borrows liberally from that one.
 #
 # Copyright (c) 2016 by David R. Andersen <k0rx@RXcomm.net>
+# New khal output format adjustment, 2016 Christoph Lassner
 # Licensed under the Gnu Public License
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -74,7 +75,7 @@ class KhalCalendar(base.ThreadedPollText):
         # get today and tomorrow
         now = datetime.datetime.now()
         tomorrow = now + datetime.timedelta(days=1)
-
+        dbg = open('/home/christoph/dbgout.txt', 'w')
         # get reminder time in datetime format
         remtime = datetime.timedelta(minutes=self.remindertime)
 
@@ -107,12 +108,11 @@ class KhalCalendar(base.ThreadedPollText):
                     else:
                         dateutil.parser.parse(output[i])
                         date = output[i]
-                        caldate = output[i]
                         continue
                 except ValueError:
                     pass  # no date.
             if endtime is not None and endtime > now:
-                data = caldate.replace(':', '') + ' ' + output[i]
+                data = date.replace(':', '') + ' ' + output[i]
                 break
             else:
                 data = 'No appointments in next ' + \
@@ -120,7 +120,7 @@ class KhalCalendar(base.ThreadedPollText):
 
         # get rid of any garbage in appointment added by khal
         data = ''.join(filter(lambda x: x in string.printable, data))
-
+        dbg.write('check1')
         # colorize the event if it is within reminder time
         if (starttime - remtime <= now) and (endtime > now):
             self.foreground = utils.hex(self.reminder_color)

--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2013 Tao Sauvage
 # Copyright (c) 2014 Sean Vig
 # Copyright (c) 2014 Tycho Andersen
+# Copyright (c) 2016 Christoph Lassner
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +67,8 @@ class Maildir(base.ThreadedPollText):
                 yield path.rsplit(":")[0]
 
         for subFolder in self.subFolders:
-            path = os.path.join(self.maildirPath, subFolder["path"])
+            path = os.path.join(os.path.expanduser(self.maildirPath),
+                                subFolder["path"])
             maildir = mailbox.Maildir(path)
             state[subFolder["label"]] = 0
 

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -10,6 +10,7 @@
 # Copyright (c) 2014 Adi Sieker
 # Copyright (c) 2014 dmpayton
 # Copyright (c) 2014 Jody Frankowski
+# Copyright (c) 2016 Christoph Lassner
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +45,9 @@ __all__ = [
 ]
 
 re_vol = re.compile('\[(\d?\d?\d?)%\]')
+BUTTON_UP = 4
+BUTTON_DOWN = 5
+BUTTON_MUTE = 1
 
 
 class Volume(base._TextBox):
@@ -94,7 +98,7 @@ class Volume(base._TextBox):
         return cmd
 
     def button_press(self, x, y, button):
-        if button == 5:
+        if button == BUTTON_DOWN:
             if self.volume_down_command is not None:
                 subprocess.call(self.volume_down_command)
             else:
@@ -102,7 +106,7 @@ class Volume(base._TextBox):
                                                            'sset',
                                                            self.channel,
                                                            '2%-'))
-        elif button == 4:
+        elif button == BUTTON_UP:
             if self.volume_up_command is not None:
                 subprocess.call(self.volume_up_command)
             else:
@@ -110,7 +114,7 @@ class Volume(base._TextBox):
                                                            'sset',
                                                            self.channel,
                                                            '2%+'))
-        elif button == 1:
+        elif button == BUTTON_MUTE:
             if self.mute_command is not None:
                 subprocess.call(self.mute_command)
             else:
@@ -223,3 +227,15 @@ class Volume(base._TextBox):
             self.drawer.draw(offsetx=self.offset, width=self.length)
         else:
             base._TextBox.draw(self)
+
+    def cmd_increase_vol(self):
+        # Emulate button press.
+        self.button_press(0, 0, BUTTON_UP)
+
+    def cmd_decrease_vol(self):
+        # Emulate button press.
+        self.button_press(0, 0, BUTTON_DOWN)
+
+    def cmd_mute(self):
+        # Emulate button press.
+        self.button_press(0, 0, BUTTON_MUTE)

--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -22,6 +22,7 @@
 
 import os
 import subprocess
+import random
 from . import base
 from .. import bar
 from libqtile.log_utils import logger
@@ -33,6 +34,9 @@ class Wallpaper(base._TextBox):
          "Wallpaper Directory"),
         ("wallpaper", None, "Wallpaper"),
         ("wallpaper_command", None, "Wallpaper command"),
+        ("random_selection", False, "If set, use random initial wallpaper and "
+         "randomly cycle through the wallpapers."),
+        ("label", None, "Use a fixed label instead of image name.")
     ]
 
     def __init__(self, **config):
@@ -44,7 +48,7 @@ class Wallpaper(base._TextBox):
         self.set_wallpaper()
 
     def get_path(self, file):
-        return self.directory + file
+        return os.path.join(self.directory, file)
 
     def get_wallpapers(self):
         try:
@@ -58,13 +62,16 @@ class Wallpaper(base._TextBox):
 
     def set_wallpaper(self):
         if len(self.images) == 0:
-            if len(self.wallpaper) == 0:
+            if self.wallpaper is None:
                 self.text = "empty"
                 return
             else:
                 self.images.append(self.wallpaper)
         cur_image = self.images[self.index]
-        self.text = os.path.basename(cur_image)
+        if self.label is None:
+            self.text = os.path.basename(cur_image)
+        else:
+            self.text = self.label
         if self.wallpaper_command:
             self.wallpaper_command.append(cur_image)
             subprocess.call(self.wallpaper_command)
@@ -77,7 +84,10 @@ class Wallpaper(base._TextBox):
 
     def button_press(self, x, y, button):
         if button == 1:
-            self.index += 1
-            self.index %= len(self.images)
+            if self.random_selection:
+                self.index = random.randint(0, len(self.images) - 1)
+            else:
+                self.index += 1
+                self.index %= len(self.images)
             self.set_wallpaper()
             self.draw()

--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -30,8 +30,7 @@ from libqtile.log_utils import logger
 
 class Wallpaper(base._TextBox):
     defaults = [
-        ("directory", os.path.expanduser("~") + "/Pictures/wallpapers/",
-         "Wallpaper Directory"),
+        ("directory", "~/Pictures/wallpapers/", "Wallpaper Directory"),
         ("wallpaper", None, "Wallpaper"),
         ("wallpaper_command", None, "Wallpaper command"),
         ("random_selection", False, "If set, use random initial wallpaper and "
@@ -48,7 +47,7 @@ class Wallpaper(base._TextBox):
         self.set_wallpaper()
 
     def get_path(self, file):
-        return os.path.join(self.directory, file)
+        return os.path.join(os.path.expanduser(self.directory), file)
 
     def get_wallpapers(self):
         try:


### PR DESCRIPTION
Hi qtile team,

this is a small collection of updates to the standard widgets to make them easier to use and more robust (or just work with the current Python version of other libraries). In detail:

**Wallpaper widget**:
* add option to display a fixed string instead of current image name. This can quite clutter the bar.
* remove a bug that required the folder name to end in '/'. Use os.path.join instead.

**khal widget**:
* use `unicode` to make it work with Python2.
* rewrote the event parsing in a more robust way that works with the current version of khal.

**mailfolder widget**:
* did not use user folder expansion for the mail folder.

**Volume widget**:
* expose commands `increase_vol`, `decrease_vol` and `mute` for easy and consistent keybinding in the configs.