### PR TITLE
add display option to Net widget and introduce f-strings

### DIFF
--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -30,8 +30,11 @@ class Net(base.ThreadedPollText):
     """Displays interface down and up speed"""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ('interface', None, 'List of interfaces or single NIC as string to monitor, \
-            None to displays all active NICs combined'),
+        ('display_format', '{interface}: {down} \u2193\u2191 {up}',
+         'Display format of down-/upload of given interfaces'),
+        ('interface', None,
+         'List of interfaces or single NIC as string to monitor, '
+         'None to display all active NICs combined'),
         ('update_interval', 1, 'The update interval.'),
         ('use_bits', False, 'Use bits instead of bytes per second?'),
     ]
@@ -41,11 +44,13 @@ class Net(base.ThreadedPollText):
         self.add_defaults(Net.defaults)
         if not isinstance(self.interface, list):
             if self.interface is None:
-                self.interface = ["all"]
+                self.interface = ['all']
             elif isinstance(self.interface, str):
                 self.interface = [self.interface]
             else:
-                raise AttributeError("Invalid Argument passed: %s\nAllowed Types: List, String, None" % self.interface)
+                raise AttributeError(
+                    (f'Invalid Argument passed: {self.interface}\n'
+                     f'Allowed Types: List, String, None'))
         self.stats = self.get_stats()
 
     def convert_b(self, num_bytes: float) -> Tuple[float, str]:
@@ -53,10 +58,10 @@ class Net(base.ThreadedPollText):
         factor = 1000.0
 
         if self.use_bits:
-            letters = ["b", "kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"]
+            letters = ['b', 'kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb']
             num_bytes *= 8
         else:
-            letters = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+            letters = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
         if num_bytes > 0:
             power = int(log(num_bytes) / log(factor))
@@ -71,9 +76,9 @@ class Net(base.ThreadedPollText):
 
     def get_stats(self):
         interfaces = {}
-        if self.interface == ["all"]:
+        if self.interface == ['all']:
             net = psutil.net_io_counters(pernic=False)
-            interfaces["all"] = {'down': net[1], 'up': net[0]}
+            interfaces['all'] = {'down': net[1], 'up': net[0]}
             return interfaces
         else:
             net = psutil.net_io_counters(pernic=True)
@@ -83,16 +88,11 @@ class Net(base.ThreadedPollText):
                 interfaces[iface] = {'down': down, 'up': up}
             return interfaces
 
-    def _format(self, down, up):
-        down = "%0.2f" % down
-        up = "%0.2f" % up
-        if len(down) > 5:
-            down = down[:5]
-        if len(up) > 5:
-            up = up[:5]
-
-        down = " " * (5 - len(down)) + down
-        up = " " * (5 - len(up)) + up
+    def _format(self, down, down_unit, up, up_unit):
+        max_len_down = 7 - len(down_unit)
+        max_len_up = 7 - len(up_unit)
+        down = f'{down:{max_len_down}.2f}'[:max_len_down]
+        up = f'{up:{max_len_up}.2f}'[:max_len_up]
         return down, up
 
     def poll(self):
@@ -100,21 +100,22 @@ class Net(base.ThreadedPollText):
         try:
             for intf in self.interface:
                 new_stats = self.get_stats()
-                down = new_stats[intf]['down'] - \
-                    self.stats[intf]['down']
-                up = new_stats[intf]['up'] - \
-                    self.stats[intf]['up']
-
-                down = down / self.update_interval
-                up = up / self.update_interval
-                down, down_letter = self.convert_b(down)
-                up, up_letter = self.convert_b(up)
-                down, up = self._format(down, up)
-                str_base = "%s: %s%s \u2193\u2191 %s%s"
+                down = ((new_stats[intf]['down'] - self.stats[intf]['down']) /
+                        self.update_interval)
+                up = ((new_stats[intf]['up'] - self.stats[intf]['up']) /
+                      self.update_interval)
+                down, down_unit = self.convert_b(down)
+                up, up_unit = self.convert_b(up)
+                down, up = self._format(down, down_unit, up, up_unit)
                 self.stats[intf] = new_stats[intf]
-                ret_stat.append(str_base % (intf, down, down_letter, up, up_letter))
+                ret_stat.append(
+                    self.display_format.format(
+                        **{
+                            'interface': intf,
+                            'down': down + down_unit,
+                            'up': up + up_unit
+                        }))
 
-            return " ".join(ret_stat)
+            return ' '.join(ret_stat)
         except Exception as excp:
