### PR TITLE
Restructure extensions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 qtile next_version:
-    !!! extention subpackage renamed to extension !!!
-    !!! extentions option renamed to extensions !!!
+    !!! Completely changed extension configuration, see the documentation !!!
+    !!! `extention` subpackage renamed to `extension` !!!
+    !!! `extentions` configuration variable changed to `extension_defaults` !!!
+    * features
+        - new RunCommand extension
 
 qtile 0.10.7, released 2017-02-14:
     * features

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ qtile next_version:
     !!! `extention` subpackage renamed to `extension` !!!
     !!! `extentions` configuration variable changed to `extension_defaults` !!!
     * features
-        - new RunCommand extension
+        - new RunCommand and J4DmenuDesktop extensions
 
 qtile 0.10.7, released 2017-02-14:
     * features

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -122,8 +122,10 @@ configuration variables that control specific aspects of Qtile's behavior:
       - {}
       - TODO
     * - floating_layout
-      - layout.Floating()
+      - layout.Floating(float_rules=[...])
       - TODO
+
+        See the configuration file for the default `float_rules`.
     * - focus_on_window_activation
       - smart
       - Behavior of the _NET_ACTIVATE_WINDOW message sent by applications
@@ -141,8 +143,8 @@ configuration variables that control specific aspects of Qtile's behavior:
       - None
       - TODO
     * - widget_defaults
-      - dict(font='Arial',
-             fontsize=16,
+      - dict(font='sans',
+             fontsize=12,
              padding=3)
       - TODO
     * - wmname

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -118,9 +118,9 @@ configuration variables that control specific aspects of Qtile's behavior:
     * - dgroups_app_rules
       - []
       - TODO
-    * - extensions
-      - {}
-      - TODO
+    * - extension_defaults
+      - same as `widget_defaults`
+      - Default settings for extensions.
     * - floating_layout
       - layout.Floating(float_rules=[...])
       - TODO
@@ -146,7 +146,7 @@ configuration variables that control specific aspects of Qtile's behavior:
       - dict(font='sans',
              fontsize=12,
              padding=3)
-      - TODO
+      - Default settings for bar widgets.
     * - wmname
       - "LG3D"
       - TODO

--- a/docs/manual/ref/extensions.rst
+++ b/docs/manual/ref/extensions.rst
@@ -4,11 +4,6 @@
 Built-in Extensions
 ===================
 
-.. qtile_class:: libqtile.extension.dmenu.Dmenu
-    :no-commands:
-
-.. qtile_class:: libqtile.extension.dmenu.DmenuRun
-    :no-commands:
-
-.. qtile_class:: libqtile.extension.window_list.WindowList
+.. qtile_module:: libqtile.extension
+    :baseclass: libqtile.extension.base._Extension
     :no-commands:

--- a/libqtile/configurable.py
+++ b/libqtile/configurable.py
@@ -23,15 +23,19 @@ class Configurable(object):
     global_defaults = {}
 
     def __init__(self, **config):
-        self._widget_defaults = {}
+        self._variable_defaults = {}
         self._user_config = config
 
     def add_defaults(self, defaults):
         """Add defaults to this object, overwriting any which already exist"""
-        self._widget_defaults.update(dict((d[0], d[1]) for d in defaults))
+        # TODO: Ensure that d[1] is an immutable object? Otherwise an instance
+        #       of this class could modify it also for all the other instances;
+        #       if d[1] is a mutable object, perhaps fail or create a (shallow)
+        #       copy, e.g. list(d[1]) in case of lists
+        self._variable_defaults.update(dict((d[0], d[1]) for d in defaults))
 
     def __getattr__(self, name):
-        if name == "_widget_defaults":
+        if name == "_variable_defaults":
             raise AttributeError
         found, value = self._find_default(name)
         if found:
@@ -43,7 +47,7 @@ class Configurable(object):
 
     def _find_default(self, name):
         """Returns a tuple (found, value)"""
-        defaults = self._widget_defaults.copy()
+        defaults = self._variable_defaults.copy()
         defaults.update(self.global_defaults)
         defaults.update(self._user_config)
         if name in defaults:

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -26,6 +26,7 @@
 import os
 import sys
 import traceback
+import warnings
 
 from libqtile.log_utils import logger
 
@@ -88,16 +89,38 @@ class File(object):
             "main",
             "auto_fullscreen",
             "widget_defaults",
+            "extension_defaults",
             "bring_front_click",
             "wmname",
-            "extensions",
         ]
 
