### PR TITLE
Improve readability of the Volume widget.

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -58,10 +58,12 @@ class Volume(base._TextBox):
         ("device", "default", "Device Name"),
         ("channel", "Master", "Channel"),
         ("padding", 3, "Padding left and right. Calculated if None."),
-        ("theme_path", None, "Path of the icons"),
         ("update_interval", 0.2, "Update time in seconds."),
+        ("theme_path", None, "Path of the icons"),
         ("emoji", False, "Use emoji to display volume states, only if ``theme_path`` is not set."
                          "The specified font needs to contain the correct unicode characters."),
+        ("text_format", "Vol: {}", "Text format to display volume values, only if ``theme_path``"
+                                   " and ``emoji`` are not set."),
         ("mute_command", None, "Mute command"),
         ("volume_app", None, "App to control volume"),
         ("volume_up_command", None, "Volume up command"),
@@ -105,7 +107,7 @@ class Volume(base._TextBox):
                 subprocess.call(self.create_amixer_command('-q',
                                                            'sset',
                                                            self.channel,
-                                                           '%d%%-' % self.step))
+                                                           '{}%-'.format(self.step)))
         elif button == BUTTON_UP:
             if self.volume_up_command is not None:
                 subprocess.call(self.volume_up_command, shell=True)
@@ -113,7 +115,7 @@ class Volume(base._TextBox):
                 subprocess.call(self.create_amixer_command('-q',
                                                            'sset',
                                                            self.channel,
-                                                           '%d%%+' % self.step))
+                                                           '{}%+'.format(self.step)))
         elif button == BUTTON_MUTE:
             if self.mute_command is not None:
                 subprocess.call(self.mute_command, shell=True)
@@ -163,9 +165,10 @@ class Volume(base._TextBox):
                 self.text = u'\U0001f50a'
         else:
             if self.volume == -1:
-                self.text = 'M'
+                volume_text = 'M'
             else:
-                self.text = '%s%%' % self.volume
+                volume_text = '{}%'.format(self.volume)
+            self.text = self.text_format.format(volume_text)
 
     def setup_images(self):
         from .. import images

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -62,8 +62,6 @@ class Volume(base._TextBox):
         ("theme_path", None, "Path of the icons"),
         ("emoji", False, "Use emoji to display volume states, only if ``theme_path`` is not set."
                          "The specified font needs to contain the correct unicode characters."),
-        ("text_format", "Vol: {}", "Text format to display volume values, only if ``theme_path``"
-                                   " and ``emoji`` are not set."),
         ("mute_command", None, "Mute command"),
         ("volume_app", None, "App to control volume"),
         ("volume_up_command", None, "Volume up command"),
@@ -165,10 +163,9 @@ class Volume(base._TextBox):
                 self.text = u'\U0001f50a'
         else:
             if self.volume == -1:
-                volume_text = 'M'
+                self.text = 'M'
             else:
-                volume_text = '{}%'.format(self.volume)
-            self.text = self.text_format.format(volume_text)
+                self.text = '{}%'.format(self.volume)
 
     def setup_images(self):
         from .. import images

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -50,15 +50,13 @@ def test_emoji():
 
 
 def test_text():
-    text_format = "Volume: {}"
-    vol = Volume(text_format=text_format)
+    fmt = "Volume: {}"
+    vol = Volume(fmt=fmt)
     vol.volume = -1
     vol._update_drawer()
-    assert vol.text == text_format.format('M')
+    assert vol.text == 'M'
 
     vol.volume = 50
     vol._update_drawer()
-    assert vol.text == text_format.format('50%')
-
-
+    assert vol.text == '50%'
 

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -28,3 +28,37 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     assert len(vol.surfaces) == len(names)
     for name, surfpat in vol.surfaces.items():
         assert isinstance(surfpat, cairocffi.SurfacePattern)
+
+
+def test_emoji():
+    vol = Volume(emoji=True)
+    vol.volume = -1
+    vol._update_drawer()
+    assert vol.text == u'\U0001f507'
+
+    vol.volume = 29
+    vol._update_drawer()
+    assert vol.text == u'\U0001f508'
+
+    vol.volume = 79
+    vol._update_drawer()
+    assert vol.text == u'\U0001f509'
+
+    vol.volume = 80
+    vol._update_drawer()
+    assert vol.text == u'\U0001f50a'
+
+
+def test_text():
+    text_format = "Volume: {}"
+    vol = Volume(text_format=text_format)
+    vol.volume = -1
+    vol._update_drawer()
+    assert vol.text == text_format.format('M')
+
+    vol.volume = 50
+    vol._update_drawer()
+    assert vol.text == text_format.format('50%')
+
+
+


### PR DESCRIPTION
Currently, the text of the volume widget is not very readable, I have to explicitly place a textbox before it in order to work around it, so I think it will be better to let users customize the text format.

    bottom=bar.Bar(
        [
            #...,
            widget.TextBox('Vol:'),
            widget.Volume(),
            #...,
        ],

As for the tests, I don't know if it's acceptable to set the member `self.volume` and to call the "private" method `self._update_drawer()` directly, what do you think?