### PR TITLE
Adds new formating options for tasklist

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -317,7 +317,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
         try:
             self.layout.text = text
-        except Exception:
+        except TypeError:
             # In some cases text needs to be encoded once more
             self.layout.text = text.encode('ascii', 'xmlcharrefreplace')
 


### PR DESCRIPTION
The purpose of this PR is to add new formatting options for task titles in this tasklist including pangomarkup.
Adds new formatting options for tasklist:

  * adds markup_* options for formatting of the taskname
  * adds suport for pangomarkup in markup_*
  * adds support for uniform distribution of taskboxes sizes

Tested on python 2 and python 3