### PR TITLE
Drop xvfbwrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ckpatch: lint check
 
 .PHONY: clean
 clean:
-	-rm -rf dist qtile.egg-info docs/_build build/
+	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/
 
 # This is a little ugly: we want to be able to have users just run
 # 'python setup.py install' to install qtile, but we would also like to install

--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -10,20 +10,19 @@ install them from your package manager.
 
 * `pytest <http://pytest.org/latest/>`_
 * `Xephyr <http://www.freedesktop.org/wiki/Software/Xephyr>`_
-* `xvfbwrapper <https://github.com/cgoldberg/xvfbwrapper>`_
 * ``xrandr``, ``xcalc``, ``xeyes`` and ``xclock`` (``x11-apps`` on Ubuntu)
 
 On Ubuntu, if testing on Python 3, this can be done with:
 
 .. code-block:: bash
 
-    sudo apt-get install python3-pytest xserver-xephyr python3-xvfbwrapper x11-apps
+    sudo apt-get install python3-pytest xserver-xephyr x11-apps
 
 Or, on Python 2:
 
 .. code-block:: bash
 
-    sudo apt-get install python-pytest xserver-xephyr python-xvfbwrapper x11-apps
+    sudo apt-get install python-pytest xserver-xephyr x11-apps
 
 Building cffi module
 ====================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@ flake8
 pep8-naming
 psutil
 pytest-cov
-xvfbwrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,13 +44,12 @@ setup_requires =
 install_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 0.9.0
-  xcffib >= 0.5.0
+  xcffib >= 0.8.1
 tests_require =
   flake8
   pep8-naming
   psutil
   pytest-cov
-  xvfbwrapper
 scripts =
   bin/dqtile-cmd
   bin/iqshell
@@ -78,7 +77,6 @@ test =
   flake8
   pep8-naming
   pytest-cov
-  xvfbwrapper
 ipython =
   ipykernel
   jupyter_console

--- a/test/test_xcbq.py
+++ b/test/test_xcbq.py
@@ -1,16 +1,14 @@
+import os
 import pytest
-from xvfbwrapper import Xvfb
 import xcffib
+import xcffib.testing
 from libqtile.core import xcbq
 
 
 @pytest.fixture(scope='function', autouse=True)
 def xdisplay(request):
-    xvfb = Xvfb(width=1280, height=720)
-    xvfb.start()
-    display = ':{}'.format(xvfb.new_display)
-    yield display
-    xvfb.stop()
+    with xcffib.testing.XvfbTest(width=1280, height=720):
+        yield os.environ['DISPLAY']
 
 
 def test_new_window(xdisplay):

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,10 @@ setenv = LC_CTYPE = en_US.UTF-8
 passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
 # xcffib has to be installed before cairocffi
-# xvfbwrapper has problems being installed by setuptools
 deps =
     pytest-runner
     setuptools >= 40.5.0
-    xcffib
-    xvfbwrapper
+    xcffib >= 0.8.1
 commands =
     python setup.py pytest --addopts "--cov libqtile --cov-report term-missing {posargs}"
 


### PR DESCRIPTION
Here's a better version of #1281 where we just drop xvfbwrapper as a dependency all together.