### PR TITLE
Logging tweaks

### DIFF
--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -68,6 +68,8 @@ class ColorFormatter(Formatter):
 
 def init_log(log_level=WARNING, log_path=True, log_truncate=False,
              log_size=10000000, log_numbackups=1, log_color=True):
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
     formatter = Formatter(
         "%(asctime)s %(levelname)s %(name)s %(filename)s:%(funcName)s():L%(lineno)d %(message)s"
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -234,7 +234,7 @@ class Qtile(object):
 
         def run_qtile():
             try:
-                init_log(logging.INFO, log_path=None)
+                init_log(logging.INFO, log_path=None, log_color=False)
                 q = QtileManager(config_class(), self.display, self.sockfile)
                 q.loop()
             except Exception:
@@ -259,7 +259,7 @@ class Qtile(object):
         an error and the returned manager should not be started, otherwise this
         will likely block the thread.
         """
-        init_log(logging.INFO, log_path=None)
+        init_log(logging.INFO, log_path=None, log_color=False)
         return QtileManager(config_class(), self.display, self.sockfile)
 
     def terminate(self):

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -50,7 +50,7 @@ def hook_fixture():
         pass
 
     dummy = Dummy()
-    libqtile.log_utils.init_log(logging.CRITICAL)
+    libqtile.log_utils.init_log(logging.CRITICAL, log_path=None, log_color=False)
     libqtile.hook.init(dummy)
 
     yield


### PR DESCRIPTION
This patch is a couple small changes to logging. It speeds up running tests by a bit.
I did a couple runs of `tox -e py36` and `tox -e py27-trollius` and measured the time. These commits cut off 10-20% of the runtime.

* Remove existing handlers to root logger when calling init_log

During tests init_log ends up being called multiple times
and we end up with n handlers added to the root logger.

* Turn off colorized logs in test suite
* Stop the logger from writing to disk in test_hook.hook_fixture