### PR TITLE
Fix caps lock affected behaviour of key bindings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ qtile 0.x.x, released xxxx-xx-xx:
         - fix floating of file transfer windows and java drop-downs
         - fix exception when calling `cmd_next` and `cmd_previous` on layout
           without windows
+        - fix caps lock affected behaviour of key bindings
 
 qtile 0.11.1, released 2018-03-01:
     * bug fix


### PR DESCRIPTION
Key bindings work only when caps lock is turned off. You have to grab key with `'lock'` modifier to overcome this.

But if you try to actually do this by explicit binding with `'lock'` modifier along with normal one, it becomes broken again: now you can only use your bindings _with_ caps lock. You can see what happens in code:

https://github.com/qtile/qtile/blob/3fa0f9d8b6c474a532cd83c99afb6609afa7dc7f/libqtile/manager.py#L426

Qtile strips out our explicitly passed modifier and treats two key bindings as one. This makes only one of the two (with and without lock modifier) actually trigger the code.

Since caps lock is excluded from `validMask` I guess it would be right thing to automatically grab keys with caps lock modifier. For some reasone qtile does this with active `numlockMask`, but skips otherwise. This patch adds explicit grabbing with `lock` modifier.