### PR TITLE
Tile layout: unify commands so that it aligns well with other existing layouts

### DIFF
--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -10,6 +10,7 @@
 # Copyright (c) 2014 dmpayton
 # Copyright (c) 2014 dequis
 # Copyright (c) 2017 Dirk Hartmann.
+# Copyright (c) 2018 Nazar Mokrynskyi
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -153,16 +154,21 @@ class Tile(_SimpleLayoutBase):
         ))
         return d
 
-    def cmd_down(self):
+    def cmd_shuffle_down(self):
         self.down()
 
-    def cmd_up(self):
+    def cmd_shuffle_up(self):
         self.up()
 
-    cmd_shuffle_up = cmd_up
-    cmd_shuffle_down = cmd_down
+    cmd_shuffle_left = cmd_shuffle_up
+    cmd_shuffle_right = cmd_shuffle_down
+
     cmd_previous = _SimpleLayoutBase.previous
     cmd_next = _SimpleLayoutBase.next
+    cmd_up = cmd_previous
+    cmd_down = cmd_next
+    cmd_left = cmd_previous
+    cmd_right = cmd_next
 
     def cmd_decrease_ratio(self):
         self.ratio -= self.ratio_increment

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -63,9 +63,9 @@ def test_tile_updown(qtile):
     qtile.testWindow("two")
     qtile.testWindow("three")
     assert qtile.c.layout.info()["clients"] == ["three", "two", "one"]
-    qtile.c.layout.down()
+    qtile.c.layout.shuffle_down()
     assert qtile.c.layout.info()["clients"] == ["two", "one", "three"]
-    qtile.c.layout.up()
+    qtile.c.layout.shuffle_up()
     assert qtile.c.layout.info()["clients"] == ["three", "two", "one"]
 
 


### PR DESCRIPTION
Consider keys config like following:
```
	'M-<Left>'     : lazy.layout.left(),
	'M-<Down>'     : lazy.layout.down(),
	'M-<Up>'       : lazy.layout.up(),
	'M-<Right>'    : lazy.layout.right(),
	'M-S-<Left>'   : [lazy.layout.move_left(), lazy.layout.shuffle_up()],
	'M-S-<Down>'   : [lazy.layout.move_down(), lazy.layout.shuffle_down()],
	'M-S-<Up>'     : [lazy.layout.move_up(), lazy.layout.shuffle_up()],
	'M-S-<Right>'  : [lazy.layout.move_right(), lazy.layout.shuffle_down()],
```

With current Tile layout implementation, shortcuts that on other layouts switch to other windows, in Tile cause windows rearrangement. This PR aligns Tile layout's commands so that they have the same effect as on other layouts.