### PR TITLE
Tasklist: task names may consume as much space as available

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -63,6 +63,13 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             "hints (one of 'border' or 'text')"
         ),
         (
+            "unfocused_border",
+            None,
+            "Border color for unfocused windows. "
+            "Affects only hightlight_method 'border' and 'block'. "
+            "Defaults to None, which means no special color."
+        ),
+        (
             "max_title_width",
             None,
             "Max size in pixels of task title."
@@ -322,7 +329,8 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
                 border = self.border
                 text_color = border
             else:
-                border = self.background or self.bar.background
+                border = self.unfocused_border or (self.background or
+                                                   self.bar.background)
                 text_color = self.foreground
 
             if self.highlight_method == 'text':

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -134,7 +134,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         # calculated width for each task according to icon and task name
         # consisting of state abbreviation and window name
         width_boxes = [(self.box_width(names[idx]) +
-                        ((self.icon_size+self.padding_x) if icons[idx] else 0))
+                        ((self.icon_size + self.padding_x) if icons[idx] else 0))
                        for idx in range(window_count)]
         width_sum = sum(width_boxes)
 
@@ -146,14 +146,15 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             ratio = ((width_widget - width_shorter_sum) /
                      (width_sum - width_shorter_sum))
             # determine new box widths by shrinking boxes greater than avg
-            width_boxes = [(w if w < width_avg else w*ratio)
+            width_boxes = [(w if w < width_avg else w * ratio)
                            for w in width_boxes]
 
         return zip(windows, icons, names, width_boxes)
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
-        self.icon_size = self.bar.height - (self.borderwidth + 2) * 2
+        self.icon_size = self.bar.height - 2 * (self.borderwidth +
+                                                self.margin_y)
 
         if self.fontsize is None:
             calc = self.bar.height - self.margin_y * 2 - \
@@ -314,8 +315,8 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             else:
                 text_color = self.foreground
 
-            textwidth = (bw - self.margin_x * 2 - self.padding_x*2 -
-                         ((self.icon_size+self.padding_x) if icon else 0))
+            textwidth = (bw - 2 * (self.margin_x + self.padding_x) -
+                         ((self.icon_size + self.padding_x) if icon else 0))
             self.drawbox(
                 self.margin_x + offset,
                 task,

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -97,8 +97,6 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             self.fontsize
         )
         width = width + 2 * (self.padding_x + self.borderwidth)
-        if (self.max_title_width is not None):
-            width = max(width, self.max_title_width)
         return width
 
     def get_taskname(self, window):
@@ -133,7 +131,6 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             return []
 
         # Determine available and max average width for task name boxes.
-        # If a max_title_width is given, obey it as max average width
         width_total = (self.width - 2 * self.margin_x -
                        (window_count - 1) * self.spacing)
         width_avg = width_total / window_count
@@ -143,11 +140,15 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
         # calculated width for each task according to icon and task name
         # consisting of state abbreviation and window name
+        # Obey max_title_width if specified
         width_boxes = [(self.box_width(names[idx]) +
                         ((self.icon_size + self.padding_x) if icons[idx] else 0))
                        for idx in range(window_count)]
+        if self.max_title_width:
+            width_boxes = [min(w, self.max_title_width) for w in width_boxes]
         width_sum = sum(width_boxes)
 
+        # calculated box width are to wide for available widget space:
         if width_sum > width_total:
             # sum the width of tasks shorter than calculated average
             # and calculate a ratio to shrink boxes greater than width_avg

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -118,7 +118,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         elif window.minimized:
             state = '\U0001F5D5 '  # minimize character
         elif window.maximized:
-            state = '\u0001F5d6 '  # maximize character
+            state = '\U0001F5d6 '  # maximize character
         elif window.floating:
             state = '\U0001F5D7 '  # overlap character
 


### PR DESCRIPTION
Allows task names in `TaskList` widget to consume as much space as is available to the widget.
And on the other hand shrink task name boxes such that all tasks can be displayed.

Since the TaskList is a stretch widget, there may be more space available than the initial `max_title_width` and task names may also contain useful information which may get truncated otherwise. 
If the available space is not sufficient, only task names wider than the average box width are shortened.
See screenshots below for clarification.

This pull request also
- adds a `spacing` widget argument to be used for spacing between task names (instead of margin_x), like for the GroupBox widget.
- adds an `unfocused_border` widget argument for defining a color for unfocused tasks, used with highlight_method 'border' or 'block'.
- changed default of `max_title_width` to None. However, if it is defined, it is obeyed such as before.
Setting `max_title_width` should lead to the same behaviour as without these changes.
- changed window state characters to some special unicode characters. Mainly 'V' for floating gets the 'overlap' character: '🗗'.

If enough space is available all tasks are displayed to its full extend.
![tasklist1](https://cloud.githubusercontent.com/assets/25911123/23592404/9aa74ea2-0200-11e7-8122-d02cb92c6483.png)

If not enough space is available, boxes wider than the computed average are shortened percentually
![tasklist2](https://cloud.githubusercontent.com/assets/25911123/23592409/b29c0106-0200-11e7-91bd-da90cfcc7da9.png)
![tasklist3](https://cloud.githubusercontent.com/assets/25911123/23592410/b7f3a140-0200-11e7-87d9-e6a7d7f7b70c.png)

However, if all task names are wider than the average,
and there are many short task names and few long ones,
the percentually shrinking currently leads to following unexpected (and unwanted) behaviour:
![tasklist4](https://cloud.githubusercontent.com/assets/25911123/23592414/bd61f212-0200-11e7-9cde-c68482b23824.png)
