### PR TITLE
Custom keyboard display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ qtile X.X.X, released XXXX-XX-XX:
     * features
         - added `guess_terminal` in utils
         - added keybinding cheet sheet image generator
+        - custom keyboardlayout display 
 
 qtile 0.15.0, released 2020-04-12:
     !!! Config breakage !!!

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -43,6 +43,9 @@ class KeyboardLayout(base.InLoopPollText):
         ("configured_keyboards", ["us"], "A list of predefined keyboard layouts "
             "represented as strings. For example: "
             "['us', 'us colemak', 'es', 'fr']."),
+        ("display_map", {}, "Custom display of layout. Key should be in format "
+            "'layout variant'. For example: "
+            "{'us': 'us ', 'lt sgs': 'sgs', 'ru phonetic': 'ru '}"),
         ("option", None, "string of setxkbmap option. Ex., 'compose:menu,grp_led:scroll'"),
     ]
 
@@ -76,6 +79,8 @@ class KeyboardLayout(base.InLoopPollText):
         self.tick()
 
     def poll(self):
+        if self.keyboard in self.display_map.keys():
+            return self.display_map[self.keyboard]
         return self.keyboard.upper()
 
     def get_keyboard_layout(self, setxkbmap_output):


### PR DESCRIPTION
the idea is to avoid long naming or do what you want :)
Ex. I have "RU PHONETIC" and this information is needless for me. RU it is enough.

config.py
```
keyboard_widget = widget.KeyboardLayout(
        configured_keyboards=['us', 'lt', 'ru phonetic'],
        display_map={'ru phonetic': 'ru'},
        options='compose:menu,grp_led:scroll',
        foreground=GREEN
        )
```