### PR TITLE
Fix windows disorder after toggling fullscreen

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -265,9 +265,10 @@ class _Group(CommandObject):
             pass  # doesn't matter
         if win.floating:
             self.floating_layout.add(win)
-        else:
-            for i in self.layouts:
-                i.add(win)
+
+        for i in self.layouts:
+            i.add(win)
+
         if focus:
             self.focus(win, warp=True, force=force)
 
@@ -275,21 +276,24 @@ class _Group(CommandObject):
         self.windows.remove(win)
         hadfocus = self._remove_from_focus_history(win)
         win.group = None
+        nextfocus = None
+
+        # Remove it from normal layouts first, and then from the floating layout
+        for i in self.layouts:
+            if i is self.layout:
+                nextfocus = i.remove(win)
+            else:
+                i.remove(win)
 
         if win.floating:
             nextfocus = self.floating_layout.remove(win)
 
+        if win.floating:
             nextfocus = nextfocus or \
                 self.current_window or \
                 self.layout.focus_first() or \
                 self.floating_layout.focus_first(group=self)
         else:
-            for i in self.layouts:
-                if i is self.layout:
-                    nextfocus = i.remove(win)
-                else:
-                    i.remove(win)
-
             nextfocus = nextfocus or \
                 self.floating_layout.focus_first(group=self) or \
                 self.current_window or \

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -311,7 +311,6 @@ class _Group(CommandObject):
                 pass
             else:
                 for i in self.layouts:
-                    i.remove(win)
                     if win is self.current_window:
                         i.blur()
                 self.floating_layout.add(win)
@@ -321,7 +320,6 @@ class _Group(CommandObject):
             self.floating_layout.remove(win)
             self.floating_layout.blur()
             for i in self.layouts:
-                i.add(win)
                 if win is self.current_window:
                     i.focus(win)
         self.layout_all()

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -315,6 +315,7 @@ class _Group(CommandObject):
                 pass
             else:
                 for i in self.layouts:
+                    i.floating_on(win)
                     if win is self.current_window:
                         i.blur()
                 self.floating_layout.add(win)
@@ -324,6 +325,7 @@ class _Group(CommandObject):
             self.floating_layout.remove(win)
             self.floating_layout.blur()
             for i in self.layouts:
+                i.floating_off(win)
                 if win is self.current_window:
                     i.focus(win)
         self.layout_all()

--- a/libqtile/layout/__init__.py
+++ b/libqtile/layout/__init__.py
@@ -26,7 +26,7 @@
 
 from .bsp import Bsp
 from .columns import Columns
-from .floating import Floating
+from .floating import Floating, FloatingTile
 from .matrix import Matrix
 from .max import Max
 from .ratiotile import RatioTile

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -383,11 +383,6 @@ class _ClientList:
         '''Get only non-floating clients'''
         return [i for i in self._clients if not i.floating]
 
-    def _actual_index(self, non_floating_clients_index):
-        '''Find the actual index of the list based on non-floating clients' index'''
-        client = self.non_floating_clients[non_floating_clients_index]
-        return self._clients.index(client)
-
     @property
     def current_index(self):
         return self._current_idx
@@ -482,11 +477,12 @@ class _ClientList:
         """
         if client not in self._clients:
             return
+        floating = client.floating
         idx = self._clients.index(client)
         del self._clients[idx]
         if len(self) == 0:
             self._current_idx = 0
-        elif idx <= self._current_idx:
+        elif floating and idx <= self._current_idx:
             self._current_idx = max(0, self._current_idx - 1)
 
     def rotate_up(self, maintain_index=True):
@@ -567,6 +563,11 @@ class _ClientList:
                             self._clients[pos::])
         else:
             self._clients.extend(other._clients)
+
+    def _actual_index(self, non_floating_clients_index):
+        '''Find the actual index of the list based on non-floating clients' index'''
+        client = self.non_floating_clients[non_floating_clients_index]
+        return self._clients.index(client)
 
     def index(self, client):
         return self.non_floating_clients.index(client)

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -559,7 +559,10 @@ class _ClientList:
         Add clients from 'other' _ClientList to self.
         'offset_to_current' works as described for add()
         """
-        pos = max(0, self._actual_index(self.current_index) + offset_to_current)
+        try:
+            pos = max(0, self._actual_index(self.current_index + offset_to_current))
+        except IndexError:
+            pos = 0
         if pos < len(self._clients):
             self._clients = (self._clients[:pos:] + other._clients +
                             self._clients[pos::])

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -113,6 +113,14 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         """Return a dictionary of info for this object"""
         return self.info()
 
+    def floating_on(self, client):
+        '''Called when `client` is floating on.'''
+        pass
+
+    def floating_off(self, client):
+        '''Called when `client` is floating off.'''
+        pass
+
     @abstractmethod
     def add(self, client):
         """Called whenever a window is added to the group

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -573,7 +573,7 @@ class _ClientList:
             pos = len(self._clients)  # default is to append to self
         if pos < len(self._clients):
             self._clients = (self._clients[:pos:] + other._clients +
-                            self._clients[pos::])
+                             self._clients[pos::])
         else:
             self._clients.extend(other._clients)
 

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -240,6 +240,7 @@ class SingleWindow(Layout):
             win.hide()
 
     def remove(self, win):
+        # XXX self.clients is not initialized in the class hierarchy
         cli = self.clients.pop(0)
         if cli == win:
             return self.clients[0]
@@ -379,7 +380,7 @@ class _ClientList:
 
     @property
     def non_floating_clients(self):
-        '''A helper to get only non-floating clients'''
+        '''Get only non-floating clients'''
         return [i for i in self._clients if not i.floating]
 
     def _actual_index(self, non_floating_clients_index):
@@ -421,22 +422,19 @@ class _ClientList:
         """
         Returns the first client in collection.
         """
-        return self.non_floating_clients[0]
+        return self[0]
 
     def focus_next(self, win):
         """
         Returns the client next from win in collection.
         """
-        try:
-            return self.non_floating_clients[self.index(win) + 1]
-        except IndexError:
-            return None
+        return self[self.index(win) + 1]
 
     def focus_last(self):
         """
         Returns the last client in collection.
         """
-        return self.non_floating_clients[-1]
+        return self[-1]
 
     def focus_previous(self, win):
         """
