### PR TITLE
Return function from hook.subscribe so you can use them as decorators

### DIFF
--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -59,6 +59,7 @@ class Subscribe(object):
         lst = subscriptions.setdefault(event, [])
         if func not in lst:
             lst.append(func)
+        return func
 
     def startup_once(self, func):
         """Called when Qtile has started on first start


### PR DESCRIPTION
This lets one use the hook.subscribe methods as decorators when there is more than one hook.subscribe call
e.g.,

```python
@hook.subscribe.client_name_updated
@hook.subscribe.client_new
def dyn_tmux_above(window):
    STACKMODE_ABOVE = 0
    name = window.name
    if name and ('- dyn-tmux' in name):
        window.remove_border = True
        window.floating = True
        xcb_win = window.window
        xcb_win.configure(stackmode=STACKMODE_ABOVE)
```

instead of
```python
def dyn_tmux_above(window):
    STACKMODE_ABOVE = 0
    name = window.name
    if name and ('- dyn-tmux' in name):
        window.remove_border = True
        window.floating = True
        xcb_win = window.window
        xcb_win.configure(stackmode=STACKMODE_ABOVE)

hook.subscribe.client_name_updated(dyn_tmux_above)
hook.subscribe.client_new(dyn_tmux_above)
```