### PR TITLE
Allow to move a window to a group, and switch to that group.

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -371,9 +371,7 @@ class Screen(CommandObject):
         self.qtile.call_soon(self.group.layout_all)
 
     def cmd_info(self):
-        """
-            Returns a dictionary of info for this screen.
-        """
+        """Returns a dictionary of info for this screen."""
         return dict(
             index=self.index,
             width=self.width,

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -71,7 +71,10 @@ for i in groups:
         Key([mod], i.name, lazy.group[i.name].toscreen()),
 
         # mod1 + shift + letter of group = switch to & move focused window to group
-        Key([mod, "shift"], i.name, lazy.window.togroup(i.name)),
+        Key([mod, "shift"], i.name, lazy.window.togroup(i.name, switch_group=True)),
+        # Or, use below if you prefer not to switch to that group.
+        # # mod1 + shift + letter of group = move focused window to group
+        # Key([mod, "shift"], i.name, lazy.window.togroup(i.name)),
     ])
 
 layouts = [

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1026,7 +1026,7 @@ class Window(_Window):
             self.height = h
         self._reconfigure_floating(new_float_state=new_float_state)
 
-    def togroup(self, group_name=None, switch_group=False):
+    def togroup(self, group_name=None, *, switch_group=False):
         """Move window to a specified group
 
         Also switch to that group if switch_group is True.
@@ -1293,7 +1293,7 @@ class Window(_Window):
         """
         self.kill()
 
-    def cmd_togroup(self, groupName=None, switch_group=False):  # noqa: 803
+    def cmd_togroup(self, groupName=None, *, switch_group=False):  # noqa: 803
         """Move window to a specified group.
 
         If groupName is not specified, we assume the current group.
@@ -1314,7 +1314,7 @@ class Window(_Window):
 
             togroup("a", switch_group=True)
         """
-        self.togroup(groupName, switch_group)
+        self.togroup(groupName, switch_group=switch_group)
 
     def cmd_toscreen(self, index=None):
         """Move window to a specified screen.

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1026,8 +1026,11 @@ class Window(_Window):
             self.height = h
         self._reconfigure_floating(new_float_state=new_float_state)
 
-    def togroup(self, group_name=None):
-        """Move window to a specified group"""
+    def togroup(self, group_name=None, switch_group=False):
+        """Move window to a specified group
+
+        Also switch to that group if switch_group is True.
+        """
         if group_name is None:
             group = self.qtile.current_group
         else:
@@ -1046,9 +1049,11 @@ class Window(_Window):
             if group.screen and self.x < group.screen.x:
                 self.x += group.screen.x
             group.add(self)
+            if switch_group:
+                group.cmd_toscreen()
 
     def toscreen(self, index=None):
-        """ Move window to a specified screen, or the current screen. """
+        """Move window to a specified screen, or the current screen."""
         if index is None:
             screen = self.qtile.current_screen
         else:
@@ -1288,10 +1293,11 @@ class Window(_Window):
         """
         self.kill()
 
-    def cmd_togroup(self, groupName=None):  # noqa: 803
+    def cmd_togroup(self, groupName=None, switch_group=False):  # noqa: 803
         """Move window to a specified group.
 
-        If groupName is not specified, we assume the current group
+        If groupName is not specified, we assume the current group.
+        If switch_group is True, also switch to that group.
 
         Examples
         ========
@@ -1303,8 +1309,12 @@ class Window(_Window):
         Move window to group "a"::
 
             togroup("a")
+
+        Move window to group "a", and switch to group "a"::
+
+            togroup("a", switch_group=True)
         """
-        self.togroup(groupName)
+        self.togroup(groupName, switch_group)
 
     def cmd_toscreen(self, index=None):
         """Move window to a specified screen.

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -164,11 +164,19 @@ def test_togroup(qtile):
     with pytest.raises(CommandError):
         self.c.window.togroup("nonexistent")
     assert self.c.groups()["a"]["focus"] == "one"
+
     self.c.window.togroup("a")
     assert self.c.groups()["a"]["focus"] == "one"
-    self.c.window.togroup("b")
+
+    self.c.window.togroup("b", switch_group=True)
     assert self.c.groups()["b"]["focus"] == "one"
     assert self.c.groups()["a"]["focus"] is None
+    assert self.c.group.info()["name"] == "b"
+
+    self.c.window.togroup("a")
+    assert self.c.groups()["a"]["focus"] == "one"
+    assert self.c.group.info()["name"] == "b"
+
     self.c.to_screen(1)
     self.c.window.togroup("c")
     assert self.c.groups()["c"]["focus"] == "one"


### PR DESCRIPTION
At first I just switch to that group always, as I think most of the time it makes sense to switch to the group at the same time. But then I wonder maybe there are folks who are just happy with current behavior of qtile, so I add an additional `switch_group` parameter, which defaults to `False`.

Let me know what you think.