-            logger.error('%s: Caught Exception:\n%s',
-                         self.__class__.__name__, excp)
+            logger.error(f'{self.__class__.name}: Caught Exception:\n{excp}')

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -31,10 +31,9 @@ class Net(base.ThreadedPollText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ('display_format', '{interface}: {down} \u2193\u2191 {up}',
-         'Display format of down-/upload of given interfaces'),
-        ('interface', None,
-         'List of interfaces or single NIC as string to monitor, '
-         'None to display all active NICs combined'),
+         'Display format of down-/upload speed of given interfaces'),
+        ('interface', None, 'List of interfaces or single NIC as string to monitor, \
+            None to displays all active NICs combined'),
         ('update_interval', 1, 'The update interval.'),
         ('use_bits', False, 'Use bits instead of bytes per second?'),
     ]
@@ -44,13 +43,11 @@ class Net(base.ThreadedPollText):
         self.add_defaults(Net.defaults)
         if not isinstance(self.interface, list):
             if self.interface is None:
-                self.interface = ['all']
+                self.interface = ["all"]
             elif isinstance(self.interface, str):
                 self.interface = [self.interface]
             else:
-                raise AttributeError(
-                    (f'Invalid Argument passed: {self.interface}\n'
-                     f'Allowed Types: List, String, None'))
+                raise AttributeError("Invalid Argument passed: %s\nAllowed Types: List, String, None" % self.interface)
         self.stats = self.get_stats()
 
     def convert_b(self, num_bytes: float) -> Tuple[float, str]:
@@ -58,10 +55,10 @@ class Net(base.ThreadedPollText):
         factor = 1000.0
 
         if self.use_bits:
-            letters = ['b', 'kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb']
+            letters = ["b", "kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"]
             num_bytes *= 8
         else:
-            letters = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+            letters = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
 
         if num_bytes > 0:
             power = int(log(num_bytes) / log(factor))
@@ -76,9 +73,9 @@ class Net(base.ThreadedPollText):
 
     def get_stats(self):
         interfaces = {}
-        if self.interface == ['all']:
+        if self.interface == ["all"]:
             net = psutil.net_io_counters(pernic=False)
-            interfaces['all'] = {'down': net[1], 'up': net[0]}
+            interfaces["all"] = {'down': net[1], 'up': net[0]}
             return interfaces
         else:
             net = psutil.net_io_counters(pernic=True)
@@ -88,34 +85,38 @@ class Net(base.ThreadedPollText):
                 interfaces[iface] = {'down': down, 'up': up}
             return interfaces
 
-    def _format(self, down, down_unit, up, up_unit):
-        max_len_down = 7 - len(down_unit)
-        max_len_up = 7 - len(up_unit)
-        down = f'{down:{max_len_down}.2f}'[:max_len_down]
-        up = f'{up:{max_len_up}.2f}'[:max_len_up]
-        return down, up
+    def _format(self, down, down_letter, up, up_letter):
+        max_len_down = 7 - len(down_letter)
+        max_len_up = 7 - len(up_letter)
+        down = '{val:{max_len}.2f}'.format(val=down, max_len=max_len_down)
+        up = '{val:{max_len}.2f}'.format(val=up, max_len=max_len_up)
+        return down[:max_len_down], up[:max_len_up]
 
     def poll(self):
         ret_stat = []
         try:
             for intf in self.interface:
                 new_stats = self.get_stats()
-                down = ((new_stats[intf]['down'] - self.stats[intf]['down']) /
-                        self.update_interval)
-                up = ((new_stats[intf]['up'] - self.stats[intf]['up']) /
-                      self.update_interval)
-                down, down_unit = self.convert_b(down)
-                up, up_unit = self.convert_b(up)
-                down, up = self._format(down, down_unit, up, up_unit)
+                down = new_stats[intf]['down'] - \
+                    self.stats[intf]['down']
+                up = new_stats[intf]['up'] - \
+                    self.stats[intf]['up']
+
+                down = down / self.update_interval
+                up = up / self.update_interval
+                down, down_letter = self.convert_b(down)
+                up, up_letter = self.convert_b(up)
+                down, up = self._format(down, down_letter, up, up_letter)
                 self.stats[intf] = new_stats[intf]
                 ret_stat.append(
                     self.display_format.format(
                         **{
                             'interface': intf,
-                            'down': down + down_unit,
-                            'up': up + up_unit
+                            'down': down + down_letter,
+                            'up': up + up_letter
                         }))
 
-            return ' '.join(ret_stat)
+            return " ".join(ret_stat)
         except Exception as excp:
-            logger.error(f'{self.__class__.name}: Caught Exception:\n{excp}')
+            logger.error('%s: Caught Exception:\n%s',
+                         self.__class__.__name__, excp)


### PR DESCRIPTION
I added a `display_format` option to the Net widget similar to how it is already implemented in the CheckUpdates widget. If the unit string contains one digit (i.e. 'b' and 'B'), an additional space is inserted to make sure the bar is not shifting back and forth. I also replaced string formats with f-strings and did minor formatting to make it more consistent. What do you think?