### PR TITLE
Fix switching group failure (fix #755)

### DIFF
--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -155,6 +155,8 @@ Qtile's conversations with the X server. To capture one of these, create an
 This will put the xtrace output in Qtile's logfile as well. You can then
 demonstrate the bug, and paste the contents of this file into the bug report.
 
+Note that xtrace may be named ``x11trace`` on some platforms, for example, on Fedora.
+
 Resources
 =========
 

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -273,7 +273,6 @@ class XCore(base.Core):
         """
         assert self.qtile is not None
 
-        chain = []
         handler = "handle_{event_type}".format(event_type=event_type)
         # Certain events expose the affected window id as an "event" attribute.
         event_events = [
@@ -291,6 +290,7 @@ class XCore(base.Core):
         else:
             window = None
 
+        chain = []
         if window is not None and hasattr(window, handler):
             chain.append(getattr(window, handler))
 

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -158,7 +158,7 @@ class InteractiveCommandClient:
 
         Parameters
         ----------
-        command: InteractiveCommandInterface
+        command: CommandInterface
             The object that is used to resolve command graph calls, as well as
             navigate the command graph.
         current_node: CommandGraphNode

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -47,14 +47,14 @@ class Key:
     commands:
         A list of lazy command objects generated with the lazy.lazy helper.
         If multiple Call objects are specified, they are run in sequence.
-    kwds:
+    kwargs:
         A dictionary containing "desc", allowing a description to be added
     """
-    def __init__(self, modifiers, key, *commands, **kwds):
+    def __init__(self, modifiers, key, *commands, **kwargs):
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
-        self.desc = kwds.get("desc", "")
+        self.desc = kwargs.get("desc", "")
 
     def __repr__(self):
         return "<Key (%s, %s)>" % (self.modifiers, self.key)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -789,7 +789,8 @@ class Qtile(CommandObject):
             self.current_group.focus(self.current_window, warp)
 
     def move_to_group(self, group):
-        """Create a group if it doesn't exist and move a windows there"""
+        """Create a group if it doesn't exist and move
+        the current window there"""
         if self.current_window and group:
             self.add_group(group)
             self.current_window.togroup(group)

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -248,7 +248,7 @@ class DGroups:
             del self.timeout[client]
 
         # Wait the delay until really delete the group
-        logger.info('Add dgroup timer')
+        logger.info('Add dgroup timer with delay {}s'.format(self.delay))
         self.timeout[client] = self.qtile.call_later(
             self.delay, delete_client
         )

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -168,7 +168,7 @@ class _Group(CommandObject):
                     self.current_window.focus(warp)
 
     def _set_screen(self, screen):
-        """Set this group's screen to new_screen"""
+        """Set this group's screen to screen"""
         if screen == self.screen:
             return
         self.screen = screen

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -134,6 +134,7 @@ follow_mouse_focus = True
 bring_front_click = False
 cursor_warp = False
 floating_layout = layout.Floating(float_rules=[
+    # Run the utility of `xprop` to see the wm class and name of an X client.
     {'wmclass': 'confirm'},
     {'wmclass': 'dialog'},
     {'wmclass': 'download'},

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -21,6 +21,7 @@ import array
 import contextlib
 import inspect
 import traceback
+import time
 import warnings
 from xcffib.xproto import EventMask, StackMode, SetMode
 import xcffib.xproto
@@ -63,8 +64,8 @@ UrgencyHint = (1 << 8)
 AllHints = (InputHint | StateHint | IconPixmapHint | IconWindowHint |
             IconPositionHint | IconMaskHint | WindowGroupHint | MessageHint |
             UrgencyHint)
-WithdrawnState = 0
 
+WithdrawnState = 0
 DontCareState = 0
 NormalState = 1
 ZoomState = 2
@@ -549,7 +550,15 @@ class _Window(CommandObject):
                     "WM_TAKE_FOCUS" in self.window.get_wm_protocols():
                 data = [
                     self.qtile.conn.atoms["WM_TAKE_FOCUS"],
-                    xcffib.xproto.Time.CurrentTime,
+                    # The timestamp here must be a valid timestamp, not CurrentTime.
+                    #
+                    # see https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.7
+                    # > Windows with the atom WM_TAKE_FOCUS in their WM_PROTOCOLS
+                    # > property may receive a ClientMessage event from the
+                    # > window manager (as described in section 4.2.8) with
+                    # > WM_TAKE_FOCUS in its data[0] field and a valid timestamp
+                    # > (i.e. not *CurrentTime* ) in its data[1] field.
+                    int(time.time()),
                     0,
                     0,
                     0


### PR DESCRIPTION
This fixes #755 , which described a weird behavior that qtile's hotkeys don't work after Emacs closes, and it can work again if clicking on a groupbox label.