### PR TITLE
don't check result of unmap

### DIFF
--- a/libqtile/core/xcbq.py
+++ b/libqtile/core/xcbq.py
@@ -741,7 +741,7 @@ class Window:
         self.conn.conn.core.MapWindow(self.wid)
 
     def unmap(self):
-        self.conn.conn.core.UnmapWindowChecked(self.wid).check()
+        self.conn.conn.core.UnmapWindowUnchecked(self.wid)
 
     def get_attributes(self):
         return self.conn.conn.core.GetWindowAttributes(self.wid).reply()


### PR DESCRIPTION
We have reports of stack traces like:

```
File "/home/steven/.config/qtile/extra.py", line 179, in __call__
    qtile.current_screen.cmd_toggle_group(self.name)
  File "/usr/lib/python3.7/site-packages/libqtile/config.py", line 406, in cmd_toggle_group
    self.set_group(group)
  File "/usr/lib/python3.7/site-packages/libqtile/config.py", line 324, in set_group
    old_group._set_screen(None)
  File "/usr/lib/python3.7/site-packages/libqtile/group.py", line 183, in _set_screen
    self.hide()
  File "/usr/lib/python3.7/site-packages/libqtile/group.py", line 191, in hide
    i.hide()
  File "/usr/lib/python3.7/site-packages/libqtile/window.py", line 422, in hide
    self.window.unmap()
  File "/usr/lib/python3.7/site-packages/libqtile/core/xcbq.py", line 744, in unmap
    self.conn.conn.core.UnmapWindowChecked(self.wid).check()
  File "/usr/lib/python3.7/site-packages/xcffib/__init__.py", line 338, in check
    self.conn.request_check(self.sequence)
  File "/usr/lib/python3.7/site-packages/xcffib/__init__.py", line 570, in wrapper
    return f(*args)
  File "/usr/lib/python3.7/site-packages/xcffib/__init__.py", line 679, in request_check
    self._process_error(err)
  File "/usr/lib/python3.7/site-packages/xcffib/__init__.py", line 647, in _process_error
    raise error(buf)
xcffib.xproto.WindowError
```

with the latest xcffib. The WindowError here means we passed a bad window id,
which means the window died sometime before configure() can happen. xcffib
0.8.0 included what seems to be a fairly significant optimization, which may
result in these sorts of races popping up more and more.

Instead of getting this error, let's simply ignore (i.e. call the Unchecked()
version of the function) any errors from Unmap(). Note that this is probably
not ok in the general case, but Unmap() takes only one argument, the wid, so
the only error it will ever generate is a WindowError. If we encounter this in
the future with other functions, we may want to keep calling the Checked()
version to validate other inputs, and just catch and ignore WindowError.

See #1325 and #1150

Signed-off-by: Tycho Andersen <tycho@tycho.ws>