### PR TITLE
Always focus the latest focused window when removing a window

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -255,32 +255,17 @@ class _Group(CommandObject):
         win.group = None
 
         if win.floating:
-            nextfocus = self.floating_layout.remove(win)
-
-            nextfocus = nextfocus or \
-                self.current_window or \
-                self.layout.focus_first() or \
-                self.floating_layout.focus_first(group=self)
-        else:
-            for i in self.layouts:
-                if i is self.layout:
-                    nextfocus = i.remove(win)
-                else:
-                    i.remove(win)
-
-            nextfocus = nextfocus or \
-                self.floating_layout.focus_first(group=self) or \
-                self.current_window or \
-                self.layout.focus_first()
+            self.floating_layout.remove(win)
+        for i in self.layouts:
+            i.remove(win)
 
         # a notification may not have focus
         if hadfocus:
-            self.focus(nextfocus, warp=True, force=force)
-            # no next focus window means focus changed to nothing
-            if not nextfocus:
+            if self.focus_history:
+                self.focus(self.focus_history[-1], warp=True, force=force)
+            else:
                 hook.fire("focus_change")
-        elif self.screen:
-            self.layout_all()
+        self.layout_all()
 
     def mark_floating(self, win, floating):
         if floating:

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -122,8 +122,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         Called whether the layout is current or not. The layout should just
         de-register the window from its data structures, without unmapping the
         window.
-
-        Returns the "next" window that should gain focus or None.
         """
         pass
 
@@ -494,7 +492,7 @@ class _SimpleLayoutBase(Layout):
         return self.clients.add(client, offset_to_current)
 
     def remove(self, client):
-        return self.clients.remove(client)
+        self.clients.remove(client)
 
     def info(self):
         d = Layout.info(self)

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -198,7 +198,6 @@ class Bsp(Layout):
                     self.current = self.root
                 else:
                     self.current = self.get_node(newclient)
-                return newclient
             node.client = None
             self.current = self.root
 

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -215,7 +215,6 @@ class Columns(Layout):
                 break
         if remove is not None:
             self.remove_column(c)
-        return self.columns[self.current].cw
 
     def configure(self, client, screen_rect):
         pos = 0

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -283,11 +283,9 @@ class Floating(Layout):
         if client not in self.clients:
             return
 
-        next_focus = self.focus_next(client)
         if client is self.focused:
             self.blur()
         self.clients.remove(client)
-        return next_focus
 
     def info(self):
         d = Layout.info(self)

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -233,7 +233,7 @@ class RatioTile(_SimpleLayoutBase):
 
     def remove(self, w):
         self.dirty = True
-        return _SimpleLayoutBase.remove(self, w)
+        _SimpleLayoutBase.remove(self, w)
 
     def configure(self, win, screen):
         # force recalc

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -189,14 +189,7 @@ class Slice(Layout):
 
     def remove(self, win):
         lay = self.layouts.pop(win)
-        focus = lay.remove(win)
-        if not focus:
-            layouts = self._get_layouts()
-            idx = layouts.index(lay)
-            while idx < len(layouts) - 1 and not focus:
-                idx += 1
-                focus = layouts[idx].focus_first()
-        return focus
+        lay.remove(win)
 
     def hide(self):
         for lay in self._get_layouts():

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -191,20 +191,10 @@ class Stack(Layout):
             self.current_stack.add(client)
 
     def remove(self, client):
-        current_offset = self.current_stack_offset
         for i in self.stacks:
             if client in i:
                 i.remove(client)
                 break
-        if self.stacks[current_offset].cw:
-            return self.stacks[current_offset].cw
-        else:
-            n = self._find_next(
-                list(reversed(self.stacks)),
-                len(self.stacks) - current_offset - 1
-            )
-            if n:
-                return n.cw
 
     def configure(self, client, screen_rect):
         # pylint: disable=undefined-loop-variable

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -104,7 +104,7 @@ class VerticalTile(_SimpleLayoutBase):
     def remove(self, window):
         if self.maximized is window:
             self.maximized = None
-        return self.clients.remove(window)
+        self.clients.remove(window)
 
     def clone(self, group):
         c = _SimpleLayoutBase.clone(self, group)

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -212,7 +212,7 @@ class MonadTall(_SimpleLayoutBase):
     def remove(self, client):
         "Remove client from layout"
         self.do_normalize = True
-        return self.clients.remove(client)
+        self.clients.remove(client)
 
     def cmd_normalize(self, redraw=True):
         "Evenly distribute screen-space among secondary clients"


### PR DESCRIPTION
This is an alternative PR to https://github.com/qtile/qtile/pull/1052, that implements my proposition of always focusing the latest focused window at the group level when a window is removed, and not letting the current layout handling that.

It still needs some work to understand why it breaks the BSP layout tests.