### PR TITLE
Fixed focus issues

### DIFF
--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -225,7 +225,7 @@ class VerticalTile(Layout):
             index = self.clients.index(window)
             return self.clients[index + 1]
         except IndexError:
-            pass
+            return self.clients[0]
 
     def focus_previous(self, window):
         if not self.clients:
@@ -235,7 +235,7 @@ class VerticalTile(Layout):
             index = self.clients.index(window)
             return self.clients[index - 1]
         except IndexError:
-            pass
+            return self.clients[-1]
 
     def grow(self):
         if self.ratio + self.steps < 1:
@@ -247,21 +247,13 @@ class VerticalTile(Layout):
             self.ratio -= self.steps
             self.group.layoutAll()
 
-    def cmd_next(self):
-        self.focus_next(self.focused)
-        self.group.focus(self.focused)
-
     def cmd_previous(self):
-        self.focus_previous(self.focused)
-        self.group.focus(self.focused)
+        self.group.focus(self.focus_previous(self.focused))
+    cmd_up = cmd_previous
 
-    def cmd_down(self):
-        self.focus_next(self.focused)
-        self.group.focus(self.focused)
-
-    def cmd_up(self):
-        self.focus_previous(self.focused)
-        self.group.focus(self.focused)
+    def cmd_next(self):
+        self.group.focus(self.focus_next(self.focused))
+    cmd_down = cmd_next
 
     def cmd_shuffle_up(self):
         index = self.clients.index(self.focused)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -584,6 +584,12 @@ class _Window(command.CommandObject):
     def _select(self, name, sel):
         return None
 
+    def cmd_focus(self, warp=None):
+        """Focuses the window."""
+        if warp is None:
+            warp = self.qtile.config.cursor_warp
+        self.focus(warp=warp)
+
     def cmd_info(self):
         """Returns a dictionary of info for this object"""
         return self.info()


### PR DESCRIPTION
Two issues have been addressed:
1. Broken `VerticalTile` layout which did not switch focus between windows. Now it works and also cycling among windows is enabled.
2. Added `cmd_focus` to `Window`, which allows for tricks like this:

```
keys.append(Key([mod, "shift"], g.name,
        lazy.window.togroup(g.name),
        lazy.group[g.name].toscreen(screen),
        lazy.window.focus()))
```
