### PR TITLE
Don't crash qtile if you try to use a widget that has unmet deps

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -248,7 +248,7 @@ def describe_attributes(obj, attrs, func=None):
     return ', '.join(pairs)
 
 
-def safe_import(module_names, class_name, globals_):
+def safe_import(module_names, class_name, globals_, fallback=None):
     """
     Try to import a module, and if it fails because an ImporError
     it logs on WARNING, and logs the traceback on DEBUG level
@@ -270,3 +270,5 @@ def safe_import(module_names, class_name, globals_):
         logger.warning("Unmet dependencies for optional Widget: '%s.%s', %s",
                        module_path, class_name, error)
         logger.debug("%s", traceback.format_exc())
+        if fallback:
+            globals_[class_name] = fallback(module_path, class_name, error)

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -21,10 +21,12 @@
 # SOFTWARE.
 
 from ..utils import safe_import as safe_import_
+from .import_error import make_error
 
 
 def safe_import(module_name, class_name):
-    safe_import_((".widget", module_name), class_name, globals())
+    safe_import_((".widget", module_name), class_name, globals(),
+                 fallback=make_error)
 
 
 safe_import("backlight", "Backlight")

--- a/libqtile/widget/import_error.py
+++ b/libqtile/widget/import_error.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2018 Roger Duran
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .base import _TextBox
+
+
+def make_error(module_path, class_name, error):
+    class ImportErrorWidget(_TextBox):
+        def __init__(self, **config):
+            _TextBox.__init__(self, **config)
+            self.text = "Import Error: %s" % class_name
+    return ImportErrorWidget


### PR DESCRIPTION
Some users don't realize they are trying to use some widgets that needs
optional dependencies, regardless of the fact, the log warns about that
in the startup of qtile.

This replaces the "broken" widgets with a textbox saying the widget has
an import error.

This  fixes https://github.com/qtile/qtile/issues/1110