### PR TITLE
Move event loop setup out of manager

### DIFF
--- a/libqtile/command_interface.py
+++ b/libqtile/command_interface.py
@@ -22,7 +22,6 @@
 The interface to execute commands on the command graph
 """
 
-import os
 import traceback
 from abc import abstractmethod, ABCMeta
 from typing import Any, Dict, List, Tuple
@@ -276,19 +275,15 @@ class IPCCommandInterface(CommandInterface):
         return items is not None and item in items
 
 
-class IPCCommandServer(ipc.Server):
+class IPCCommandServer:
     """Execute the object commands for the calls that are sent to it"""
 
-    def __init__(self, fname, qtile, eventloop) -> None:
+    def __init__(self, qtile) -> None:
         """Wrapper around the ipc server for communitacing with the IPCCommandInterface
 
         Sets up the IPC server such that it will receive and send messages to
         and from the IPCCommandInterface.
         """
-        if os.path.exists(fname):
-            os.unlink(fname)
-
-        super().__init__(fname, self.call, eventloop)
         self.qtile = qtile
 
     def call(self, data: Tuple[List[SelectorType], str, Tuple, Dict]) -> Tuple[int, Any]:

--- a/libqtile/core/base.py
+++ b/libqtile/core/base.py
@@ -3,6 +3,11 @@ import typing
 
 
 class Core(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        pass
+
     @abstractmethod
     def get_keys(self) -> typing.List[str]:
         pass

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -20,7 +20,6 @@
 
 from libqtile.dgroups import DGroups
 from xcffib.xproto import EventMask, WindowError, AccessError, DrawableError
-import asyncio
 import functools
 import io
 import logging
@@ -280,7 +279,7 @@ class Qtile(CommandObject):
             # because of dbus, if dbus isn't around there's no need to run
             # this thread.
             import dbus  # noqa
-            from gi.repository import GLib
+            from gi.repository import GLib  # type: ignore
 
             def gobject_thread():
                 ctx = GLib.main_context_default()

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -42,7 +42,7 @@ from ..group import _Group
 from ..scratchpad import ScratchPad
 from ..log_utils import logger
 from ..state import QtileState
-from ..utils import QtileError, get_cache_dir
+from ..utils import get_cache_dir
 from ..widget.base import _Widget
 from ..extension.base import _Extension
 from .. import hook
@@ -53,7 +53,6 @@ from libqtile import command_interface
 from libqtile.command_client import InteractiveCommandClient
 from libqtile.command_interface import QtileCommandInterface, IPCCommandServer
 from libqtile.command_object import CommandObject, CommandError, CommandException
-from libqtile.ipc import find_sockfile
 from libqtile.lazy import lazy
 
 
@@ -76,7 +75,6 @@ class Qtile(CommandObject):
         kore,
         config,
         eventloop,
-        display_name=None,
         no_spawn=False,
         state=None
     ):
@@ -86,7 +84,7 @@ class Qtile(CommandObject):
         self._finalize = False
         self.mouse_position = (0, 0)
 
-        self.conn = xcbq.Connection(display_name)
+        self.core = kore
         self.config = config
         hook.init(self)
 
@@ -236,6 +234,10 @@ class Qtile(CommandObject):
         }
         self.setup_selection()
         hook.fire("startup_complete")
+
+    @property
+    def conn(self):
+        return self.core.conn
 
     def setup_selection(self):
         primary = self.conn.atoms["PRIMARY"]

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -75,6 +75,7 @@ class Qtile(CommandObject):
         self,
         kore,
         config,
+        eventloop,
         display_name=None,
         fname=None,
         no_spawn=False,
@@ -83,7 +84,6 @@ class Qtile(CommandObject):
         self._restart = False
         self.no_spawn = no_spawn
 
-        self._eventloop = None
         self._finalize = False
         self.mouse_position = (0, 0)
 
@@ -185,6 +185,7 @@ class Qtile(CommandObject):
                 self.groups.append(sp)
                 self.groups_map[sp.name] = sp
 
+        self._eventloop = eventloop
         self.setup_eventloop()
         self.server = IPCCommandServer(self.fname, self, self._eventloop)
 
@@ -271,8 +272,7 @@ class Qtile(CommandObject):
         self.convert_selection(primary)
         self.convert_selection(clipboard)
 
-    def setup_eventloop(self):
-        self._eventloop = asyncio.new_event_loop()
+    def setup_eventloop(self) -> None:
         self._eventloop.add_signal_handler(signal.SIGINT, self.stop)
         self._eventloop.add_signal_handler(signal.SIGTERM, self.stop)
         self._eventloop.set_exception_handler(
@@ -283,9 +283,6 @@ class Qtile(CommandObject):
         fd = self.conn.conn.get_file_descriptor()
         self._eventloop.add_reader(fd, self._xpoll)
 
-        self.setup_python_dbus()
-
-    def setup_python_dbus(self):
         # This is a little strange. python-dbus internally depends on gobject,
         # so gobject's threads need to be running, and a gobject "main loop
         # thread" needs to be spawned, but we try to let it only interact with

--- a/libqtile/core/session_manager.py
+++ b/libqtile/core/session_manager.py
@@ -1,0 +1,32 @@
+import asyncio
+
+from libqtile.core.manager import Qtile
+
+
+class SessionManager:
+    def __init__(self, kore, config, *, display_name=None, fname=None, no_spawn=None, state=None) -> None:
+        """Manages a qtile session
+
+        :param kore:
+            The core backend to use for the session.
+        :param config:
+            The configuration to use for the qtile instance.
+        :param display_name:
+            The name of the display to configure.
+        :param fname:
+            The file name to use as the qtile socket file.
+        :param no_spawn:
+            If the instance has already been started, then don't re-run the
+            startup once hook.
+        :param state:
+            The state to restart the qtile instance with.
+        """
+        eventloop = asyncio.new_event_loop()
+
+        self.qtile = Qtile(
+            kore, config, eventloop, display_name=display_name, fname=fname, no_spawn=no_spawn, state=state
+        )
+
+    def loop(self) -> None:
+        """Run the event loop"""
+        self.qtile.loop()

--- a/libqtile/core/session_manager.py
+++ b/libqtile/core/session_manager.py
@@ -63,6 +63,5 @@ class SessionManager:
 
     def loop(self) -> None:
         """Run the event loop"""
-        self.server.start()
-        self.qtile.loop()
-        self.server.close()
+        with self.server:
+            self.qtile.loop()

--- a/libqtile/core/session_manager.py
+++ b/libqtile/core/session_manager.py
@@ -1,21 +1,14 @@
 import asyncio
 import os
 
+import libqtile.core.base as base
 import libqtile.ipc as ipc
 from libqtile.core.manager import Qtile
-from libqtile.utils import QtileError
 
 
 class SessionManager:
     def __init__(
-        self,
-        kore,
-        config,
-        *,
-        display_name: str = None,
-        fname: str = None,
-        no_spawn=False,
-        state=None
+        self, kore: base.Core, config, *, fname: str = None, no_spawn=False, state=None
     ) -> None:
         """Manages a qtile session
 
