### PR TITLE
Fully rewrite the wallpaper widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+qtile 0.13.0, TBA:
+    !!! Config breakage !!
+        - the wallpaper widget now takes "cycle" or "random" as special
+        arguments to the wallpaper option instead of seperate options
+
+     * features
+        - wallpapers can now be loaded from several different directories
+        - wallpapers can be set to change within an interval
+     * bugfixes
+        - various bugfixes relating to the wallpaper widget
+
 qtile 0.12.0, released 2018-07-20:
     !!! Config breakage !!!
         - Tile layout commands up/down/shuffle_up/shuffle_down changed to be

--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2015 Muhammed Abuali
+# Copyright (c) 2018 Valentijn van de Beek
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,84 +22,128 @@
 # To use this widget, you will need to install feh wallpaper changer
 
 import os
+import pathlib
 import subprocess
 import random
-from . import base
-from .. import bar
+
+from libqtile.widget import base
+from libqtile import bar
 from libqtile.log_utils import logger
 
+user_dir_path = os.path.expanduser("~/.config/user-dirs.dirs")
+pictures_dir = "~/Pictures/wallpapers"
+if os.path.exists(user_dir_path):
+    with open(user_dir_path, 'r') as f:
+        for line in f.read().split('\n'):
+            if line[0] == '#' or line is None:
+                continue
+            key, value = line.split('=')
+            if key == "XDG_PICTURES_DIR":
+                pictures_dir = os.path.expandvars(value).replace('"', '')
+                break
 
-class Wallpaper(base._TextBox):
+
+class Wallpaper(base.ThreadPoolText):
+    """
+    A simple wallpaper widget that can set the wallpaper and change it
+    on an interval or if you press on the widget.
+    """
     defaults = [
-        ("directory", "~/Pictures/wallpapers/", "Wallpaper Directory"),
-        ("wallpaper", None, "Wallpaper"),
-        ("wallpaper_command", None, "Wallpaper command"),
-        ("random_selection", False, "If set, use random initial wallpaper and "
-         "randomly cycle through the wallpapers."),
+        ("wallpaper", "cycle", "the path to a wallpaper or the special value cycle or random"),
+        ("directories", pictures_dir, "Either an absolute or relative path to directory or "
+         "list of absolute or relative paths to directories. Relative paths are resolved "
+         "to $XDG_PICTURES_DIR"),
+        ("wallpaper_command", ('feh', '--bg-max'), "Wallpaper command"),
         ("label", None, "Use a fixed label instead of image name."),
-        (
-            "one_screen",
-            False,
-            "Treat the whole X display as one screen when setting wallpapers "
-            "(does not work if wallpaper_command is set)."
-        ),
+        ("one_screen", False, "Treat the whole X display as one screen when setting wallpapers "),
+        ("update_interval", None, "Update interval in seconds, if none, it won't update")
     ]
 
     def __init__(self, **config):
         base._TextBox.__init__(self, 'empty', width=bar.CALCULATED, **config)
         self.add_defaults(Wallpaper.defaults)
-        self.index = 0
         self.images = []
-        self.get_wallpapers()
-        if self.random_selection:  # Random selection after reading all files
-            self.index = random.randint(0, len(self.images) - 1)
-        self.set_wallpaper()
+        self.command, *self.args = self.wallpaper_command
 
-    def get_path(self, file):
-        return os.path.join(os.path.expanduser(self.directory), file)
+        if self.one_screen:
+            # Support other commands other than feh?
+            self.wallpaper_command.append("--no-xinerama")
+
+        self.cycle = self.wallpaper.lower() == "cycle"
+        self.random = self.wallpaper.lower() == "random"
+
+        if self.cycle or self.random:
+            self.get_wallpapers()
+
+        self.index = 0
+
+    def poll(self):
+        """
+        Return the current wallpaper
+        """
+        return self.wallpaper
+
+    def _get_wallpapers_in_directory(self, directory):
+        """
+        Add all the wallpapers in a given directory to the images list
+        """
+        if directory[0] not in ('~', '/'):
+            directory = pictures_dir + directory
+
+        path = pathlib.Path(directory).expanduser()
+
+        for ext in ('jpg', 'png', 'jpeg'):
+            self.images.extend([img for img in path.glob('**/*' + ext)])
 
     def get_wallpapers(self):
