### PR TITLE
doc: fix debian version to unstable

### DIFF
--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -2,7 +2,7 @@
 Installing on Debian or Ubuntu
 ==============================
 
-On recent Ubuntu (17.04 or greater) and Debian (10 or greater) versions, there are
+On recent Ubuntu (17.04 or greater) and Debian unstable versions, there are
 Qtile packages available via:
 
 .. code-block:: bash


### PR DESCRIPTION
Looks like qtile never made it out of unstable, so let's not claim it did.

Closes #1493

Signed-off-by: Tycho Andersen <tycho@tycho.ws>