-        # Keep supporting the deprecated misspelled option "extentions"
+        extension_defaults = {}
+
+        # Keep supporting the deprecated 'extentions' option
         # TODO: Remove in the future
-        if hasattr(config, "extentions") and not hasattr(config, "extensions"):
-            config.extensions = config.extentions
-            delattr(config, "extentions")
+        if hasattr(config, "extentions"):
+            warnings.warn("'extentions' is deprecated, use "
+                          "'extension_defaults'", DeprecationWarning)
+            # 'dmenu' was the only supported key when the 'extentions' option
+            # was deprecated
+            extension_defaults.update(config.extentions.get('dmenu', {}))
+            del config.extentions
+
+        # Keep supporting the deprecated 'extensions' option
+        # TODO: Remove in the future
+        if hasattr(config, "extensions"):
+            warnings.warn("'extensions' is deprecated, use "
+                          "'extension_defaults'", DeprecationWarning)
+            # 'dmenu' was the only supported key when the 'extensions' option
+            # was deprecated
+            extension_defaults.update(config.extensions.get('dmenu', {}))
+            del config.extensions
+
+        if hasattr(config, "extension_defaults"):
+            # extension_defaults should override the deprecated variables
+            extension_defaults.update(config.extension_defaults)
+
+        config.extension_defaults = extension_defaults
 
         for option in config_options:
             if hasattr(config, option):

--- a/libqtile/extension/__init__.py
+++ b/libqtile/extension/__init__.py
@@ -25,5 +25,6 @@ def safe_import(module_name, class_name):
     safe_import_((".extension", module_name), class_name, globals())
 
 
+safe_import("base", "RunCommand")
 safe_import("dmenu", ["Dmenu", "DmenuRun"])
 safe_import("window_list", "WindowList")

--- a/libqtile/extension/__init__.py
+++ b/libqtile/extension/__init__.py
@@ -18,5 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .dmenu import Dmenu, DmenuRun      # noqa
-from .window_list import WindowList     # noqa
+from ..utils import safe_import as safe_import_
+
+
+def safe_import(module_name, class_name):
+    safe_import_((".extension", module_name), class_name, globals())
+
+
+safe_import("dmenu", ["Dmenu", "DmenuRun"])
+safe_import("window_list", "WindowList")

--- a/libqtile/extension/__init__.py
+++ b/libqtile/extension/__init__.py
@@ -26,5 +26,5 @@ def safe_import(module_name, class_name):
 
 
 safe_import("base", "RunCommand")
-safe_import("dmenu", ["Dmenu", "DmenuRun"])
+safe_import("dmenu", ["Dmenu", "DmenuRun", "J4DmenuDesktop"])
 safe_import("window_list", "WindowList")

