### PR TITLE
Fix NetGraph always at maximum.

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -331,7 +331,9 @@ class NetGraph(_Graph):
 
     def update_graph(self):
         val = self._get_values()
-        self.push(val)
+        change = val - self.bytes
+        self.bytes = val
+        self.push(change)
 
     @staticmethod
     def get_main_iface():


### PR DESCRIPTION
Compute the changes between `psutil.net_io_counters` readings before
updating the graph. Otherwise the graph 'maxes' out since the counters will always increase (#1353).