### PR TITLE
Tile layout: fix master_match

### DIFF
--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -10,6 +10,7 @@
 # Copyright (c) 2014 dmpayton
 # Copyright (c) 2014 dequis
 # Copyright (c) 2017 Dirk Hartmann.
+# Copyright (c) 2018 Nazar Mokrynskyi
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -85,9 +86,9 @@ class Tile(_SimpleLayoutBase):
             return
         if self.clients:
             masters = [c for c in self.clients if match.compare(c)]
-            self.clients = masters + [
-                c for c in self.clients if c not in masters
-            ]
+            for client in masters:
+                self.clients.remove(client)
+                self.clients.appendHead(client)
 
     def shift(self, idx1, idx2):
         if self.clients:


### PR DESCRIPTION
I was getting `AttributeError: 'list' object has no attribute 'current_client'` because code was replacing `_ClientList` with plain `list`.

Not sure if this is a correct way to do it since I'm not a Python developer, but it works for me.