### PR TITLE
columns: add separate wrapping config for stacked mode

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -125,6 +125,8 @@ class Columns(Layout):
          "Wrap the screen when moving focus across columns."),
         ("wrap_focus_rows", True,
          "Wrap the screen when moving focus across rows."),
+        ("wrap_focus_stacks", True,
+         "Wrap the screen when moving focus across stacked."),
     ]
 
     def __init__(self, **config):
@@ -319,9 +321,14 @@ class Columns(Layout):
                 self.current = (self.current + 1)
         self.group.focus(self.cc.cw, True)
 
+    def want_wrap(self, col):
+        if col.split:
+            return self.wrap_focus_rows
+        return self.wrap_focus_stacks
+
     def cmd_up(self):
         col = self.cc
-        if self.wrap_focus_rows:
+        if self.want_wrap(col):
             if len(col) > 1:
                 col.current_index -= 1
         else:
@@ -331,7 +338,7 @@ class Columns(Layout):
 
     def cmd_down(self):
         col = self.cc
-        if self.wrap_focus_rows:
+        if self.want_wrap(col):
             if len(col) > 1:
                 col.current_index += 1
         else:


### PR DESCRIPTION
When windows are stacked, I want cmd_up/down to wrap.  When they
are not stacked, I want them to stop at top/bottom.  Provide a
separate config.  The default is True so that the defaults are
unchanged.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>