### PR TITLE
Added patch to discover resources during build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
 import sys
 import textwrap
 
@@ -143,7 +144,12 @@ setup(
               'libqtile.widget',
               'libqtile.resources'
               ],
-    package_data={'libqtile.resources': ['battery-icons/*.png']},
+    package_data={'libqtile.resources': [
+        '{}/*'.format(item)
+        for item
+        in os.listdir('libqtile/resources')
+        if os.path.isdir(os.path.join('libqtile/resources', item))
+    ]},
     entry_points={
         'console_scripts': [
             'qtile = libqtile.scripts.qtile:main',


### PR DESCRIPTION
I noticed a bug when installing `qtile` on a different machine: `setup.py` wasn't properly including the `layout-icons` dir into `resources` dir during build.

So I've made this small fix to discover existing dirs & avoid this issue in future if someone forgets to add his resources into `setup.py`.

Although I prefer having such things hard-coded and don't like having this sort of "magic" discovery code, but I feel like this one is still gonna save someone's time in the future.