### PR TITLE
Stop cmus widget flooding stdout

### DIFF
--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -14,13 +14,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from . import base
-
 import subprocess
+
+from . import base
 
 
 class Cmus(base.ThreadPoolText):
-
     """A simple Cmus widget.
 
     Show the artist and album of now listening song and allow basic mouse
@@ -49,7 +48,7 @@ class Cmus(base.ThreadPoolText):
     def get_info(self):
         """Return a dictionary with info about the current cmus status."""
         try:
-            output = self.call_process(['cmus-remote', '-Q'])
+            output = self.call_process(['cmus-remote', '-C', 'status'])
         except subprocess.CalledProcessError as err:
             output = err.output.decode()
         if output.startswith("status"):


### PR DESCRIPTION
The widget, since always, has been flooding the _stdout_ with a
`cmus-remote: cmus is not running` message when `cmus` is not
running.

This behaviour doesn't affect the proper operation of the widget, nor
get logged in any place, so I has been delaying the fix to
«when I have some time».

It just bugged me a bit every time I shutdown `qtile`, because then
you saw a great sequence of that message filling your screen.
So I fixed it.

**Note**: the change in the imports orders is because I use [isort](https://pypi.python.org/pypi/isort) in my code editor. Hope it won't be a problem ;).