### PR TITLE
command set extension

### DIFF
--- a/libqtile/extension/__init__.py
+++ b/libqtile/extension/__init__.py
@@ -28,3 +28,4 @@ def safe_import(module_name, class_name):
 safe_import("base", "RunCommand")
 safe_import("dmenu", ["Dmenu", "DmenuRun", "J4DmenuDesktop"])
 safe_import("window_list", "WindowList")
+safe_import("command_set", "CommandSet")

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -41,11 +41,12 @@ class CommandSet(Dmenu):
             },
         pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
         **Theme.dmenu))),
+
     """
 
     defaults = [
-        ("commands", {}, "dictionary of commands where key is runable command"),
-        ("pre_commands", [], "list of commands to be executed before getting dmenu answer"),
+        ("commands", None, "dictionary of commands where key is runable command"),
+        ("pre_commands", None, "list of commands to be executed before getting dmenu answer"),
     ]
 
     def __init__(self, **config):
@@ -56,8 +57,12 @@ class CommandSet(Dmenu):
         Dmenu._configure(self, qtile)
 
     def run(self):
-        for cmd in self.pre_commands:
-            system(cmd)
+        if not self.commands:
+            return
+
+        if self.pre_commands:
+            for cmd in self.pre_commands:
+                system(cmd)
 
         out = super(CommandSet, self).run(items=self.commands.keys())
 

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -41,6 +41,7 @@ class CommandSet(Dmenu):
             },
         pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
         **Theme.dmenu))),
+
     """
 
     defaults = [

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -19,7 +19,6 @@
 # SOFTWARE.
 
 from os import system
-
 from .dmenu import Dmenu
 
 
@@ -29,18 +28,21 @@ class CommandSet(Dmenu):
 
     ex. manage mocp deamon:
 
-    Key([mod], 'm', lazy.run_extension(extension.CommandSet(
-        commands={
-            'play/pause': '[ $(mocp -i | wc -l) -lt 2 ] && mocp -p || mocp -G',
-            'next': 'mocp -f',
-            'previous': 'mocp -r',
-            'quit': 'mocp -x',
-            'open': 'urxvt -e mocp',
-            'shuffle': 'mocp -t shuffle',
-            'repeat': 'mocp -t repeat',
-            },
-        pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
-        **Theme.dmenu))),
+    .. code-block:: python
+
+        Key([mod], 'm', lazy.run_extension(extension.CommandSet(
+            commands={
+                'play/pause': '[ $(mocp -i | wc -l) -lt 2 ] && mocp -p || mocp -G',
+                'next': 'mocp -f',
+                'previous': 'mocp -r',
+                'quit': 'mocp -x',
+                'open': 'urxvt -e mocp',
+                'shuffle': 'mocp -t shuffle',
+                'repeat': 'mocp -t repeat',
+                },
+            pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
+            **Theme.dmenu))),
+
     """
 
     defaults = [

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -41,7 +41,6 @@ class CommandSet(Dmenu):
             },
         pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
         **Theme.dmenu))),
-
     """
 
     defaults = [

--- a/libqtile/extension/dmenu.py
+++ b/libqtile/extension/dmenu.py
@@ -89,11 +89,8 @@ class Dmenu(base.RunCommand):
             self.configured_command.extend(("-h", str(self.dmenu_height)))
 
     def run(self, items=None):
-        if items:
-            if self.dmenu_lines:
-                lines = min(len(items), self.dmenu_lines)
-            else:
-                lines = len(items)
+        if items and self.dmenu_lines:
+            lines = min(len(items), self.dmenu_lines)
             self.configured_command.extend(("-l", str(lines)))
 
         proc = super(Dmenu, self).run()

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -29,7 +29,7 @@ class WindowList(Dmenu):
     defaults = [
         ("item_format", "{group}.{id}: {window}", "the format for the menu items"),
         ("all_groups", True, "If True, list windows from all groups; otherwise only from the current group"),
-        ("dmenu_lines", 80, "Give lines vertically. Set to None get inline"),
+        ("dmenu_lines", "80", "Give lines vertically. Set to None get inline"),
     ]
 
     def __init__(self, **config):


### PR DESCRIPTION
simple command launcher through dmenu. Support dictionary of commands and commands that should be executed before. Ex. MOC manager in config.py

```
    Key([mod], 'm', lazy.run_extension(extension.CommandSet(
        commands={
            'play/pause': '[ $(mocp -i | wc -l) -lt 2 ] && mocp -p || mocp -G',
            'next': 'mocp -f',
            'previous': 'mocp -r',
            'quit': 'mocp -x',
            'open': 'urxvt -e mocp',
            'shuffle': 'mocp -t shuffle',
            'repeat': 'mocp -t repeat',
            },
        pre_commands=['[ $(mocp -i | wc -l) -lt 1 ] && mocp -S'],
        **Theme.dmenu))),
```