### PR TITLE
Change to run the static checker(mypy) with make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ check-cov:
 lint:
 	flake8 ./libqtile bin/q* ./test
 
+.PHONY: static_check
+static_check:
+	mypy -p libqtile
+
 .PHONY: ckpatch
-ckpatch: lint check
+ckpatch: lint check static_check
 
 .PHONY: clean
 clean:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ flake8
 pep8-naming
 psutil
 pytest-cov
+mypy


### PR DESCRIPTION
In the CI, the code is checked by the mypy, but ckpatch command in Makefile has no checking the test. I think it is forgot to add the test. This patch fixes the problem.