### PR TITLE
Make it possible to use a custom command for the CheckUpdate widget

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -28,6 +28,7 @@ class CheckUpdates(base.ThreadedPollText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("distro", "Arch", "Name of your distribution"),
+        ("custom_command", None, "Custom shell command for checking updates (counts the lines of the output)"),
         ("update_interval", 60, "Update interval in seconds."),
         ('execute', None, 'Command to execute on click'),
         ("display_format", "Updates: {updates}", "Display format if updates available"),
@@ -63,7 +64,11 @@ class CheckUpdates(base.ThreadedPollText):
     def _check_updates(self):
         # type: () -> str
         try:
-            updates = self.call_process(self.cmd)
+            if self.custom_command is None:
+                updates = self.call_process(self.cmd)
+            else:
+                updates = self.call_process(self.custom_command, shell=True)
+                self.subtr = 0
         except CalledProcessError:
             updates = ""
         num_updates = len(updates.splitlines()) - self.subtr


### PR DESCRIPTION
This PR adds a way to use a custom shell command in order to check the number of updates. 
For example, to also check AUR packages, I use this command:
`checkupdates && pikaur -Syu 2>/dev/null | sed "/^\s*$/d"` (pikaur is the AUR helper I use)

I didn't try and use the `self.subtr` logic but rather let the user take care of it in the command itself. Because it can be more subtle than just subtracting a fixed number; for example in the command above, if, and only if, no AUR packages are to be updated, it will still print out an empty line so I needed to take care of this special case with a sed command.

So I made  the concession to use an unfortunate `shell=True` in order to allow more flexibility. Let me know what you think!