### PR TITLE
Un-pin the pytest version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
-    pytest < 5.0.0
     pytest-runner
     setuptools >= 40.5.0
     xcffib >= 0.8.1


### PR DESCRIPTION
With #1404 merged, we are able to unpin the pytest version used in Travis.