### PR TITLE
Fix exception during `previous()`/`next()` calls when there are no windows opened

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -410,7 +410,7 @@ class _ClientList(object):
         """
         try:
             return self[self.index(win) + 1]
-        except IndexError:
+        except (IndexError, ValueError):
             return None
 
     def focus_last(self):
@@ -425,7 +425,7 @@ class _ClientList(object):
         """
         try:
             idx = self.index(win)
-        except IndexError:
+        except (IndexError, ValueError):
             return None
         else:
             if idx > 0:


### PR DESCRIPTION
In order to reproduce this issue use Matrix group with no windows open and call `next()` or `previous()` using hotkey, you'll get a stacktrace from #1146

Fixes #1146