@@ -448,7 +446,7 @@ class _ClientList:
             return None
         else:
             if idx > 0:
-                return self.non_floating_clients[idx - 1]
+                return self[idx - 1]
 
     def add(self, client, offset_to_current=0):
         """

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -568,9 +568,9 @@ class _ClientList:
         'offset_to_current' works as described for add()
         """
         try:
-            pos = max(0, self._actual_index(self.current_index + offset_to_current))
+            pos = max(0, self._actual_index(self.current_index) + offset_to_current)
         except IndexError:
-            pos = 0
+            pos = len(self._clients)  # default is to append to self
         if pos < len(self._clients):
             self._clients = (self._clients[:pos:] + other._clients +
                             self._clients[pos::])

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -402,14 +402,11 @@ class _ClientList:
 
     @property
     def current_client(self):
-        non_floating_clients = self.non_floating_clients
-        if not non_floating_clients:
-            return None
-        return non_floating_clients[self._current_idx]
+        return self[self._current_idx]
 
     @current_client.setter
     def current_client(self, client):
-        self._current_idx = self.non_floating_clients.index(client)
+        self._current_idx = self.index(client)
 
     def focus(self, client):
         """

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -457,7 +457,9 @@ class _ClientList:
             self._clients.insert(pos, client)
         else:
             self._clients.append(client)
-        self.current_client = client
+
+        if not client.floating:
+            self.current_client = client
 
     def append_head(self, client):
         """

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -139,7 +139,7 @@ class _BspNode():
 
 class Bsp(Layout):
     """This layout is inspired by bspwm, but it does not try to copy its
-    features. All clients are organized as a full binary tree.
+    features.
 
     The first client occupies the entire srceen space.  When a new client
     is created, the selected space is partitioned in 2 and the new client
@@ -151,6 +151,8 @@ class Bsp(Layout):
     otherwise, they are created on top of each other.  The partition
     direction can be freely toggled.  All subspaces can be resized and
     clients can be shuffled around.
+
+    All clients are organized at the leaves of a full binary tree.
 
     An example key configuration is::
 

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -35,7 +35,7 @@ class _Column(_ClientList):
         info = _ClientList.info(self)
         info.update(
             dict(
-                heights=[self.heights[c] for c in self.clients],
+                heights=[self.heights[c] for c in self.non_floating_clients],
                 split=self.split,
             ))
         return info
@@ -70,7 +70,7 @@ class _Column(_ClientList):
         return "_Column: " + ", ".join([
             "[%s: %d]" % (c.name, self.heights[c])
             if c == cur else "%s: %d" % (c.name, self.heights[c])
-            for c in self.clients
+            for c in self.non_floating_clients
         ])
 
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -106,7 +106,7 @@ class Floating(Layout):
                 return True
         return False
 
-    def interested_in_client(self, client):
+    def _interested_in_client(self, client):
         '''Test if a client is interested in.'''
         floating = client.floating
         if (self._floating_clients_only and floating) or \
@@ -118,7 +118,7 @@ class Floating(Layout):
         """Find all clients belonging to a given group"""
         clients = []
         for c in self._clients:
-            if (group is None or c.group is group) and self.interested_in_client(c):
+            if (group is None or c.group is group) and self._interested_in_client(c):
                 clients.append(c)
         return clients
 
@@ -181,7 +181,7 @@ class Floating(Layout):
             return clients[idx - 1]
 
     def focus(self, client):
-        if self.interested_in_client(client):
+        if self._interested_in_client(client):
             self.focused = client
 
     def blur(self):
@@ -253,7 +253,7 @@ class Floating(Layout):
 
     def add(self, client):
         self._clients.append(client)
-        if self.interested_in_client(client):
+        if self._interested_in_client(client):
             self.focused = client
 
     def remove(self, client):

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -289,7 +289,6 @@ class FloatingTile(Floating):
         ("name", "floatingtile", "Name of this layout.")
     ]
 
-
     def __init__(self, **config):
         Floating.__init__(self, **config)
         self._floating_clients_only = False

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -157,10 +157,10 @@ class Floating(Layout):
             return clients[0]
 
     def focus_next(self, win):
-        if win not in self._clients or win.group is None:
+        clients = self.find_clients(win.group)
+        if win not in clients or win.group is None:
             return
 
-        clients = self.find_clients(win.group)
         idx = clients.index(win)
         if len(clients) > idx + 1:
             return clients[idx + 1]
@@ -172,10 +172,10 @@ class Floating(Layout):
             return clients[-1]
 
     def focus_previous(self, win):
-        if win not in self._clients or win.group is None:
+        clients = self.find_clients(win.group)
+        if win not in clients or win.group is None:
             return
 
-        clients = self.find_clients(win.group)
         idx = clients.index(win)
         if idx > 0:
             return clients[idx - 1]

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -89,7 +89,7 @@ class Floating(Layout):
         the screen.
         """
         Layout.__init__(self, **config)
-        self.clients = []
+        self._clients = []
         self.focused = None
         self.group = None
         self.float_rules = float_rules or DEFAULT_FLOAT_RULES
@@ -117,7 +117,7 @@ class Floating(Layout):
     def find_clients(self, group):
         """Find all clients belonging to a given group"""
         clients = []
