### PR TITLE
xcbq: decode WM_NAME as a UTF8 string

### DIFF
--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -455,7 +455,7 @@ class Window(object):
             xcffib.xproto.GetPropertyType.Any
         )
         if r:
-            return self._propertyString(r)
+            return self._propertyUTF8(r)
 
     def get_wm_hints(self):
         r = self.get_property("WM_HINTS", xcffib.xproto.GetPropertyType.Any)

--- a/libqtile/xcbq.py
+++ b/libqtile/xcbq.py
@@ -450,12 +450,16 @@ class Window(object):
         if r:
             return self._propertyUTF8(r)
 
+        r = self.get_property(xcffib.xproto.Atom.WM_NAME, "UTF8_STRING")
+        if r:
+            return self._propertyUTF8(r)
+
         r = self.get_property(
             xcffib.xproto.Atom.WM_NAME,
             xcffib.xproto.GetPropertyType.Any
         )
         if r:
-            return self._propertyUTF8(r)
+            return self._propertyString(r)
 
     def get_wm_hints(self):
         r = self.get_property("WM_HINTS", xcffib.xproto.GetPropertyType.Any)


### PR DESCRIPTION
Fixes unicode in titles in apps like steam, which doesn't have the other properties like _NET_WM_NAME.

_propertyString() decodes as latin1 by default. This was probably left like this because it was a rarely reached path.