### PR TITLE
Keep layout state to restore its layout if window is readded. Fix #1202

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -197,22 +197,24 @@ class MonadTall(_SimpleLayoutBase):
 
     def add(self, client):
         "Add client to layout"
-        if "index" in client.layout_state:
-            self.clients.add(client, client.layout_state["index"])
+
+        # Make sure layout wont crash if another layout puts its state
+        if isinstance(client.layout_state, int):
+            self.clients.add(client, client.layout_state)
         else:
             self.clients.add(client, 0 if self.new_at_current else 1)
 
-        "Cleanup layout state"
+        # Make sure this state will be never reused
         client.reset_layout_state()
 
         self.do_normalize = True
 
     def remove(self, client):
-        "Save layout state"
-        index = self.clients.index(client)
-        client.set_layout_state({"index": index})
-
         "Remove client from layout"
+
+        index = self.clients.index(client)
+        client.set_layout_state(index)
+
         self.do_normalize = True
         return self.clients.remove(client)
 

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -197,10 +197,21 @@ class MonadTall(_SimpleLayoutBase):
 
     def add(self, client):
         "Add client to layout"
-        self.clients.add(client, 0 if self.new_at_current else 1)
+        if "index" in client.layout_state:
+            self.clients.add(client, client.layout_state["index"])
+        else:
+            self.clients.add(client, 0 if self.new_at_current else 1)
+
+        "Cleanup layout state"
+        client.reset_layout_state()
+
         self.do_normalize = True
 
     def remove(self, client):
+        "Save layout state"
+        index = self.clients.index(client)
+        client.set_layout_state({"index": index})
+
         "Remove client from layout"
         self.do_normalize = True
         return self.clients.remove(client)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -251,7 +251,7 @@ class _Window(command.CommandObject):
         return self == self.qtile.current_window
 
     def reset_layout_state(self):
-        self.layout_state = {}
+        self.layout_state = None
 
     def set_layout_state(self, state):
         self.layout_state = state

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -159,7 +159,7 @@ class _Window(command.CommandObject):
         self.hidden = True
         self.group = None
         self.icons = {}
-        self.layout_state = {}
+        self.layout_state = None
         window.set_attribute(eventmask=self._window_mask)
 
         self._float_info = {

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -159,6 +159,7 @@ class _Window(command.CommandObject):
         self.hidden = True
         self.group = None
         self.icons = {}
+        self.layout_state = {}
         window.set_attribute(eventmask=self._window_mask)
 
         self._float_info = {
@@ -248,6 +249,12 @@ class _Window(command.CommandObject):
     @property
     def has_focus(self):
         return self == self.qtile.current_window
+
+    def reset_layout_state(self):
+        self.layout_state = {}
+
+    def set_layout_state(self, state):
+        self.layout_state = state
 
     def update_name(self):
         try:

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -637,3 +637,43 @@ def test_wide_window_focus_cycle(qtile):
 
     # assert window focus cycle, according to order in layout
     assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+
+@monadtall_config
+def test_tall_toggle_fullscreen_order(qtile):
+    qtile.test_window('one')
+    qtile.test_window('two')
+    qtile.test_window('three')
+
+    qtile.c.layout.next()
+
+    # make sure focused is the first one
+    assert_focused(qtile, 'one')
+
+    qtile.c.window.toggle_fullscreen()
+    qtile.c.window.toggle_fullscreen()
+
+    # make sure focus is still on the same one
+    assert_focused(qtile, 'one')
+    # make sure layout is unchanged
+    assert qtile.c.layout.info()["main"] == 'one'
+    assert qtile.c.layout.info()["secondary"] == ['two', 'three']
+
+@monadwide_config
+def test_wide_toggle_fullscreen_order(qtile):
+    qtile.test_window('one')
+    qtile.test_window('two')
+    qtile.test_window('three')
+
+    qtile.c.layout.next()
+
+    # make sure focused is the first one
+    assert_focused(qtile, 'one')
+
+    qtile.c.window.toggle_fullscreen()
+    qtile.c.window.toggle_fullscreen()
+
+    # make sure focus is still on the same one
+    assert_focused(qtile, 'one')
+    # make sure layout is unchanged
+    assert qtile.c.layout.info()["main"] == 'one'
+    assert qtile.c.layout.info()["secondary"] == ['two', 'three']

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -638,6 +638,7 @@ def test_wide_window_focus_cycle(qtile):
     # assert window focus cycle, according to order in layout
     assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
 
+
 @monadtall_config
 def test_tall_toggle_fullscreen_order(qtile):
     qtile.test_window('one')
@@ -657,6 +658,7 @@ def test_tall_toggle_fullscreen_order(qtile):
     # make sure layout is unchanged
     assert qtile.c.layout.info()["main"] == 'one'
     assert qtile.c.layout.info()["secondary"] == ['two', 'three']
+
 
 @monadwide_config
 def test_wide_toggle_fullscreen_order(qtile):


### PR DESCRIPTION
Fix of #1202

I assume other layouts might want to save their own state for the same problems. This solution works well for both tests and real testing. Still, I am not sure if it is a good decision or a hacky one. 

BTW. I am amazed at how well the code is written. For a while, I was a bit afraid dig here, but now I see how easy is to contribute. 