-        for c in self.clients:
+        for c in self._clients:
             if (group is None or c.group is group) and self.interested_in_client(c):
                 clients.append(c)
         return clients
@@ -157,7 +157,7 @@ class Floating(Layout):
             return clients[0]
 
     def focus_next(self, win):
-        if win not in self.clients or win.group is None:
+        if win not in self._clients or win.group is None:
             return
 
         clients = self.find_clients(win.group)
@@ -172,7 +172,7 @@ class Floating(Layout):
             return clients[-1]
 
     def focus_previous(self, win):
-        if win not in self.clients or win.group is None:
+        if win not in self._clients or win.group is None:
             return
 
         clients = self.find_clients(win.group)
@@ -252,18 +252,18 @@ class Floating(Layout):
         client.unhide()
 
     def add(self, client):
-        self.clients.append(client)
+        self._clients.append(client)
         if self.interested_in_client(client):
             self.focused = client
 
     def remove(self, client):
-        if client not in self.clients:
+        if client not in self._clients:
             return
 
         next_focus = self.focus_next(client)
         if client is self.focused:
             self.blur()
-        self.clients.remove(client)
+        self._clients.remove(client)
         return next_focus
 
     def info(self):

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -9,6 +9,7 @@
 # Copyright (c) 2014 Sean Vig
 # Copyright (c) 2014 dequis
 # Copyright (c) 2018 Nazar Mokrynskyi
+# Copyright (c) 2019 Guangwang Huang
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -93,6 +94,7 @@ class Floating(Layout):
         self.group = None
         self.float_rules = float_rules or DEFAULT_FLOAT_RULES
         self.no_reposition_match = no_reposition_match
+        self._floating_clients_only = True  # If only floating clients are interested
         self.add_defaults(Floating.defaults)
 
     def match(self, win):
@@ -104,9 +106,21 @@ class Floating(Layout):
                 return True
         return False
 
+    def interested_in_client(self, client):
+        '''Test if a client is interested in.'''
+        floating = client.floating
+        if (self._floating_clients_only and floating) or \
+           (not self._floating_clients_only and not floating):
+            return True
+        return False
+
     def find_clients(self, group):
         """Find all clients belonging to a given group"""
-        return [c for c in self.clients if c.group is group]
+        clients = []
+        for c in self.clients:
+            if (group is None or c.group is group) and self.interested_in_client(c):
+                clients.append(c)
+        return clients
 
     def to_screen(self, group, new_screen):
         """Adjust offsets of clients within current screen"""
@@ -137,10 +151,7 @@ class Floating(Layout):
             win.group = new_screen.group
 
     def focus_first(self, group=None):
-        if group is None:
-            clients = self.clients
-        else:
-            clients = self.find_clients(group)
+        clients = self.find_clients(group)
 
         if clients:
             return clients[0]
@@ -155,10 +166,7 @@ class Floating(Layout):
             return clients[idx + 1]
 
     def focus_last(self, group=None):
-        if group is None:
-            clients = self.clients
-        else:
-            clients = self.find_clients(group)
+        clients = self.find_clients(group)
 
         if clients:
             return clients[-1]
@@ -173,7 +181,8 @@ class Floating(Layout):
             return clients[idx - 1]
 
     def focus(self, client):
-        self.focused = client
+        if self.interested_in_client(client):
+            self.focused = client
 
     def blur(self):
         self.focused = None
@@ -244,7 +253,8 @@ class Floating(Layout):
 
     def add(self, client):
         self.clients.append(client)
-        self.focused = client
+        if self.interested_in_client(client):
+            self.focused = client
 
     def remove(self, client):
         if client not in self.clients:
@@ -258,7 +268,7 @@ class Floating(Layout):
 
     def info(self):
         d = Layout.info(self)
-        d["clients"] = [c.name for c in self.clients]
+        d["clients"] = [c.name for c in self.find_clients(group=None)]
         return d
 
     def cmd_next(self):
@@ -268,3 +278,19 @@ class Floating(Layout):
     def cmd_previous(self):
         # This can't ever be called, but implement the abstract method
         pass
+
+
+class FloatingTile(Floating):
+    '''Floating layout for tile layouts config: the `layouts` symbol in config.py.
+
+    It is almost exact with Floating, except that it's intended to be use a tile layout.'''
+
+    defaults = [
+        ("name", "floatingtile", "Name of this layout.")
+    ]
+
+
+    def __init__(self, **config):
+        Floating.__init__(self, **config)
+        self._floating_clients_only = False
+        self.add_defaults(FloatingTile.defaults)

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -35,7 +35,7 @@ class _WinStack(_ClientList):
 
     def __str__(self):
         return "_WinStack: %s, %s" % (
-            self.current, str([client.name for client in self.clients])
+            self.current, str([client.name for client in self.non_floating_clients])
         )
 
     def info(self):
@@ -86,7 +86,7 @@ class Stack(Layout):
     def clients(self):
         client_list = []
         for stack in self.stacks:
-            client_list.extend(stack.clients)
+            client_list.extend(stack.non_floating_clients)
         return client_list
 
     def clone(self, group):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -393,6 +393,44 @@ class TreeTab(Layout):
     left border of the screen, which allows you to overview all opened windows.
     It's designed to work with ``uzbl-browser`` but works with other windows
     too.
