### PR TITLE
refactor: Use lazy.lazy in default config instead of command.lazy (deprecated)

### DIFF
--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -2,7 +2,7 @@
 Lazy objects
 ============
 
-The ``command.lazy`` object is a special helper object to specify a command for
+The ``lazy.lazy`` object is a special helper object to specify a command for
 later execution. This object acts like the root of the object graph, which
 means that we can specify a key binding command with the same syntax used to
 call the command through a script or through :doc:`/manual/commands/qshell`.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -45,7 +45,7 @@ class Key:
     key:
         A key specification, e.g. "a", "Tab", "Return", "space".
     commands:
-        A list of lazy command objects generated with the command.lazy helper.
+        A list of lazy command objects generated with the lazy.lazy helper.
         If multiple Call objects are specified, they are run in sequence.
     kwds:
         A dictionary containing "desc", allowing a description to be added

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -25,7 +25,7 @@
 # SOFTWARE.
 
 from libqtile.config import Key, Screen, Group, Drag, Click
-from libqtile.command import lazy
+from libqtile.lazy import lazy
 from libqtile import layout, bar, widget
 
 from typing import List  # noqa: F401


### PR DESCRIPTION
Issue #1420. Behavior should stay exactly the same.

I was not able to run the tests locally (see #1425), let see what Travis says.