### PR TITLE
Simplify confreader.py & config fallback

### DIFF
--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -23,6 +23,7 @@
 # whose defaults depend on a reasonable locale sees something reasonable.
 import locale
 import logging
+from os import path, getenv
 
 from libqtile.log_utils import init_log, logger
 from libqtile import confreader
@@ -64,10 +65,11 @@ def make_qtile():
     parser.add_argument(
         "-c", "--config",
         action="store",
-        default=None,
+        default=path.expanduser(path.join(
+            getenv('XDG_CONFIG_HOME', '~/.config'), 'qtile', 'config.py')),
         dest="configfile",
         help='Use specified configuration file,'
-        ' "default" will load the system default config.'
+        ' "default" will load the system default config.',
     )
     parser.add_argument(
         "-s", "--socket",
@@ -101,7 +103,7 @@ def make_qtile():
     init_log(log_level=log_level)
 
     try:
-        config = confreader.File(options.configfile, is_restart=options.no_spawn)
+        config = confreader.Config.from_file(options.configfile)
     except Exception as e:
         logger.exception('Error while reading config file (%s)', e)
         raise

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -106,7 +106,10 @@ def make_qtile():
         config = confreader.Config.from_file(options.configfile)
     except Exception as e:
         logger.exception('Error while reading config file (%s)', e)
-        raise
+        config = confreader.Config()
+        from libqtile.widget import TextBox
+        widgets = config.screens[0].bottom.widgets
+        widgets.insert(0, TextBox('Config Err!'))
     # XXX: the import is here becouse we need to call init_log
     # before start importing stuff
     from libqtile import manager

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -68,8 +68,7 @@ def make_qtile():
         default=path.expanduser(path.join(
             getenv('XDG_CONFIG_HOME', '~/.config'), 'qtile', 'config.py')),
         dest="configfile",
-        help='Use specified configuration file,'
-        ' "default" will load the system default config.',
+        help='Use the specified configuration file',
     )
     parser.add_argument(
         "-s", "--socket",

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -31,16 +31,16 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 
 def test_syntaxerr():
     with pytest.raises(confreader.ConfigError):
-        confreader.File(os.path.join(tests_dir, "configs", "syntaxerr.py"))
+        confreader.Config.from_file(os.path.join(tests_dir, "configs", "syntaxerr.py"))
 
 
 def test_basic():
-    f = confreader.File(os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
     assert f.keys
 
 
 def test_falls_back():
-    f = confreader.File(os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
 
     # We just care that it has a default, we don't actually care what the
     # default is; don't assert anything at all about the default in case


### PR DESCRIPTION
* Simplify confreader.py
* Make qtile always fallback to the default config when it raises an exception in loading the config file.

Reasoning:
It's frustrating when using a display manager and you run into an issue with your config file.
It instantly kicks you back to the greeter, and you have no information as to why. You then have to choose another wm or tty to debug, login again, and then look up the logfile saved to disk. Then you make your change, and if it doesn't fix the issue you have to redo these steps.