### PR TITLE
Update OS informations

### DIFF
--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -2,14 +2,14 @@
 Installing on Debian or Ubuntu
 ==============================
 
-On recent Ubuntu (17.04 Zesty+) and Debian unstable (Sid) versions, there are
+On recent Ubuntu (17.04 or greater) and Debian (10 or greater) versions, there are
 Qtile packages available via:
 
 .. code-block:: bash
 
     sudo apt-get install qtile
 
-On older versions of Ubuntu (Wily+) and Debian testing (Stretch), the
+On older versions of Ubuntu (15.10 or lower) and Debian (9 or lower), the
 dependencies are available via:
 
 .. code-block:: bash

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -9,7 +9,7 @@ Qtile packages available via:
 
     sudo apt-get install qtile
 
-On older versions of Ubuntu (15.10 to 16.10) and Debian (9 or lower), the
+On older versions of Ubuntu (15.10 to 16.10) and Debian 9, the
 dependencies are available via:
 
 .. code-block:: bash

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -9,7 +9,7 @@ Qtile packages available via:
 
     sudo apt-get install qtile
 
-On older versions of Ubuntu (15.10 or lower) and Debian (9 or lower), the
+On older versions of Ubuntu (15.10 to 16.10) and Debian (9 or lower), the
 dependencies are available via:
 
 .. code-block:: bash


### PR DESCRIPTION
- Use number instead of codename
- Update Debian information to let the user know that qtile previously in unstable is now in stable since the Buster release