### PR TITLE
bugfix for wallpaper when user use custom wallpaper_command

### DIFF
--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -82,6 +82,7 @@ class Wallpaper(base._TextBox):
         if self.wallpaper_command:
             self.wallpaper_command.append(cur_image)
             subprocess.call(self.wallpaper_command)
+            self.wallpaper_command.pop()
             return
         command = [
             'feh',


### PR DESCRIPTION
the cur_image should be removed after "subprocess.call" when a user custom wallpaper_command like this:
`wallpaper_command = [
    'feh', '--bg-max'
]`
