### PR TITLE
Keep track of changing timezones

### DIFF
--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -80,6 +80,7 @@ class Clock(base.InLoopPollText):
     # theoreticaly call our method too early and we could get something
     # like (x-1).999 instead of x.000
     def _get_time(self):
+        time.tzset()
         now = datetime.now(utc).astimezone()
         return (now + self.DELTA).strftime(self.format)
 


### PR DESCRIPTION
Currently, when using the clock widget without a specified timezone, the
timezone is chosen to be the one currently being used at startup and never
updated. In particular the widget does not reflect changes to the system
timezone. This PS change this behaviour.
