### PR TITLE
MonadTall: Add option to place new windows at position of active window.

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -159,6 +159,7 @@ class MonadTall(Layout):
             "(one of ``MonadTall._left`` or ``MonadTall._right``)"),
         ("change_ratio", .05, "Resize ratio"),
         ("change_size", 20, "Resize change in pixels"),
+        ("new_at_current", False, "Place new windows at the position of the active window."),
     ]
 
     def __init__(self, **config):
@@ -209,7 +210,8 @@ class MonadTall(Layout):
 
     def add(self, client):
         "Add client to layout"
-        self.clients.insert(self.focused + 1, client)
+        new_index = self.focused + (0 if self.new_at_current else 1)
+        self.clients.insert(new_index, client)
         self.do_normalize = True
 
     def remove(self, client):


### PR DESCRIPTION
This PR adds an option `new_at_current` for the `MonadTall` layout, which if set to `True` will place new windows at the location of the currently active window. This mimics the actual behaviour of xmonads tall layout. The current behaviour is to place the window at the next position after the current window.

The default behaviour remains unchanged. The default could be changed to be more in line with xmonads Tall layout, but I opted for the path of minimal change.

If someone has a better name than `new_at_current` I'm all ears.