### PR TITLE
Toggle group if setting a group twice.

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -290,6 +290,7 @@ class Screen(CommandObject):
     def set_group(self, new_group, save_prev=True):
         """Put group on this screen"""
         if new_group.screen == self:
+            self.cmd_toggle_group()
             return
 
         if save_prev:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -287,10 +287,6 @@ class Screen(CommandObject):
     def get_rect(self):
         return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
 
-    @property
-    def current_group(self):
-        return self.group
-
     def set_group(self, new_group, save_prev=True):
         """Put group on this screen"""
         if new_group is None:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -289,15 +289,15 @@ class Screen(CommandObject):
 
     def set_group(self, new_group, save_prev=True):
         """Put group on this screen"""
+        if new_group is None:
+            return
+
         if new_group.screen == self:
             self.cmd_toggle_group()
             return
 
         if save_prev:
             self.previous_group = self.group
-
-        if new_group is None:
-            return
 
         if new_group.screen:
             # g1 <-> s1 (self)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -293,7 +293,7 @@ class Screen(CommandObject):
             return
 
         if new_group.screen == self:
-            self.cmd_toggle_group()
+            self.toggle_group()
             return
 
         if save_prev:
@@ -331,6 +331,12 @@ class Screen(CommandObject):
             self.group.layouts[self.group.current_layout],
             self.group
         )
+
+    def toggle_group(self, group=None):
+        """Switch to the selected group or to the previously active one"""
+        if group in (self.group, None):
+            group = self.previous_group
+        self.set_group(group)
 
     def _items(self, name):
         if name == "layout":
@@ -400,9 +406,7 @@ class Screen(CommandObject):
     def cmd_toggle_group(self, group_name=None):
         """Switch to the selected group or to the previously active one"""
         group = self.qtile.groups_map.get(group_name)
-        if group in (self.group, None):
-            group = self.previous_group
-        self.set_group(group)
+        self.toggle_group(group)
 
     def cmd_togglegroup(self, groupName=None):  # noqa
         """Switch to the selected group or to the previously active one

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -287,13 +287,16 @@ class Screen(CommandObject):
     def get_rect(self):
         return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
 
+    @property
+    def current_group(self):
+        return self.group
+
     def set_group(self, new_group, save_prev=True):
         """Put group on this screen"""
         if new_group is None:
             return
 
         if new_group.screen == self:
-            self.toggle_group()
             return
 
         if save_prev:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -541,7 +541,7 @@ class Qtile(CommandObject):
 
     @property
     def current_group(self):
-        return self.current_screen.current_group
+        return self.current_screen.group
 
     @property
     def current_window(self):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -541,7 +541,7 @@ class Qtile(CommandObject):
 
     @property
     def current_group(self):
-        return self.current_screen.group
+        return self.current_screen.current_group
 
     @property
     def current_window(self):

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -360,6 +360,8 @@ class _Group(CommandObject):
     def cmd_toscreen(self, screen=None):
         """Pull a group to a specified screen.
 
+        If this group is already on the screen, then toggle group.
+
         Parameters
         ==========
         screen :
@@ -379,7 +381,11 @@ class _Group(CommandObject):
             screen = self.qtile.current_screen
         else:
             screen = self.qtile.screens[screen]
-        screen.set_group(self)
+
+        if screen.current_group == self:
+            screen.toggle_group(self)
+        else:
+            screen.set_group(self)
 
     def _get_group(self, direction, skip_empty=False, skip_managed=False):
         """Find a group walking the groups list in the specified direction

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -382,7 +382,7 @@ class _Group(CommandObject):
         else:
             screen = self.qtile.screens[screen]
 
-        if screen.current_group == self:
+        if screen.group == self:
             screen.toggle_group(self)
         else:
             screen.set_group(self)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -290,7 +290,7 @@ class GroupBox(_GroupBase):
                 self.clicked = group
 
         if group:
-            if self.bar.screen.current_group != group or not self.disable_drag:
+            if self.bar.screen.group != group or not self.disable_drag:
                 self.bar.screen.set_group(group)
             else:
                 self.bar.screen.toggle_group(group)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -290,7 +290,10 @@ class GroupBox(_GroupBase):
                 self.clicked = group
 
         if group:
-            self.bar.screen.set_group(group)
+            if self.bar.screen.current_group == group:
+                self.bar.screen.toggle_group(group)
+            else:
+                self.bar.screen.set_group(group)
 
     def button_release(self, x, y, button):
         if button not in (5, 4):

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -290,10 +290,10 @@ class GroupBox(_GroupBase):
                 self.clicked = group
 
         if group:
-            if self.bar.screen.current_group == group:
-                self.bar.screen.toggle_group(group)
-            else:
+            if self.bar.screen.current_group != group or not self.disable_drag:
                 self.bar.screen.set_group(group)
+            else:
+                self.bar.screen.toggle_group(group)
 
     def button_release(self, x, y, button):
         if button not in (5, 4):

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -925,9 +925,15 @@ def test_setgroup(qtile):
     else:
         assert self.c.groups()["a"]["screen"] == 1
     assert self.c.groups()["b"]["screen"] == 0
+
     self.c.group["c"].toscreen()
     self.groupconsistency()
     assert self.c.groups()["c"]["screen"] == 0
+
+    # Setting the current group once again switches back to the previous group
+    self.c.group["c"].toscreen()
+    self.groupconsistency()
+    assert self.c.group.info()["name"] == "b"
 
 
 @pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)


### PR DESCRIPTION
Here is a quick fix for this use case: quickly switch to a group and take a look, then switch it back to the previous group.

Assume the current group is group `a`, and I want to take a quick look at group `b`. There are two way with shortcut keys of the default config:
1. Clicking on label b of the groupbox, and then clicking it again.

    One who is used to use mouse to switch group will benefit a bit more from this patch, as he/she doesn't need to know the previous group (hence its shortcut key), and just clicks on the label twice.

2. Hitting `mod+b` twice.