### PR TITLE
Remove old compatibility code for cffi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - python: pypy-5.4.1
           env: TOXENV=pypy-trollius
         - python: pypy3.3-5.2-alpha1
-          env: TOXENV=pypy-trollius
+          env: TOXENV=pypy3-trollius
 
         - python: 3.6
           env: TOXENV=packaging
@@ -37,7 +37,7 @@ matrix:
         - python: nightly
           env: TOXENV=py-nightly
         - python: pypy3.3-5.2-alpha1
-          env: TOXENV=pypy-trollius
+          env: TOXENV=pypy3-trollius
 
 cache:
   directories:

--- a/libqtile/ffi_build.py
+++ b/libqtile/ffi_build.py
@@ -26,9 +26,7 @@ from xcffib.ffi_build import ffi as xcffib_ffi
 from cairocffi.ffi_build import ffi as cairocffi_ffi
 
 pango_ffi = FFI()
-# PyPy < 2.6 compatibility
-if hasattr(pango_ffi, 'set_source'):
-    pango_ffi.set_source("libqtile._ffi_pango", None)
+pango_ffi.set_source("libqtile._ffi_pango", None)
 
 pango_ffi.include(cairocffi_ffi)
 
@@ -144,9 +142,7 @@ pango_ffi.cdef("""
 """)
 
 xcursors_ffi = FFI()
-# PyPy < 2.6 compatibility
-if hasattr(xcursors_ffi, 'set_source'):
-    xcursors_ffi.set_source("libqtile._ffi_xcursors", None)
+xcursors_ffi.set_source("libqtile._ffi_xcursors", None)
 
 xcursors_ffi.include(xcffib_ffi)
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
+xcffib
 cairocffi
 cffi
 six
-xcffib

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,13 @@ Features
       unit-tested window mangers around.
 """
 
-dependencies = ['xcffib>=0.5.0', 'cairocffi>=0.7', 'six>=1.4.1', 'cffi>=1.1.0']
+if '_cffi_backend' in sys.builtin_module_names: # pypy has cffi builtin
+    import _cffi_backend
+    requires_cffi = "cffi==" + _cffi_backend.__version__
+else:
+    requires_cffi = "cffi>=1.1.0"
+
+dependencies = ['xcffib>=0.5.0', 'cairocffi>=0.7', 'six>=1.4.1', requires_cffi]
 if sys.version_info >= (3, 4):
     pass
 elif sys.version_info >= (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -80,25 +80,7 @@ Features
       unit-tested window mangers around.
 """
 
-if '_cffi_backend' in sys.builtin_module_names:
-    import _cffi_backend
-    requires_cffi = "cffi==" + _cffi_backend.__version__
-else:
-    requires_cffi = "cffi>=1.1.0"
-
-# PyPy < 2.6 compatibility
-if requires_cffi.startswith("cffi==0."):
-    cffi_args = dict(
-        zip_safe=False
-    )
-else:
-    cffi_args = dict(cffi_modules=[
-        'libqtile/ffi_build.py:pango_ffi',
-        'libqtile/ffi_build.py:xcursors_ffi'
-    ])
-
-dependencies = ['xcffib>=0.5.0', 'cairocffi>=0.7', 'six>=1.4.1', requires_cffi]
-
+dependencies = ['xcffib>=0.5.0', 'cairocffi>=0.7', 'six>=1.4.1', 'cffi>=1.1.0']
 if sys.version_info >= (3, 4):
     pass
 elif sys.version_info >= (3, 3):
@@ -167,5 +149,8 @@ setup(
         ('share/man/man1', ['resources/qtile.1',
                             'resources/qshell.1'])],
     cmdclass={'install': CheckCairoXcb},
-    **cffi_args
+    cffi_modules=[
+        'libqtile/ffi_build.py:pango_ffi',
+        'libqtile/ffi_build.py:xcursors_ffi',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ envlist =
 setenv = LC_CTYPE = en_US.UTF-8
 # Pass Display down to have it for the tests available
 passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-whitelist_externals = /bin/bash
 # Install trollius for 2 and pypy
 # Install either trollius or tulip for 3.3
 # Asyncio is in the standard library for 3.4+
@@ -36,8 +35,7 @@ commands =
     pip install xcffib
     # Install unpinned requirements from requirements.in
     pip install -r {toxinidir}/requirements.in
-    # build pangocffi module
-    bash -c "python -c 'import cffi, sys; sys.exit(cffi.__version_info__[0])' || python {toxinidir}/libqtile/ffi_build.py"
+    python {toxinidir}/libqtile/ffi_build.py
     py.test --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]


### PR DESCRIPTION
This patch removes code for cffi version < 1.0, since version 1.0 was released in the middle of 2015.