### PR TITLE
Do not spam logs when the battery device is temporarily inaccessible

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -233,9 +233,14 @@ class _LinuxBattery(_Battery, configurable.Configurable):
         try:
             with open(path, 'r') as f:
                 return f.read().strip(), value_type
-        except FileNotFoundError:
-            logger.debug("Failed to get %s" % name)
-        return None
+        except OSError as e:
+            logger.debug("Failed to read '{}': {}".format(path, e))
+            if isinstance(e, FileNotFoundError):
+                # Let's try another file if this one doesn't exist
+                return None
+            # Do not fail if the file exists but we can not read it this time
+            # See https://github.com/qtile/qtile/pull/1516 for rationale
+            return "-1", "N/A"
 
     def _get_param(self, name) -> Tuple[str, str]:
         if name in self.filenames and self.filenames[name]:


### PR DESCRIPTION
With the battery widget enabled, my logs are full of this error:

```
2020-01-08 10:47:52,577 ERROR libqtile base.py:worker():L478 problem polling to update widget battery
Traceback (most recent call last):
  File "qtile/libqtile/widget/base.py", line 474, in worker
    text = self.poll()
  File "qtile/libqtile/widget/battery.py", line 351, in poll
    status = self._battery.update_status()
  File "qtile/libqtile/widget/battery.py", line 276, in update_status
    power_str, power_unit = self._get_param('power_now_file')
  File "qtile/libqtile/widget/battery.py", line 255, in _get_param
    value = self._load_file(filename)
  File "qtile/libqtile/widget/battery.py", line 235, in _load_file
    return f.read().strip(), value_type
OSError: [Errno 19] No such device
```

I'm not sure why this happens, but from what I can see, when the battery is full and the AC takes over, it seems that the kernel stops answering for the battery device but keeps the files there for some reason.