### PR TITLE
Multiscreen widgets

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -169,9 +169,14 @@ class GroupBox(_GroupBase):
             "Border or line colour for group on this screen when unfocused."
         ),
         (
+            "other_current_screen_border",
+            "404040",
+            "Border or line colour for group on other screen when focused."
+        ),
+        (
             "other_screen_border",
             "404040",
-            "Border or line colour for group on other screen."
+            "Border or line colour for group on other screen when unfocused."
         ),
         (
             "highlight_color",
@@ -303,7 +308,10 @@ class GroupBox(_GroupBase):
                         else:
                             border = self.this_screen_border
                     else:
-                        border = self.other_screen_border
+                        if self.qtile.currentScreen == g.screen:
+                            border = self.other_current_screen_border
+                        else:
+                            border = self.other_screen_border
             elif self.group_has_urgent(g) and \
                     self.urgent_alert_method in ('border', 'block', 'line'):
                 border = self.urgent_border

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -32,7 +32,8 @@ class WindowName(base._TextBox):
     """Displays the name of the window that currently has focus"""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ('show_state', True, 'show window status before window name')
+        ('show_state', True, 'show window status before window name'),
+        ('for_current_screen', False, 'instead of this bars screen use currently active screen')
     ]
 
     def __init__(self, width=bar.STRETCH, **config):
@@ -44,9 +45,16 @@ class WindowName(base._TextBox):
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
         hook.subscribe.float_change(self.update)
+        @hook.subscribe.current_screen_change
+        def on_screen_changed():
+            if self.for_current_screen:
+                self.update()
 
     def update(self):
-        w = self.bar.screen.group.currentWindow
+        if self.for_current_screen:
+            w = self.qtile.currentScreen.group.currentWindow
+        else:
+            w = self.bar.screen.group.currentWindow
         state = ''
         if self.show_state and w is not None:
             if w.maximized:

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -45,6 +45,7 @@ class WindowName(base._TextBox):
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
         hook.subscribe.float_change(self.update)
+
         @hook.subscribe.current_screen_change
         def on_screen_changed():
             if self.for_current_screen:


### PR DESCRIPTION
These changes make multi-screen setups not require multi-bars. Personally I only want one bar for all my screens, not one on each of them.
- WindowName will show name of currently focused window, even if not on the same screen as bar,
- GroupBox will highlight non-focused screens.

For a default config the old behaviour is retained; to obtain the new behaviour options must be passed to the widgets.
