### PR TITLE
fix: Don't print help if qtile-cmd function returns nothing

### DIFF
--- a/libqtile/scripts/qtile_cmd.py
+++ b/libqtile/scripts/qtile_cmd.py
@@ -201,8 +201,6 @@ def main() -> None:
             ret = run_function(obj, args.function, args.args)
             if ret is not None:
                 pprint.pprint(ret)
-            else:
-                print_commands("-o " + " ".join(args.obj_spec), obj)
     else:
         print_base_objects()
         sys.exit(1)


### PR DESCRIPTION
Issue #1408.

Just removed the `print` when the function returns `None`.