### PR TITLE
change invocation to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
     # Install unpinned requirements from requirements.in
     pip install -r {toxinidir}/requirements.in
     python {toxinidir}/libqtile/ffi_build.py
-    py.test --cov libqtile --cov-report term-missing {posargs}
+    pytest --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
pytest supports and recommends its invocation via `pytest` since 3.0