### PR TITLE
Clean up and test battery widget interfaces

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -28,14 +28,20 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 import os
-import re
 import platform
+import re
+
 from abc import ABC, abstractclassmethod
 from enum import Enum, auto, unique
+from pathlib import Path
 from subprocess import check_output, CalledProcessError
+from typing import Any, List, NamedTuple, Optional, Tuple
+
 from libqtile import bar
 from libqtile.log_utils import logger
+from libqtile.images import Img
 from . import base
 from .. import images, configurable
 
@@ -43,12 +49,19 @@ from typing import Dict
 
 
 @unique
-class State(Enum):
+class BatteryState(Enum):
     CHARGING = auto()
     DISCHARGING = auto()
     FULL = auto()
     EMPTY = auto()
     UNKNOWN = auto()
+
+
+class BatteryStatus(NamedTuple):
+    state: BatteryState
+    percent: float
+    power: float
+    time: int
 
 
 class _Battery(ABC):
@@ -57,74 +70,38 @@ class _Battery(ABC):
         battery implementation should provide.
     """
     @abstractclassmethod
-    def _update_data(self):
-        """
-            Reads the battery status from the system and stores the
-            result internally for later retrieval. Is called every
-            time battery status is queried.
+    def update_status(self) -> BatteryStatus:
+        """Read the battery status
 
-            No return
+            Reads the battery status from the system and returns the result.
 
             Raises RuntimeError on error.
         """
         pass
 
-    @abstractclassmethod
-    def _get_state(self):
-        """
-            Returns the state of the battery.
 
-            Return value is one of:
-                State.CHARGING
-                State.DISCHARGING
-                State.FULL
-                State.EMPTY
-                State.UNKNOWN
+def load_battery(**config) -> _Battery:
+    """Default battery loading function
 
-            Raises RuntimeError on error.
-        """
-        pass
+    Loads and returns the _Battery interface suitable for the current running
+    platform.
 
-    @abstractclassmethod
-    def _get_percentage(self):
-        """
-            Returns the percentage remaining in the battery in decimal
-            form.
+    Parameters
+    ----------
+    config: Dictionary of config options that are passed to the generated
+    battery.
 
-            Return value:
-                float containing remaining charge percentage in
-                decimal form
-
-            Raises RuntimeError on error.
-        """
-        pass
-
-    @abstractclassmethod
-    def _get_power(self):
-        """
-            Returns the current power consumption in watts [W] as a
-            number.
-
-            Return value:
-                float containing the current power consumption in
-                watts [W].
-
-            Raises RuntimeErorr on error.
-        """
-        pass
-
-    @abstractclassmethod
-    def _get_time(self):
-        """
-            Returns the estimated remaining battery time in seconds.
-
-            Return value:
-                int containing the seconds of battery time
-                remaining.
-
-            Raises RuntimeError on error.
-        """
-        pass
+    Return
+    ------
+    The configured _Battery for the current platform.
+    """
+    system = platform.system()
+    if system == 'FreeBSD':
+        return _FreeBSDBattery(str(config["battery"]))
+    elif system == 'Linux':
+        return _LinuxBattery(**config)
+    else:
+        raise RuntimeError('Unknown platform!')
 
 
 class _FreeBSDBattery(_Battery):
