### PR TITLE
Center-align groupboxes by default.

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -41,7 +41,7 @@ from typing import Any, List, Tuple  # noqa: F401
 class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
     defaults = [
         ("borderwidth", 3, "Current group border width"),
-        ("center_aligned", False, "center-aligned group box"),
+        ("center_aligned", True, "center-aligned group box"),
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, **config):


### PR DESCRIPTION
The difference can be noticed by setting `widget.GroupBox(center_aligned=True)` or not,
as illustrated by below screenshots:

1. before setting
![1](https://user-images.githubusercontent.com/1397818/64920903-305bf800-d7ef-11e9-875f-f4a7584ecefb.png)

2. after setting
![2](https://user-images.githubusercontent.com/1397818/64920906-3651d900-d7ef-11e9-9142-129e3e0f3bc4.png)
