### PR TITLE
Indicate reboot required

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -34,7 +34,7 @@ class CheckUpdates(base.ThreadedPollText):
         ("display_format", "Updates: {updates}", "Display format if updates available"),
         ("colour_no_updates", "ffffff", "Colour when there's no updates."),
         ("colour_have_updates", "ffffff", "Colour when there are updates."),
-        ("restart_indicator", "", "Indicator to represent reboot is required.")
+        ("restart_indicator", "", "Indicator to represent reboot is required. (Ubuntu only)")
     ]
 
     def __init__(self, **config):
@@ -66,20 +66,18 @@ class CheckUpdates(base.ThreadedPollText):
         # type: () -> str
         try:
             updates = self.call_process(self.cmd)
-            restart_required = os.path.exists('/var/run/reboot-required')
         except CalledProcessError:
             updates = ""
-            restart_required = False
         num_updates = str(len(updates.splitlines()) - self.subtr)
 
-        if self.restart_indicator and restart_required:
+        if self.restart_indicator and os.path.exists('/var/run/reboot-required'):
             num_updates += self.restart_indicator
 
         self._set_colour(num_updates)
         return self.display_format.format(**{"updates": num_updates})
 
     def _set_colour(self, num_updates):
-        # type: (int) -> None
+        # type: (str) -> None
         if num_updates:
             self.layout.colour = self.colour_have_updates
         else:

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -34,7 +34,7 @@ class CheckUpdates(base.ThreadedPollText):
         ("display_format", "Updates: {updates}", "Display format if updates available"),
         ("colour_no_updates", "ffffff", "Colour when there's no updates."),
         ("colour_have_updates", "ffffff", "Colour when there are updates."),
-        ("restart_indicator", "*", "Indicator to represent reboot is required.")
+        ("restart_indicator", "", "Indicator to represent reboot is required.")
     ]
 
     def __init__(self, **config):
@@ -72,7 +72,7 @@ class CheckUpdates(base.ThreadedPollText):
             restart_required = False
         num_updates = str(len(updates.splitlines()) - self.subtr)
 
-        if restart_required and self.restart_indicator:
+        if self.restart_indicator and restart_required:
             num_updates += self.restart_indicator
 
         self._set_colour(num_updates)

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -70,13 +70,13 @@ class CheckUpdates(base.ThreadedPollText):
         except CalledProcessError:
             updates = ""
             restart_required = ''
-        num_updates = len(updates.splitlines()) - self.subtr
+        num_updates = str(len(updates.splitlines()) - self.subtr)
 
         if restart_required:
             num_updates += self.restart_indicator
 
         self._set_colour(num_updates)
-        return self.display_format.format(**{"updates": str(num_updates)})
+        return self.display_format.format(**{"updates": num_updates})
 
     def _set_colour(self, num_updates):
         # type: (int) -> None

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -69,10 +69,10 @@ class CheckUpdates(base.ThreadedPollText):
             restart_required = os.path.exists('/var/run/reboot-required')
         except CalledProcessError:
             updates = ""
-            restart_required = ''
+            restart_required = False
         num_updates = str(len(updates.splitlines()) - self.subtr)
 
-        if restart_required:
+        if restart_required and self.restart_indicator:
             num_updates += self.restart_indicator
 
         self._set_colour(num_updates)

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
 from . import base
 from libqtile.log_utils import logger
 from subprocess import CalledProcessError, Popen
@@ -32,7 +33,8 @@ class CheckUpdates(base.ThreadedPollText):
         ('execute', None, 'Command to execute on click'),
         ("display_format", "Updates: {updates}", "Display format if updates available"),
         ("colour_no_updates", "ffffff", "Colour when there's no updates."),
-        ("colour_have_updates", "ffffff", "Colour when there are updates.")
+        ("colour_have_updates", "ffffff", "Colour when there are updates."),
+        ("restart_indicator", "*", "Indicator to represent reboot is required.")
     ]
 
     def __init__(self, **config):
@@ -64,9 +66,15 @@ class CheckUpdates(base.ThreadedPollText):
         # type: () -> str
         try:
             updates = self.call_process(self.cmd)
+            restart_required = os.path.exists('/var/run/reboot-required')
         except CalledProcessError:
             updates = ""
+            restart_required = ''
         num_updates = len(updates.splitlines()) - self.subtr
+
+        if restart_required:
+            num_updates += self.restart_indicator
+
         self._set_colour(num_updates)
         return self.display_format.format(**{"updates": str(num_updates)})
 


### PR DESCRIPTION
For Ubuntu distros, this PR adds an optional indicator to the check_updates widget to represent that a system reboot is required.