### PR TITLE
Don't make distutils copy man pages to /share/man

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ scripts =
   bin/iqshell
 
 [options.data_files]
-/share/man/man1 =
+share/man/man1 =
   resources/qtile.1
   resources/qshell.1
 


### PR DESCRIPTION
Running `python setup.py install` fails while trying to copy qtile's man pages to `/share/man`, which requires root permissions. This breaks installing qtile as python package inside a virtualenv for isolation or testing. This was possible before 749dfc9bc