### PR TITLE
Use `border_focus` only for currently focused window

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -242,7 +242,7 @@ class Columns(Layout):
         else:
             client.hide()
             return
-        if client == self.cc.cw:
+        if client.has_focus:
             color = self.group.qtile.colorPixel(self.border_focus)
         else:
             color = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -169,7 +169,7 @@ class Floating(Layout):
         self.focused = None
 
     def configure(self, client, screen):
-        if client is self.focused:
+        if client.has_focus:
             bc = client.group.qtile.colorPixel(self.border_focus)
         else:
             bc = client.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -132,7 +132,7 @@ class Matrix(Layout):
         column = idx % self.columns
         row = idx // self.columns
         column_size = int(math.ceil(len(self.clients) / self.columns))
-        if (column, row) == self.current_window:
+        if client.has_focus:
             px = self.group.qtile.colorPixel(self.border_focus)
         else:
             px = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -290,7 +290,7 @@ class RatioTile(Layout):
             win.hide()
             return
         x, y, w, h = self.layout_info[idx]
-        if win is self.focused:
+        if win.has_focus:
             bc = self.group.qtile.colorPixel(self.border_focus)
         else:
             bc = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -291,7 +291,7 @@ class Stack(Layout):
             client.hide()
             return
 
-        if client is self.group.currentWindow:
+        if client.has_focus:
             px = self.group.qtile.colorPixel(self.border_focus)
         else:
             px = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -186,7 +186,7 @@ class Tile(Layout):
                 h = screenHeight // (len(self.slave_windows))
                 x = screen.x + int(screenWidth * self.ratio)
                 y = screen.y + self.clients[self.master:].index(client) * h
-            if client is self.focused:
+            if client.has_focus:
                 bc = self.group.qtile.colorPixel(self.border_focus)
             else:
                 bc = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -149,7 +149,7 @@ class VerticalTile(Layout):
             else:
                 border_width = 0
 
-            if window is self.focused:
+            if window.has_focus:
                 border_color = self.group.qtile.colorPixel(self.border_focus)
             else:
                 border_color = self.group.qtile.colorPixel(self.border_normal)

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -296,9 +296,14 @@ class MonadTall(Layout):
             client.hide()
             return
 
+        # determine focus border-color
+        if client.has_focus:
+            px = self.group.qtile.colorPixel(self.border_focus)
+        else:
+            px = self.group.qtile.colorPixel(self.border_normal)
+
         # single client - fullscreen
         if len(self.clients) == 1:
-            px = self.group.qtile.colorPixel(self.border_focus)
             client.place(
                 self.group.screen.dx,
                 self.group.screen.dy,
@@ -312,12 +317,6 @@ class MonadTall(Layout):
             return
 
         cidx = self.clients.index(client)
-
-        # determine focus border-color
-        if cidx == self.focused:
-            px = self.group.qtile.colorPixel(self.border_focus)
-        else:
-            px = self.group.qtile.colorPixel(self.border_normal)
 
         # calculate main/secondary column widths
         width_main = int(self.group.screen.dwidth * self.ratio)

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -1092,6 +1092,7 @@ class Qtile(command.CommandObject):
         self.currentScreen = self.screens[n]
         if old != self.currentScreen:
             hook.fire("current_screen_change")
+            old.group.layoutAll()
             self.currentGroup.focus(self.currentWindow, warp)
 
     def moveToGroup(self, group):

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -240,6 +240,10 @@ class _Window(command.CommandObject):
         fget=_float_getter("height")
     )
 
+    @property
+    def has_focus(self):
+        return self == self.qtile.currentWindow
+
     def updateName(self):
         try:
             self.name = self.window.get_name()


### PR DESCRIPTION
Currently, whichever window is considered 'active' by the layout of each screen uses the `border_focus` property for the border colour. That makes it difficult to see which window is truly focused (i.e: the one that will process input) when you have multiple screens.

This PR adds a read-only property `has_focus` to windows to check if it is the one and only focused window, and adjusts most layouts (see below) to use that to select `border_focus` or `border_normal`.

This requires a re-layout of the previous screen when switching screens to update the border colours on the previous screen, so that is included in this PR.

Note that I skipped the `wmii` layout for now because it uses a third border colour and I don't know how these colours should represent the state of the layout (or even what the layout does).