### PR TITLE
shutdown: try to be slightly more graceful

### DIFF
--- a/libqtile/manager.py
+++ b/libqtile/manager.py
@@ -773,7 +773,7 @@ class Qtile(command.CommandObject):
         for pid in pids:
             try:
                 os.kill(pid, signal.SIGTERM)
-            except ProcessLookupError:
+            except OSError:
                 # might have died recently
                 pass
 
@@ -782,7 +782,7 @@ class Qtile(command.CommandObject):
             try:
                 os.kill(pid, 0)
                 return True
-            except ProcessLookupError:
+            except OSError:
                 return False
 
         # give everyone a little time to exit and write their state. but don't


### PR DESCRIPTION
Right now, qtile just closes the X session, which causes everything in that
session to get a SIGKILL. Instead, let's send a SIGTERM to everyone and
wait a little bit so that maybe they'll be able to save their state in some
nice way.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>