### PR TITLE
Added missing kwargs argument in EzKey class constructor

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -152,9 +152,9 @@ class EzConfig:
 
 
 class EzKey(EzConfig, Key):
-    def __init__(self, keydef, *commands):
+    def __init__(self, keydef, *commands, **kwargs):
         modkeys, key = self.parse(keydef)
-        super().__init__(modkeys, key, *commands)
+        super().__init__(modkeys, key, *commands, **kwargs)
 
 
 class EzClick(EzConfig, Click):


### PR DESCRIPTION
This fixes #1510 .

### Summary 

`kwargs` dictionary was missing in `EzKey` class constructor, so you couldn't add a description for `EzKey`'s.
