### PR TITLE
Multiple gaps per position

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -62,21 +62,21 @@ class Gap(command.CommandObject):
         self.screen = screen
         # If both horizontal and vertical gaps are present, screen corners are
         # given to the horizontal ones
-        if screen.top is self:
+        if self.position == "top":
             self.x = screen.x
             self.y = screen.y
             self.length = screen.width
             self.width = self.length
             self.height = self.size
             self.horizontal = True
-        elif screen.bottom is self:
+        elif self.position == "bottom":
             self.x = screen.x
             self.y = screen.dy + screen.dheight
             self.length = screen.width
             self.width = self.length
             self.height = self.size
             self.horizontal = True
-        elif screen.left is self:
+        elif self.position == "left":
             self.x = screen.x
             self.y = screen.dy
             self.length = screen.dheight
@@ -111,7 +111,7 @@ class Gap(command.CommandObject):
     @property
     def position(self):
         for i in ["top", "bottom", "left", "right"]:
-            if getattr(self.screen, i) is self:
+            if self in getattr(self.screen, i):
                 return i
 
     def info(self):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -360,7 +360,12 @@ class Screen(command.CommandObject):
         elif name == "window":
             return (True, [i.window.wid for i in self.group.windows])
         elif name == "bar":
-            return (False, [x.position for x in self.gaps])
+            keys = []
+            for gap in self.gaps:
+                position = getattr(self, gap.position)
+                index = position.index(gap)
+                keys.append("{}_{}".format(gap.position, index))
+            return False, keys
 
     def _select(self, name, sel):
         if name == "layout":
@@ -376,7 +381,8 @@ class Screen(command.CommandObject):
                     if i.window.wid == sel:
                         return i
         elif name == "bar":
-            return getattr(self, sel)
+            position, index = sel.split("_")
+            return getattr(self, position)[int(index)]
 
     def resize(self, x=None, y=None, w=None, h=None):
         if x is None:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -294,7 +294,7 @@ class Screen(command.CommandObject):
         val = self.width
         for gap in self.left:
             val -= gap.size
-        if self.right:
+        for gap in self.right:
             val -= gap.size
         return val
 

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -336,9 +336,8 @@ class Qtile(command.CommandObject):
                 l.finalize()
 
             for screen in self.screens:
-                for bar in [screen.top, screen.bottom, screen.left, screen.right]:
-                    if bar is not None:
-                        bar.finalize()
+                for gap in screen.gaps:
+                    gap.finalize()
 
             logger.info('Removing io watch')
             fd = self.conn.conn.get_file_descriptor()
@@ -1331,10 +1330,10 @@ class Qtile(command.CommandObject):
             width=i.width,
             height=i.height,
             gaps=dict(
-                top=i.top.geometry() if i.top else None,
-                bottom=i.bottom.geometry() if i.bottom else None,
-                left=i.left.geometry() if i.left else None,
-                right=i.right.geometry() if i.right else None,
+                top=[gap.geometry() for gap in i.top],
+                bottom=[gap.geometry() for gap in i.bottom],
+                left=[gap.geometry() for gap in i.left],
+                right=[gap.geometry() for gap in i.right],
             )
         ) for i in self.screens]
         return lst