--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2017 Dario Giovannetti
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import shlex
+from subprocess import Popen, PIPE
+from .. import configurable
+
+
+class _Extension(configurable.Configurable):
+    """Base Extension class"""
+
+    installed_extensions = []
+
+    defaults = [
+        ("font", "sans", "defines the font name to be used"),
+        ("fontsize", None, "defines the font size to be used"),
+        ("background", None, "defines the normal background color"),
+        ("foreground", None, "defines the normal foreground color"),
+        ("selected_background", None, "defines the selected background color"),
+        ("selected_foreground", None, "defines the selected foreground color"),
+    ]
+
+    def __init__(self, **config):
+        configurable.Configurable.__init__(self, **config)
+        self.add_defaults(_Extension.defaults)
+        _Extension.installed_extensions.append(self)
+
+    def _configure(self, qtile):
+        self.qtile = qtile
+
+    def run(self):
+        """
+        This method must be implemented by the subclasses.
+        """
+        raise NotImplementedError()
+
+
+class RunCommand(_Extension):
+    """
+    Run an arbitrary command.
+
+    Mostly useful as a superclass for more specific extensions that need to
+    interact with the qtile object.
+
+    Also consider simply using lazy.spawn() or writing a
+    `client <http://docs.qtile.org/en/latest/manual/commands/scripting.html>`_.
+    """
+    defaults = [
+        # NOTE: Do not use a list as a default value, since it would be shared
+        #       among all the objects inheriting this class, and if one of them
+        #       modified it, all the other objects would see the modified list;
+        #       use a string or a tuple instead, which are immutable
+        ("command", None, "the command to be launched (string or list with arguments)"),
+    ]
+
+    def __init__(self, **config):
+        _Extension.__init__(self, **config)
+        self.add_defaults(RunCommand.defaults)
+
+    def _configure(self, qtile):
+        _Extension._configure(self, qtile)
+
+    def run(self):
+        """
+        An extension can inherit this class, define configured_command and use
+        the process object by overriding this method and using super():
+
+        .. code-block:: python
+
+            def _configure(self, qtile):
+                Superclass._configure(self, qtile)
+                self.configured_command = "foo --bar"
+
+            def run(self):
+                process = super(Subclass, self).run()
+        """
+        if self.configured_command:
+            if isinstance(self.configured_command, str):
+                self.configured_command = shlex.split(self.configured_command)
+            # Else assume that self.configured_command is already a sequence
+        else:
+            self.configured_command = self.command
+        return Popen(self.configured_command, stdout=PIPE, stdin=PIPE)

--- a/libqtile/extension/dmenu.py
+++ b/libqtile/extension/dmenu.py
@@ -138,3 +138,40 @@ class DmenuRun(Dmenu):
 
     def _configure(self, qtile):
         Dmenu._configure(self, qtile)
+
+
+class J4DmenuDesktop(Dmenu):
+    """
+    Python wrapper for j4-dmenu-desktop
+    https://github.com/enkore/j4-dmenu-desktop
+    """
+
+    defaults = [
+        ("j4dmenu_command", 'j4-dmenu-desktop', "the dmenu command to be launched"),
+        ("j4dmenu_use_xdg_de", False, "read $XDG_CURRENT_DESKTOP to determine the desktop environment"),
+        ("j4dmenu_display_binary", False, "display binary name after each entry"),
+        ("j4dmenu_generic", True, "include the generic name of desktop entries"),
+        ("j4dmenu_terminal", None, "terminal emulator used to start terminal apps"),
+        ("j4dmenu_usage_log", None, "file used to sort items by usage frequency"),
+    ]
+
+    def __init__(self, **config):
+        Dmenu.__init__(self, **config)
+        self.add_defaults(J4DmenuDesktop.defaults)
+
+    def _configure(self, qtile):
+        Dmenu._configure(self, qtile)
+
+        self.configured_command = [self.j4dmenu_command, '--dmenu',
+                                   " ".join(shlex.quote(arg) for arg in self.configured_command)]
+        if self.j4dmenu_use_xdg_de:
+            self.configured_command.append("--use-xdg-de")
+        if self.j4dmenu_display_binary:
+            self.configured_command.append("--display-binary")
+        if not self.j4dmenu_generic:
+            self.configured_command.append("--no-generic")
+        if self.j4dmenu_terminal:
+            self.configured_command.extend(("--term", self.j4dmenu_terminal))
+        if self.j4dmenu_usage_log:
+            self.configured_command.extend(("--usage-log",
+                                            self.j4dmenu_usage_log))

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -22,21 +22,21 @@ import re
 
 from .dmenu import Dmenu
 
-class WindowList():
+class WindowList(Dmenu):
     """
     Give vertical list of all open windows in dmenu. Switch to selected.
     """
-    config = {}
-    qtile = None
-    wins = []
-    id_map = {}
 
