### PR TITLE
Rework of Layout classes to fix window focus cycle.

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -415,6 +415,13 @@ class _Group(command.CommandObject):
         self.layoutAll()
 
     def cmd_next_window(self):
+        """
+        Focus the next window in group.
+
+        Method cycles _all_ windows in group regardless if tiled in current
+        layout or floating. Cycling of tiled and floating windows is not mixed.
+        The cycling order depends on the current Layout.
+        """
         if not self.windows:
             return
         if self.currentWindow.floating:
@@ -428,6 +435,13 @@ class _Group(command.CommandObject):
         self.focus(nxt, True)
 
     def cmd_prev_window(self):
+        """
+        Focus the previous window in group.
+
+        Method cycles _all_ windows in group regardless if tiled in current
+        layout or floating. Cycling of tiled and floating windows is not mixed.
+        The cycling order depends on the current Layout.
+        """
         if not self.windows:
             return
         if self.currentWindow.floating:

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -21,7 +21,6 @@
 
 import copy
 import six
-import _collections_abc
 from abc import ABCMeta, abstractmethod
 
 from .. import command, configurable
@@ -352,7 +351,7 @@ class Delegate(Layout):
         return d
 
 
-class _ClientList(_collections_abc.Sequence):
+class _ClientList(object):
     """
     ClientList maintains a list of clients and a current client.
 

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2008, Aldo Cortesi. All rights reserved.
+# Copyright (c) 2017, Dirk Hartmann.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -17,10 +18,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from .base import SingleWindow
 
+from .base import _SimpleLayoutBase
 
-class Max(SingleWindow):
+class Max(_SimpleLayoutBase):
     """Maximized layout
 
     A simple layout that only displays one window at a time, filling the
