### PR TITLE
Focus change on last window close

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -295,6 +295,9 @@ class _Group(command.CommandObject):
         # a notification may not have focus
         if hadfocus:
             self.focus(nextfocus, warp=True, force=force)
+            # no next focus window means focus changed to nothing
+            if not nextfocus:
+                hook.fire("focus_change")
         elif self.screen:
             self.layoutAll()
 

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -44,12 +44,6 @@ class WindowName(base._TextBox):
         hook.subscribe.window_name_change(self.update)
         hook.subscribe.focus_change(self.update)
         hook.subscribe.float_change(self.update)
-        # Clear the widget if group has no window
-        @hook.subscribe.client_killed
-        def on_client_killed(window):
-            if window == self.bar.screen.group.currentWindow:
-                self.text = ""
-                self.bar.draw()
 
     def update(self):
         w = self.bar.screen.group.currentWindow


### PR DESCRIPTION
This PR causes the `focus_change` hook to be fired when the last window in a group is closed. Conceptually, the focus changed from some window to nothing, so firing the hook makes sense to me.

I looked for a way of putting it in `group.focus`, but currently that function does nothing if `win` is `None`. Specifically, it doesn't actually clear the focus so firing the hook from there seems wrong. One remaining alternative is to fire the hook from `_remove_from_focus_history`. Currently that makes little difference since it is only called from `group.remove`, but it might be more future-proof. Thoughts?

Note that this change also allowed to simplify the `WindowName` widget which no longer needs to subscribe to the `client_killed` hook.