### PR TITLE
tests: don't leak an fd

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -321,10 +321,6 @@ class Qtile:
         if self.proc is None:
             print("Qtile is not alive", file=sys.stderr)
         else:
-            # try to send SIGTERM and wait up to 10 sec to quit
-            self.proc.terminate()
-            self.proc.join(10)
-
             if self.proc.is_alive():
                 # desperate times... this probably messes with multiprocessing...
                 try:


### PR DESCRIPTION
test/test_hook.py::test_can_call_by_selection_notify
  /home/tycho/packages/qtile/test/conftest.py:195: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/.X358037035-lock' mode='w' encoding='UTF-8'>
    self.display = ":{}".format(_find_display())

The problem here is that Xvfb._get_next_unused_display() opens a lockfile,
but since we're not using Xvfb() in a finally block, we don't close it.
Let's just open-code this, and try to drop the xvfb dep in the future, as
it's only used in one other place, and we could presumably use xcffib's
XvfbTest wrapper instead.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>