### PR TITLE
warp cursor on screen change

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -175,7 +175,7 @@ class _Group(command.CommandObject):
         if self.screen:
             # move all floating guys offset to new screen
             self.floating_layout.to_screen(self, self.screen)
-            self.layout_all()
+            self.layout_all(warp=self.qtile.config.cursor_warp)
             rect = self.screen.get_rect()
             self.floating_layout.show(rect)
             self.layout.show(rect)


### PR DESCRIPTION
In the case of a screen change, we're changing the window focus, so we should
warp the cursor to the middle of the newly selected window.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>