### PR TITLE
Enable a custom TaskList icon size

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -99,6 +99,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             'Text representation of the floating window state. '
             'e.g., "V " or "\U0001F5D7 "'
         ),
+        (
+            'icon_size',
+            None,
+            'Icon size. '
+            '(Calculated if set to None. Icons are hidden if set to 0.)'
+        ),
     ]
 
     def __init__(self, **config):
@@ -165,7 +171,11 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         width_avg = width_total / window_count
 
         names = [self.get_taskname(w) for w in windows]
-        icons = [self.get_window_icon(w) for w in windows]
+
+        if self.icon_size == 0:
+            icons = len(windows) * [None]
+        else:
+            icons = [self.get_window_icon(w) for w in windows]
 
         # calculated width for each task according to icon and task name
         # consisting of state abbreviation and window name
@@ -193,8 +203,9 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
-        self.icon_size = self.bar.height - 2 * (self.borderwidth +
-                                                self.margin_y)
+        if self.icon_size is None:
+            self.icon_size = self.bar.height - 2 * (self.borderwidth +
+                                                    self.margin_y)
 
         if self.fontsize is None:
             calc = self.bar.height - self.margin_y * 2 - \


### PR DESCRIPTION
This enables setting a custom icon size for icons in the TaskList widget.

I had the experience that the calculated icon sizes didn't match up well with my small font, so I figured a setting would be useful to control the icon size myself. As a side effect, it's now also possible to hide icons completely, if required.

(Travis seems to fail because of #1100, unrelated to the actual changes in this PR.)