### PR TITLE
Add {posargs} to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     pip install -r {toxinidir}/requirements.in
     # build pangocffi module
     bash -c "python -c 'import cffi, sys; sys.exit(cffi.__version_info__[0])' || python {toxinidir}/libqtile/ffi_build.py"
-    py.test --cov libqtile --cov-report term-missing
+    py.test --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
This lets us pass arguments to pytest while using tox.
http://tox.readthedocs.io/en/latest/example/general.html

e.g., we can run just some of the tests:
    tox -e py36 -- -x test/test_manager.py