### PR TITLE
Get py-nightly tox test running

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 1.8
 envlist =
     py36,
     py37,
+    py-nightly
     docs,
     pep8,
     mypy,


### PR DESCRIPTION
The py-nightly test is currently failing only because the tox test is not properly configured. Change the configuration to get the test to run successfully.