### PR TITLE
Make widgets.Clock much more robust and simple with pytz

### DIFF
--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -38,9 +38,10 @@ class Clock(base.InLoopPollText):
     defaults = [
         ('format', '%H:%M', 'A Python datetime format string'),
         ('update_interval', 1., 'Update interval for the clock'),
-        ('timezone', None, 'The timezone to use for this clock, '
-            'e.g. "US/Central" (or anything in /usr/share/zoneinfo). None means '
-            'the default timezone.')
+        ('timezone', None, 'The timezone to use for this clock, either as'
+         ' string if pytz is installed (e.g. "US/Central" or anything in'
+         ' /usr/share/zoneinfo), or as tzinfo (e.g. datetime.timezone.utc).'
+         ' None means the system local timezone and is the default.')
     ]
     DELTA = timedelta(seconds=0.5)
 

--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -24,6 +24,7 @@
 import time
 from datetime import datetime, timedelta, timezone
 from . import base
+from ..log_utils import logger
 
 try:
     import pytz
@@ -46,8 +47,15 @@ class Clock(base.InLoopPollText):
     def __init__(self, **config):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(Clock.defaults)
-        if pytz and isinstance(self.timezone, str):
-            self.timezone = pytz.timezone(self.timezone)
+        if isinstance(self.timezone, str):
+            if pytz is None:
+                logger.warning('Clock widget can not infer its timezone from a'
+                               ' string without the pytz library. Install pytz'
+                               ' or give it a datetime.tzinfo instance.')
+            else:
+                self.timezone = pytz.timezone(self.timezone)
+        if self.timezone is None:
+            logger.info('Defaulting to the system local timezone.')
 
     def tick(self):
         self.update(self.poll())

--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import sys
 import time
 from datetime import datetime, timedelta, timezone
 from . import base
@@ -29,7 +30,7 @@ from ..log_utils import logger
 try:
     import pytz
 except ImportError:
-    pytz = None
+    pass
 
 
 class Clock(base.InLoopPollText):
@@ -49,12 +50,12 @@ class Clock(base.InLoopPollText):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(Clock.defaults)
         if isinstance(self.timezone, str):
-            if pytz is None:
+            if "pytz" in sys.modules:
+                self.timezone = pytz.timezone(self.timezone)
+            else:
                 logger.warning('Clock widget can not infer its timezone from a'
                                ' string without the pytz library. Install pytz'
                                ' or give it a datetime.tzinfo instance.')
-            else:
-                self.timezone = pytz.timezone(self.timezone)
         if self.timezone is None:
             logger.info('Defaulting to the system local timezone.')
 


### PR DESCRIPTION
The idea here is mostly to remove the environment's `TZ` hackery (which, I guess, avoid having different clocks on different timezones), and thus making the code way simpler.

It also allows users to pass a `tzinfo` class directly to the widget rather than a string.