### PR TITLE
Mock the cairocffi.pixbuf module for documentation building

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ MOCK_MODULES = [
     'libqtile._ffi_pango',
     'libqtile.core._ffi_xcursors',
     'cairocffi',
+    'cairocffi.pixbuf',
     'cffi',
     'dateutil',
     'dateutil.parser',


### PR DESCRIPTION
Fixes #1319.