### PR TITLE
Implement an fmt option for all textboxes

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -293,6 +293,7 @@ class _TextBox(_Widget):
             "font shadow color, default is None(no shadow)"
         ),
         ("markup", False, "Whether or not to use pango markup"),
+        ("fmt", "{}", "How to format the text")
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -300,17 +301,6 @@ class _TextBox(_Widget):
         _Widget.__init__(self, width, **config)
         self.text = text
         self.add_defaults(_TextBox.defaults)
-
-    @property
-    def text(self):
-        return self._text
-
-    @text.setter
-    def text(self, value):
-        assert value is None or isinstance(value, str)
-        self._text = value
-        if self.layout:
-            self.layout.text = value
 
     @property
     def foreground(self):
@@ -376,6 +366,7 @@ class _TextBox(_Widget):
         if self.offsetx is None:
             return
         self.drawer.clear(self.background or self.bar.background)
+        self.layout.text = self.fmt.format(self.text)
         self.layout.draw(
             self.actual_padding or 0,
             int(self.bar.height / 2.0 - self.layout.height / 2.0) + 1


### PR DESCRIPTION
Right now, if you want to add some stuff around your widgets, you probably do something like this:

```python
widget.TextBox(text="!!! "),
widget.Notify(),
widget.TextBox(text="clock: {}"),
widget.Clock()
```

This PR allows to do stuff like that:

```python
widget.Notify(fmt="!!! {}"),
widget.Clock(fmt="clock: {}")
```

It's better because it re-uses the settings of the widget (font size, color, etc), but also respects the way the widget uses the text (for example, it won't leave `!!!` around when there is no new notification with `Notify`). And it's shorter to write!