### PR TITLE
Allow setting wallpaper per Screen in config

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -26,6 +26,7 @@ from typing import Callable, Iterator, List, Optional, Tuple, TYPE_CHECKING
 
 import xcffib
 import xcffib.xproto
+import xcffib.render
 
 from . import xcbq
 from libqtile import config, hook, utils, window
@@ -123,6 +124,7 @@ class XCore(base.Core):
         self._root.set_cursor("left_ptr")
 
         self.qtile = None  # type: Optional[Qtile]
+        self._painter = None
 
         numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])
         self._numlock_mask = xcbq.ModMasks.get(self.conn.get_modifier(numlock_code), 0)
@@ -246,6 +248,9 @@ class XCore(base.Core):
                 xcffib.xproto.WindowError,
                 xcffib.xproto.AccessError,
                 xcffib.xproto.DrawableError,
+                xcffib.xproto.GContextError,
+                xcffib.xproto.PixmapError,
+                xcffib.render.PictureError,
             ):
                 pass
             except Exception:
@@ -551,3 +556,9 @@ class XCore(base.Core):
 
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
         hook.fire("screen_change", self.qtile, event)
+
+    @property
+    def painter(self):
+        if self._painter is None:
+            self._painter = xcbq.Painter(self._display_name)
+        return self._painter

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -31,6 +31,7 @@ import warnings
 from . import configurable
 from . import hook
 from . import utils
+from .log_utils import logger
 from libqtile.command_object import CommandObject
 
 
@@ -218,19 +219,28 @@ class Screen(CommandObject):
     and ``height`` aren't specified usually unless you are using 'fake
     screens'.
 
+    The screen's wallpaper can be set by passing in a dict as the ``wallpaper``
+    kwarg, which must contain a 'path' key to specify the image to use, and can
+    optionally contain an 'option' key containing the string 'fill' or
+    'stretch' to specify how to fit the image onto the screen. 'fill' will
+    centre the image on the screen and fill it without warping it, 'stretch'
+    will warp the image to fit all of it into the screen. By default the image
+    will be placed at the screens origin and retain its own dimensions.
+
     Parameters
     ==========
     top: Gap/Bar object, or None.
     bottom: Gap/Bar object, or None.
     left: Gap/Bar object, or None.
     right: Gap/Bar object, or None.
+    wallpaper: Dict, or None.
     x : int or None
     y : int or None
     width : int or None
     height : int or None
     """
     def __init__(self, top=None, bottom=None, left=None, right=None,
-                 x=None, y=None, width=None, height=None):
+                 wallpaper=None, x=None, y=None, width=None, height=None):
         self.group = None
         self.previous_group = None
 
@@ -238,6 +248,7 @@ class Screen(CommandObject):
         self.bottom = bottom
         self.left = left
         self.right = right
+        self.wallpaper = wallpaper
         self.qtile = None
         self.index = None
         # x position of upper left corner can be > 0
@@ -257,6 +268,14 @@ class Screen(CommandObject):
         self.set_group(group)
         for i in self.gaps:
             i._configure(qtile, self)
+        if self.wallpaper:
+            try:
+                self.paint(**self.wallpaper)
+            except TypeError:
+                logger.exception("Error in wallpaper configuration.")
+
+    def paint(self, path, option=None):
+        self.qtile.paint_screen(self, path, option)
 
     @property
     def gaps(self):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -317,6 +317,9 @@ class Qtile(CommandObject):
             )
             self.screens.append(scr)
 
+    def paint_screen(self, screen, image_path, option=None):
+        self.core.painter.paint(screen, image_path, option)
+
     def process_configure(self, width: int, height: int) -> None:
         screen = self.current_screen
         screen.resize(0, 0, width, height)


### PR DESCRIPTION
This commit lets you have something like this in your config to paint your screens with a wallpaper:

```
screens = [
    Screen(wallpaper={'path': '/path/to/image.png'}),
    Screen(wallpaper={'path': '/path/to/another_image.png'}),
]
```

It works with multiple screens and different images, using xcffib, cairocffi and the Qtile object's own X connection.

The wallpaper kwarg is a dict for the purpose of specifying how to paint the wallpaper. By default, the image is positioned at the corresponding screen's origin and retains its dimensions. Alternatively, passing 'fill' or 'stretch' will make the image fill or stretch to fit the screen. I.e.:

```
wallpaper = {
    'path': '/path/to/image.png',
    'option': 'fill',
}
screens = [
    Screen(wallpaper=wallpaper),
    Screen(wallpaper=wallpaper),
]
```

It has been working well for me with single and double screens and removes the need for another tool installed just for setting the wallpaper (like feh). I understand this may be considered out of scope for Qtile, but I figured if Qtile has its own bar then painting the root window might not be too far out!