### PR TITLE
copy default config attributes over to test configs

### DIFF
--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -29,6 +29,7 @@ import libqtile.core
 import libqtile.utils
 import libqtile.hook
 import logging
+from libqtile.resources import default_config
 
 from .conftest import BareConfig
 
@@ -95,6 +96,9 @@ def test_can_unsubscribe_from_hook():
 
 def test_can_subscribe_to_startup_hooks(qtile_nospawn):
     config = BareConfig
+    for attr in dir(default_config):
+        if not hasattr(config, attr):
+            setattr(config, attr, getattr(default_config, attr))
     self = qtile_nospawn
 
     self.startup_once_calls = Value('i', 0)


### PR DESCRIPTION
The recent cursor_warp fix meant that now some of the test code configs
need cursor_warp. It's a pain in the ass to add unrelated variables to the
test configs every time we add a new config variable, and it trips a lot of
people up.

Instead, let's just copy everything that doesn't already exist over from
the default config, so nobody has to mess around with this any more.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>