@@ -1765,25 +1764,18 @@ class Qtile(command.CommandObject):
             one of: "top", "bottom", "left", "right", or "all" (default: "all")
         """
         if position in ["top", "bottom", "left", "right"]:
-            bar = getattr(self.currentScreen, position)
-            if bar:
-                bar.show(not bar.is_show())
-                self.currentGroup.layoutAll()
-            else:
-                logger.warning(
-                    "Not found bar in position '%s' for hide/show." % position)
+            gaps = getattr(self.currentScreen, position)
+            for gap in gaps:
+                gap.show(not gap.is_show())
+            self.currentGroup.layoutAll()
         elif position == "all":
-            screen = self.currentScreen
             is_show = None
-            for bar in [screen.left, screen.right, screen.top, screen.bottom]:
-                if bar:
-                    if is_show is None:
-                        is_show = not bar.is_show()
-                    bar.show(is_show)
+            for gap in self.currentScreen.gaps:
+                if is_show is None:
+                    is_show = not gap.is_show()
+                    gap.show(is_show)
             if is_show is not None:
                 self.currentGroup.layoutAll()
-            else:
-                logger.warning("Not found bar for hide/show.")
         else:
             logger.error("Invalid position value:{0:s}".format(position))
 

--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -1102,7 +1102,12 @@ class Qtile(command.CommandObject):
         elif name == "widget":
             return False, list(self.widgetMap.keys())
         elif name == "bar":
-            return False, [x.position for x in self.currentScreen.gaps]
+            keys = []
+            for gap in self.currentScreen.gaps:
+                position = getattr(self.currentScreen, gap.position)
+                index = position.index(gap)
+                keys.append("{}_{}".format(gap.position, index))
+            return False, keys
         elif name == "window":
             return True, self.listWID()
         elif name == "screen":
@@ -1122,7 +1127,8 @@ class Qtile(command.CommandObject):
         elif name == "widget":
             return self.widgetMap.get(sel)
         elif name == "bar":
-            return getattr(self.currentScreen, sel)
+            position, index = sel.split("_")
+            return getattr(self.currentScreen, position)[int(index)]
         elif name == "window":
             if sel is None:
                 return self.currentWindow

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -117,7 +117,7 @@ def test_completion():
 @gb_config
 def test_draw(qtile):
     qtile.testWindow("one")
-    b = qtile.c.bar["bottom"].info()
+    b = qtile.c.bar["bottom_0"].info()
     assert b["widgets"][0]["name"] == "groupbox"
 
 
@@ -163,7 +163,7 @@ def test_textbox_errors(qtile):
 def test_groupbox_button_press(qtile):
     qtile.c.group["ccc"].toscreen()
     assert qtile.c.groups()["a"]["screen"] is None
-    qtile.c.bar["bottom"].fake_button_press(0, "bottom", 10, 10, 1)
+    qtile.c.bar["bottom_0"].fake_button_press(0, "bottom", 10, 10, 1)
     assert qtile.c.groups()["a"]["screen"] == 0
 
 
@@ -214,10 +214,10 @@ class DWidget(object):
 def test_geometry(qtile):
     qtile.testXeyes()
     g = qtile.c.screens()[0]["gaps"]
-    assert g["top"] == (0, 0, 800, 10)
-    assert g["bottom"] == (0, 590, 800, 10)
-    assert g["left"] == (0, 10, 10, 580)
-    assert g["right"] == (790, 10, 10, 580)
+    assert g["top"] == [(0, 0, 800, 10)]
+    assert g["bottom"] == [(0, 590, 800, 10)]
+    assert g["left"] == [(0, 10, 10, 580)]
+    assert g["right"] == [(790, 10, 10, 580)]
     assert len(qtile.c.windows()) == 1
     geom = qtile.c.windows()[0]
     assert geom["x"] == 10
@@ -226,7 +226,7 @@ def test_geometry(qtile):
     assert geom["height"] == 578
     internal = qtile.c.internal_windows()
     assert len(internal) == 4
-    wid = qtile.c.bar["bottom"].info()["window"]
+    wid = qtile.c.bar["bottom_0"].info()["window"]
     assert qtile.c.window[wid].inspect()
 
 
@@ -375,7 +375,7 @@ def test_basic(qtile_nospawn):
 
     qtile_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = qtile_nospawn.c.bar["bottom_0"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][1]["offset"] == 10
     assert i["widgets"][1]["width"] == 780
@@ -398,7 +398,7 @@ def test_singlespacer(qtile_nospawn):
 
     qtile_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = qtile_nospawn.c.bar["bottom_0"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][0]["width"] == 800
     libqtile.hook.clear()
@@ -420,7 +420,7 @@ def test_nospacer(qtile_nospawn):
 
     qtile_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = qtile_nospawn.c.bar["bottom_0"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][1]["offset"] == 10
     libqtile.hook.clear()

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -202,7 +202,7 @@ server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
 def test_cmd_commands(qtile):
     assert qtile.c.commands()
     assert qtile.c.layout.commands()
-    assert qtile.c.screen.bar["bottom"].commands()
+    assert qtile.c.screen.bar["bottom_0"].commands()
 
 
 @server_config
@@ -226,7 +226,7 @@ def test_items_qtile(qtile):
     assert not v[0]
     assert sorted(v[1]) == ['one', 'two']
 
-    assert qtile.c.items("bar") == (False, ["bottom"])
+    assert qtile.c.items("bar") == (False, ["bottom_0"])
     t, lst = qtile.c.items("window")
     assert t
     assert len(lst) == 2
@@ -252,7 +252,7 @@ def test_select_qtile(qtile):
     with pytest.raises(libqtile.command.CommandError):
         qtile.c.widget.info()
 
-    assert qtile.c.bar["bottom"].info()["position"] == "bottom"
+    assert qtile.c.bar["bottom_0"].info()["position"] == "bottom"
 
     qtile.testWindow("one")
     wid = qtile.c.window.info()["id"]
@@ -310,7 +310,7 @@ def test_items_screen(qtile):
     wid = qtile.c.window.info()["id"]
     assert s.items("window") == (True, [wid])
 
-    assert s.items("bar") == (False, ["bottom"])
+    assert s.items("bar") == (False, ["bottom_0"])
 
 
 @server_config
@@ -333,19 +333,19 @@ def test_select_screen(qtile):
         s.bar.info()
     with pytest.raises(libqtile.command.CommandError):
         s.bar["top"].info()
-    assert s.bar["bottom"].info()["position"] == "bottom"
+    assert s.bar["bottom_0"].info()["position"] == "bottom"
 
 
 @server_config
 def test_items_bar(qtile):
-    assert qtile.c.bar["bottom"].items("screen") == (True, None)
+    assert qtile.c.bar["bottom_0"].items("screen") == (True, None)
 
 
 @server_config
 def test_select_bar(qtile):
-    assert qtile.c.screen[1].bar["bottom"].screen.info()["index"] == 1
+    assert qtile.c.screen[1].bar["bottom_0"].screen.info()["index"] == 1
     b = qtile.c.bar
-    assert b["bottom"].screen.info()["index"] == 0
+    assert b["bottom_0"].screen.info()["index"] == 0
     with pytest.raises(libqtile.command.CommandError):
         b.screen.info()
 
@@ -404,4 +404,4 @@ def test_select_widget(qtile):
     w = qtile.c.widget["one"]
     assert w.bar.info()["position"] == "bottom"
     with pytest.raises(libqtile.command.CommandError):
-        w.bar["bottom"].info()
+        w.bar["bottom_0"].info()

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -179,21 +179,21 @@ def test_basic(qtile):
 @fakescreen_config
 def test_gaps(qtile):
     g = qtile.c.screens()[0]["gaps"]
-    assert g["bottom"] == (0, 456, 600, 24)
-    assert g["left"] == (0, 0, 16, 456)
-    assert g["right"] == (580, 0, 20, 456)
+    assert g["bottom"] == [(0, 456, 600, 24)]
+    assert g["left"] == [(0, 0, 16, 456)]
+    assert g["right"] == [(580, 0, 20, 456)]
     g = qtile.c.screens()[1]["gaps"]
-    assert g["top"] == (600, 0, 300, 30)
-    assert g["bottom"] == (600, 556, 300, 24)
-    assert g["left"] == (600, 30, 12, 526)
+    assert g["top"] == [(600, 0, 300, 30)]
+    assert g["bottom"] == [(600, 556, 300, 24)]
+    assert g["left"] == [(600, 30, 12, 526)]
     g = qtile.c.screens()[2]["gaps"]
-    assert g["top"] == (0, 480, 500, 30)
-    assert g["bottom"] == (0, 864, 500, 16)
-    assert g["right"] == (460, 510, 40, 354)
+    assert g["top"] == [(0, 480, 500, 30)]
+    assert g["bottom"] == [(0, 864, 500, 16)]
+    assert g["right"] == [(460, 510, 40, 354)]
     g = qtile.c.screens()[3]["gaps"]
-    assert g["top"] == (500, 580, 400, 30)
-    assert g["left"] == (500, 610, 20, 370)
-    assert g["right"] == (876, 610, 24, 370)
+    assert g["top"] == [(500, 580, 400, 30)]
+    assert g["left"] == [(500, 610, 20, 370)]
+    assert g["right"] == [(876, 610, 24, 370)]
 
 
 @fakescreen_config

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -975,7 +975,7 @@ def test_dheight():
     s = TScreen(top=libqtile.bar.Gap(10))
     s._configure(None, 0, 0, 0, 100, 100, None)
     assert s.dheight == 90
-    s.bottom = libqtile.bar.Gap(10)
+    s.bottom = [libqtile.bar.Gap(10)]
     assert s.dheight == 80
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -961,7 +961,7 @@ def test_dwidth():
     s = TScreen(left=libqtile.bar.Gap(10))
     s._configure(None, 0, 0, 0, 100, 100, None)
     assert s.dwidth == 90
-    s.right = libqtile.bar.Gap(10)
+    s.right = [libqtile.bar.Gap(10)]
     assert s.dwidth == 80
 
 


### PR DESCRIPTION
[The documentation says](http://docs.qtile.org/en/latest/manual/config/screens.html#screen) that we can give a list of `Gap`/`Bar` object to `Screen.top` (and alike), but it looks like it never was the case. So I implemented it.

It fixes #1230 (see #826, also).

To that end, I had to modify everything related to bars in Qtile's IPC land. Since I could not manage to do it with two dimensions (i.e. I could not manage to make `qtile.c.bar["bottom"][0]` work), I hacked something so that it looks like this: `qtile.c.bar["bottom_0"]`. This is indeed suboptimal but I feel that it's the only way without rewriting the whole `CommandTree` logic.

The only thing left is to fix the tests in `test_fakescreen.py`, that are broken but I've no idea why; the error doesn't help at all: `AssertionError: retry failed!`. I need help on this.