@@ -136,88 +113,78 @@ class _FreeBSDBattery(_Battery):
         that should be monitored.
     """
 
-    def __init__(self, battery='0'):
+    def __init__(self, battery='0') -> None:
         self.battery = battery
-        self._update_data()
 
-    def _update_data(self):
+    def update_status(self) -> BatteryStatus:
         try:
-            self.info = \
-                check_output(['acpiconf', '-i', self.battery]).decode('utf-8')
+            info = check_output(['acpiconf', '-i', self.battery]).decode('utf-8')
         except CalledProcessError:
             raise RuntimeError('acpiconf exited incorrectly')
 
-    def _get_state(self):
-        stat = re.search(r'State:\t+([a-z]+)', self.info)
+        stat = re.search(r'State:\t+([a-z]+)', info)
 
         if stat is None:
             raise RuntimeError('Could not get battery state!')
 
         stat = stat.group(1)
         if stat == 'charging':
-            result = State.CHARGING
+            state = BatteryState.CHARGING
         elif stat == 'discharging':
-            result = State.DISCHARGING
+            state = BatteryState.DISCHARGING
         elif stat == 'high':
-            result = State.FULL
+            state = BatteryState.FULL
         else:
-            result = State.UNKNOWN
+            state = BatteryState.UNKNOWN
 
-        return result
-
-    def _get_percentage(self):
-        pct = re.search(r'Remaining capacity:\t+([0-9]+)', self.info)
-        if pct:
-            return int(pct.group(1)) / 100
+        percent_re = re.search(r'Remaining capacity:\t+([0-9]+)', info)
+        if percent_re:
+            percent = int(percent_re.group(1)) / 100
         else:
             raise RuntimeError('Could not get battery percentage!')
 
-    def _get_power(self):
-        pow = re.search(r'Present rate:\t+(?:[0-9]+ mA )*\(?([0-9]+) mW',
-                        self.info)
-        if pow:
-            return float(pow.group(1)) / 1000
+        power_re = re.search(r'Present rate:\t+(?:[0-9]+ mA )*\(?([0-9]+) mW',
+                             info)
+        if power_re:
+            power = float(power_re.group(1)) / 1000
         else:
             raise RuntimeError('Could not get battery power!')
 
-    def _get_time(self):
-        time = re.search(r'Remaining time:\t+([0-9]+:[0-9]+|unknown)',
-                         self.info)
-        if time:
-            if time.group(1) == 'unknown':
-                return 0
+        time_re = re.search(r'Remaining time:\t+([0-9]+:[0-9]+|unknown)',
+                            info)
+        if time_re:
+            if time_re.group(1) == 'unknown':
+                time = 0
             else:
-                time = time.group(1).split(':')
-                return int(time[0]) * 3600 + int(time[1]) * 60
+                hours, _, minutes = time_re.group(1).partition(':')
+                time = int(hours) * 3600 + int(minutes) * 60
         else:
             raise RuntimeError('Could not get remaining battery time!')
+
+        return BatteryStatus(state, percent=percent, power=power, time=time)
 
 
 class _LinuxBattery(_Battery, configurable.Configurable):
     defaults = [
         (
             'status_file',
-            'status',
-            'Name of status file in'
-            ' /sys/class/power_supply/battery_name'
+            None,
+            'Name of status file in /sys/class/power_supply/battery_name'
         ),
         (
             'energy_now_file',
             None,
-            'Name of file with the '
-            'current energy in /sys/class/power_supply/battery_name'
+            'Name of file with the current energy in /sys/class/power_supply/battery_name'
         ),
         (
             'energy_full_file',
             None,
-            'Name of file with the maximum'
-            ' energy in /sys/class/power_supply/battery_name'
+            'Name of file with the maximum energy in /sys/class/power_supply/battery_name'
         ),
         (
             'power_now_file',
             None,
-            'Name of file with the current'
-            ' power draw in /sys/class/power_supply/battery_name'
+            'Name of file with the current power draw in /sys/class/power_supply/battery_name'
         )
     ]
 
@@ -233,24 +200,6 @@ class _LinuxBattery(_Battery, configurable.Configurable):
         'status_file': ['status'],
     }
 
-    CHARGED = 'Full'
-    CHARGING = 'Charging'
-    DISCHARGING = 'Discharging'
-    UNKNOWN = 'Unknown'
-
-    stat = ''
-    now = 0
-    full = 0
-    power = 0
-    voltage = 0
-
-    def _get_battery_name(self):
-        if os.path.isdir(self.BAT_DIR):
-            bats = [f for f in os.listdir(self.BAT_DIR) if f.startswith('BAT')]
-            if bats:
-                return bats[0]
-        return 'BAT0'
-
     def __init__(self, **config):
         _LinuxBattery.defaults.append(('battery',
                                        self._get_battery_name(),
@@ -259,112 +208,94 @@ class _LinuxBattery(_Battery, configurable.Configurable):
         configurable.Configurable.__init__(self, **config)
         self.add_defaults(_LinuxBattery.defaults)
 
-    def _load_file(self, name):
+    def _get_battery_name(self):
+        if os.path.isdir(self.BAT_DIR):
+            bats = [f for f in os.listdir(self.BAT_DIR) if f.startswith('BAT')]
+            if bats:
+                return bats[0]
+        return 'BAT0'
+
+    def _load_file(self, name) -> Optional[Tuple[str, str]]:
         try:
             path = os.path.join(self.BAT_DIR, self.battery, name)
-            if 'energy'in name or 'power' in name:
+            if 'energy' in name or 'power' in name:
                 value_type = 'uW'
-            elif 'charge' in name or 'current' in name:
+            elif 'charge' in name:
+                value_type = 'uAh'
+            elif 'current' in name:
                 value_type = 'uA'
-            elif 'voltage' in name:
-                value_type = 'V'
             else:
                 value_type = ''
 
             with open(path, 'r') as f:
-                return (f.read().strip(), value_type,)
-        except IOError:
-            if name == 'current_now':
-                return 0
-            return False
+                return f.read().strip(), value_type
         except Exception:
             logger.exception("Failed to get %s" % name)
-
-    def _get_param(self, name):
-        if name in self.filenames and self.filenames[name]:
-            return self._load_file(self.filenames[name])
-        elif name not in self.filenames:
-            # Don't have the file name cached, figure it out
-
-            # Don't modify the global list! Copy with [:]
-            file_list = self.BATTERY_INFO_FILES.get(name, [])[:]
-
-            if getattr(self, name, None):
-                # If a file is manually specified, check it first
-                file_list.insert(0, getattr(self, name))
-
-            # Iterate over the possibilities, and return the first valid value
-            for file in file_list:
-                value = self._load_file(file)
-                if value is not False and value is not None:
-                    self.filenames[name] = file
-                    return value
-
-        # If we made it this far, we don't have a valid file.
-        # Set it to None to avoid trying the next time.
-        self.filenames[name] = None
-
         return None
 
-    def _update_data(self):
-        try:
-            self.stat = self._get_param('status_file')[0]
+    def _get_param(self, name) -> Tuple[str, str]:
+        if name in self.filenames and self.filenames[name]:
+            result = self._load_file(self.filenames[name])
+            if result is not None:
+                return result
 
-            self.now = self._get_param('energy_now_file')
-            self.now = (float(self.now[0]), self.now[1],)
+        # Don't have the file name cached, figure it out
+        # Don't modify the global list! Copy with [:]
+        file_list = self.BATTERY_INFO_FILES.get(name, [])[:]
+        user_file_name = getattr(self, name, None)
+        if user_file_name is not None:
+            file_list.insert(0, user_file_name)
 
-            self.full = self._get_param('energy_full_file')
-            self.full = (float(self.full[0]), self.full[1],)
+        # Iterate over the possibilities, and return the first valid value
+        for filename in file_list:
+            value = self._load_file(filename)
+            if value is not None:
+                self.filenames[name] = filename
+                return value
 
-            self.power = self._get_param('power_now_file')
-            self.power = (float(self.power[0]), self.power[1],)
+        raise RuntimeError("Unable to read status for {}".format(name))
 
-            self.voltage = self._get_param('voltage_now_file')
-            self.voltage = (float(self.voltage[0]), self.voltage[1],)
-        except TypeError:
-            raise RuntimeError('Got unexpected data type when updating ' +
-                               'LinuxBattery data.')
+    def update_status(self) -> BatteryStatus:
+        stat = self._get_param('status_file')[0]
 
-    def _get_state(self):
-        state = State.UNKNOWN
-        if self.stat == self.CHARGED:
-            state = State.FULL
-        elif self.stat == self.CHARGING:
-            state = State.CHARGING
-        elif self.stat == self.DISCHARGING:
-            state = State.DISCHARGING
+        if stat == "Full":
+            state = BatteryState.FULL
+        elif stat == "Charging":
+            state = BatteryState.CHARGING
+        elif stat == "Discharging":
+            state = BatteryState.DISCHARGING
+        else:
+            state = BatteryState.UNKNOWN
 
-        return state
+        now_str, now_unit = self._get_param('energy_now_file')
+        full_str, full_unit = self._get_param('energy_full_file')
+        power_str, power_unit = self._get_param('power_now_file')
+        # the units of energy is uWh or uAh, multiply to get to uWs or uAs
+        now = 3600 * float(now_str)
+        full = 3600 * float(full_str)
+        power = float(power_str)
 
-    def _get_percentage(self):
-        return self.now[0] / self.full[0]
+        if now_unit != full_unit:
+            raise RuntimeError("Current and full energy units do not match")
+        if full == 0:
+            percent = 0.
+        else:
+            percent = now / full
 
-    def _get_power(self):
-        power = 0
-        if self.power[1] == 'uA':
-            power = (self.voltage[0] * self.power[0]) / 1e12
-        elif self.power[1] == 'uW':
-            power = self.power[0] / 1e6
-        return power
+        if power_unit == 'uA':
+            voltage = float(self._get_param('voltage_now_file')[0])
+            power = voltage * power / 1e12
+        elif power_unit == 'uW':
+            power = power / 1e6
 
-    def _get_time(self):
-        if self.power[0] == 0:
-            return 0
+        if power == 0:
+            time = 0
+        elif state == BatteryState.DISCHARGING:
+            time = int(now / power)
+        else:
+            time = int((full - now) / power)
 
-        time = 0
-        state = self._get_state()
-
-        # Multiply the uAh and uWh by 3600 to get results in seconds.
-        now = self.now[0] * 3600
-        full = self.full[0] * 3600
-        power = self.power[0]
-
-        if state == State.DISCHARGING:
-            time = now / power
-        elif state == State.CHARGING:
-            time = (full - now) / power
-
-        return int(time)
+        return BatteryStatus(state=state, percent=percent, power=power, time=time)
 
 
 class Battery(base._TextBox):
@@ -372,118 +303,113 @@ class Battery(base._TextBox):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ('charge_char', '^', 'Character to indicate the battery is charging'),
-        ('discharge_char',
-         'V',
-         'Character to indicate the battery is discharging'
-         ),
+        ('discharge_char', 'V', 'Character to indicate the battery is discharging'),
         ('full_char', '=', 'Character to indicate the battery is full'),
         ('empty_char', 'x', 'Character to indicate the battery is empty'),
-        ('unknown_char',
-         '?',
-         'Character to indicate the battery status is unknown'),
-        ('format',
-         '{char} {percent:2.0%} {hour:d}:{min:02d} {watt:.2f} W',
-         'Display format'
-         ),
-        ('hide_threshold',
-         None,
-         'Hide the text when there is enough energy 0 <= x < 1'),
-        ('low_percentage',
-         0.10,
-         "Indicates when to use the low_foreground color 0 < x < 1"
-         ),
+        ('unknown_char', '?', 'Character to indicate the battery status is unknown'),
+        ('format', '{char} {percent:2.0%} {hour:d}:{min:02d} {watt:.2f} W', 'Display format'),
+        ('hide_threshold', None, 'Hide the text when there is enough energy 0 <= x < 1'),
+        ('show_short_text', True, 'Show "Full" or "Empty" rather than formated text'),
+        ('low_percentage', 0.10, "Indicates when to use the low_foreground color 0 < x < 1"),
         ('low_foreground', 'FF0000', 'Font color on low battery'),
         ('update_delay', 60, 'Seconds between status updates'),
         ('battery', 0, 'Which battery should be monitored'),
     ]
 
-    def __init__(self, **config):
+    def __init__(self, **config) -> None:
         base._TextBox.__init__(self, "BAT", bar.CALCULATED, **config)
         self.add_defaults(self.defaults)
 
-        system = platform.system()
-        if system == 'FreeBSD':
-            self.battery = _FreeBSDBattery(str(self.battery))
-        elif system == 'Linux':
-            self.battery = _LinuxBattery(**config)
-        else:
-            raise RuntimeError('Unknown platform!')
+        self._battery = self._load_battery(**config)
 
-    def timer_setup(self):
+    @staticmethod
+    def _load_battery(**config):
+        """Function used to load the Battery object
+
+        Battery behavior can be changed by overloading this function in a base
+        class.
+        """
+        return load_battery(**config)
+
+    def timer_setup(self) -> None:
         self.update()
         self.timeout_add(self.update_delay, self.timer_setup)
 
-    def _configure(self, qtile, bar):
+    def _configure(self, qtile, bar) -> None:
         if self.configured:
             self.update()
 
         base._TextBox._configure(self, qtile, bar)
 
-    def _get_text(self):
-        """
-            Function returning a string with battery information to
-            display on the status bar. Should only use the public
-            interface in _Battery to get necessary information for
-            constructing the string.
+    def _get_text(self) -> str:
+        """Determine the text to display
 
-            If some information is missing, modify the interface to
-            keep portability.
+        Function returning a string with battery information to display on the
+        status bar. Should only use the public interface in _Battery to get
+        necessary information for constructing the string.
         """
         try:
