### PR TITLE
Fix for Tile layout where master windows are reversed on reset

### DIFF
--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -87,7 +87,7 @@ class Tile(_SimpleLayoutBase):
             return
         if self.clients:
             masters = [c for c in self.clients if match.compare(c)]
-            for client in masters:
+            for client in reversed(masters):
                 self.clients.remove(client)
                 self.clients.appendHead(client)
 


### PR DESCRIPTION
This is a followup to #1144.
Since we add master windows to the beginning of the list, we need to go in reverse order, otherwise master windows will end up in the reverse order each time `resetMaster()` is called