### PR TITLE
Accept Pango markup by default on all text widgets

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -292,7 +292,7 @@ class _TextBox(_Widget):
             None,
             "font shadow color, default is None(no shadow)"
         ),
-        ("markup", False, "Whether or not to use pango markup"),
+        ("markup", True, "Whether or not to use pango markup"),
         ("fmt", "{}", "How to format the text")
     ]  # type: List[Tuple[str, Any, str]]
 


### PR DESCRIPTION
I think it's great to be more "powerful" by default. Do you see any reason to limit Pango markup usage?