+
+    The panel at the left border contains sections, each of which contains
+    windows. Initially the panel looks like flat lists inside its
+    section, and looks like trees if some of the windows are "moved" left or
+    right.
+
+    For example, it looks like below with two sections initially:
+
+    ::
+
+        +------------+
+        |Section Foo |
+        +------------+
+        | Window A   |
+        +------------+
+        | Window B   |
+        +------------+
+        | Window C   |
+        +------------+
+        |Section Bar |
+        +------------+
+
+    And then it will look like below if "Window B" is moved right and "Window C"
+    is moved right too:
+
+    ::
+
+        +------------+
+        |Section Foo |
+        +------------+
+        | Window A   |
+        +------------+
+        |  Window B  |
+        +------------+
+        |   Window C |
+        +------------+
+        |Section Bar |
+        +------------+
     """
 
     defaults = [

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -89,7 +89,7 @@ class TreeNode:
         if not self.expanded and self.children:
             return "{:d}".format(
                 len(self.children)
-            ).translate(to_superscript).encode('utf-8') + title
+            ).translate(to_superscript) + title
         return title
 
     def get_first_window(self):
@@ -100,10 +100,11 @@ class TreeNode:
         """
         if isinstance(self, Window):
             return self
-        for i in self.children:
-            node = i.get_first_window()
-            if node:
-                return node
+        if self.expanded:
+            for i in self.children:
+                node = i.get_first_window()
+                if node:
+                    return node
 
     def get_last_window(self):
         """Find the last Window under this node
@@ -111,10 +112,11 @@ class TreeNode:
         Finds last `Window` by depth-first search, otherwise returns self if
         this is a `Window`.
         """
-        for i in reversed(self.children):
-            node = i.get_last_window()
-            if node:
-                return node
+        if self.expanded:
+            for i in reversed(self.children):
+                node = i.get_last_window()
+                if node:
+                    return node
         if isinstance(self, Window):
             return self
 

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -325,6 +325,10 @@ class Window(TreeNode):
             p = p.parent()
         return p
 
+    @parent.setter
+    def parent(self):
+        raise NotImplementedError  # No use case for now
+
     def draw(self, layout, top, level=0):
         '''Draw the window title on the panel of ``layout``.'''
         self._title_top = top

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -590,7 +590,8 @@ class TreeTab(Layout):
 
         children = self._tree.children
         d = Layout.info(self)
-        d["clients"] = [x.name for x in self._nodes if not x.floating]  # not in order
+        # Sort client names to workaround an internal difference between Python 3.5 and Python 3.6+
+        d["clients"] = sorted([x.name for x in self._nodes if not x.floating])
         d["sections"] = [x.title for x in children]
 
         trees = {}

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -463,9 +463,45 @@ class TreeTab(Layout):
             self._drawer.finalize()
 
     def info(self):
+
+        def show_section_tree(root):
+            '''Show a section tree in a nested list, whose every element has the form: `[root, [subtrees]]`.
+
+            For `[root, [subtrees]]`, The first element is the root node, and the second is its a list of its subtrees.
+            For example, a section with below windows hierarchy on the panel:
+            - a
+              - d
+                - e
+              - f
+            - b
+              - g
+              - h
+            - c
+
+            will return [
+                         [a,
+                           [d, [e]],
+                           [f]],
+                         [b, [g], [h]],
+                         [c],
+                        ]
+            '''
+            tree = []
+            if isinstance(root, Window):
+                tree.append(root.window.name)
+            if root.expanded and root.children:
+                for child in root.children:
+                    tree.append(show_section_tree(child))
+            return tree
+
         d = Layout.info(self)
-        d["clients"] = [x.name for x in self._nodes]
+        d["clients"] = [x.name for x in self._nodes]  # not in order
         d["sections"] = [x.title for x in self._tree.children]
+
+        trees = {}
+        for section in self._tree.children:
+            trees[section.title] = show_section_tree(section)
+        d["client_trees"] = trees
         return d
 
     def show(self, screen):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -10,6 +10,7 @@
 # Copyright (c) 2014 Nathan Hoad
 # Copyright (c) 2014 dequis
 # Copyright (c) 2014 Thomas Sarboni
+# Copyright (c) 2019 Guangwang Huang
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,30 +36,70 @@ from .. import drawer, hook, window
 to_superscript = dict(zip(map(ord, u'0123456789'), map(ord, u'⁰¹²³⁴⁵⁶⁷⁸⁹')))
 
 
+# For floating windows, replace its position with its first preorder child
+# conceptually, thought it isn't removed so as to keep its position if
+# been unfloating back.
 class TreeNode:
     def __init__(self):
-        self.children = []
-        self.parent = None
+        self._children = []
+        self._parent = None
         self.expanded = True
         self._children_top = None
         self._children_bot = None
 
     def add(self, node, hint=None):
-        """Add a node below this node
+        """Add a node to `self` as a child
 
-        The `hint` is a node to place the new node after in this nodes
-        children.
+        The `hint` is a node if not None, after which to place the new node
         """
-        node.parent = self
+        node._parent = self
         if hint is not None:
             try:
-                idx = self.children.index(hint)
+                idx = self._children.index(hint)
             except ValueError:
                 pass
             else:
-                self.children.insert(idx + 1, node)
+                self._children.insert(idx + 1, node)
                 return
-        self.children.append(node)
+        self._children.append(node)
+
+    def remove_child(self, node):
+        '''Remove a `node` from `self`'s descendants.'''
+        node._parent._children.remove(node)
+
+    @property
+    def children(self):
+        '''Get effective children.'''
+        return self._children
+
+    @property
+    def parent(self):
+        '''Get the effective parent.'''
+        return self._parent
+
+    @parent.setter
+    def parent(self, new_parent):
+        '''Set the parent to `new_parent`.'''
+        self._parent = new_parent
+
+    def _swap_children_literally(self, i, j):
+        '''Swap children at i and j literally.'''
+        if i != j and 0 <= i < len(self._children) and 0 <= j < len(self._children):
+            self._children[i], self._children[j] = self._children[j], self._children[i]
+
+    def move_up(self):
+        '''Move up current node, the tree is "drawn" from left to right'''
+        parent = self.parent
+        virtual_children = parent.children
+        idx = virtual_children.index(self)
+        parent._swap_children_literally(idx, idx - 1)
+
+    def move_down(self):
+        '''Move down current node, the tree is "drawn" from left to right'''
+        parent = self.parent
+        virtual_children = parent.children
+        idx = virtual_children.index(self)
+        parent._swap_children_literally(idx, idx + 1)
 
     def draw(self, layout, top, level=0):
         """Draw the node and its children to a layout
