### PR TITLE
Update requirements-dev.txt to include xvfbwrapper

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8
 pytest-cov
 pip-tools
+xvfbwrapper


### PR DESCRIPTION
In this previous patch (https://github.com/qtile/qtile/pull/1043)
I forgot to explicitly include the xvfbwrapper test
dependency in requirements-dev.txt.