### PR TITLE
Use pytest-runner to run unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,15 +17,14 @@ setenv = LC_CTYPE = en_US.UTF-8
 # Pass Display down to have it for the tests available
 passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
+# xcffib has to be installed before cairocffi
+# xvfbwrapper has problems being installed by setuptools
 deps =
-    pytest-cov
+    pytest-runner
+    xcffib
     xvfbwrapper
 commands =
-    # xcffib has to be installed before cairocffi
-    pip install xcffib
-    pip install -r {toxinidir}/requirements.txt
-    {toxinidir}/scripts/ffibuild
-    pytest --cov libqtile --cov-report term-missing {posargs}
+    python setup.py pytest --addopts "--cov libqtile --cov-report term-missing {posargs}"
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
All of the tests can be run through an environment configured with
setuptools.  This has the advantage of also ensuring that the setup.cfg
is properly configured to allow us to run all of the tests.