### PR TITLE
fix cursor warp when using default layout implementation

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -233,7 +233,6 @@ class _Group(command.CommandObject):
                 for l in self.layouts:
                     l.focus(win)
             hook.fire("focus_change")
-            # !!! note that warp isn't hooked up now
             self.layoutAll(warp)
 
     def info(self):

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -608,11 +608,11 @@ class _SimpleLayoutBase(Layout):
 
     def previous(self):
         client = self.focus_previous(self.clients.current_client) or self.focus_last()
-        self.group.focus(client, False)
+        self.group.focus(client, True)
 
     def next(self):
         client = self.focus_next(self.clients.current_client) or self.focus_first()
-        self.group.focus(client, False)
+        self.group.focus(client, True)
 
     def add(self, client, offset_to_current=0):
         return self.clients.add(client, offset_to_current)


### PR DESCRIPTION
Layouts like xmonad don't manage their own window lists, so the
cursor_warp = True parameter doesn't work for them.

Instead, let's by default on next/prev for these layouts enable warping (of
course, it is disabled if people don't set cursor_warp=True). A better fix
might just be to always default this to true... I'm not sure if there's a
real case where it should be false.

This commit also removes an outdated comment -- cursor warp is hooked up
now :)

Signed-off-by: Tycho Andersen <tycho@tycho.ws>