### PR TITLE
hooks: pass group and window to group_window_add

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -249,7 +249,7 @@ class _Group(command.CommandObject):
         )
 
     def add(self, win, focus=True, force=False):
-        hook.fire("group_window_add")
+        hook.fire("group_window_add", self, win)
         self.windows.add(win)
         win.group = self
         try:


### PR DESCRIPTION
This hook's signature was fine for our own single user who already had a
qtile object it could look everything up in, but it's a little awkward to
use from configs. Let's pass the group and window, so people can do things
with them if they want.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>