### PR TITLE
Make files transfer windows floating out of the box

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -39,6 +39,7 @@ DEFAULT_FLOAT_WM_TYPES = set([
 
 DEFAULT_FLOAT_RULES = [
     {"role": "About"},
+    {"wmclass": "file_progress"},
 ]
 
 


### PR DESCRIPTION
This class is used in Nemo file manager and probably in others. Would be nice to support it in default config.