### PR TITLE
Directly import the currentlayout widgets

### DIFF
--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -23,7 +23,10 @@
 from ..utils import safe_import as safe_import_
 from .import_error import make_error
 
+# only directly import widgets that do not have any third party dependencies
+# other than those required by qtile, otherwise use the same import function
 from .clock import Clock  # noqa: F401
+from .currentlayout import CurrentLayout, CurrentLayoutIcon  # noqa: F401
 from .groupbox import AGroupBox, GroupBox  # noqa: F401
 from .prompt import Prompt  # noqa: F401
 from .systray import Systray  # noqa: F401
@@ -38,7 +41,6 @@ def safe_import(module_name, class_name):
 
 safe_import("backlight", "Backlight")
 safe_import("battery", ["Battery", "BatteryIcon"])
-safe_import("currentlayout", ["CurrentLayout", "CurrentLayoutIcon"])
 safe_import("currentscreen", "CurrentScreen")
 safe_import("debuginfo", "DebugInfo")
 safe_import("graph", ["CPUGraph", "MemoryGraph", "SwapGraph", "NetGraph",


### PR DESCRIPTION
There is currently a mypy failure in the default layout because it is
importing one of these widgets and it is not able to introspect through
the safe import to see the call.  The currentlayout widgets do not use
any third party libraries, so it is safe to directly import these at the
top level.  Add the widget imports here, as well as a note on what can
and cannot be included via direct import.