@@ -23,8 +16,6 @@ class SessionManager:
             The core backend to use for the session.
         :param config:
             The configuration to use for the qtile instance.
-        :param display_name:
-            The name of the display to configure.
         :param fname:
             The file name to use as the qtile socket file.
         :param no_spawn:
@@ -35,23 +26,12 @@ class SessionManager:
         """
         eventloop = asyncio.new_event_loop()
 
-        if display_name is None:
-            display_name = os.environ.get("DISPLAY")
-            if not display_name:
-                raise QtileError("No DISPLAY set")
-
-        self.qtile = Qtile(
-            kore,
-            config,
-            eventloop,
-            display_name=display_name,
-            no_spawn=no_spawn,
-            state=state,
-        )
+        self.qtile = Qtile(kore, config, eventloop, no_spawn=no_spawn, state=state)
 
         if fname is None:
             # Dots might appear in the host part of the display name
             # during remote X sessions. Let's strip the host part first
+            display_name = kore.display_name
             display_number = display_name.partition(":")[2]
             if "." not in display_number:
                 display_name += ".0"

--- a/libqtile/core/xcore.py
+++ b/libqtile/core/xcore.py
@@ -1,11 +1,31 @@
-
+import os
 import typing
 
 from . import base
 from . import xcbq
+from libqtile.utils import QtileError
 
 
 class XCore(base.Core):
+    def __init__(self, display_name: str = None) -> None:
+        """Setup the X11 core backend
+
+        :param display_name:
+            The display name to setup the X11 connection to.  Uses the DISPLAY
+            environment variable if not given.
+        """
+        if display_name is None:
+            display_name = os.environ.get("DISPLAY")
+            if not display_name:
+                raise QtileError("No DISPLAY set")
+
+        self.conn = xcbq.Connection(display_name)
+        self._display_name = display_name
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
     def get_keys(self) -> typing.List[str]:
         return list(xcbq.keysyms.keys())
 

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -115,8 +115,8 @@ def make_qtile():
         widgets.insert(0, TextBox('Config Err!'))
     # XXX: the import is here because we need to call init_log
     # before start importing stuff
-    from libqtile.core import manager
-    return manager.Qtile(
+    from libqtile.core import session_manager
+    return session_manager.SessionManager(
         kore,
         config,
         fname=options.socket,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -263,10 +263,10 @@ class Qtile:
         rpipe, wpipe = multiprocessing.Pipe()
 
         def run_qtile():
-            kore = xcore.XCore()
             try:
+                kore = xcore.XCore(display_name=self.display)
                 init_log(self.log_level, log_path=None, log_color=False)
-                q = SessionManager(kore, config_class(), display_name=self.display, fname=self.sockfile)
+                q = SessionManager(kore, config_class(), fname=self.sockfile)
                 q.loop()
             except Exception:
                 wpipe.send(traceback.format_exc())
@@ -293,13 +293,13 @@ class Qtile:
         will likely block the thread.
         """
         init_log(self.log_level, log_path=None, log_color=False)
