### PR TITLE
checkupdate widget: colour_no_updates argument was not working 

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -65,9 +65,9 @@ class CheckUpdates(base.ThreadedPollText):
             updates = self.call_process(self.cmd)
         except CalledProcessError:
             updates = ""
-        num_updates = str(len(updates.splitlines()) - self.subtr)
+        num_updates = len(updates.splitlines()) - self.subtr
         self._set_colour(num_updates)
-        return self.display_format.format(**{"updates": num_updates})
+        return self.display_format.format(**{"updates": str(num_updates)})
 
     def _set_colour(self, num_updates):
         if num_updates:


### PR DESCRIPTION
The `_set_colour()` function expects an int to work properly. A string was passed instead.