### PR TITLE
Add groupbox feature: Font colour when box highlighting

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -155,6 +155,7 @@ class GroupBox(_GroupBase):
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
+        ("selected", "000000", "Active selected group font colour"),
         ("active", "FFFFFF", "Active group font colour"),
         ("inactive", "404040", "Inactive group font colour"),
         (
@@ -334,6 +335,7 @@ class GroupBox(_GroupBase):
                     border = self.bar.background
                     text_color = self.this_current_screen_border
                 else:
+                    text_color = self.selected
                     if self.bar.screen.group.name == g.name:
                         if self.qtile.current_screen == self.bar.screen:
                             border = self.this_current_screen_border

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -155,9 +155,9 @@ class GroupBox(_GroupBase):
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("selected", "000000", "Selected group font colour"),
-        ("active", "FFFFFF", "Active group font colour"),
-        ("inactive", "404040", "Inactive group font colour"),
+        ("block_highlight_text_color", "000000", "Selected group font colour"),
+        ("active_text_color", "FFFFFF", "Active group font colour"),
+        ("inactive_text_color", "404040", "Inactive group font colour"),
         (
             "highlight_method",
             "border",
@@ -326,16 +326,16 @@ class GroupBox(_GroupBase):
             if self.group_has_urgent(g) and self.urgent_alert_method == "text":
                 text_color = self.urgent_text
             elif g.windows:
-                text_color = self.active
+                text_color = self.active_text_color
             else:
-                text_color = self.inactive
+                text_color = self.inactive_text_color
 
             if g.screen:
                 if self.highlight_method == 'text':
                     border = self.bar.background
                     text_color = self.this_current_screen_border
                 else:
-                    text_color = self.selected
+                    text_color = self.block_highlight_text_color
                     if self.bar.screen.group.name == g.name:
                         if self.qtile.current_screen == self.bar.screen:
                             border = self.this_current_screen_border

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -155,7 +155,7 @@ class GroupBox(_GroupBase):
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("selected", "000000", "Active selected group font colour"),
+        ("selected", "000000", "Selected group font colour"),
         ("active", "FFFFFF", "Active group font colour"),
         ("inactive", "404040", "Inactive group font colour"),
         (

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -156,8 +156,8 @@ class GroupBox(_GroupBase):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("block_highlight_text_color", "000000", "Selected group font colour"),
-        ("active_text_color", "FFFFFF", "Active group font colour"),
-        ("inactive_text_color", "404040", "Inactive group font colour"),
+        ("active", "FFFFFF", "Active group font colour"),
+        ("inactive", "404040", "Inactive group font colour"),
         (
             "highlight_method",
             "border",
@@ -326,9 +326,9 @@ class GroupBox(_GroupBase):
             if self.group_has_urgent(g) and self.urgent_alert_method == "text":
                 text_color = self.urgent_text
             elif g.windows:
-                text_color = self.active_text_color
+                text_color = self.active
             else:
-                text_color = self.inactive_text_color
+                text_color = self.inactive
 
             if g.screen:
                 if self.highlight_method == 'text':


### PR DESCRIPTION
This creates a third font colour called "selected", which is set to a groupbox item when highlight method "block" is used.

Background: Usually, the bar is of dark colour while the fonts are of bright colour. When using highlight method "block", the block must be of bright colour, too, to have a contrast to the bar. Then the font inside the block must be dark again, while the (in)active font colour is still bright. Thus, the font clour inside the block - selected - should be configurable.