### PR TITLE
Create a initial config for user if not existing yet.

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -17,6 +17,8 @@ Qtile looks in the following places for a configuration file, in order:
 * It reads the module ``libqtile.resources.default_config``, included by
   default with every Qtile installation.
 
+Qtile will try to create the configuration file as a copy of the default config, if it doesn't exist yet.
+
 Default Configuration
 =====================
 

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -23,7 +23,7 @@
 # whose defaults depend on a reasonable locale sees something reasonable.
 import locale
 import logging
-from os import path, getenv
+from os import path, getenv, makedirs
 
 from libqtile.log_utils import init_log, logger
 from libqtile import confreader
@@ -106,6 +106,20 @@ def make_qtile():
 
     kore = xcore.XCore()
     try:
+        if not path.isfile(options.configfile):
+            try:
+                makedirs(path.dirname(options.configfile), exist_ok=True)
+                from shutil import copyfile
+                default_config_path = path.join(path.dirname(__file__),
+                                                "..",
+                                                "resources",
+                                                "default_config.py")
+                copyfile(default_config_path, options.configfile)
+                logger.info('Copied default_config.py to %s', options.configfile)
+            except Exception as e:
+                logger.exception('Failed to copy default_config.py to %s: (%s)',
+                                 options.configfile, e)
+
         config = confreader.Config.from_file(kore, options.configfile)
     except Exception as e:
         logger.exception('Error while reading config file (%s)', e)
@@ -113,6 +127,7 @@ def make_qtile():
         from libqtile.widget import TextBox
         widgets = config.screens[0].bottom.widgets
         widgets.insert(0, TextBox('Config Err!'))
+
     # XXX: the import is here because we need to call init_log
     # before start importing stuff
     from libqtile.core import manager


### PR DESCRIPTION
This tries to create an initial config.py for user if not existing yet, which is an exact copy of the default_config.py, so that it will lower the chance of incompatibility between the source code and config, which has been seen in #1483 #1479 #1273 .

And `qtile.1` should be updated too, but I haven't figured out how to generate it from the .rst file :(