### PR TITLE
Add type annotations to IPC module

### DIFF
--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -25,12 +25,13 @@
     un-marshalling untrusted data can result in arbitrary code execution).
 """
 import asyncio
+import fcntl
+import json
 import marshal
 import os.path
 import socket
 import struct
-import fcntl
-import json
+from typing import cast, Any, Callable, Optional, Tuple
 
 from .log_utils import logger
 
@@ -42,12 +43,28 @@ class IPCError(Exception):
 
 
 class _IPC:
-    def _unpack(self, data):
+    """A helper class to handle properly packing and unpacking messages"""
 
+    @classmethod
+    def unpack(cls, data: Optional[bytes]) -> Tuple[Any, bool]:
+        """Unpack the incoming message
+
+        Parameters
+        ----------
+        data : Optional[bytes]
+            The incoming message to unpack, if None, an IPCError is raised.
+
+        Returns
+        -------
+        Tuple[Any, bool]
+            A tuple of the unpacked object and a boolean denoting if the
+            message was deserialized using json.  If True, the return message
+            should be packed as json.
+        """
         if data is None:
             raise IPCError("received data is None")
         try:
-            return json.loads(data.decode('utf-8')), True
+            return json.loads(data.decode("utf-8")), True
         except ValueError:
             pass
 
@@ -55,7 +72,7 @@ class _IPC:
             assert len(data) >= HDRLEN
             size = struct.unpack("!L", data[:HDRLEN])[0]
             assert size >= len(data[HDRLEN:])
-            return self._unpack_body(data[HDRLEN:HDRLEN + size]), False
+            return cls._unpack_body(data[HDRLEN:HDRLEN + size]), False
         except AssertionError:
             raise IPCError(
                 "error reading reply!"
@@ -63,22 +80,24 @@ class _IPC:
             )
 
     @staticmethod
-    def _unpack_body(body):
-        return marshal.loads(body)
-
-    @staticmethod
-    def _pack_json(msg):
+    def pack_json(msg: Any) -> bytes:
         json_obj = json.dumps(msg)
         return json_obj.encode('utf-8')
 
     @staticmethod
-    def _pack(msg):
-        msg = marshal.dumps(msg)
-        size = struct.pack("!L", len(msg))
-        return size + msg
+    def pack(msg: Any) -> bytes:
+        # mashal seems incorrectly annotated to take and return str
+        msg_bytes = cast(bytes, marshal.dumps(msg))
+        size = struct.pack("!L", len(msg_bytes))
+        return size + msg_bytes
+
+    @staticmethod
+    def _unpack_body(body: bytes) -> Any:
+        # mashal seems incorrectly annotated to take and return str
+        return marshal.loads(cast(str, body))
 
 
-class _ClientProtocol(asyncio.Protocol, _IPC):
+class _ClientProtocol(asyncio.Protocol):
     """IPC Client Protocol
 
     1. Once the connection is made, the client initializes a Future self.reply,
@@ -93,16 +112,24 @@ class _ClientProtocol(asyncio.Protocol, _IPC):
     4. When the server sends on EOF, the data is unpacked and stored to the
     reply future.
     """
-    def connection_made(self, transport):
+    def __init__(self) -> None:
+        self.transport = None  # type: Optional[asyncio.WriteTransport]
+        self.recv = None  # type: Optional[bytes]
+        self.reply = None  # type: Optional[asyncio.Future]
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        assert isinstance(transport, asyncio.WriteTransport)
         self.transport = transport
         self.recv = b''
         self.reply = asyncio.Future()
 
-    def send(self, msg, is_json=False):
+    def send(self, msg: Any, is_json=False) -> None:
+        assert self.transport is not None
+
         if is_json:
-            send_data = self._pack_json(msg)
+            send_data = _IPC.pack_json(msg)
         else:
-            send_data = self._pack(msg)
+            send_data = _IPC.pack(msg)
 
         self.transport.write(send_data)
 
@@ -111,33 +138,57 @@ class _ClientProtocol(asyncio.Protocol, _IPC):
         except AttributeError:
             logger.exception('Swallowing AttributeError due to asyncio bug!')
 
-    def data_received(self, data):
+    def data_received(self, data: bytes) -> None:
+        assert self.recv is not None
         self.recv += data
 
-    def eof_received(self):
+    def eof_received(self) -> None:
+        assert self.reply is not None
+
         # The server sends EOF when there is data ready to be processed
         try:
-            data, _ = self._unpack(self.recv)
+            data, _ = _IPC.unpack(self.recv)
         except IPCError as e:
             self.reply.set_exception(e)
         else:
             self.reply.set_result(data)
 
-    def connection_lost(self, exc):
+    def connection_lost(self, exc) -> None:
+        assert self.reply is not None
+
         # The client shouldn't just lose the connection without an EOF
         if exc:
             self.reply.set_exception(exc)
+
         if not self.reply.done():
             self.reply.set_exception(IPCError)
 
 
 class Client:
-    def __init__(self, fname, is_json=False):
+    def __init__(self, fname: str, is_json=False) -> None:
+        """Create a new IPC client
+
+        Parameters
+        ----------
+        fname : str
+            The file path to the file that is used to open the connection to
+            the running IPC server.
+        is_json : bool
+            Pack and unpack messages as json
+        """
         self.fname = fname
         self.loop = asyncio.get_event_loop()
         self.is_json = is_json
 
-    def send(self, msg):
+    def send(self, msg: Any) -> Any:
+        """Send the message and return the response from the server
+
+        If any exception is raised by the server, that will propogate out of
+        this call.
+
+        Parameters
+        ----------
+        """
         client_coroutine = self.loop.create_unix_connection(_ClientProtocol, path=self.fname)
 
         try:
@@ -145,7 +196,9 @@ class Client:
         except OSError:
             raise IPCError("Could not open %s" % self.fname)
 
+        client_proto = cast(_ClientProtocol, client_proto)
         client_proto.send(msg, is_json=self.is_json)
+        assert client_proto.reply is not None
 
         try:
             self.loop.run_until_complete(asyncio.wait_for(client_proto.reply, timeout=10))
@@ -154,11 +207,11 @@ class Client:
 
         return client_proto.reply.result()
 
-    def call(self, data):
+    def call(self, data: Any) -> Any:
         return self.send(data)
 
 
-class _ServerProtocol(asyncio.Protocol, _IPC):
+class _ServerProtocol(asyncio.Protocol):
     """IPC Server Protocol
 
     1. The server is initialized with a handler callback function for evaluating
