### PR TITLE
Add a function to rename of current window.

### DIFF
--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -637,6 +637,12 @@ class TreeTab(Layout):
         self.panel_width -= 10
         self.group.layoutAll()
 
+    def cmd_rename_window(self, name):
+        win = self._get_window()
+        if win:
+            win.name = name
+            self.group.layoutAll()
+
     def _create_drawer(self):
         if self._drawer is None:
             self._drawer = drawer.Drawer(


### PR DESCRIPTION
In the current implementation, sometimes, there are windows which are the same names. It makes me difficult to find a window that I want from that reason. so, I added.

we can use the function via following configuration, but it is one of the examples.
```
...
Keys = [
    Key([mod], 'i', lazy.widget['prompt'].exec_general(
        'window name:',
        'layout',
        'rename_window'))
]
...
```
- gif

![output](https://user-images.githubusercontent.com/6248028/47477244-322b6e80-d85f-11e8-88c5-fb7e3495278e.gif)
