### PR TITLE
docs: update install commands

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -81,13 +81,13 @@ With the dependencies in place, you can now install qtile:
 
     git clone git://github.com/qtile/qtile.git
     cd qtile
-    sudo python setup.py install
+    pip3 install .
 
 Stable versions of Qtile can be installed from PyPI:
 
 .. code-block:: bash
 
-    pip install qtile
+    pip3 install qtile
 
 As long as the necessary libraries are in place, this can be done at any point,
 however, it is recommended that you first install xcffib to ensure the


### PR DESCRIPTION
in particular, use pip3, but also drop sudo, since it's not necessary (and
pip actually complains about it these days)

Signed-off-by: Tycho Andersen <tycho@tycho.ws>