@@ -74,7 +115,7 @@ class TreeNode:
         return top
 
     def button_press(self, x, y):
-        """Returns self or sibling which got the click"""
+        """Returns self or a child which got the click"""
         # if we store the locations of each child, it would be possible to do
         # this without having to traverse the tree...
         if not (self._children_top <= y < self._children_bot):
@@ -86,19 +127,20 @@ class TreeNode:
 
     def add_superscript(self, title):
         """Prepend superscript denoting the number of hidden children"""
-        if not self.expanded and self.children:
+        children = self.children
+        if not self.expanded and children:
             return "{:d}".format(
-                len(self.children)
+                len(children)
             ).translate(to_superscript) + title
         return title
 
     def get_first_window(self):
-        """Find the first Window under this node
+        """Find the first Window under this node by preorder tree traverse.
 
         Returns self if this is a `Window`, otherwise finds first `Window` by
         depth-first search
         """
-        if isinstance(self, Window):
+        if isinstance(self, Window) and not self.window.floating:
             return self
         if self.expanded:
             for i in self.children:
@@ -117,12 +159,15 @@ class TreeNode:
                 node = i.get_last_window()
                 if node:
                     return node
-        if isinstance(self, Window):
+        if isinstance(self, Window) and not self.window.floating:
             return self
 
     def get_next_window(self):
-        if self.children and self.expanded:
-            return self.children[0]
+        children = self.children
+        if children and self.expanded:
+            for child in children:
+                return child
+
         node = self
         while not isinstance(node, Root):
             parent = node.parent
@@ -137,11 +182,12 @@ class TreeNode:
         node = self
         while not isinstance(node, Root):
             parent = node.parent
-            idx = parent.children.index(node)
-            if idx == 0 and isinstance(parent, Window):
+            children = parent.children
+            idx = children.index(node)
+            if idx == 0 and isinstance(parent, Window) and not parent.window.floating:
                 return parent
             for i in range(idx - 1, -1, -1):
-                res = parent.children[i].get_last_window()
+                res = children[i].get_last_window()
                 if res:
                     return res
             node = parent
@@ -164,7 +210,7 @@ class Root(TreeNode):
         Adds a new `Window` to the tree.  The location of the new node is
         controlled by looking:
 
-            * `hint` kwarg - place the node next to this node
+            * `hint` kwarg - place the node after this node
             * win.tree_section - place the window in the given section, by name
             * default section - fallback to default section (first section, if
               not otherwise set)
@@ -175,7 +221,7 @@ class Root(TreeNode):
             parent = hint.parent
 
         if parent is None:
-            sect = getattr(win, 'tree_section', None)
+            sect = getattr(win, 'tree_section', None)  # XXX no one sets it!
             if sect is not None:
                 parent = self.sections.get(sect)
 
@@ -191,27 +237,27 @@ class Root(TreeNode):
         if name in self.sections:
             raise ValueError("Duplicate section name")
         node = Section(name)
-        node.parent = self
+        node._parent = self
         self.sections[name] = node
-        self.children.append(node)
+        self._children.append(node)
 
     def del_section(self, name):
         """Remove the Section with the given name"""
         if name not in self.sections:
             raise ValueError("Section name not found")
-        if len(self.children) == 1:
+        if len(self._children) == 1:
             raise ValueError("Can't delete last section")
 
         sec = self.sections[name]
         # move the children of the deleted section to the previous section
         # if delecting the first section, add children to second section
-        idx = min(self.children.index(sec), 1)
-        next_sec = self.children[idx - 1]
+        idx = min(self._children.index(sec), 1)
+        next_sec = self._children[idx - 1]
         # delete old section, reparent children to next section
-        del self.children[idx]
-        next_sec.children.extend(sec.children)
-        for i in sec.children:
-            i.parent = next_sec
+        del self._children[idx]
+        next_sec._children.extend(sec._children)
+        for i in sec._children:
+            i._parent = next_sec
 
 
 class Section(TreeNode):
@@ -220,6 +266,7 @@ class Section(TreeNode):
         self.title = title
 
     def draw(self, layout, top, level=0):
+        '''Draw the section title and its children on the panel of `layout`.'''
         del layout._layout.width  # no centering
         # draw a horizontal line above the section
         layout._drawer.draw_hbar(
@@ -253,35 +300,63 @@ class Window(TreeNode):
         self.window = win
         self._title_top = None
 
+    @property
+    def children(self):
+        '''Get effective children.'''
+        children = []
+        for c in self._children:
+            if not c.window.floating:
+                children.append(c)
+            else:
+                # For a floating client, replace it with its first child
+                for cc in c.children():
+                    if cc:
+                        children.append(cc[0])
+                        break
+        return children
+
+    @property
+    def parent(self):
+        '''Get the effective parent.
+
+        Return the nearest ancestor which isn't a window or is a non-floating window.'''
+        p = self._parent
+        while isinstance(p, Window) and p.window.floating:
+            p = p.parent()
+        return p
+
     def draw(self, layout, top, level=0):
+        '''Draw the window title on the panel of ``layout``.'''
         self._title_top = top
 
-        # setup parameters for drawing self
-        left = layout.padding_left + level * layout.level_shift
-        layout._layout.font_size = layout.fontsize
-        layout._layout.text = self.add_superscript(self.window.name)
-        if self.window is layout._focused:
-            fg = layout.active_fg
-            bg = layout.active_bg
-        else:
-            fg = layout.inactive_fg
-            bg = layout.inactive_bg
-        layout._layout.colour = fg
-        layout._layout.width = layout.panel_width - left
-        # get a text frame from the above
-        framed = layout._layout.framed(
-            layout.border_width,
-            bg,
-            layout.padding_x,
-            layout.padding_y
-        )
-        # draw the text frame at the given point
-        framed.draw_fill(left, top)
+        if not self.window.floating:
+            # setup parameters for drawing self
+            left = layout.padding_left + level * layout.level_shift
+            layout._layout.font_size = layout.fontsize
+            layout._layout.text = self.add_superscript(self.window.name)
+            if self.window is layout._focused:
+                fg = layout.active_fg
+                bg = layout.active_bg
+            else:
+                fg = layout.inactive_fg
+                bg = layout.inactive_bg
+            layout._layout.colour = fg
+            layout._layout.width = layout.panel_width - left
+            # get a text frame from the above
+            framed = layout._layout.framed(
+                layout.border_width,
+                bg,
+                layout.padding_x,
+                layout.padding_y
+            )
+            # draw the text frame at the given point
+            framed.draw_fill(left, top)
 
-        top += framed.height + layout.vspace + layout.border_width
+            top += framed.height + layout.vspace + layout.border_width
+            level += 1
 
         # run the TreeNode draw to draw children (if expanded)
-        return super().draw(layout, top, level + 1)
+        return super().draw(layout, top, level)
 
     def button_press(self, x, y):
         """Returns self if clicked on title else returns sibling"""
@@ -295,16 +370,16 @@ class Window(TreeNode):
         If this window has children, the first child takes the place of this
         window, and any remaining children are reparented to that node
         """
