### PR TITLE
Check if environment variable exists and don't error when it doesn't (on full qtile restart)

### DIFF
--- a/docs/manual/config/gnome.rst
+++ b/docs/manual/config/gnome.rst
@@ -16,7 +16,9 @@ be on your $PATH.
 
     @hook.subscribe.startup
     def dbus_register():
-        x = os.environ['DESKTOP_AUTOSTART_ID']
+        id = os.environ.get('DESKTOP_AUTOSTART_ID')
+        if not id:
+            return
         subprocess.Popen(['dbus-send',
                           '--session',
                           '--print-reply=string',
@@ -24,7 +26,7 @@ be on your $PATH.
                           '/org/gnome/SessionManager',
                           'org.gnome.SessionManager.RegisterClient',
                           'string:qtile',
-                          'string:' + x])
+                          'string:' + id])
 
 This adds a new entry "Qtile GNOME" to GDM's login screen.
 


### PR DESCRIPTION
This is a second tweak that should be in documentation, otherwise unnecessary error is inevitable