### PR TITLE
Support of group display name (label) other than the name

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -427,6 +427,7 @@ class Group(object):
 
     These groups can spawn apps, only allow certain Matched windows to be on
     them, hide when they're not in use, etc.
+    Groups are identified by their name.
 
     Parameters
     ==========
@@ -452,11 +453,17 @@ class Group(object):
         is this group alive when qtile starts?
     position : int
         group position
+    label : string
+        the display name of the group.
+        Use this to define a display name other than name of the group.
+        If set to None, the display name is set to the name.
     """
     def __init__(self, name, matches=None, exclusive=False,
                  spawn=None, layout=None, layouts=None, persist=True, init=True,
-                 layout_opts=None, screen_affinity=None, position=MAXSIZE):
+                 layout_opts=None, screen_affinity=None, position=MAXSIZE,
+                 label=None):
         self.name = name
+        self.label = label
         self.exclusive = exclusive
         self.spawn = spawn
         self.layout = layout

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -120,7 +120,7 @@ class DGroups(object):
         rules = [Rule(m, group=group.name) for m in group.matches]
         self.rules.extend(rules)
         if start:
-            self.qtile.addGroup(group.name, group.layout, group.layouts)
+            self.qtile.addGroup(group.name, group.layout, group.layouts, group.label)
 
     def _setup_groups(self):
         for group in self.groups:

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -48,7 +48,7 @@ class WindowList(Dmenu):
         for win in windows:
             if win.group:
                 item = self.item_format.format(
-                    group=win.group.name, id=id, window=win.name)
+                    group=win.group.label or win.group.name, id=id, window=win.name)
                 self.item_to_win[item] = win
                 id += 1
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -42,9 +42,12 @@ class _Group(command.CommandObject):
 
     Analogous to workspaces in other window managers. Each client window
     managed by the window manager belongs to exactly one group.
+
+    A group is identified by its name but displayed in GroupBox widget by its label.
     """
-    def __init__(self, name, layout=None):
+    def __init__(self, name, layout=None, label=None):
         self.name = name
+        self.label = name if label is None else label
         self.customLayout = layout  # will be set on _configure
         self.windows = set()
         self.qtile = None
@@ -236,6 +239,7 @@ class _Group(command.CommandObject):
     def info(self):
         return dict(
             name=self.name,
+            label=self.label,
             focus=self.currentWindow.name if self.currentWindow else None,
             windows=[i.name for i in self.windows],
             focusHistory=[i.name for i in self.focusHistory],
@@ -491,6 +495,15 @@ class _Group(command.CommandObject):
     def cmd_switch_groups(self, name):
         """Switch position of current group with name"""
         self.qtile.cmd_switch_groups(self.name, name)
+
+    def cmd_set_label(self, label):
+        """
+        Set the display name of current group to be used in GroupBox widget.
+        If label is None, the name of the group is used as display name.
+        If label is the empty string, the group is invisible in GroupBox.
+        """
+        self.label = label if label is not None else self.name
+        hook.fire("changegroup")
 
     def __repr__(self):
         return "<group.Group (%r)>" % self.name

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -466,9 +466,9 @@ class Qtile(command.CommandObject):
         )
         self.root.set_property("_NET_CURRENT_DESKTOP", index)
 
-    def addGroup(self, name, layout=None, layouts=None):
+    def addGroup(self, name, layout=None, layouts=None, label=None):
         if name not in self.groupMap.keys():
-            g = _Group(name, layout)
+            g = _Group(name, layout, label=label)
             self.groups.append(g)
             if not layouts:
                 layouts = self.config.layouts
@@ -1705,9 +1705,9 @@ class Qtile(command.CommandObject):
             return
         mb.startInput(prompt, f, "qshell")
 
-    def cmd_addgroup(self, group):
+    def cmd_addgroup(self, group, label=None):
         """Add a group with the given name"""
-        return self.addGroup(group)
+        return self.addGroup(group, label=label)
 
     def cmd_delgroup(self, group):
         """Delete a group with the given name"""

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -50,7 +50,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
 
     def box_width(self, groups):
         width, _ = self.drawer.max_layout_size(
-            [i.name for i in groups],
+            [i.label for i in groups],
             self.font,
             self.fontsize
         )
@@ -146,7 +146,11 @@ class AGroupBox(_GroupBase):
 
 
 class GroupBox(_GroupBase):
-    """A widget that graphically displays the current group"""
+    """
+    A widget that graphically displays the current group.
+    All groups are displayed by their label.
+    If the label of a group is the empty string that group will not be displayed.
+    """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("active", "FFFFFF", "Active group font colour"),
@@ -201,8 +205,9 @@ class GroupBox(_GroupBase):
         (
             "visible_groups",
             None,
-            "Groups that will be visible "
-            "(if set to None or [], all groups will be visible)"
+            "Groups that will be visible. "
+            "If set to None or [], all groups will be visible."
+            "Visible groups are identified by name not by their displayed label."
         ),
         (
             "spacing",
@@ -220,8 +225,17 @@ class GroupBox(_GroupBase):
 
     @property
     def groups(self):
-        return self.qtile.groups if not self.visible_groups else \
-            [g for g in self.qtile.groups if g.name in self.visible_groups]
+        """
+        returns list of visible groups.
+        The existing groups are filtered by the visible_groups attribute and
+        their label. Groups with an empty string as label are never contained.
+        Groups that are not named in visible_groups are not returned.
+        """
+        if self.visible_groups:
+            return [g for g in self.qtile.groups
+                    if g.label and g.name in self.visible_groups]
+        else:
+            return [g for g in self.qtile.groups if g.label]
 
     def get_clicked_group(self, x, y):
         group = None
@@ -324,7 +338,7 @@ class GroupBox(_GroupBase):
 
             self.drawbox(
                 offset,
-                g.name,
+                g.label,
                 border,
                 text_color,
                 highlight_color=self.highlight_color,


### PR DESCRIPTION
Adds label attribute to Group which is used in GroupBox widget
as a display name.
This this PR the current displayed label can be different from the
group name and changed at runtime.
If the label is the empty string the group is not displayed in GroupBox widget.
If the label is not set, or set to None, the groups name is used as label.
Furthermore the display names must not be unique.

Originally i wanted an easy way to hide groups in GroupBox
(and not the opposite way to define visible groups, which is already possible) and found #492.
This PRs solves my problem and the originally request of #492.