### PR TITLE
Minor docu upgrade about groups and layout default names

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -440,9 +440,12 @@ class Group(object):
         this will be ``exec()`` d when the group is created, you can pass
         either a program name or a list of programs to ``exec()``
     layout : string
-        the default layout for this group (e.g. 'max' or 'stack')
+        the name of default layout for this group (e.g. 'max' or 'stack').
+        This is the name specified for a particular layout in config.py
+        or if not defined it defaults in general the class name in all lower case.
     layouts : list
-        the group layouts list overriding global layouts
+        the group layouts list overriding global layouts.
+        Use this to define a separate list of layouts for this particular group.
     persist : boolean
         should this group stay alive with no member windows?
     init : boolean

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -90,7 +90,7 @@ class VerticalTile(_SimpleLayoutBase):
         ('border_normal', '#FFFFFF', 'Border color for un-focused windows.'),
         ('border_width', 1, 'Border width.'),
         ('margin', 0, 'Border margin.'),
-        ('name', 'VerticalTile', 'Name of this layout.'),
+        ('name', 'verticaltile', 'Name of this layout.'),
     ]
 
     ratio = 0.75

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -146,7 +146,7 @@ class MonadTall(_SimpleLayoutBase):
         ("border_normal", "#000000", "Border colour for un-focused windows."),
         ("border_width", 2, "Border width."),
         ("single_border_width", None, "Border width for single window"),
-        ("name", "xmonad-tall", "Name of this layout."),
+        ("name", "xmonadtall", "Name of this layout."),
         ("margin", 0, "Margin of the layout"),
         ("ratio", .5,
             "The percent of the screen-space the master pane should occupy "

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -40,6 +40,7 @@ class Zoomy(_SimpleLayoutBase):
         ("property_small", "0.1", "Property value to set on zoomed window"),
         ("property_big", "1.0", "Property value to set on normal window"),
         ("margin", 0, "Margin of the layout"),
+        ("name", "zoomy", "Name of this layout."),
     ]
 
     def __init__(self, **config):


### PR DESCRIPTION
This PR addresses #971 and #953

1. slightly enhanced group docstrings about layouts and layout
arguments.
2. Default names of layout is class name in all lower case.
corrected name in layout defaults were defined otherwise,
because never had any effects, except for documentation.