### PR TITLE
refactor: Remove pythonwifi related code in Wlan widget

### DIFF
--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -26,32 +26,19 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import iwlib
+
 from . import base
 from libqtile.log_utils import logger
 
-try:
-    from pythonwifi.iwlibs import Wireless, Iwstats
 
-    def get_status(interface_name):
-        interface = Wireless(interface_name)
-        try:
-            stats = Iwstats(interface_name)
-        except IOError:
-            return None, None
-        quality = stats.qual.quality
-        essid = interface.getEssid()
-        return essid, quality
-
-except ImportError:
-    import iwlib
-
-    def get_status(interface_name):
-        interface = iwlib.get_iwconfig(interface_name)
-        if 'stats' not in interface:
-            return None, None
-        quality = interface['stats']['quality']
-        essid = bytes(interface['ESSID']).decode()
-        return essid, quality
+def get_status(interface_name):
+    interface = iwlib.get_iwconfig(interface_name)
+    if 'stats' not in interface:
+        return None, None
+    quality = interface['stats']['quality']
+    essid = bytes(interface['ESSID']).decode()
+    return essid, quality
 
 
 class Wlan(base.InLoopPollText):


### PR DESCRIPTION
Issue #1416.

If I understand correctly, when `iwlib` is not installed the `ImportError` will be caught a level above, and the widget will render "Import Error", so I don't have to handle the case in `wlan.py`.

I did not find any other occurrence of `pythonwifi` throughout the project.