-        kore = xcore.XCore()
+        kore = xcore.XCore(display_name=self.display)
         config = config_class()
         for attr in dir(default_config):
             if not hasattr(config, attr):
                 setattr(config, attr, getattr(default_config, attr))
 
-        return SessionManager(kore, config, display_name=self.display, fname=self.sockfile)
+        return SessionManager(kore, config, fname=self.sockfile)
 
     def terminate(self):
         if self.proc is None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,7 +37,7 @@ import xcffib.testing
 import xcffib.xproto
 
 import libqtile.config
-from libqtile.core.manager import Qtile as QtileManager
+from libqtile.core.session_manager import SessionManager
 from libqtile.core import xcore
 from libqtile.log_utils import init_log
 from libqtile.resources import default_config
@@ -266,7 +266,7 @@ class Qtile:
             kore = xcore.XCore()
             try:
                 init_log(self.log_level, log_path=None, log_color=False)
-                q = QtileManager(kore, config_class(), self.display, self.sockfile)
+                q = SessionManager(kore, config_class(), display_name=self.display, fname=self.sockfile)
                 q.loop()
             except Exception:
                 wpipe.send(traceback.format_exc())
@@ -299,7 +299,7 @@ class Qtile:
             if not hasattr(config, attr):
                 setattr(config, attr, getattr(default_config, attr))
 
-        return QtileManager(kore, config, self.display, self.sockfile)
+        return SessionManager(kore, config, display_name=self.display, fname=self.sockfile)
 
     def terminate(self):
         if self.proc is None:


### PR DESCRIPTION
This moves some of the eventloop and display handling functionality out of the main qtile manager and into separate modules. The eventloop is setup in a new session manager, which can become the object that handles setting up all of the resources for a given session (backend, event loop, listeners on the event loop, etc) as well as starting and restarting the qtile manager, which can be moved to handle more functionality around configuration. The display logic is moved to the x core backend.