### PR TITLE
add widget caps_num_lock_indicator

### DIFF
--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -32,8 +32,8 @@ from .windowname import WindowName  # noqa: F401
 
 
 def safe_import(module_name, class_name):
-    safe_import_((".widget", module_name), class_name, globals(),
-                 fallback=make_error)
+    safe_import_(
+        (".widget", module_name), class_name, globals(), fallback=make_error)
 
 
 safe_import("backlight", "Backlight")
@@ -41,8 +41,10 @@ safe_import("battery", ["Battery", "BatteryIcon"])
 safe_import("currentlayout", ["CurrentLayout", "CurrentLayoutIcon"])
 safe_import("currentscreen", "CurrentScreen")
 safe_import("debuginfo", "DebugInfo")
-safe_import("graph", ["CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph",
-                      "HDDGraph", "HDDBusyGraph"])
+safe_import("graph", [
+    "CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph", "HDDGraph",
+    "HDDBusyGraph"
+])
 safe_import("maildir", "Maildir")
 safe_import("notify", "Notify")
 safe_import("sensors", "ThermalSensor")
@@ -81,3 +83,4 @@ safe_import("memory", "Memory")
 safe_import("idlerpg", "IdleRPG")
 safe_import("pomodoro", "Pomodoro")
 safe_import("stock_ticker", "StockTicker")
+safe_import("caps_num_lock_indicator", "CapsNumLockIndicator")

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -32,8 +32,8 @@ from .windowname import WindowName  # noqa: F401
 
 
 def safe_import(module_name, class_name):
-    safe_import_(
-        (".widget", module_name), class_name, globals(), fallback=make_error)
+    safe_import_((".widget", module_name), class_name, globals(),
+                 fallback=make_error)
 
 
 safe_import("backlight", "Backlight")
@@ -41,10 +41,8 @@ safe_import("battery", ["Battery", "BatteryIcon"])
 safe_import("currentlayout", ["CurrentLayout", "CurrentLayoutIcon"])
 safe_import("currentscreen", "CurrentScreen")
 safe_import("debuginfo", "DebugInfo")
-safe_import("graph", [
-    "CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph", "HDDGraph",
-    "HDDBusyGraph"
-])
+safe_import("graph", ["CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph",
+                      "HDDGraph", "HDDBusyGraph"])
 safe_import("maildir", "Maildir")
 safe_import("notify", "Notify")
 safe_import("sensors", "ThermalSensor")

--- a/libqtile/widget/caps_num_lock_indicator.py
+++ b/libqtile/widget/caps_num_lock_indicator.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Juan Riquelme González
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from . import base
+
+import re
+import subprocess
+
+
+class CapsNumLockIndicator(base.ThreadPoolText):
+    """Really simple widget to show the current Caps/Num Lock state."""
+
+    orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [('update_interval', 0.5, 'Update Time in seconds.')]
+
+    def __init__(self, **config):
+        base.ThreadPoolText.__init__(self, "", **config)
+        self.add_defaults(CapsNumLockIndicator.defaults)
+
+    def get_indicators(self):
+        """Return a list with the current state of the keys."""
+        try:
+            output = self.call_process(['xset', 'q'])
+        except subprocess.CalledProcessError as err:
+            output = err.output.decode()
+        if output.startswith("Keyboard"):
+            indicators = re.findall(r"(Caps|Num)\s+Lock:\s*(\w*)", output)
+            return indicators
+
+    def status(self):
+        """Return a string with the Caps Lock/Num Lock status."""
+        indicators = self.get_indicators()
+        status = " ".join([" ".join(indicator) for indicator in indicators])
+        return status
+
+    def poll(self):
+        """Poll content for the text box."""
+        return self.status()

--- a/libqtile/widget/caps_num_lock_indicator.py
+++ b/libqtile/widget/caps_num_lock_indicator.py
@@ -40,12 +40,8 @@ class CapsNumLockIndicator(base.ThreadPoolText):
             indicators = re.findall(r"(Caps|Num)\s+Lock:\s*(\w*)", output)
             return indicators
 
-    def status(self):
-        """Return a string with the Caps Lock/Num Lock status."""
+    def poll(self):
+        """Poll content for the text box."""
         indicators = self.get_indicators()
         status = " ".join([" ".join(indicator) for indicator in indicators])
         return status
-
-    def poll(self):
-        """Poll content for the text box."""
-        return self.status()

--- a/libqtile/widget/caps_num_lock_indicator.py
+++ b/libqtile/widget/caps_num_lock_indicator.py
@@ -1,18 +1,23 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018 Juan Riquelme González
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 from . import base
 


### PR DESCRIPTION
This is a really simple widget I did for myself, but now I share it, just in case it could be also useful for someone else.
I bought a laptop this summer and it doesn't have any led indicator to warn if Caps Lock or Num Lock is on or off and it was making me crazy in some situations (like typing passwords in terminal emulator, as example, but not the only case) xD. So I did this as a helper/alternative, to cover the absence of that leds.
It is useful for me, at least.