### PR TITLE
Initialise fake_screens and add documentation

### DIFF
--- a/docs/manual/config/screens.rst
+++ b/docs/manual/config/screens.rst
@@ -38,6 +38,96 @@ background="#000000")` will give you a black back ground (the default), while
 :code:`bar.Bar(..., background=["#000000", "#FFFFFF"])` will give you a
 background that fades from black to white.
 
+Fake Screens
+============
+
+instead of using the variable `screens` the variable `fake_screens` can be used to set split a physical monitor into multiple screens.
+They can be used like this:
+
+::
+
+    from libqtile.config import Screen
+    from libqtile import bar, widget
+
+    # screens look like this
+    #     600         300
+    #  |-------------|-----|
+    #  |          480|     |580
+    #  |   A         |  B  |
+    #  |----------|--|     |
+    #  |       400|--|-----|
+    #  |   C      |        |400
+    #  |----------|   D    |
+    #     500     |--------|
+    #                 400
+    #
+    # Notice there is a hole in the middle
+    # also D goes down below the others
+
+    fake_screens = [
+      Screen(
+          bottom=bar.Bar(
+              [
+                  widget.Prompt(),
+                  widget.Sep(),
+                  widget.WindowName(),
+                  widget.Sep(),
+                  widget.Systray(),
+                  widget.Sep(),
+                  widget.Clock(format='%H:%M:%S %d.%m.%Y')
+              ],
+              24,
+              background="#555555"
+          ),
+          x=0,
+          y=0,
+          width=600,
+          height=480
+      ),
+      Screen(
+          top=bar.Bar(
+              [
+                  widget.GroupBox(),
+                  widget.WindowName(),
+                  widget.Clock()
+              ],
+              30,
+          ),
+          x=600,
+          y=0,
+          width=300,
+          height=580
+      ),
+      Screen(
+          top=bar.Bar(
+              [
+                  widget.GroupBox(),
+                  widget.WindowName(),
+                  widget.Clock()
+              ],
+              30,
+          ),
+          x=0,
+          y=480,
+          width=500,
+          height=400
+      ),
+      Screen(
+          top=bar.Bar(
+              [
+                  widget.GroupBox(),
+                  widget.WindowName(),
+                  widget.Clock()
+              ],
+              30,
+          ),
+          x=500,
+          y=580,
+          width=400,
+          height=400
+      ),
+    ]
+
 Third-party bars
 ================
 

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -43,6 +43,7 @@ class Config(object):
         "layouts",
         "floating_layout",
         "screens",
+        "fake_screens",
         "main",
         "auto_fullscreen",
         "widget_defaults",


### PR DESCRIPTION
closes #1238  and as a replacement of #1192:

Initialize fake_screens if they exist plus some documentation.


I literally just copied the documentation from the file [test/test_fakescreen.py](https://github.com/qtile/qtile/blob/develop/test/test_fakescreen.py) and trimmed it a bit. I also added a short oneline explanation. I hope this is enough :)