### PR TITLE
docs: Fix missing psutil mock

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ MOCK_MODULES = [
     'iwlib',
     'keyring',
     'mpd',
+    'psutil',
     'trollius',
     'xcffib',
     'xcffib.randr',


### PR DESCRIPTION
The `Memory` and `Net` widgets' docs were not build correctly due to `psutil` not being mocked in `docs/conf.py`. Fixes #1431 