### PR TITLE
Handle 'sensors' command errors

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -176,6 +176,10 @@ class UnixCommandNotFound(Warning):
     pass
 
 
+class UnixCommandRuntimeError(Warning):
+    pass
+
+
 def catch_exception_and_warn(warning=Warning, return_on_exception=None,
                              excepts=Exception):
     """

--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -25,11 +25,14 @@
 # SOFTWARE.
 
 import re
+from subprocess import CalledProcessError
 
 from six import PY2
 
 from . import base
-from ..utils import UnixCommandNotFound, catch_exception_and_warn
+from ..utils import (
+    UnixCommandNotFound, UnixCommandRuntimeError, catch_exception_and_warn
+)
 from libqtile.log_utils import logger
 
 
@@ -83,6 +86,9 @@ class ThermalSensor(base.InLoopPollText):
                 break
 
     @catch_exception_and_warn(warning=UnixCommandNotFound, excepts=OSError)
+    @catch_exception_and_warn(warning=UnixCommandRuntimeError,
+                              excepts=CalledProcessError,
+                              return_on_exception="")
     def get_temp_sensors(self):
         """calls the unix `sensors` command with `-f` flag if user has specified that
         the output should be read in Fahrenheit.


### PR DESCRIPTION
Fixes #1077 

Handles the error returned by the 'sensors' command as if 'sensors' returned no sensor data and issues a warning.

'sensors' returns the code 1 in more situations than [when no sensors are found](https://github.com/groeck/lm-sensors/blob/1b36ea429930b05e1b3cb77cdbc24cb1ffbcac61/prog/sensors/main.c#L352), like if [sensors failed an initialization](https://github.com/groeck/lm-sensors/blob/1b36ea429930b05e1b3cb77cdbc24cb1ffbcac61/prog/sensors/main.c#L112) for whatever reason, so the downside of this change is that it would hide critical 'sensors' errors from the user; the previous behavior was crashing.

I think a warning is better than a crash in this situation.