### PR TITLE
docs: Fix parameter type of Screen's top/left/right/bottom

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -216,10 +216,10 @@ class Screen(CommandObject):
 
     Parameters
     ==========
-    top: List of Gap/Bar objects, or None.
-    bottom: List of Gap/Bar objects, or None.
-    left: List of Gap/Bar objects, or None.
-    right: List of Gap/Bar objects, or None.
+    top: Gap/Bar object, or None.
+    bottom: Gap/Bar object, or None.
+    left: Gap/Bar object, or None.
+    right: Gap/Bar object, or None.
     x : int or None
     y : int or None
     width : int or None


### PR DESCRIPTION
Previously typed as `List of Bar/Gap objects, or None`, which is not correct: these parameter do not accept lists, only a single bar or a single gap. Too bad, I wanted to setup two top bars :wink: 