### PR TITLE
Fix BatteryIcon widget for python3

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -341,7 +341,8 @@ class BatteryIcon(_Battery):
 
             width = input_width / sp
             if width > self.length:
-                self.length = int(width) + self.actual_padding * 2
+                # cast to `int` only after handling all potentially-float values
+                self.length = int(width + self.actual_padding * 2)
 
             imgpat = cairocffi.SurfacePattern(img)
 


### PR DESCRIPTION
self.actual_padding is calculated as self.fontsize/2 unless set.
Since python3, `/` operator always produces `float`.
As a result, `self.length` for battery widget was set to `float`.

This fix casts it to integer, thus avoiding this error
(which is repeated multiple times):

2016-12-12 08:07:54,091 libqtile manager.py:<lambda>():L261  Got an exception in poll loop
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/events.py", line 125, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.5/site-packages/libqtile/manager.py", line 1157, in f
    func(*args)
  File "/usr/lib/python3.5/site-packages/libqtile/widget/battery.py", line 283, in timer_setup
    self.update()
  File "/usr/lib/python3.5/site-packages/libqtile/widget/battery.py", line 316, in update
    self.draw()
  File "/usr/lib/python3.5/site-packages/libqtile/widget/battery.py", line 323, in draw
    self.drawer.draw(offsetx=self.offset, width=self.length)
  File "/usr/lib/python3.5/site-packages/libqtile/drawer.py", line 315, in draw
    self.height if height is None else height
  File "/usr/lib/python3.5/site-packages/xcffib/xproto.py", line 2794, in CopyArea
    buf.write(struct.pack("=xx2xIIIhhhhHH", src_drawable, dst_drawable, gc, src_x, src_y, dst_x, dst_y, width, height))
struct.error: required argument is not an intege