-            self.battery._update_data()
+            status = self._battery.update_status()
+        except RuntimeError as e:
+            return f'Error: {e}'
 
-            state = self.battery._get_state()
-            percent = self.battery._get_percentage()
-            power = self.battery._get_power()
-            time = self.battery._get_time()
+        if self.hide_threshold is not None and status.percent > self.hide_threshold:
+            return ''
 
-            if self.hide_threshold is not None and \
-                    percent > self.hide_threshold:
-                return ''
-
-            if state == State.DISCHARGING and percent < self.low_percentage:
+        if self.layout is not None:
+            if status.state == BatteryState.DISCHARGING and status.percent < self.low_percentage:
                 self.layout.colour = self.low_foreground
             else:
                 self.layout.colour = self.foreground
 
-            if state == State.CHARGING:
-                char = self.charge_char
-            elif state == State.DISCHARGING:
-                char = self.discharge_char
-            elif state == State.FULL:
-                char = self.full_char
-            elif state == State.EMPTY:
-                char = self.empty_char
-            elif state == State.UNKNOWN:
-                char = self.unknown_char
+        if status.state == BatteryState.CHARGING:
+            char = self.charge_char
+        elif status.state == BatteryState.DISCHARGING:
+            char = self.discharge_char
+        elif status.state == BatteryState.FULL:
+            if self.show_short_text:
+                return "Full"
+            char = self.full_char
+        elif status.state == BatteryState.EMPTY or \
+                (status.state == BatteryState.UNKNOWN and status.percent == 0):
+            if self.show_short_text:
+                return "Empty"
+            char = self.empty_char
+        else:
+            char = self.unknown_char
 
