### PR TITLE
fix #1200 typo in ratiotile.py

### DIFF
--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -304,7 +304,7 @@ class RatioTile(_SimpleLayoutBase):
             self.group.layoutAll()
 
     cmd_down = _SimpleLayoutBase.previous
-    cmd_upn = _SimpleLayoutBase.next
+    cmd_up = _SimpleLayoutBase.next
 
     cmd_previous = _SimpleLayoutBase.previous
     cmd_next = _SimpleLayoutBase.next


### PR DESCRIPTION
Yeah, so silly change. But removes an issue, I guess xD.
An older one.