@@ -173,25 +226,29 @@ class _ServerProtocol(asyncio.Protocol, _IPC):
     point the server then unpacks the data and runs it through the handler.
     The result is returned to the client and the connection is closed.
     """
-    def __init__(self, handler):
-        asyncio.Protocol.__init__(self)
-        self.handler = handler
-        self.transport = None
-        self.data = None
+    def __init__(self, handler: Callable) -> None:
+        super().__init__()
 
-    def connection_made(self, transport):
+        self.handler = handler
+        self.transport = None  # type: Optional[asyncio.WriteTransport]
+        self.data = None  # type: Optional[bytes]
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        assert isinstance(transport, asyncio.WriteTransport)
         self.transport = transport
         logger.debug('Connection made to server')
         self.data = b''
 
-    def data_received(self, recv):
+    def data_received(self, recv: bytes) -> None:
         logger.debug('Data received by server')
+        assert self.data is not None
         self.data += recv
 
-    def eof_received(self):
+    def eof_received(self) -> None:
+        assert self.transport is not None
         logger.debug('EOF received by server')
         try:
-            req, is_json = self._unpack(self.data)
+            req, is_json = _IPC.unpack(self.data)
         except IPCError:
             logger.warn('Invalid data received, closing connection')
             self.transport.close()
@@ -206,22 +263,25 @@ class _ServerProtocol(asyncio.Protocol, _IPC):
         rep = self.handler(req)
 
         if is_json:
-            result = self._pack_json(rep)
+            result = _IPC.pack_json(rep)
         else:
-            result = self._pack(rep)
+            result = _IPC.pack(rep)
 
         logger.debug('Sending result on receive EOF')
         self.transport.write(result)
         logger.debug('Closing connection on receive EOF')
         self.transport.write_eof()
 
+        self.data = None
+        self.transport = None
+
 
 class Server:
-    def __init__(self, fname, handler, loop):
+    def __init__(self, fname: str, handler, loop) -> None:
         self.fname = fname
         self.handler = handler
         self.loop = loop
-        self.server = None
+        self.server = None  # type: Optional[asyncio.BaseTransport]
 
         if os.path.exists(fname):
             os.unlink(fname)
@@ -231,16 +291,18 @@ class Server:
             socket.SOCK_STREAM,
             0
         )
-        flags = fcntl.fcntl(self.sock, fcntl.F_GETFD)
-        fcntl.fcntl(self.sock, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
+        flags = fcntl.fcntl(self.sock.fileno(), fcntl.F_GETFD)
+        fcntl.fcntl(self.sock.fileno(), fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
         self.sock.bind(self.fname)
 
-    def close(self):
+    def close(self) -> None:
         logger.debug('Stopping server on server close')
+        assert self.server is not None
         self.server.close()
         self.sock.close()
 
-    def start(self):
+    def start(self) -> None:
+        assert self.server is None
         serverprotocol = _ServerProtocol(self.handler)
         server_coroutine = self.loop.create_unix_server(lambda: serverprotocol, sock=self.sock, backlog=5)
 


### PR DESCRIPTION
Add some type annotations to the IPC module. This also splits out the `_IPC` class to be purely a static helper class rather than a parent class.