### PR TITLE
create cache dir if necessary

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -34,6 +34,7 @@
 import glob
 import os
 import pickle
+import six
 import string
 from collections import OrderedDict, deque
 
@@ -561,10 +562,13 @@ class Prompt(base._TextBox):
 
                 if self.position < self.max_history:
                     self.position += 1
-                try:
-                    os.makedirs(os.path.dirname(self.history_path))
-                except FileExistsError:
-                    pass
+                if six.PY3:
+                    os.makedirs(os.path.dirname(self.history_path), exist_ok=True)
+                else:
+                    try:
+                        os.makedirs(os.path.dirname(self.history_path))
+                    except OSError:  # file exists
+                        pass
                 with open(self.history_path, mode='wb') as f:
                     pickle.dump(self.history, f, protocol=2)
             self.callback(self.userInput)

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -561,6 +561,10 @@ class Prompt(base._TextBox):
 
                 if self.position < self.max_history:
                     self.position += 1
+                try:
+                    os.makedirs(os.path.dirname(self.history_path))
+                except FileExistsError:
+                    pass
                 with open(self.history_path, mode='wb') as f:
                     pickle.dump(self.history, f, protocol=2)
             self.callback(self.userInput)


### PR DESCRIPTION
While this directory will usually exist by virtue of the cache socket, I
recently noticed that if one deletes their qtile cache dir while qtile is
running, the prompt won't work any more, since it gets ENOENT when trying
to write history. Let's fix that by creating the cache dir if necessary.

it would be nicer to use os.makedirs(..., exists_ok=True), but that only
works in python >= 3.2, and since we still support 2.7...

Signed-off-by: Tycho Andersen <tycho@tycho.ws>