### PR TITLE
Fix dbus-send call

### DIFF
--- a/docs/manual/config/gnome.rst
+++ b/docs/manual/config/gnome.rst
@@ -19,7 +19,7 @@ be on your $PATH.
         x = os.environ['DESKTOP_AUTOSTART_ID']
         subprocess.Popen(['dbus-send',
                           '--session',
-                          '--print-reply=string',
+                          '--print-reply',
                           '--dest=org.gnome.SessionManager',
                           '/org/gnome/SessionManager',
                           'org.gnome.SessionManager.RegisterClient',


### PR DESCRIPTION
`=string` causes `dbus-send` to complain and as the result the whole command execution fails.
At least this is what happens on my Ubuntu 18.04.