### PR TITLE
qshell path reference / tab completion improvements

### DIFF
--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -125,11 +125,11 @@ def test_complete(qtile):
         "critical",
     ]
 
-    assert qtile.sh._complete("cd l", "l") == ["layout"]
+    assert qtile.sh._complete("cd l", "l") == ["layout/"]
     assert qtile.sh._complete("cd layout/", "layout/") == [
         "layout/" + x for x in ["group", "window", "screen", "0"]
     ]
-    assert qtile.sh._complete("cd layout/", "layout/g") == ["layout/group"]
+    assert qtile.sh._complete("cd layout/", "layout/g") == ["layout/group/"]
 
 
 @sh_config


### PR DESCRIPTION
- Allow root-relative paths
- Actually use the argument passed to ls
- Add a slash when there's only one cd tab completion suggestion to
continue tab completing inner paths