### PR TITLE
Improve cmd_set_position by asking layouts to implement a swap method

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -136,6 +136,14 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def swap(self, client1, client2):
+        """Called to swap a window with another one
+
+        The layout should exchange the position of the two windows.
+        """
+        pass
+
+    @abstractmethod
     def configure(self, client, screen):
         """Configure the layout
 
@@ -629,6 +637,9 @@ class _SimpleLayoutBase(Layout):
 
     def remove(self, client):
         return self.clients.remove(client)
+
+    def swap(self, client1, client2):
+        return self.clients.swap(client1, client2)
 
     def info(self):
         d = Layout.info(self)

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -205,6 +205,24 @@ class Columns(Layout):
             self.remove_column(c)
         return self.columns[self.current].cw
 
+    def swap(self, client1, client2):
+        column1 = None
+        column2 = None
+        for c in self.columns:
+            if client1 in c:
+                column1 = c
+            if client2 in c:
+                column2 = c
+        if not (column1 and column2):
+            return
+        if column1 is column2:
+            column1.swap(client1, client2)
+        else:
+            column1.add(client2)
+            column2.add(client1)
+            column1.remove(client1)
+            column2.remove(client2)
+
     def configure(self, client, screen):
         pos = 0
         for col in self.columns:

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -261,6 +261,10 @@ class Floating(Layout):
         d["clients"] = [c.name for c in self.clients]
         return d
 
+    def swap(self, client1, client2):
+        # This can't ever be called, but implement the abstract method
+        pass
+
     def cmd_next(self):
         # This can't ever be called, but implement the abstract method
         pass

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -205,6 +205,24 @@ class Stack(Layout):
             if n:
                 return n.cw
 
+    def swap(self, client1, client2):
+        stack1 = None
+        stack2 = None
+        for s in self.stacks:
+            if client1 in s:
+                stack1 = s
+            if client2 in s:
+                stack2 = s
+        if not (stack1 and stack2):
+            return
+        if stack1 is stack2:
+            stack1.swap(client1, client2)
+        else:
+            stack1.add(client2)
+            stack2.add(client1)
+            stack1.remove(client1)
+            stack2.remove(client2)
+
     def configure(self, client, screen):
         for i, s in enumerate(self.stacks):
             if client in s:

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -415,6 +415,9 @@ class TreeTab(Layout):
         del self._nodes[win]
         self.draw_panel()
 
+    def swap(self, client1, client2):
+        pass
+
     def _create_panel(self):
         self._panel = window.Internal.create(
             self.group.qtile,

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1425,10 +1425,6 @@ class Window(_Window):
                 continue
             curx, cury = self.qtile.get_mouse_position()
             if self._is_in_window(curx, cury, window):
-                clients = self.group.layout.clients
-                index1 = clients.index(self)
-                index2 = clients.index(window)
-                clients[index1], clients[index2] = clients[index2], clients[index1]
-                self.group.layout.focused = index2
-                self.group.layout_all()
+                self.group.layout.swap(self, window)
+                self.group.focus(self, force=True)
                 break


### PR DESCRIPTION
I wrote this code after reading https://github.com/qtile/qtile/issues/297 and https://github.com/qtile/qtile/pull/410 again, and digging a bit on what a user can do with this as of today. Sadly, it looks like it doesn't work with many (any?) layouts right now. As a reminder, it is about changing the placement of a window without making it float (just by swapping in place with other windows)

As all layouts don't handle their windows the same way (some have a `_ClientList`, others have more than one, and others have a `list`), I propose to ask every layout to implement a new `swap` method, that will be used so that `cmd_set_position` really becomes layout-agnostic. The only problem with this method is that it doesn't make sense to swap with the mouse on some layouts (Max or TreeTab for example), and we should find a way to avoid it being tried so that weird things don't happen.

Another way of doing this, which would be a big architecture change and require way more work, would be to keep the list of windows only in the group, not in layouts, so that we could just invert the two windows in that list of group clients. Layouts would just expose "slots" that the group would use to throw windows in. This solution could probably help for our serialization problems, by isolating responsibilities.

This PR also needs tests and documentation if anything.