### PR TITLE
let maildir widget display inbox grand total

### DIFF
--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -38,6 +38,8 @@ class Maildir(base.ThreadedPollText):
         ("sub_folders", [], 'The subfolders to scan (e.g. [{"path": "INBOX", '
             '"label": "Home mail"}, {"path": "spam", "label": "Home junk"}]'),
         ("separator", " ", "the string to put between the subfolder strings."),
+        ("total", False, "Whether or not to sum subfolders into a grand \
+            total. The first label will be used."),
     ]
 
     def __init__(self, **config):
@@ -89,6 +91,12 @@ class Maildir(base.ThreadedPollText):
         =======
         a string representation of the given state
         """
-        return self.separator.join(
-            "{0}: {1}".format(*item) for item in state.items()
-        )
+        if self.total:
+            return self.separator.join([
+                self.sub_folders[0]["label"],
+                str(sum(state.values()))
+            ])
+        else:
+            return self.separator.join(
+                "{0}: {1}".format(*item) for item in state.items()
+            )


### PR DESCRIPTION
I often found myself checking my maildir status on the bar and caring more about the total unread emails I had than which inboxes they were in. I think this must be a work/life balance issue and I shouldn't check emails when only my work inbox has mail.

In any case, to enable this troubling behaviour, I made this change to the maildir widget. Passing `total=True` will sum the number of emails in all specified subfolders and the widget will display only that number. The label assigned to the first subfolder is used as the label.