### PR TITLE
Fix «Hacking on Qtile» documentation page

### DIFF
--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -49,7 +49,7 @@ Run it from the top-level of the repository, like this:
 In practice, the development cycle looks something like this:
 
 1. make minor code change
-#. run appropriate test: ``pytest --tests=test_module``
+#. run appropriate test: ``pytest tests/test_module.py``
 #. GOTO 1, until hackage is complete
 #. run entire test suite: ``pytest``
 #. commit


### PR DESCRIPTION
Specifically this

```sh
pytest --tests=test_module
```

I think this is wrong. The `--tests` option doesn't appear in
`pytest --help`, neither in the [official
docs](https://readthedocs.org/projects/pytest/search/?q=--tests).
I think this is a mistake, derived from the previous use of
`nosetests`, where a `--tests` option exists. In `pytest`, there isn't such an option.