@@ -28,90 +29,21 @@ class Max(SingleWindow):
     screens. Conceptually, the windows are managed as a stack, with commands to
     switch to next and previous windows in the stack.
     """
+
     defaults = [("name", "max", "Name of this layout.")]
 
     def __init__(self, **config):
-        SingleWindow.__init__(self, **config)
-        self.clients = []
+        _SimpleLayoutBase.__init__(self, **config)
         self.add_defaults(Max.defaults)
-        self.current = None
-
-    def _get_window(self):
-        return self.current
-
-    def focus(self, client):
-        self.group.layoutAll()
-        self.current = client
-
-    def focus_first(self):
-        if self.clients:
-            return self.clients[0]
-
-    def focus_last(self):
-        if self.clients:
-            return self.clients[-1]
-
-    def focus_next(self, window):
-        if not self.clients:
-            return
-        if window is None:
-            return
-
-        idx = self.clients.index(window)
-        if idx + 1 < len(self.clients):
-            return self.clients[idx + 1]
-
-    def focus_previous(self, window):
-        if not self.clients:
-            return
-        if window is None:
-            return
-
-        idx = self.clients.index(window)
-        if idx > 0:
-            return self.clients[idx - 1]
-
-    def up(self):
-        client = self.focus_previous(self.current) or self.focus_last()
-        self.group.focus(client, False)
-
-    def down(self):
-        client = self.focus_next(self.current) or self.focus_first()
-        self.group.focus(client, False)
 
     def clone(self, group):
-        c = SingleWindow.clone(self, group)
-        c.clients = []
-        return c
+        return _SimpleLayoutBase.clone(self, group)
 
     def add(self, client):
-        try:
-            idx = self.clients.index(self._get_window())
-        except ValueError:
-            self.clients.append(client)
-        else:
-            self.clients.insert(idx + 1, client)
-
-    def remove(self, client):
-        try:
-            idx = self.clients.index(client)
-        except ValueError:
-            return
-        else:
-            del self.clients[idx]
-
-        if client is self.current:
-            try:
-                # The previous client must become current
-                # if idx == 0, using self.clients[-1] is indeed correct
-                self.current = self.clients[idx - 1]
-            except IndexError:
-                self.current = None
-
-        return self.current
+        return self.clients.add(client, 1)
 
     def configure(self, client, screen):
-        if self.clients and client is self.current:
+        if self.clients and client is self.clients.current_client:
             client.place(
                 screen.x,
                 screen.y,
@@ -124,19 +56,8 @@ class Max(SingleWindow):
         else:
             client.hide()
 
-    def info(self):
-        d = SingleWindow.info(self)
-        d["clients"] = [x.name for x in self.clients]
-        return d
+    cmd_previous = _SimpleLayoutBase.previous
+    cmd_next = _SimpleLayoutBase.next
 
-    def cmd_down(self):
-        """Switch down in the window list"""
-        self.down()
-
-    cmd_next = cmd_down
-
-    def cmd_up(self):
-        """Switch up in the window list"""
-        self.up()
-
-    cmd_previous = cmd_up
+    cmd_up = cmd_previous
+    cmd_down = cmd_next

--- a/libqtile/layout/wmii.py
+++ b/libqtile/layout/wmii.py
@@ -97,7 +97,7 @@ class Wmii(Layout):
 
     def info(self):
         d = Layout.info(self)
-        d["current_window"] = self.current_window
+        d["current_window"] = self.current_window.name if self.current_window else None
         d["clients"] = [x.name for x in self.clients]
         return d
 

--- a/libqtile/layout/wmii.py
+++ b/libqtile/layout/wmii.py
@@ -240,12 +240,36 @@ class Wmii(Layout):
         self.group.layoutAll()
 
     def focus_next(self, win):
-        self.cmd_down()
-        return self.curent_window
+        # First: try to get next window in column of win
+        for idx, col in enumerate(self.columns):
+            rows = col['rows']
+            if win in rows:
+                i = rows.index(win)
+                if i + 1 < len(rows):
+                    return rows[i + 1]
+                else:
+                    break
+        # if there was no next, get first client from next column
+        if idx + 1 < len(self.columns):
+            rows = self.columns[idx + 1]['rows']
+            if len(rows):
+                return rows[0]
 
     def focus_previous(self, win):
-        self.cmd_up()
-        return self.current_window
+        # First: try to focus previous client in column
+        for idx, col in enumerate(self.columns):
+            rows = col['rows']
+            if win in rows:
+                i = rows.index(win)
+                if i > 0:
+                    return rows[i - 1]
+                else:
+                    break
+        # If there was no previous, get last from previous column
+        if idx > 0:
+            rows = self.columns[idx + 1]['rows']
+            if len(rows):
+                return rows[-1]
 
     def focus_first(self):
         if len(self.columns) == 0:

--- a/test/layouts/test_matrix.py
+++ b/test/layouts/test_matrix.py
@@ -31,7 +31,7 @@ from libqtile import layout
 import libqtile.manager
 import libqtile.config
 from ..conftest import no_xinerama
-
+from .layout_utils import assertFocused, assertFocusPath
 
 class MatrixConfig(object):
     auto_fullscreen = True
@@ -101,3 +101,25 @@ def test_matrix_add_remove_columns(qtile):
     assert qtile.c.layout.info()["rows"] == [["one", "two", "three"], ["four", "five"]]
     qtile.c.layout.delete()
     assert qtile.c.layout.info()["rows"] == [["one", "two"], ["three", "four"], ["five"]]
+
+
+@matrix_config
+def test_matrix_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'float1','float2','one','two','three' )
+
+    

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -31,7 +31,7 @@ from libqtile import layout
 import libqtile.manager
 import libqtile.config
 from ..conftest import no_xinerama
-
+from .layout_utils import assertFocused, assertFocusPath
 
 class MaxConfig(object):
     auto_fullscreen = True
@@ -189,3 +189,23 @@ def test_closing_notification(qtile):
     assert qtile.c.window.info()['name'] == "two", qtile.c.window.info()['name']
     qtile.kill_window(notification3)
     assert qtile.c.window.info()['name'] == "two", qtile.c.window.info()['name']
+
+
+@max_config
+def test_max_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'float1','float2','one','two','three' )

--- a/test/layouts/test_ratiotile.py
+++ b/test/layouts/test_ratiotile.py
@@ -32,6 +32,7 @@ from libqtile import layout
 import libqtile.manager
 import libqtile.config
 from ..conftest import no_xinerama
+from .layout_utils import assertFocused, assertFocusPath
 
 
 class RatioTileConfig(object):
@@ -192,3 +193,22 @@ def test_ratiotile_basic(qtile):
     assert qtile.c.window.info()['x'] == 532
     assert qtile.c.window.info()['y'] == 0
     assert qtile.c.window.info()['name'] == 'one'
+
+@ratiotile_config
+def test_ratiotile_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions, RatioTile adds clients to head
+    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'two','one','float1','float2','three' )

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -95,13 +95,13 @@ def test_slice_focus(qtile):
     assertFocused(qtile, 'slice')
     assertFocusPath(qtile, 'slice')
     three = qtile.testWindow('three')
-    assertFocusPath(qtile, 'slice', 'three')
+    assertFocusPath(qtile, 'two','one','slice', 'three')
     qtile.kill_window(two)
-    assertFocusPath(qtile, 'slice', 'one')
+    assertFocusPath(qtile, 'one', 'slice', 'three')
     qtile.kill_window(slice)
-    assertFocusPath(qtile, 'one')
+    assertFocusPath(qtile, 'one', 'three')
     slice = qtile.testWindow('slice')
-    assertFocusPath(qtile, 'one', 'slice')
+    assertFocusPath(qtile, 'three', 'one', 'slice')
 
 
 @slice_config

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -31,7 +31,7 @@ from libqtile import layout
 import libqtile.manager
 import libqtile.config
 from ..conftest import no_xinerama
-
+from .layout_utils import assertFocused, assertFocusPath
 
 class StackConfig(object):
     auto_fullscreen = True
@@ -230,3 +230,23 @@ def test_stack_client_to(qtile):
 def test_stack_info(qtile):
     one = qtile.testWindow("one")
     assert qtile.c.layout.info()["stacks"]
+
+@stack_config
+def test_stack_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions, stack adds clients at pos of current
+    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'two','one','float1','float2','three' )
+

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -243,10 +243,10 @@ def test_stack_window_focus_cycle(qtile):
     qtile.testWindow("three")
     
     # test preconditions, stack adds clients at pos of current
-    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    assert qtile.c.layout.info()['clients'] == ['three', 'one','two']
     # last added window has focus
     assertFocused(qtile,"three")
     
     # assert window focus cycle, according to order in layout
-    assertFocusPath(qtile, 'two','one','float1','float2','three' )
+    assertFocusPath(qtile, 'one','two','float1','float2','three' )
 

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -31,7 +31,7 @@ from libqtile import layout
 import libqtile.manager
 import libqtile.config
 from ..conftest import no_xinerama
-
+from .layout_utils import assertFocused, assertFocusPath
 
 class TileConfig(object):
     auto_fullscreen = True
@@ -118,3 +118,23 @@ def test_tile_remove(qtile):
     assert qtile.c.layout.info()["master"] == ["three"]
     qtile.kill_window(three)
     assert qtile.c.layout.info()["master"] == ["two"]
+    
+@tile_config
+def test_tile_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions, Tile adds (by default) clients at pos of current
+    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'two','one','float1','float2','three' )
+

--- a/test/layouts/test_wmii.py
+++ b/test/layouts/test_wmii.py
@@ -1,11 +1,3 @@
-# Copyright (c) 2011 Florian Mounier
-# Copyright (c) 2012, 2014-2015 Tycho Andersen
-# Copyright (c) 2013 Mattias Svala
-# Copyright (c) 2013 Craig Barnes
-# Copyright (c) 2014 ramnes
-# Copyright (c) 2014 Sean Vig
-# Copyright (c) 2014 Adi Sieker
-# Copyright (c) 2014 Chris Wesseling
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,12 +22,10 @@ import pytest
 from libqtile import layout
 import libqtile.manager
 import libqtile.config
-from .layout_utils import assertDimensions
 from ..conftest import no_xinerama
 from .layout_utils import assertFocused, assertFocusPath
 
-
-class VerticalTileConfig(object):
+class WmiiConfig(object):
     auto_fullscreen = True
     main = None
     groups = [
@@ -45,40 +35,22 @@ class VerticalTileConfig(object):
         libqtile.config.Group("d")
     ]
     layouts = [
-        layout.VerticalTile(columns=2)
+        layout.Wmii(),
     ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = []
     mouse = []
     screens = []
+    follow_mouse_focus = False
 
 
-verticaltile_config = lambda x: \
-    no_xinerama(pytest.mark.parametrize("qtile", [VerticalTileConfig], indirect=True)(x))
+wmii_config = lambda x: \
+    no_xinerama(pytest.mark.parametrize("qtile", [WmiiConfig], indirect=True)(x))
 
+# This currently only tests the window focus cycle
 
-@verticaltile_config
-def test_verticaltile_simple(qtile):
-    qtile.testWindow("one")
-    assertDimensions(qtile, 0, 0, 800, 600)
-    qtile.testWindow("two")
-    assertDimensions(qtile, 0, 300, 798, 298)
-    qtile.testWindow("three")
-    assertDimensions(qtile, 0, 400, 798, 198)
-
-
-@verticaltile_config
-def test_verticaltile_maximize(qtile):
-    qtile.testWindow("one")
-    assertDimensions(qtile, 0, 0, 800, 600)
-    qtile.testWindow("two")
-    assertDimensions(qtile, 0, 300, 798, 298)
-    # Maximize the bottom layout, taking 75% of space
-    qtile.c.layout.maximize()
-    assertDimensions(qtile, 0, 150, 798, 448)
-    
-@verticaltile_config
-def test_verticaltile_window_focus_cycle(qtile):
+@wmii_config
+def test_wmii_window_focus_cycle(qtile):
     # setup 3 tiled and two floating clients
     qtile.testWindow("one")
     qtile.testWindow("two")
@@ -95,3 +67,4 @@ def test_verticaltile_window_focus_cycle(qtile):
     
     # assert window focus cycle, according to order in layout
     assertFocusPath(qtile, 'float1','float2','one','two','three' )
+

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -23,9 +23,8 @@ import pytest
 from libqtile import layout
 import libqtile.manager
 import libqtile.config
-from .layout_utils import assertDimensions, assertFocused
+from .layout_utils import assertDimensions, assertFocused, assertFocusPath
 from ..conftest import no_xinerama
-
 
 class MonadTallConfig(object):
     auto_fullscreen = True
@@ -598,3 +597,45 @@ def test_wide_swap(qtile):
     qtile.c.layout.swap_main()
     assert qtile.c.layout.info()['main'] == 'focused'
     assert qtile.c.layout.info()['secondary'] == ['three', 'two', 'one']
+    
+
+@monadtall_config
+def test_tall_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # starting from the last tiled client, we first cycle through floating ones,
+    # and afterwards through the tiled
+    assertFocusPath(qtile, 'float1','float2','one','two','three' )
+
+
+@monadwide_config
+def test_wide_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'float1','float2','one','two','three' )
+

--- a/test/layouts/test_zoomy.py
+++ b/test/layouts/test_zoomy.py
@@ -30,7 +30,7 @@ import pytest
 from libqtile import layout
 import libqtile.manager
 import libqtile.config
-from .layout_utils import assertDimensions, assertFocusPath
+from .layout_utils import assertDimensions, assertFocused, assertFocusPath
 from ..conftest import no_xinerama
 
 
@@ -63,3 +63,22 @@ def test_zoomy_one(qtile):
     assertDimensions(qtile, 0, 0, 600, 600)
     assertFocusPath(qtile, 'two', 'one', 'three')
     # TODO(pc) find a way to check size of inactive windows
+
+@zoomy_config
+def test_zoomy_window_focus_cycle(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.testWindow("one")
+    qtile.testWindow("two")
+    qtile.testWindow("float1")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("float2")
+    qtile.c.window.toggle_floating()
+    qtile.testWindow("three")
+    
+    # test preconditions, Zoomy adds clients at head
+    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    # last added window has focus
+    assertFocused(qtile,"three")
+    
+    # assert window focus cycle, according to order in layout
+    assertFocusPath(qtile, 'two','one','float1','float2','three' )

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -342,7 +342,7 @@ def test_float_outside_edges(qtile):
     assert qtile.c.window.info()['y'] == 0
     # empty because window is floating
     assert qtile.c.layout.info() == {
-        'clients': [], 'group': 'a', 'name': 'max'}
+        'clients': [], 'current' : 0, 'group': 'a', 'name': 'max'}
 
     # move left, but some still on screen 0
     qtile.c.window.move_floating(-30, 20, 42, 42)


### PR DESCRIPTION
This PR refactors common code of layouts to two new classes in 'libqtile/layout/base'.
This PR fixes #1023.

During fixing I saw a lot of similar or even copied code, thus I tried to rework that common code, adding two new base classes `ClientList` and `SimpleLayoutBase`.
'ClientList' is all about maintaining a list of clients and a currently active/focused client.
It adds methods for arranging (add, remove, shuffle, ...) clients in the list and implements methdos for the window focus cycle.
It is used in a new base class for layouts SimpleLayoutBase, which is now base class for all layouts except Columns and Stack. However Stack and Columns use 'ClientList' as base for their internal helper clases to managing the stacks. 

All existing layout tests passed without modification.
Tests were added to assert the desired focus cycle.