-        try:
-            # get path of all files in the directory
-            self.images = list(
-                filter(os.path.isfile,
-                       map(self.get_path,
-                           os.listdir(self.directory))))
-        except IOError as e:
-            logger.exception("I/O error(%s): %s", e.errno, e.strerror)
+        # type: () -> None
+        """
+        Create a list of all the images in a given directory.
+        """
+        if type(self.directories) is str:
+            self._get_wallpapers_in_directory(self.directories)
 
-    def set_wallpaper(self):
-        if len(self.images) == 0:
-            if self.wallpaper is None:
-                self.text = "empty"
-                return
-            else:
-                self.images.append(self.wallpaper)
-        cur_image = self.images[self.index]
-        if self.label is None:
-            self.text = os.path.basename(cur_image)
-        else:
-            self.text = self.label
-        if self.wallpaper_command:
-            self.wallpaper_command.append(cur_image)
-            subprocess.call(self.wallpaper_command)
-            self.wallpaper_command.pop()
-            return
-        command = [
-            'feh',
-            '--bg-fill',
-            cur_image
-        ]
-        if self.one_screen:
-            command.append("--no-xinerama")
-        subprocess.call(command)
+        for directory in self.directories:
+            self._get_wallpapers_in_directory(directory)
 
-    def button_press(self, x, y, button):
-        if button == 1:
-            if self.random_selection:
+    def set_wallpaper(self, *args):
+        """
+        Set the wallpaper either to given wallpaper or to one in a cycle.
+        """
+        # type: () -> None
+        image = self.wallpaper
+
+        if self.random or self.cycle:
+            if self.random:
                 self.index = random.randint(0, len(self.images) - 1)
             else:
                 self.index += 1
                 self.index %= len(self.images)
+
+            image = str(self.images[self.index])
+            print(image)
+
+        if self.label is None:
+            self.text = os.path.basename(image)
+        else:
+            self.text = self.label
+
+        try:
+            subprocess.Popen([self.command, *self.args, image])
+        except subprocess.SubprocessError as err:
+            logger.exception("Subprocess error: %s ", str(err))
+        self.draw()
+
+    def update(self, text):
+        """Update the wallpaper"""
+        if not self.update_interval:
+            return
+        self.set_wallpaper()
+
+    def button_press(self, x, y, button):
+        """
+        Handle the button press
+        """
+        # type: (int, int, int) -> None
+        if button == 1 and (self.cycle or self.random):
             self.set_wallpaper()
-            self.draw()

--- a/test/test_widget.py
+++ b/test/test_widget.py
@@ -25,7 +25,7 @@ import pytest
 
 from libqtile.config import Screen
 from libqtile.bar import Bar
-from libqtile.widget import TextBox, ThermalSensor
+from libqtile.widget import TextBox, ThermalSensor, Wallpaper
 
 from .conftest import BareConfig
 


### PR DESCRIPTION
Hello, 

This is a bit of a rewrite of the wallpaper widget. I haven't been able to find a test for this specific widget nor manual documentation so if there or you want me to add some please say so.

It changes the following things:
- Instead of separate conflicting options it now just takes a wallpaper option which can be one of two special values[1].
- Wallpapers can now be changed on a per interval basis as well
- It can now take multiple directories instead of one
- It will recursively look for images within those folders
- It obeys [xdg user dirs when finding the default picture folder](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)[2]

I hope that the changes to the changelog are also okay and not too verbose.

Thank you for your time,

Valentijn.

[1] I think it would be better for this to be an unnamed required argument instead to avoid it being weirdly named but I couldn't find a precedent for this in the other widgets.

[2] To explain why this code is a bit weird: these values aren't actually loaded into the environment but instead can only be found using a subprocess call to a separate tool or parsing the file yourself. I went for the latter. 