### PR TITLE
mpris2: fix initialization problem

### DIFF
--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -66,6 +66,7 @@ class Mpris2(base._TextBox):
         self.is_playing = False
         self.scroll_timer = None
         self.scroll_counter = None
+        self.dbus_loop = None
 
     def _configure(self, qtile, bar):
         base._TextBox._configure(self, qtile, bar)


### PR DESCRIPTION
Hmm, I don't know why this worked the first time I tested it. Anyway, this
fixes:

[0m[31m2017-03-20 04:11:52,871 [1m[31mlibqtile qtile.py:make_qtile():L119 [0m Qtile crashed during startup
Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/scripts/qtile.py", line 116, in make_qtile
    state=options.state,
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/manager.py", line 175, in __init__
    self._process_screens()
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/manager.py", line 383, in _process_screens
    self.groups[i],
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/config.py", line 268, in _configure
    i._configure(qtile, self)
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/bar.py", line 205, in _configure
    i._configure(qtile, self)
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/widget/mpris2widget.py", line 75, in _configure
    if self.dbus_loop is not None:
  File "/home/tycho/.local/lib/python3.5/site-packages/libqtile/configurable.py", line 42, in __getattr__
    raise AttributeError("%s has no attribute: %s" % (cname, name))
AttributeError: Mpris2 has no attribute: dbus_loop[0m

Signed-off-by: Tycho Andersen <tycho@tycho.ws>