-            hour = time // 3600
-            minute = (time // 60) % 60
+        hour = status.time // 3600
+        minute = (status.time // 60) % 60
 
-            return self.format.format(
-                char=char,
-                percent=percent,
-                watt=power,
-                hour=hour,
-                min=minute
-            )
-        except RuntimeError as e:
-            return 'Error: {}'.format(str(e))
+        return self.format.format(
+            char=char,
+            percent=status.percent,
+            watt=status.power,
+            hour=hour,
+            min=minute
+        )
 
-    def update(self):
+    def update(self) -> None:
         ntext = self._get_text()
         if ntext != self.text:
             self.text = ntext
             self.bar.draw()
 
 
+def default_icon_path() -> str:
+    """Get the default path to battery icons"""
+    dir_path = Path(__file__).resolve() / ".." / ".." / "resources" / "battery-icons"
+    return str(dir_path.resolve())
+
+
 class BatteryIcon(base._TextBox):
     """Battery life indicator widget."""
 
     orientations = base.ORIENTATION_HORIZONTAL
-    defaults = [
+    defaults: List[Tuple[str, Any, str]] = [
         ('battery', 0, 'Which battery should be monitored'),
         ('update_delay', 60, 'Seconds between status updates'),
+        ('theme_path', default_icon_path(), 'Path of the icons'),
     ]
 
     icon_names = (
@@ -499,69 +425,53 @@ class BatteryIcon(base._TextBox):
         'battery-full-charged',
     )
 
-    def default_icon_path(self):
-        # default icons are in libqtile/resources/battery-icons
-        root = os.sep.join(os.path.abspath(__file__).split(os.sep)[:-2])
-        return os.path.join(root, 'resources', 'battery-icons')
-
-    def __init__(self, **config):
+    def __init__(self, **config) -> None:
         base._TextBox.__init__(self, "BAT", bar.CALCULATED, **config)
 
-        self.defaults.append(('theme_path', self.default_icon_path(),
-                              'Path of the icons'))
         self.add_defaults(self.defaults)
-
-        system = platform.system()
-        if system == 'FreeBSD':
-            self.battery = _FreeBSDBattery(str(self.battery))
-        elif system == 'Linux':
-            self.battery = _LinuxBattery(**config)
-        else:
-            raise RuntimeError('Unknown platform!')
 
         if self.theme_path:
             self.length_type = bar.STATIC
             self.length = 0
-        self.surfaces = {}
+        self.surfaces: Dict[str, Img] = {}
         self.current_icon = 'battery-missing'
 
-    def timer_setup(self):
+        self._battery = self._load_battery(**config)
+
+    @staticmethod
+    def _load_battery(**config):
+        """Function used to load the Battery object
+
+        Battery behavior can be changed by overloading this function in a base
+        class.
+        """
+        return load_battery(**config)
+
+    def timer_setup(self) -> None:
         self.update()
         self.timeout_add(self.update_delay, self.timer_setup)
 
-    def _configure(self, qtile, bar):
+    def _configure(self, qtile, bar) -> None:
         base._TextBox._configure(self, qtile, bar)
-        if self.theme_path:
-            self.setup_images()
+        self.setup_images()
 
-    def _get_icon_key(self):
-        key = 'battery'
-        percent = self.battery._get_percentage()
+    def setup_images(self) -> None:
+        d_imgs = images.Loader(self.theme_path)(*self.icon_names)
+        new_height = self.bar.height - self.actual_padding
+        for key, img in d_imgs.items():
+            img.resize(height=new_height)
+            if img.width > self.length:
+                self.length = int(img.width + self.actual_padding * 2)
+            self.surfaces[key] = img.pattern
 
-        if percent < .2:
-            key += '-caution'
-        elif percent < .4:
-            key += '-low'
-        elif percent < .8:
-            key += '-good'
-        else:
-            key += '-full'
-
-        state = self.battery._get_state()
-        if state == State.CHARGING:
-            key += '-charging'
-        elif state == State.FULL:
-            key += '-charged'
-        return key
-
-    def update(self):
-        self.battery._update_data()
-        icon = self._get_icon_key()
+    def update(self) -> None:
+        status = self._battery.update_status()
+        icon = self._get_icon_key(status)
         if icon != self.current_icon:
             self.current_icon = icon
             self.draw()
 
-    def draw(self):
+    def draw(self) -> None:
         if self.theme_path:
             self.drawer.clear(self.background or self.bar.background)
             self.drawer.ctx.set_source(self.surfaces[self.current_icon])
@@ -571,12 +481,23 @@ class BatteryIcon(base._TextBox):
             self.text = self.current_icon[8:]
             base._TextBox.draw(self)
 
-    def setup_images(self):
-        d_imgs = images.Loader(self.theme_path)(*self.icon_names)
-        new_height = self.bar.height - self.actual_padding
-        surfs = self.surfaces
-        for key, img in d_imgs.items():
-            img.resize(height=new_height)
-            if img.width > self.length:
-                self.length = int(img.width + self.actual_padding * 2)
-            surfs[key] = img.pattern
+    @staticmethod
+    def _get_icon_key(status: BatteryStatus) -> str:
+        key = 'battery'
+
+        percent = status.percent
+        if percent < .2:
+            key += '-caution'
+        elif percent < .4:
+            key += '-low'
+        elif percent < .8:
+            key += '-good'
+        else:
+            key += '-full'
+
+        state = status.state
+        if state == BatteryState.CHARGING:
+            key += '-charging'
+        elif state == BatteryState.FULL:
+            key += '-charged'
+        return key

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -1,8 +1,172 @@
 import pytest
-from libqtile.widget import BatteryIcon
+from libqtile.widget import Battery, BatteryIcon, battery
+from libqtile.widget.battery import BatteryState, BatteryStatus
 from libqtile import images
 import cairocffi
 from .conftest import TEST_DIR
+
+
+class DummyBattery:
+    def __init__(self, status):
+        self._status = status
+
+    def update_status(self):
+        return self._status
+
+
+class DummyErrorBattery:
+    def __init__(self, **config):
+        pass
+
+    def update_status(self):
+        raise RuntimeError("err")
+
+
+def dummy_load_battery(bat):
+    def load_battery(**config):
+        return DummyBattery(bat)
+
+    return load_battery
+
+
+def test_text_battery_charging(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.CHARGING,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "^ 50% 0:28 15.00 W"
+
+
+def test_text_battery_discharging(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.DISCHARGING,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "V 50% 0:28 15.00 W"
+
+
+def test_text_battery_full(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.FULL,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "Full"
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(show_short_text=False)
+
+    text = batt._get_text()
+    assert text == "= 50% 0:28 15.00 W"
+
+
+def test_text_battery_empty(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.EMPTY,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "Empty"
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(show_short_text=False)
+
+    text = batt._get_text()
+    assert text == "x 50% 0:28 15.00 W"
+
+    loaded_bat = BatteryStatus(
+        state=BatteryState.UNKNOWN,
+        percent=0.,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "Empty"
+
+
+def test_text_battery_unknown(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.UNKNOWN,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "? 50% 0:28 15.00 W"
+
+
+def test_text_battery_hidden(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.DISCHARGING,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(hide_threshold=0.6)
+
+    text = batt._get_text()
+    assert text != ""
+
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(hide_threshold=0.4)
+
+    text = batt._get_text()
+    assert text == ""
+
+
+def test_text_battery_error(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(battery, "load_battery", DummyErrorBattery)
+        batt = Battery()
+
+    text = batt._get_text()
+    assert text == "Error: err"
 
 
 def test_images_fail():
@@ -10,9 +174,9 @@ def test_images_fail():
 
     This theme path doesn't contain all of the required images.
     """
-    battery = BatteryIcon(theme_path=TEST_DIR)
+    batt = BatteryIcon(theme_path=TEST_DIR)
     with pytest.raises(images.LoadingError):
-        battery.setup_images()
+        batt.setup_images()
 
 
 def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):


### PR DESCRIPTION
Building off of #1277, formalizes and cleans up some of the interfaces around the Battery widgets. Also adds a bunch of test cases for the text formatting coming from the text version of the battery widget, and makes both of these classes easier to extend to do custom battery information extraction, as well as custom text.