-        if self.children:
-            head = self.children[0]
+        if self._children:
+            head = self._children[0]
             # add the first child to our parent, next to ourselves
             self.parent.add(head, hint=self)
             # move remaining children to be under the new head
-            for i in self.children[1:]:
+            for i in self._children[1:]:
                 head.add(i)
 
-        self.parent.children.remove(self)
-        del self.children
+        self.parent._children.remove(self)
+        del self._children
 
 
 class TreeTab(Layout):
@@ -467,9 +542,12 @@ class TreeTab(Layout):
     def info(self):
 
         def show_section_tree(root):
-            '''Show a section tree in a nested list, whose every element has the form: `[root, [subtrees]]`.
+            '''Show a section tree in a nested list.
 
-            For `[root, [subtrees]]`, The first element is the root node, and the second is its a list of its subtrees.
+            Every element of the list has this form: `[root, [subtrees]]`.
+            For `[root, [subtrees]]`, The first element is the root node,
+            and the second is its a list of its subtrees.
+
             For example, a section with below windows hierarchy on the panel:
             - a
               - d
@@ -483,25 +561,36 @@ class TreeTab(Layout):
             will return [
                          [a,
                            [d, [e]],
-                           [f]],
+                           [f]
+                         ],
                          [b, [g], [h]],
                          [c],
                         ]
             '''
-            tree = []
+            trees = []
+            children = root.children
             if isinstance(root, Window):
-                tree.append(root.window.name)
-            if root.expanded and root.children:
-                for child in root.children:
-                    tree.append(show_section_tree(child))
-            return tree
+                if not root.window.floating:
+                    trees.append(root.window.name)
+                elif children:
+                    # "Replace" root with the first child
+                    trees.append(children[0].window.name)
+                    children = children[1:]
+            if root.expanded and children:
+                for child in children:
+                    subtree = show_section_tree(child)
+                    if len(subtree) > 0:  # don't show empty subtrees
+                        trees.append(subtree)
 
+            return trees
+
+        children = self._tree.children
         d = Layout.info(self)
-        d["clients"] = [x.name for x in self._nodes]  # not in order
-        d["sections"] = [x.title for x in self._tree.children]
+        d["clients"] = [x.name for x in self._nodes if not x.floating]  # not in order
+        d["sections"] = [x.title for x in children]
 
         trees = {}
-        for section in self._tree.children:
+        for section in children:
             trees[section.title] = show_section_tree(section)
         d["client_trees"] = trees
         return d
@@ -548,11 +637,7 @@ class TreeTab(Layout):
         if not win:
             return
         node = self._nodes[win]
-        p = node.parent.children
-        idx = p.index(node)
-        if idx > 0:
-            p[idx] = p[idx - 1]
-            p[idx - 1] = node
+        node.move_up()
         self.draw_panel()
 
     def cmd_move_down(self):
@@ -560,11 +645,7 @@ class TreeTab(Layout):
         if not win:
             return
         node = self._nodes[win]
-        p = node.parent.children
-        idx = p.index(node)
-        if idx < len(p) - 1:
-            p[idx] = p[idx + 1]
-            p[idx + 1] = node
+        node.move_down()
         self.draw_panel()
 
     def cmd_move_left(self):
@@ -573,7 +654,7 @@ class TreeTab(Layout):
             return
         node = self._nodes[win]
         if not isinstance(node.parent, Section):
-            node.parent.children.remove(node)
+            node.parent.remove_child(node)
             node.parent.parent.add(node)
         self.draw_panel()
 
@@ -597,7 +678,7 @@ class TreeTab(Layout):
             snode = snode.parent
         idx = snode.parent.children.index(snode)
         if idx > 0:
-            node.parent.children.remove(node)
+            node.parent.remove_child(node)
             snode.parent.children[idx - 1].add(node)
         self.draw_panel()
 
@@ -609,10 +690,11 @@ class TreeTab(Layout):
         snode = node
         while not isinstance(snode, Section):
             snode = snode.parent
-        idx = snode.parent.children.index(snode)
-        if idx < len(snode.parent.children) - 1:
-            node.parent.children.remove(node)
-            snode.parent.children[idx + 1].add(node)
+        children = snode.parent.children
+        idx = children.index(snode)
+        if idx < len(children) - 1:
+            node.parent.remove_child(node)
+            children[idx + 1].add(node)
         self.draw_panel()
 
     def cmd_sort_windows(self, sorter, create_sections=True):
@@ -639,8 +721,8 @@ class TreeTab(Layout):
                         nsec = self._tree.sections[nname]
                     else:
                         continue
-                sec.children.remove(win)
-                nsec.children.append(win)
+                sec.remove_child(win)
+                nsec.add(win)
                 win.parent = nsec
         self.draw_panel()
 
@@ -651,7 +733,7 @@ class TreeTab(Layout):
         node = self._nodes[win]
         idx = node.parent.children.index(node)
         if idx > 0:
-            node.parent.children.remove(node)
+            node.parent.remove_child(node)
             node.parent.children[idx - 1].add(node)
         self.draw_panel()
 

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -957,7 +957,7 @@ class MonadWide(MonadTall):
         """Swap current window with closest window to the down"""
         win = self.clients.current_client
         x, y = win.x, win.y
-        candidates = [c for c in self.clients.clients if c.info()['y'] > y]
+        candidates = [c for c in self.clients.non_floating_clients if c.info()['y'] > y]
         target = self._get_closest(x, y, candidates)
         self.cmd_swap(win, target)
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -91,6 +91,7 @@ layouts = [
     # layout.TreeTab(),
     # layout.VerticalTile(),
     # layout.Zoomy(),
+    # layout.FloatingTile(),
 ]
 
 widget_defaults = dict(

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -32,7 +32,7 @@ class WindowVisibilityToggler:
     invisble, or the current group on the current screen.
     With this functionality the window can be shown and hidden by a single
     keystroke (bound to command of ScratchPad group).
-    By default, the window is also hidden if it looses focus.
+    By default, the window is also hidden if it loses focus.
     """
 
     def __init__(self, scratchpad_name, window, on_focus_lost_hide, warp_pointer):
@@ -46,7 +46,7 @@ class WindowVisibilityToggler:
         window : window
             The window to toggle
         on_focus_lost_hide : bool
-            if True the associated window is hidden if it looses focus
+            if True the associated window is hidden if it loses focus
         warp_pointer : bool
             if True the mouse pointer is warped to center of associated window
             if shown. Only used if on_focus_lost_hide is True

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -145,6 +145,13 @@ def test_focus_cycle(qtile):
         return focus_path
 
     # Toggle the current window's fullscreen state, and the focus path should not change
+    assert_focused(qtile, "three")
+    focus_path = get_focus_path(qtile)
+    qtile.c.window.toggle_fullscreen()
+    qtile.c.window.toggle_fullscreen()
+    assert_focus_path(focus_path)
+    # Toggle another window
+    qtile.c.group.focus_by_name("one")
     focus_path = get_focus_path(qtile)
     qtile.c.window.toggle_fullscreen()
     qtile.c.window.toggle_fullscreen()

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -53,7 +53,9 @@ class AllLayoutsConfig:
             else:
                 # Explicitly exclude the Slice layout, since it depends on
                 # other layouts (tested here) and has its own specific tests
-                if test and layout_name != 'Slice':
+                # Also exclude the Floating layout, as it's not suitable as
+                # a tiled layout, use FloatingTile instead.
+                if test and layout_name not in ('Slice', 'Floating'):
                     yield layout_name, layout_cls
 
     @classmethod

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -23,7 +23,7 @@ import pytest
 from libqtile import layout
 import libqtile.config
 import libqtile.hook
-from .layout_utils import assert_focused, assert_focus_path_unordered
+from .layout_utils import assert_focused, assert_focus_path, assert_focus_path_unordered
 
 
 class AllLayoutsConfig:
@@ -132,6 +132,23 @@ def test_focus_cycle(qtile):
 
     # Assert that the layout cycles the focus on all windows
     assert_focus_path_unordered(qtile, 'float1', 'float2', 'one', 'two', 'three')
+
+    def get_focus_path(self):
+        first = self.c.window.info()['name']
+        focus_path = []
+        while True:
+            self.c.group.next_window()
+            wname = self.c.window.info()['name']
+            if wname == first:
+                break
+            focus_path.append(wname)
+        return focus_path
+
+    # Toggle the current window's fullscreen state, and the focus path should not change
+    focus_path = get_focus_path(qtile)
+    qtile.c.window.toggle_fullscreen()
+    qtile.c.window.toggle_fullscreen()
+    assert_focus_path(focus_path)
 
 
 @each_layout_config

--- a/test/layouts/test_floating.py
+++ b/test/layouts/test_floating.py
@@ -33,7 +33,7 @@ class FloatingConfig:
         libqtile.config.Group("a"),
     ]
     layouts = [
-        layout.Floating()
+        layout.FloatingTile()
     ]
     floating_layout = libqtile.layout.floating.Floating()
     keys = []

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -117,3 +117,34 @@ def test_window(qtile):
     qtile.c.layout.expand_branch()
     assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
     assert_focus_path(qtile, 'four', 'five', 'float1', 'float2', 'one', 'two', 'three')
+
+
+@treetab_config
+def test_sort_windows(qtile):
+    def sorter(window):
+        try:
+            if int(window.name) % 2 == 0:
+                return 'Even'
+            else:
+                return 'Odd'
+        except ValueError:
+            return 'Bar'
+
+    qtile.test_window("one")
+    qtile.test_window("two")
+    qtile.test_window("101")
+    qtile.test_window("102")
+    qtile.test_window("103")
+    assert qtile.c.layout.info()['client_trees'] == {
+        'Foo': [['one'], ['two'], ['101'], ['102'], ['103']],
+        'Bar': []
+    }
+    return  # TODO how to serialize a function object? i.e. `sorter`
+    qtile.c.layout.sort_windows(sorter)
+    assert qtile.c.layout.info()['client_trees'] == {
+        'Foo': [],
+        'Bar': [['one'], ['two']],
+        'Even': [['102']],
+        'Odd': [['101'], ['103']]
+    }
+

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -58,8 +58,7 @@ def test_window(qtile):
     qtile.test_dialog("float2")
     qtile.test_window("three")
 
-    # test preconditions, columns adds clients at pos of current, in two stacks
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert qtile.c.layout.info()['clients'] == ['one', 'three', 'two']
     assert qtile.c.layout.info()['sections'] == ['Foo', 'Bar']
     assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
 
@@ -72,7 +71,7 @@ def test_window(qtile):
 
     # test command move_up/down
     qtile.c.layout.move_up()
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert qtile.c.layout.info()['clients'] == ['one', 'three', 'two']
     assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
     qtile.c.layout.move_down()
     assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2019 Guangwang Huang
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from libqtile import layout
+import libqtile.config
+from ..conftest import no_xinerama
+from .layout_utils import assert_focused, assert_focus_path
+
+
+class TreeTabConfig:
+    auto_fullscreen = True
+    main = None
+    groups = [
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
+        libqtile.config.Group("c"),
+        libqtile.config.Group("d")
+    ]
+    layouts = [
+        layout.TreeTab(sections=["Foo", "Bar"]),
+    ]
+    floating_layout = libqtile.layout.floating.Floating()
+    keys = []
+    mouse = []
+    screens = []
+    follow_mouse_focus = False
+
+
+def treetab_config(x):
+    return no_xinerama(pytest.mark.parametrize("qtile", [TreeTabConfig], indirect=True)(x))
+
+
+@treetab_config
+def test_window(qtile):
+    # setup 3 tiled and two floating clients
+    qtile.test_window("one")
+    qtile.test_window("two")
+    qtile.test_dialog("float1")
+    qtile.test_dialog("float2")
+    qtile.test_window("three")
+
+    # test preconditions, columns adds clients at pos of current, in two stacks
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert qtile.c.layout.info()['sections'] == ['Foo', 'Bar']
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
+
+    # last added window has focus
+    assert_focused(qtile, "three")
+    qtile.c.layout.up()
+    assert_focused(qtile, "two")
+    qtile.c.layout.down()
+    assert_focused(qtile, "three")
+
+    # test command move_up/down
+    qtile.c.layout.move_up()
+    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
+    qtile.c.layout.move_down()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
+
+    # section_down/up
+    qtile.c.layout.up()  # focus two
+    qtile.c.layout.section_down()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three']], 'Bar': [['two']]}
+    qtile.c.layout.section_up()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
+
+    # del_section
+    qtile.c.layout.up()  # focus three
+    qtile.c.layout.section_down()
+    qtile.c.layout.del_section("Bar")
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
+
+    # add_section
+    qtile.c.layout.add_section('Baz')
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Baz': []}
+    qtile.c.layout.del_section('Baz')
+
+    # move_left/right
+    qtile.c.layout.move_left()  # no effect for top-level children
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
+    qtile.c.layout.move_right()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
+    qtile.c.layout.move_right()  # no effect
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
+    qtile.test_window("four")
+    qtile.c.layout.move_right()
+    qtile.c.layout.up()
+    qtile.test_window("five")
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
+
+    # expand/collapse_branch, and check focus order
+    qtile.c.layout.up()
+    qtile.c.layout.up()  # focus three
+    qtile.c.layout.collapse_branch()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three'], ['five']]]}
+    assert_focus_path(qtile, 'five', 'float1', 'float2', 'one', 'two', 'three')
+    qtile.c.layout.expand_branch()
+    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
+    assert_focus_path(qtile, 'four', 'five', 'float1', 'float2', 'one', 'two', 'three')

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -147,4 +147,3 @@ def test_sort_windows(qtile):
         'Even': [['102']],
         'Odd': [['101'], ['103']]
     }
-

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -341,7 +341,7 @@ def test_float_outside_edges(qtile):
     assert qtile.c.layout.info() == {
         'clients': [], 'current': 0, 'group': 'a', 'name': 'max'}
 
-    # move left, but some still on screen 0
+    # move left, but some still on screen a
     qtile.c.window.move_floating(-30, 20)
     assert qtile.c.window.info()['width'] == 164
     assert qtile.c.window.info()['height'] == 164
@@ -349,7 +349,7 @@ def test_float_outside_edges(qtile):
     assert qtile.c.window.info()['y'] == 20
     assert qtile.c.window.info()['group'] == 'a'
 
-    # move up, but some still on screen 0
+    # move up, but some still on screen a
     qtile.c.window.set_position_floating(-10, -20)
     assert qtile.c.window.info()['width'] == 164
     assert qtile.c.window.info()['height'] == 164
@@ -357,7 +357,7 @@ def test_float_outside_edges(qtile):
     assert qtile.c.window.info()['y'] == -20
     assert qtile.c.window.info()['group'] == 'a'
 
-    # move above a
+    # move right, but some still on screen a
     qtile.c.window.set_position_floating(50, -20)
     assert qtile.c.window.info()['width'] == 164
     assert qtile.c.window.info()['height'] == 164


### PR DESCRIPTION
Wow, so many fails need to be fixed.

This PR tries to fix issue #1482 , which is still WIP. The rational is to make `_ClientList` only expose non-floating windows to its users(Floating layout uses a plain list), so as to keep the floating/fullscreen ones in it.