### PR TITLE
Optionally hide unused windows in GroupBox

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -215,6 +215,11 @@ class GroupBox(_GroupBase):
             "Visible groups are identified by name not by their displayed label."
         ),
         (
+            "hide_unused",
+            False,
+            "Hide groups that have no windows and that are not displayed on any screen."
+        ),
+        (
             "spacing",
             None,
             "Spacing between groups"
@@ -236,11 +241,20 @@ class GroupBox(_GroupBase):
         their label. Groups with an empty string as label are never contained.
         Groups that are not named in visible_groups are not returned.
         """
-        if self.visible_groups:
-            return [g for g in self.qtile.groups
-                    if g.label and g.name in self.visible_groups]
+        if self.hide_unused:
+            if self.visible_groups:
+                return [g for g in self.qtile.groups
+                        if g.label and (g.windows or g.screen) and
+                        g.name in self.visible_groups]
+            else:
+                return [g for g in self.qtile.groups if g.label and
+                        (g.windows or g.screen)]
         else:
-            return [g for g in self.qtile.groups if g.label]
+            if self.visible_groups:
+                return [g for g in self.qtile.groups
+                        if g.label and g.name in self.visible_groups]
+            else:
+                return [g for g in self.qtile.groups if g.label]
 
     def get_clicked_group(self, x, y):
         group = None


### PR DESCRIPTION
This is a small addition to the GroupBox widget to allow hiding unused groups.

The motivation is that the user can create a bunch of groups (say 1 thru 9) and use them without having all of them displayed and occupying the bar real state. I find myself sometimes wanting to throw windows some other place to get out of the way but all my groups are busy. That way I can have more groups than I normally use without requiring extra bar room.