-    def __init__(self, qtile):
-        self.qtile = qtile
-        if hasattr(qtile.config, 'extensions') and qtile.config.extensions['dmenu']:
-            self.config = qtile.config.extensions['dmenu']
+    defaults = []
 
-    def get_windows(self):
+    def __init__(self, **config):
+        Dmenu.__init__(self, **config)
+        self.add_defaults(WindowList.defaults)
+
+    def _configure(self, qtile):
+        Dmenu._configure(self, qtile)
+
+    def list_windows(self):
         id = 0
         self.wins = []
         self.id_map = {}
@@ -44,15 +44,11 @@ class WindowList():
             if win.group:
                 self.wins.append("%i: %s (%s)" % (id, win.name, win.group.name))
                 self.id_map[id] = win
-                id = id + 1
-
-        return id
+                id += 1
 
     def run(self):
-        win_count = self.get_windows()
-        config_tmp = self.config
-        dmenu = Dmenu(config_tmp, win_count)
-        out = dmenu.call(self.wins)
+        self.list_windows()
+        out = super(WindowList, self).run(items=self.wins)
         if not out:
             return
 

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -27,7 +27,9 @@ class WindowList(Dmenu):
     Give vertical list of all open windows in dmenu. Switch to selected.
     """
 
-    defaults = []
+    defaults = [
+        ("item_format", "{group}.{id}: {window}", "the format for the menu items"),
+    ]
 
     def __init__(self, **config):
         Dmenu.__init__(self, **config)
@@ -42,7 +44,8 @@ class WindowList(Dmenu):
         self.id_map = {}
         for win in self.qtile.windowMap.values():
             if win.group:
-                self.wins.append("%i: %s (%s)" % (id, win.name, win.group.name))
+                self.wins.append(self.item_format.format(
+                    group=win.group.name, id=id, window=win.name))
                 self.id_map[id] = win
                 id += 1
 

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -328,7 +328,7 @@ class TreeTab(Layout):
         ("border_width", 2, "Width of the border"),
         ("vspace", 2, "Space between tabs"),
         ("level_shift", 8, "Shift for children tabs"),
-        ("font", "Arial", "Font"),
+        ("font", "sans", "Font"),
         ("fontsize", 14, "Font pixel size."),
         ("fontshadow", None, "font shadow color, default is None (no shadow)"),
         ("section_fontsize", 11, "Font pixel size of section label"),

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -98,7 +98,7 @@ class VerticalTile(_SimpleLayoutBase):
 
     def __init__(self, **config):
         _SimpleLayoutBase.__init__(self, **config)
-        self.add_defaults(self.defaults)
+        self.add_defaults(VerticalTile.defaults)
         self.maximized = None
 
     def add(self, window):

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -82,6 +82,7 @@ widget_defaults = dict(
     fontsize=12,
     padding=3,
 )
+extension_defaults = widget_defaults.copy()
 
 screens = [
     Screen(
@@ -132,7 +133,6 @@ floating_layout = layout.Floating(float_rules=[
 ])
 auto_fullscreen = True
 focus_on_window_activation = "smart"
-extensions = {}
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -20,82 +20,60 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import traceback
-import importlib
-
-from libqtile.log_utils import logger
+from ..utils import safe_import as safe_import_
 
 
 def safe_import(module_name, class_name):
-    """
-    try to import a module, and if it fails because an ImporError
-    it logs on WARNING, and logs the traceback on DEBUG level
-    """
-    if type(class_name) is list:
-        for name in class_name:
-            safe_import(module_name, name)
-        return
-    package = __package__
-    # TODO: remove when we really want to drop 3.2 support
-    # python 3.2 don't set __package__
-    if not package:
-        package = __name__
-    try:
-        module = importlib.import_module(module_name, package)
-        globals()[class_name] = getattr(module, class_name)
-    except ImportError as error:
-        logger.warning("Unmet dependencies for optional Widget: '%s.%s', %s",
-                       module_name, class_name, error)
-        logger.debug("%s", traceback.format_exc())
+    safe_import_((".widget", module_name), class_name, globals())
 
 
-safe_import(".backlight", "Backlight")
-safe_import(".battery", ["Battery", "BatteryIcon"])
-safe_import(".clock", "Clock")
-safe_import(".currentlayout", ["CurrentLayout", "CurrentLayoutIcon"])
-safe_import(".currentscreen", "CurrentScreen")
-safe_import(".debuginfo", "DebugInfo")
-safe_import(".graph", ["CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph",
-                       "HDDGraph", "HDDBusyGraph"])
-safe_import(".groupbox", ["AGroupBox", "GroupBox"])
-safe_import(".maildir", "Maildir")
-safe_import(".notify", "Notify")
-safe_import(".prompt", "Prompt")
-safe_import(".sensors", "ThermalSensor")
-safe_import(".sep", "Sep")
-safe_import(".she", "She")
-safe_import(".spacer", "Spacer")
-safe_import(".systray", "Systray")
-safe_import(".textbox", "TextBox")
-safe_import(".generic_poll_text", ["GenPollText", "GenPollUrl"])
-safe_import(".volume", "Volume")
-safe_import(".windowname", "WindowName")
-safe_import(".windowtabs", "WindowTabs")
-safe_import(".keyboardlayout", "KeyboardLayout")
-safe_import(".df", "DF")
-safe_import(".image", "Image")
-safe_import(".gmail_checker", "GmailChecker")
-safe_import(".clipboard", "Clipboard")
-safe_import(".countdown", "Countdown")
-safe_import(".tasklist", "TaskList")
-safe_import(".pacman", "Pacman")
-safe_import(".launchbar", "LaunchBar")
-safe_import(".canto", "Canto")
-safe_import(".mpriswidget", "Mpris")
-safe_import(".mpris2widget", "Mpris2")
-safe_import(".mpdwidget", "Mpd")
-safe_import(".mpd2widget", "Mpd2")
-safe_import(".yahoo_weather", "YahooWeather")
-safe_import(".bitcoin_ticker", "BitcoinTicker")
-safe_import(".wlan", "Wlan")
-safe_import(".khal_calendar", "KhalCalendar")
-safe_import(".imapwidget", "ImapWidget")
-safe_import(".net", "Net")
-safe_import(".keyboardkbdd", "KeyboardKbdd")
-safe_import(".cmus", "Cmus")
-safe_import(".wallpaper", "Wallpaper")
-safe_import(".check_updates", "CheckUpdates")
-safe_import(".moc", "Moc")
-safe_import(".memory", "Memory")
-safe_import(".idlerpg", "IdleRPG")
-safe_import(".pomodoro", "Pomodoro")
+safe_import("backlight", "Backlight")
+safe_import("battery", ["Battery", "BatteryIcon"])
+safe_import("clock", "Clock")
+safe_import("currentlayout", ["CurrentLayout", "CurrentLayoutIcon"])
+safe_import("currentscreen", "CurrentScreen")
+safe_import("debuginfo", "DebugInfo")
+safe_import("graph", ["CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph",
+                      "HDDGraph", "HDDBusyGraph"])
+safe_import("groupbox", ["AGroupBox", "GroupBox"])
+safe_import("maildir", "Maildir")
+safe_import("notify", "Notify")
+safe_import("prompt", "Prompt")
+safe_import("sensors", "ThermalSensor")
+safe_import("sep", "Sep")
+safe_import("she", "She")
+safe_import("spacer", "Spacer")
+safe_import("systray", "Systray")
+safe_import("textbox", "TextBox")
+safe_import("generic_poll_text", ["GenPollText", "GenPollUrl"])
+safe_import("volume", "Volume")
+safe_import("windowname", "WindowName")
+safe_import("windowtabs", "WindowTabs")
+safe_import("keyboardlayout", "KeyboardLayout")
+safe_import("df", "DF")
+safe_import("image", "Image")
+safe_import("gmail_checker", "GmailChecker")
+safe_import("clipboard", "Clipboard")
+safe_import("countdown", "Countdown")
+safe_import("tasklist", "TaskList")
+safe_import("pacman", "Pacman")
+safe_import("launchbar", "LaunchBar")
+safe_import("canto", "Canto")
+safe_import("mpriswidget", "Mpris")
+safe_import("mpris2widget", "Mpris2")
+safe_import("mpdwidget", "Mpd")
+safe_import("mpd2widget", "Mpd2")
+safe_import("yahoo_weather", "YahooWeather")
+safe_import("bitcoin_ticker", "BitcoinTicker")
+safe_import("wlan", "Wlan")
+safe_import("khal_calendar", "KhalCalendar")
+safe_import("imapwidget", "ImapWidget")
+safe_import("net", "Net")
+safe_import("keyboardkbdd", "KeyboardKbdd")
+safe_import("cmus", "Cmus")
+safe_import("wallpaper", "Wallpaper")
+safe_import("check_updates", "CheckUpdates")
+safe_import("moc", "Moc")
+safe_import("memory", "Memory")
+safe_import("idlerpg", "IdleRPG")
+safe_import("pomodoro", "Pomodoro")

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -280,7 +280,7 @@ class _TextBox(_Widget):
     """
     orientations = ORIENTATION_HORIZONTAL
     defaults = [
-        ("font", "Arial", "Default font"),
+        ("font", "sans", "Default font"),
         ("fontsize", None, "Font size. Calculated if None."),
         ("padding", None, "Padding. Calculated if None."),
         ("foreground", "ffffff", "Foreground colour"),

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -49,7 +49,7 @@ class Image(base._Widget, base.MarginMixin):
         self.add_defaults(base.MarginMixin.defaults)
 
         # make the default 0 instead
-        self._widget_defaults["margin"] = 0
+        self._variable_defaults["margin"] = 0
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -59,7 +59,7 @@ class Mpris2(base._TextBox):
 
     def __init__(self, **config):
         base._TextBox.__init__(self, '', **config)
-        self.add_defaults(self.__class__.defaults)
+        self.add_defaults(Mpris2.defaults)
 
         self.scrolltext = None
         self.displaytext = ''

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -38,7 +38,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("font", "Arial", "Default font"),
+        ("font", "sans", "Default font"),
         ("fontsize", None, "Font size. Calculated if None."),
         ("foreground", "ffffff", "Foreground colour"),
         (

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -31,7 +31,7 @@ class TextBox(base._TextBox):
     """A flexible textbox that can be updated from bound keys, scripts, and qshell"""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("font", "Arial", "Text font"),
+        ("font", "sans", "Text font"),
         ("fontsize", None, "Font pixel size. Calculated if None."),
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
         ("padding", None, "Padding left and right. Calculated if None."),

--- a/test/test_configurable.py
+++ b/test/test_configurable.py
@@ -30,7 +30,7 @@ class ConfigurableWithFallback(configurable.Configurable):
 
     def __init__(self, **config):
         configurable.Configurable.__init__(self, **config)
-        self.add_defaults(self.defaults)
+        self.add_defaults(ConfigurableWithFallback.defaults)
 
 
 def test_use_fallback():


### PR DESCRIPTION
This PR restructures extensions and better integrates them into the rest of the code. There are also some other related changes.

Since the way in which extensions are now installed and configured is much different from before, I thought it would be better to inform the users instead of trying to preserve backwards compatibility, however I can add some conversion mechanism if you prefer.

Before the configuration was something like:
```
keys = [Key(["mod4"], 'm', lazy.run_extension(extension.DmenuRun))]
extensions = {
    'dmenu': {...}
}
```
Now extensions share the default configuration with widgets, since integrating and improving the consistency of their appearance is what this is all about I think. I thought I'd rename `widget_defaults` to `extension_defaults` because the name is more generic, and the bar could be restructured as a normal extension in the future, which would be a step forward towards implementing #622. Being a historical option, `widget_defaults` is still supported as an alias to `extension_defaults`. Extensions should now be installed like this:
```
keys = [Key(["mod4"], 'm', lazy.run_extension(extension.DmenuRun(...)))]
extension_defaults = {
    ...
}
```

I've tried to add descriptions to the commits that needed some explanation, please ask questions if something's not clear.