### PR TITLE
Add scratchpad

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -88,6 +88,7 @@ mix!)
     mouse
     screens
     hooks
+    scratchpad
 
 In addition to the above variables, there are several other boolean
 configuration variables that control specific aspects of Qtile's behavior:

--- a/docs/manual/config/scratchpad.rst
+++ b/docs/manual/config/scratchpad.rst
@@ -1,0 +1,51 @@
+==========
+Scratchpad
+==========
+
+By the use of the :mod:`~libqtile.scratchpad` module it is possible to define
+some simple scratchpad like behaviour, in your config.py file.
+Instantiate a :class:`~libqtile.scratchpad.DropDown` and define a command to
+execute and bind the `toggle` property (which returns a `lazy.function`)
+to a `Key` in ``keys`` for example:
+
+.. code-block:: python
+
+    from libqtile import scratchpad
+   
+    dropdown_terminal = scratchpad.DropDown('xterm')
+   
+    keys = [ Key( [], 'F12', dropdown_terminal.toggle), ]
+
+The above example creates a DropDown object whose visibility is toggled by
+pressing F12 key. If the DropDown is set to visible the first time, it spawns
+a process by the defined command (here: xterm). The visibility of the
+corresponding window can afterwards be toggled by the same key.
+
+The DropDown appears always on the current screen if toggled to visible,
+regardless in what group it was before. The DropDown can also be configured t
+to vanish if another window is focused.
+The position and opacity of the corresponding window can be configured as argument
+to __init__, and the window is always placed accordingly.
+
+Note that the DropDown window is always shown as floating window and that the
+window is detached from the DropDown if floating state is toggled.
+In that case the next key press spawns a new process.
+
+Example
+=======
+
+.. code-block:: python
+
+	# create the DropDown object in config.py
+	# x, y, w and h are given in fractions of the screen
+    logviewer = scratchpad.DropDown(
+        "urxvt -hold -name qtile.log "
+        "-e tail -f -n 30 ~/.local/share/qtile/qtile.log",
+        x=0.05, y=0.4, width=0.9, height=0.6, opacity=0.88,
+        on_focus_lost_hide=True)
+
+Reference
+=========
+
+.. qtile_class:: libqtile.scratchpad.DropDown
+   :no-commands:  

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2017, Dirk Hartmann
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import signal
+
+from . import command, configurable
+from . import hook, window
+
+# from .log_utils import logger
+
+class DropDown(configurable.Configurable):
+    """
+    This class is a wrapper for a window of a specified command, allowing the
+    window to be shown and hidden by keystroke on top of the current screen.
+
+    On the first use a specified command is used to spawn a process.
+    The associated window is bound to this wrapper and its visibility can be
+    toggled.
+    By default the window is shown centered in the upper area of the screen and
+    hides if it looses focus.
+
+    You may use this class to turn your favorite terminal emulator into a quake
+    like drop down terminal.
+    Add something like the following to you config.py to configure it:
+
+    quake_terminal = scratchpad.DropDown('xterm')
+    ...
+    Key( [], 'F12', quake_terminal.toggle_command )
+
+    Another interesting configuration is a temporary viewer for log file for
+    example the qtile.log file. In this example a terminal is spawned to execute
+    a command. If the terminal window looses focus it is killed.
+
+    logviewer = scratchpad.DropDown(
+        "urxvt -hold -name qtile.log "
+        "-e tail -f -n 30 /home/dhannes/.local/share/qtile/qtile.log",
+        x=0.05, y=0.4, width=0.9, height=0.6,
+        on_focus_lost_kill=True)
+    """
+    defaults = (
+        (
+            'x',
+            0.1,
+            'X position of window as fraction of current screen width. '
+            '0 is the left most position.'
+        ),
+        (
+            'y',
+            0.0,
+            'Y position of window as fraction of current screen height. '
+            '0 is the top most position. To show the window at bottom, '
+            'you have to configure a value < 1 and an appropriate height.'
+        ),
+        (
+            'width',
+            0.8,
+            'Width of window as fraction of current screen width'
+        ),
+        (
+            'height',
+            0.35,
+            'Height of window as fraction of current screen.'
+        ),
+        (
+            'opacity',
+            0.9,
+            'Opacity of window as fraction. Zero is opaque.'
+        ),
+        (
+            'on_focus_lost_hide',
+            True,
+            'Shall the window be hidden if focus is lost? If so, the DropDown '
+            'is hidden if window focus or the group is changed.'
+        ),
+        (
+            'on_focus_lost_kill',
+            False,
+            'Shall the window be killed if focus is lost. If so, the window is '
+            'closed and a new process is spawned on next call to `show`. '
+            'If `on_focus_lost_kill` is True, the window is always killed'
+            'regardless of state of `on_focus_lost_hide`.'
+        ),
+        (
+            'warp_pointer',
+            True,
+            'Shall pointer warp to center of window on activation? '
+            'This has only effect if any of the on_focus_lost_xxx '
+            'configurations is True'
+        ),
+    )
+
+    def __init__(self, cmd='xterm', **config):
+        """
+        Initialize DropDown window wrapper.
+        Define a command to spawn a process for the first time the DropDown
+        is shown.
+        """
+        configurable.Configurable.__init__(self, **config)
+        self.add_defaults(self.defaults)
+        self._command = cmd
+        self._proc_id = None
+        self._window = None
+        self._visible = False
+
+    @property
+    def visible(self):
+        """
+        Determine if window is associated and is currently visible as
+        floating window in a group.
+        """
+        return self._window is not None and self._visible
+
+    def spawn(self, qtile):
+        """
+        Spawn a process by defined command.
+        Method is only called if no window is associated. This is either on the
+        first call to show or if the window was killed.
+        The process id of spawned process is saved and compared to new windows.
+        In case of a match the window gets associated to this DropDown object.
+        """
+        if self._proc_id is None:
+            hook.subscribe.client_new(self.on_client_new)
+            self._proc_id = qtile.cmd_spawn(self._command)
+            # logger.debug('DropDown at %x :: Spawned: id="%x"' %
+            #              (id(self), self._proc_id))
+
+    def show(self, qtile):
+        """
+        Show the associated window on top of current screen.
+        If no window is currently associated, the defined command is used
+        to spawn a process. Otherwise the window is added to the current group
+        as floating window and positioned as defined.
+
+        If 'warp_pointer' is True the mouse pointer is warped to center of the
+        window if 'on_focus_lost_hide' or 'on_focus_lost_kill' is True.
+        Otherwise, if pointer is moved to window it might be closed before
+        reaching it.
+        """
+        # logger.debug('DropDown at %x :: Show' % id(self))
+        if self._proc_id is None:
+            self.spawn(qtile)
+        elif self._window is None:
+            # window is not associated, yet
+            # logger.debug('DropDown at %x :: Show - No window associated yet.' %
+            #              id(self))
+            return
+        elif not self._visible:
+            screen = qtile.currentScreen
+            win = self._window
+            # calculate windows floating position and width/height
+            # these may differ for screens, and thus always recalculated.
+            win.x = int(screen.dx + self.x * screen.dwidth)
+            win.y = int(screen.dy + self.y * screen.dheight)
+            win.float_x = win.x
+            win.float_y = win.y
+            win.width = int(screen.dwidth * self.width)
+            win.height = int(screen.dheight * self.height)
+            win._float_state = window.TOP
+            # add to group and bring it to front.
+            win.togroup()
+            win.cmd_bring_to_front()
+            # add hooks to determine if focus get lost
+            if self.on_focus_lost_hide or self.on_focus_lost_kill:
+                if self.warp_pointer:
+                    win.window.warp_pointer(win.width // 2, win.height // 2)
+                hook.subscribe.client_focus(self.on_focus_change)
+                hook.subscribe.setgroup(self.on_focus_change)
+            # float change hook is always subscribed
+            hook.subscribe.float_change(self.on_float_change)
+            # toggle internal flag of visibility
+            self._visible = True
+
+    def hide(self, qtile):
+        """
+        Hide the associated window.
+        If the associated window is visible, it is hidden and removed from
+        its group.
+        """
+        if self.visible:
+            # logger.debug('DropDown at %x :: Hide' % id(self))
+            # unsubscribe the hook methods, since the window is not shown
+            if self.on_focus_lost_hide or self.on_focus_lost_kill:
+                hook.unsubscribe.client_focus(self.on_focus_change)
+                hook.unsubscribe.setgroup(self.on_focus_change)
+            # float change is always unsubscribed
+            hook.unsubscribe.float_change(self.on_float_change)
+            # remove the window from its group, thus it is not shown in widgets
+            self._window.hide()
+            self._window.group.remove(self._window)
+            self._visible = False
+        # else:
+        #    logger.debug('DropDown at %x :: Hide, but window is not visible' %
+        #                 id(self))
+
+    @property
+    def toggle(self):
+        """
+        Toggle the visibility of associated window. Either show() or hide().
+        Use this property in KeyBinding.
+        Technically a lazy.function is returned by this property
+        """
+        @command.lazy.function
+        def _toggle(qtile, *args, **kwargs):
+            if not self.visible:
+                self.show(qtile)
+            else:
+                # if window is visible on another group than the current, then it
+                # is shown on current screen, since it is currently not visible
+                if (self._window.group is not self._window.qtile.currentGroup):
+                    # for show to work properly, set _visible to False
+                    self._visible = False
+                    self.show(qtile)
+                else:
+                    self.hide(qtile)
+        return _toggle
+
+    def on_client_new(self, client, *args, **kwargs):
+        """
+        hook method which is called on new windows.
+        Method is subscribed if the given command is spawned and unsubscribed
+        if the associated window is determined.
+        """
+        # logger.debug('DropDown at %x :: hook: New client' % id(self))
+        if self._proc_id is not None and self._window is None:
+            client_pid = client.window.get_net_wm_pid()
+            # logger.debug('DropDown at %x :: hook: New client "%s", pid %s, wm_pid %s' %
+            #              (id(self), client.name, self._proc_id, client_pid))
+            if self._proc_id == client_pid:
+                self._window = client
+                self._window.setOpacity(self.opacity)
+                self._visible = False
+                # unsubscribe current hook method, the window is found
+                hook.unsubscribe.client_new(self.on_client_new)
+                # subscribe methods for current visible client
+                hook.subscribe.client_killed(self.on_client_killed)
+                hook.subscribe.float_change(self.on_float_change)
+                # show is called to add the window as floating and placed
+                # according to given x, y, width, height arguments
+                self.show(self._window.qtile)
+
+    def on_focus_change(self, *args, **kwargs):
+        """
+        hook method which is called on window focus change and group change.
+        Depending on 'on_focus_lost_xxx' arguments, the associated window may
+        get hidden (by call to hide) or even killed.
+        """
+        if self.visible:
+            currentGroup = self._window.qtile.currentGroup
+            if (self._window.group is not currentGroup or
+                    self._window is not currentGroup.currentWindow):
+                # logger.debug('DropDown at %x :: hook: focus change' % id(self))
+                if self.on_focus_lost_kill:
+                    # logger.debug('DropDown at %x :: --> kill' % id(self))
+                    hook.unsubscribe.client_focus(self.on_focus_change)
+                    hook.unsubscribe.setgroup(self.on_focus_change)
+                    # kill the spawned process
+                    os.kill(self._proc_id, signal.SIGTERM)
+                elif self.on_focus_lost_hide:
+                    self.hide(self._window.qtile)
+
+    def reset(self):
+        self._window = None
+        self._proc_id = None
+        self._visible = False
+        hook.unsubscribe.float_change(self.on_float_change)
+
+    def on_client_killed(self, client, *args, **kwargs):
+        """
+        hook method which is called if a client is killed.
+        If the associated window is killed, reset internal state.
+        """
+        if client is self._window:
+            # logger.debug('DropDown at %x :: hook: client killed' % id(self))
+            self.reset()
+
+    def on_float_change(self, *args, **kwargs):
+        """
+        hook method which is called if window float state is changed.
+        If the current associated window is not floated (any more) the window
+        and process is detached from DRopDown, thus the next call to Show
+        will spawn a new process.
+        """
+        if self.visible and not self._window.floating:
+            # logger.debug('DropDown at %x :: hook: float change - Reset' %
+            #              id(self))
+            hook.unsubscribe.client_focus(self.on_focus_change)
+            hook.unsubscribe.setgroup(self.on_focus_change)
+            self.reset()

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2017 Dirk Hartmann
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import time
+import six
+
+import libqtile.layout
+import libqtile.bar
+import libqtile.widget
+import libqtile.manager
+import libqtile.config
+import libqtile.confreader
+from libqtile import command
+
+import libqtile.scratchpad
+from libqtile import scratchpad
+
+from libqtile.log_utils import logger
+
+from .layouts.layout_utils import assertFocused
+
+def generate_keys(**kwargs):
+    return [libqtile.config.Key( ["control"], '%i'%d,
+            scratchpad.DropDown('xterm -display :%i' % d, **kwargs).toggle)
+            for d in range(10)]
+
+class ScratchBaseConfic(object):
+    screens = []
+    groups = [
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
+    ]
+    layouts = [libqtile.layout.max.Max()]
+    floating_layout = libqtile.layout.floating.Floating()
+    mouse = []
+    auto_fullscreen = True
+    follow_mouse_focus = True
+    main = None
+
+
+class ScratchToggleConfig(ScratchBaseConfic):
+    keys = generate_keys(on_focus_lost_hide=False, on_focus_lost_kill=False)
+
+class ScratchHideConfig(ScratchBaseConfic):
+    keys = generate_keys(on_focus_lost_hide=True, on_focus_lost_kill=False)
+
+class ScratchKillConfig(ScratchBaseConfic):
+    keys = generate_keys(on_focus_lost_hide=False, on_focus_lost_kill=True)
+
+
+def simulate_keypress_expect_new_window(qtile):
+    """
+    simulate a keypress and wait for a window to appear.
+    There are several DropDown objects created for spawning xterm on different
+    displays. 
+    """
+    # determine current display, and stimulate appropriate keys 
+    key = qtile.display[1]
+    
+    start = len(qtile.c.windows())
+    # First keypress --> spawn
+    qtile.c.simulate_keypress(["control"], key)
+    # wait for window
+    for _ in range(100):
+        if start < len(qtile.c.windows()):
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("Window did not appear...")
+
+def command_expect_kill_window(qtile, cmd):
+    """
+    execute the given lazy command an d expect a window to be killed.
+    This is used for configurations, were the client is killed,
+    if it looses focus
+    """
+    start = len(qtile.c.windows())
+    # execute given lazy command
+    cmd()
+    # wait for window
+    for _ in range(100):
+        if start >= len(qtile.c.windows()):
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("Window could not be killed...")
+
+@pytest.mark.parametrize("qtile", [ScratchToggleConfig], indirect=True)
+def test_toggle(qtile):
+    qtile.testWindow("one")
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    # determine current display, and stimulate appropriate keys 
+    key = qtile.display[1]
+
+    # First keypress: wait fro window
+    simulate_keypress_expect_new_window(qtile)
+
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'xterm')
+
+    # press again --> hide
+    qtile.c.simulate_keypress(["control"], key)
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assertFocused(qtile,'one')
+    
+    # press again --> show
+    qtile.c.simulate_keypress(["control"], key)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'xterm')
+
+    # changing focus twice
+    qtile.c.group.next_window()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'one')
+    qtile.c.group.next_window()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'xterm')
+    
+    # press again --> hide
+    qtile.c.simulate_keypress(["control"], key)
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assertFocused(qtile,'one')
+    
+    # changing focus, does not focus the hidden dropdown
+    qtile.c.group.next_window()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+    assertFocused(qtile,'one')
+
+
+@pytest.mark.parametrize("qtile", [ScratchHideConfig], indirect=True)
+def test_float_change(qtile):
+    qtile.testWindow("one")
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    # determine current display, and stimulate appropriate keys 
+    key = qtile.display[1]
+
+    # First keypress: wait for window
+    simulate_keypress_expect_new_window(qtile)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'xterm')
+
+    # toggle floating, makes the window tiled and focus stays
+    qtile.c.window.toggle_floating()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assertFocused(qtile,'xterm')
+    
+    # press again: spawns new process
+    simulate_keypress_expect_new_window(qtile)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm', 'xterm']
+    assertFocused(qtile,'xterm')
+
+
+
+@pytest.mark.parametrize("qtile", [ScratchHideConfig], indirect=True)
+def test_hide(qtile):
+    qtile.testWindow("one")
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assert len(qtile.c.windows()) == 1
+    # determine current display, and stimulate appropriate keys 
+    key = qtile.display[1]
+
+    simulate_keypress_expect_new_window(qtile)
+
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assert len(qtile.c.windows()) == 2
+
+    # press again --> hide
+    qtile.c.simulate_keypress(["control"], key)
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assert len(qtile.c.windows()) == 2
+
+    # press again --> show
+    qtile.c.simulate_keypress(["control"], key)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assert len(qtile.c.windows()) == 2
+    
+    # changing focus twice, will not return focus to dropdown,
+    # since first focus changes removes it from group
+    qtile.c.group.next_window()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+    assertFocused(qtile,'one')
+    qtile.c.group.next_window()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+    assertFocused(qtile,'one')
+    assert len(qtile.c.windows()) == 2
+    
+    # press again --> show
+    qtile.c.simulate_keypress(["control"], key)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assert len(qtile.c.windows()) == 2
+    
+    # change group
+    qtile.c.group["b"].toscreen()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+
+    # change group back to a --> dropdown is removed from group
+    qtile.c.group["a"].toscreen()
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+    assert len(qtile.c.windows()) == 2
+
+
+@pytest.mark.parametrize("qtile", [ScratchKillConfig], indirect=True)
+def test_kill(qtile):
+    qtile.testWindow("one")
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assert len(qtile.c.windows()) == 1
+    # determine current display, and stimulate appropriate keys 
+    key = qtile.display[1]
+    
+    # press key first time --> spawn and show
+    simulate_keypress_expect_new_window(qtile)
+
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assert len(qtile.c.windows()) == 2
+
+    # changing focus --> kills
+    command_expect_kill_window(qtile, qtile.c.group.next_window)
+    assert qtile.c.group["a"].info()['windows'] == ['one']
+    assert len(qtile.c.windows()) == 1
+
+    # press again --> spawn again and show
+    simulate_keypress_expect_new_window(qtile)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'xterm']
+    assert len(qtile.c.windows()) == 2
+    
+    # change group to "b" --> kills
+    command_expect_kill_window(qtile, qtile.c.group["b"].toscreen)
+    assert sorted(qtile.c.group["a"].info()['windows']) == ['one']
+    assert len(qtile.c.windows()) == 1


### PR DESCRIPTION
Add simple scratchpad behaviour to be used in configuration.
Module provides DropDown class to wrap a window of a spawned
process, whose visibilty can be toggled by keystoke afterwards.

Adds code, test and docs

