### PR TITLE
Safe guard graceful shutdown in case the X connection invalid.

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -775,7 +775,11 @@ class Qtile(CommandObject):
             # managed and don't have any state.
             if not isinstance(win, window.Window):
                 return None
-            return win.window.get_net_wm_pid()
+            try:
+                return win.window.get_net_wm_pid()
+            except Exception:
+                # the X connection may be invalid due to server crash
+                return None
         pids = map(get_interesting_pid, self.windows_map.values())
         pids = list(filter(lambda x: x is not None, pids))
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -778,7 +778,7 @@ class Qtile(CommandObject):
             try:
                 return win.window.get_net_wm_pid()
             except Exception:
-                # the X connection may be invalid due to server crash
+                logger.exception("Got an exception in getting the window pid")
                 return None
         pids = map(get_interesting_pid, self.windows_map.values())
         pids = list(filter(lambda x: x is not None, pids))


### PR DESCRIPTION
This fixes the problem that an infinite loop happens after below steps:
1. Start Xephyr and qtile by running `./scripts/xephyr`, it will open an `xterm` window inside xephyr, and don't close that window.
2. Stop the script by hitting `Ctrl+C`, then it will end in a infinite loop with below tracebacks

        2019-09-15 23:32:53,806 libqtile manager.py:_xpoll():L761  Shutting down due to X connection error XCB_CONN_ERROR (1)
        Traceback (most recent call last):
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 730, in _xpoll
            e = self.conn.conn.poll_for_event()
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 568, in wrapper
            self.invalid()
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 558, in invalid
            raise ConnectionException(err)
        xcffib.ConnectionException: xcb connection errors because of socket, pipe and other stream errors.
        2019-09-15 23:32:53,807 libqtile manager.py:<lambda>():L279  Got an exception in poll loop
        Traceback (most recent call last):
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 730, in _xpoll
            e = self.conn.conn.poll_for_event()
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 568, in wrapper
            self.invalid()
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 558, in invalid
            raise ConnectionException(err)
        xcffib.ConnectionException: xcb connection errors because of socket, pipe and other stream errors.
        
        During handling of the above exception, another exception occurred:
        
        Traceback (most recent call last):
          File "/usr/lib64/python3.7/asyncio/events.py", line 88, in _run
            self._context.run(self._callback, *self._args)
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 762, in _xpoll
            self.stop()
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 812, in stop
            self.graceful_shutdown()
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 782, in graceful_shutdown
            pids = list(filter(lambda x: x is not None, pids))
          File "/home/whatacold/workspace/python/qtile/libqtile/core/manager.py", line 780, in get_interesting_pid
            return win.window.get_net_wm_pid()
          File "/home/whatacold/workspace/python/qtile/libqtile/core/xcbq.py", line 610, in get_net_wm_pid
            r = self.get_property("_NET_WM_PID", unpack=int)
          File "/home/whatacold/workspace/python/qtile/libqtile/core/xcbq.py", line 711, in get_property
            0, (2 ** 32) - 1
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/xproto.py", line 2720, in GetProperty
            return self.send_request(20, buf, GetPropertyCookie, is_checked=is_checked)
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 390, in send_request
            seq = self.conn.send_request(flags, xcb_parts + 2, xcb_req)
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 568, in wrapper
            self.invalid()
          File "/home/whatacold/local/qtile/qtile-env/lib64/python3.7/site-packages/xcffib/__init__.py", line 558, in invalid
            raise ConnectionException(err)
        xcffib.ConnectionException: xcb connection errors because of socket, pipe and other stream errors.
