### PR TITLE
Fix qtile-cmd failure, #1410.

### DIFF
--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -27,7 +27,7 @@ that interacts with qtile objects, it should favor using the command graph
 clients to do this interaction.
 """
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from libqtile.command_graph import (
     CommandGraphCall,
@@ -211,7 +211,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.navigate(name, None)
         return self.__class__(self._command, current_node=next_node)
 
-    def __getitem__(self, name: Union[str, int]) -> "InteractiveCommandClient":
+    def __getitem__(self, name: str) -> "InteractiveCommandClient":
         """Get the selected element of the currently selected object
 
         From the current command graph object, select the instance with the
@@ -219,7 +219,7 @@ class InteractiveCommandClient:
 
         Parameters
         ----------
-        name : Union[str, int]
+        name : str
             The name, or index if it's of int type, of the item to resolve
 
         Return
@@ -234,10 +234,10 @@ class InteractiveCommandClient:
 
         if not isinstance(self._current_node, CommandGraphObject):
             raise SelectError("Unable to make selection on current node",
-                              str(name), self._current_node.selectors)
+                              name, self._current_node.selectors)
 
         if self._current_node.selector is not None:
-            raise SelectError("Selection already made", str(name),
+            raise SelectError("Selection already made", name,
                               self._current_node.selectors)
 
         def _check_item(item):
@@ -257,5 +257,5 @@ class InteractiveCommandClient:
         else:
             _check_item(name)
 
-        next_node = self._current_node.parent.navigate(self._current_node.object_type, str(name))
+        next_node = self._current_node.parent.navigate(self._current_node.object_type, name)
         return self.__class__(self._command, current_node=next_node)

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -240,16 +240,6 @@ class InteractiveCommandClient:
             raise SelectError("Selection already made", str(name),
                               self._current_node.selectors)
 
-        def _normalize_item(object_type: str, item: Union[str, int]) -> Union[str, int]:
-            "Normalize the item according to Qtile._items()."
-            if object_type in ["group", "widget", "bar"]:
-                return str(item)
-            elif object_type in ["layout", "window", "screen"]:
-                return int(item)
-            else:
-                return item
-
-        name = _normalize_item(self._current_node.object_type, name)
         # check the selection is valid in the server-side qtile manager
         if not self._command.has_item(self._current_node.parent,
                                       self._current_node.object_type, name):
@@ -258,3 +248,14 @@ class InteractiveCommandClient:
 
         next_node = self._current_node.parent.navigate(self._current_node.object_type, name)
         return self.__class__(self._command, current_node=next_node)
+
+    def normalize_item(self, item: Union[str, int]) -> Union[str, int]:
+        "Normalize the item according to Qtile._items()."
+        object_type = self._current_node.object_type \
+            if isinstance(self._current_node, CommandGraphObject) else None
+        if object_type in ["group", "widget", "bar"]:
+            return str(item)
+        elif object_type in ["layout", "window", "screen"]:
+            return int(item)
+        else:
+            return item

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -237,9 +237,20 @@ class InteractiveCommandClient:
         if self._current_node.selector is not None:
             raise SelectError("Selection already made", name, self._current_node.selectors)
 
-        # check that the selection is valid in the server-side qtile manager
-        if not self._command.has_item(self._current_node.parent, self._current_node.object_type, name):
-            raise SelectError("Item not available in object", name, self._current_node.selectors)
+        def _check_item(item):
+            """check that the selection is valid in the server-side qtile manager"""
+            if not self._command.has_item(self._current_node.parent, self._current_node.object_type, item):
+                raise SelectError("Item not available in object", item, self._current_node.selectors)
+
+        if name.isdigit():
+            # Check the item as is, and check its int version once more if it fails
+            try:
+                _check_item(name)
+            except SelectError:
+                name = int(name)
+                _check_item(name)
+        else:
+            _check_item(name)
 
         next_node = self._current_node.parent.navigate(self._current_node.object_type, name)
         return self.__class__(self._command, current_node=next_node)

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -228,13 +228,16 @@ class InteractiveCommandClient:
             The current client, navigated to the specified command graph
             object.
         """
+        if isinstance(self._current_node, CommandGraphRoot):
+            raise KeyError("Root node has no available items", name, self._current_node.selectors)
+
         if not isinstance(self._current_node, CommandGraphObject):
             raise SelectError("Unable to make selection on current node", name, self._current_node.selectors)
 
         if self._current_node.selector is not None:
             raise SelectError("Selection already made", name, self._current_node.selectors)
 
-        # check that the selection is valid
+        # check that the selection is valid in the server-side qtile manager
         if not self._command.has_item(self._current_node.parent, self._current_node.object_type, name):
             raise SelectError("Item not available in object", name, self._current_node.selectors)
 

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -27,7 +27,7 @@ that interacts with qtile objects, it should favor using the command graph
 clients to do this interaction.
 """
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from libqtile.command_graph import (
     CommandGraphCall,
@@ -211,7 +211,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.navigate(name, None)
         return self.__class__(self._command, current_node=next_node)
 
-    def __getitem__(self, name: str) -> "InteractiveCommandClient":
+    def __getitem__(self, name: Union[str, int]) -> "InteractiveCommandClient":
         """Get the selected element of the currently selected object
 
         From the current command graph object, select the instance with the
@@ -219,8 +219,8 @@ class InteractiveCommandClient:
 
         Parameters
         ----------
-        name : str
-            The name of the item to resolve
+        name : Union[str, int]
+            The name, or index if it's of int type, of the item to resolve
 
         Return
         ------
@@ -242,7 +242,7 @@ class InteractiveCommandClient:
             if not self._command.has_item(self._current_node.parent, self._current_node.object_type, item):
                 raise SelectError("Item not available in object", item, self._current_node.selectors)
 
-        if name.isdigit():
+        if isinstance(name, str) and name.isdigit():
             # Check the item as is, and check its int version once more if it fails
             try:
                 _check_item(name)

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -27,7 +27,7 @@ that interacts with qtile objects, it should favor using the command graph
 clients to do this interaction.
 """
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 from libqtile.command_graph import (
     CommandGraphCall,
@@ -211,7 +211,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.navigate(name, None)
         return self.__class__(self._command, current_node=next_node)
 
-    def __getitem__(self, name: str) -> "InteractiveCommandClient":
+    def __getitem__(self, name: Union[str, int]) -> "InteractiveCommandClient":
         """Get the selected element of the currently selected object
 
         From the current command graph object, select the instance with the
@@ -234,10 +234,10 @@ class InteractiveCommandClient:
 
         if not isinstance(self._current_node, CommandGraphObject):
             raise SelectError("Unable to make selection on current node",
-                              name, self._current_node.selectors)
+                              str(name), self._current_node.selectors)
 
         if self._current_node.selector is not None:
-            raise SelectError("Selection already made", name,
+            raise SelectError("Selection already made", str(name),
                               self._current_node.selectors)
 
         def _normalize_item(object_type: str, item: Union[str, int]) -> Union[str, int]:

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -229,18 +229,23 @@ class InteractiveCommandClient:
             object.
         """
         if isinstance(self._current_node, CommandGraphRoot):
-            raise KeyError("Root node has no available items", name, self._current_node.selectors)
+            raise KeyError("Root node has no available items",
+                           name, self._current_node.selectors)
 
         if not isinstance(self._current_node, CommandGraphObject):
-            raise SelectError("Unable to make selection on current node", name, self._current_node.selectors)
+            raise SelectError("Unable to make selection on current node",
+                              str(name), self._current_node.selectors)
 
         if self._current_node.selector is not None:
-            raise SelectError("Selection already made", name, self._current_node.selectors)
+            raise SelectError("Selection already made", str(name),
+                              self._current_node.selectors)
 
         def _check_item(item):
             """check that the selection is valid in the server-side qtile manager"""
-            if not self._command.has_item(self._current_node.parent, self._current_node.object_type, item):
-                raise SelectError("Item not available in object", item, self._current_node.selectors)
+            if not self._command.has_item(self._current_node.parent,
+                                          self._current_node.object_type, item):
+                raise SelectError("Item not available in object",
+                                  str(item), self._current_node.selectors)
 
         if isinstance(name, str) and name.isdigit():
             # Check the item as is, and check its int version once more if it fails
@@ -252,5 +257,5 @@ class InteractiveCommandClient:
         else:
             _check_item(name)
 
-        next_node = self._current_node.parent.navigate(self._current_node.object_type, name)
+        next_node = self._current_node.parent.navigate(self._current_node.object_type, str(name))
         return self.__class__(self._command, current_node=next_node)

--- a/libqtile/command_graph.py
+++ b/libqtile/command_graph.py
@@ -26,7 +26,7 @@ abstract command graph
 import abc
 from typing import Dict, List, Optional, Tuple, Type, Union  # noqa: F401
 
-SelectorType = Tuple[str, Optional[str]]
+SelectorType = Tuple[str, Optional[Union[str, int]]]
 GraphType = Union["CommandGraphNode", "CommandGraphCall"]
 
 
@@ -39,7 +39,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def selector(self) -> Optional[str]:
+    def selector(self) -> Optional[Union[str, int]]:
         """The selector for the current node"""
 
     @property
@@ -57,7 +57,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
     def children(self) -> List[str]:
         """The child objects that are contained within this object"""
 
-    def navigate(self, name: str, selector: Optional[str]) -> "CommandGraphNode":
+    def navigate(self, name: str, selector: Optional[Union[str, int]]) -> "CommandGraphNode":
         """Navigate from the current node to the specified child"""
         if name in self.children:
             return _COMMAND_GRAPH_MAP[name](selector, self)
@@ -133,7 +133,7 @@ class CommandGraphRoot(CommandGraphNode):
 class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
     """An object in the command graph that contains a collection of objects"""
 
-    def __init__(self, selector: Optional[str], parent: CommandGraphNode) -> None:
+    def __init__(self, selector: Optional[Union[str, int]], parent: CommandGraphNode) -> None:
         """A container object in the command graph
 
         Parameters
@@ -148,7 +148,7 @@ class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
         self._parent = parent
 
     @property
-    def selector(self) -> Optional[str]:
+    def selector(self) -> Optional[Union[str, int]]:
         """The selector for the current node"""
         return self._selector
 

--- a/libqtile/command_interface.py
+++ b/libqtile/command_interface.py
@@ -24,7 +24,7 @@ The interface to execute commands on the command graph
 
 import traceback
 from abc import abstractmethod, ABCMeta
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from libqtile import ipc
 from libqtile.command_graph import CommandGraphCall, CommandGraphNode, SelectorType
@@ -90,7 +90,7 @@ class CommandInterface(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def has_item(self, node: CommandGraphNode, object_type: str, item: str) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
         """Check if the given item exists
 
         Parameters
@@ -166,7 +166,7 @@ class QtileCommandInterface(CommandInterface):
         cmd = obj.command(command)
         return cmd is not None
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: str) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
         """Check if the given item exists
 
         Parameters
@@ -175,8 +175,8 @@ class QtileCommandInterface(CommandInterface):
             The node to check for items
         object_type : str
             The type of object to check for items.
-        command : str
-            The name of the item to check for
+        item : str
+            The name or index of the item to check for
 
         Returns
         -------
@@ -249,7 +249,7 @@ class IPCCommandInterface(CommandInterface):
         commands = self.execute(cmd_call, (), {})
         return command in commands
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: str) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
         """Check if the given item exists
 
         Resolves the available commands for the given command node of the given

--- a/libqtile/command_object.py
+++ b/libqtile/command_object.py
@@ -25,7 +25,7 @@ The objects in the command graph and command resolution on the objects
 import abc
 import inspect
 import traceback
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 from libqtile.command_graph import SelectorType
 from libqtile.log_utils import logger
@@ -111,7 +111,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def _select(self, name: str, sel: Optional[str]) -> "CommandObject":
+    def _select(self, name: str, sel: Optional[Union[str, int]]) -> "CommandObject":
         """Select the given item of the given item class
 
         This method is called with the following guarantees:

--- a/libqtile/command_object.py
+++ b/libqtile/command_object.py
@@ -35,7 +35,9 @@ class SelectError(Exception):
     """Error raised in resolving a command graph object"""
 
     def __init__(self, err_string: str, name: str, selectors: List[SelectorType]):
-        super().__init__(err_string)
+        super().__init__("{}, name: {}, selectors: {}".format(err_string,
+                                                              name,
+                                                              selectors))
         self.name = name
         self.selectors = selectors
 

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, List, Optional, Tuple  # noqa: F401
+from typing import Dict, List, Optional, Tuple, Union  # noqa: F401
 
 from libqtile.command_client import InteractiveCommandClient
 from libqtile.command_interface import CommandInterface
@@ -96,7 +96,7 @@ class LazyCommandObject(CommandInterface):
         """Lazily resolve the given command"""
         return True
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: str) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
         """Lazily resolve the given item"""
         return True
 

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -78,7 +78,7 @@ def make_qtile():
         action="store",
         default=None,
         dest="socket",
-        help='Path to Qtile comms socket.'
+        help='Path of the Qtile IPC socket.'
     )
     parser.add_argument(
         "-n", "--no-spawn",

--- a/libqtile/scripts/qtile_cmd.py
+++ b/libqtile/scripts/qtile_cmd.py
@@ -113,7 +113,7 @@ def get_object(client: InteractiveCommandClient, argv: List[str]) -> Interactive
     for arg in argv:
         try:
             # check if it is an item
-            client = client[arg]
+            client = client[client.normalize_item(arg)]
             continue
         except KeyError:
             pass

--- a/libqtile/scripts/qtile_cmd.py
+++ b/libqtile/scripts/qtile_cmd.py
@@ -184,10 +184,14 @@ def main() -> None:
                         help='Set arguments supplied to function.')
     parser.add_argument('--info', '-i', action='store_true',
                         help='With both --object and --function args prints documentation for function.')
+    parser.add_argument(
+        "--socket", "-s",
+        help='Path of the Qtile IPC socket.'
+    )
     args = parser.parse_args()
 
     if args.obj_spec:
-        sock_file = find_sockfile()
+        sock_file = args.socket or find_sockfile()
         ipc_client = Client(sock_file)
         cmd_object = IPCCommandInterface(ipc_client)
         cmd_client = InteractiveCommandClient(cmd_object)

--- a/libqtile/scripts/qtile_cmd.py
+++ b/libqtile/scripts/qtile_cmd.py
@@ -119,7 +119,7 @@ def get_object(client: InteractiveCommandClient, argv: List[str]) -> Interactive
             pass
 
         try:
-            # check it it is an attr
+            # check if it is an attr
             client = getattr(client, arg)
             continue
         except AttributeError:

--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -4,6 +4,7 @@ HERE=$(dirname $(readlink -f $0))
 SCREEN_SIZE=${SCREEN_SIZE:-800x600}
 XDISPLAY=${XDISPLAY:-:1}
 LOG_LEVEL=${LOG_LEVEL:-INFO}
+APP=${APP:-xterm}
 if [[ -z $PYTHON ]]; then
     PYTHON=python
 fi
@@ -14,7 +15,7 @@ XEPHYR_PID=$!
   sleep 1
   env DISPLAY=${XDISPLAY} ${PYTHON} "${HERE}"/../bin/qtile -l ${LOG_LEVEL} $@ &
   QTILE_PID=$!
-  env DISPLAY=${XDISPLAY} xterm &
+  env DISPLAY=${XDISPLAY} ${APP} &
   wait $QTILE_PID
   kill $XEPHYR_PID
 )

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -162,15 +162,6 @@ server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
 
 
 @server_config
-def test_item_types(qtile):
-    qtile.test_window("one")
-    wid = qtile.c.window.info()["id"]
-    assert type(wid) == int
-    assert qtile.c.window[wid].info()["id"] == wid
-    assert qtile.c.window[str(wid)].info()["id"] == wid
-
-
-@server_config
 def test_cmd_commands(qtile):
     assert qtile.c.commands()
     assert qtile.c.layout.commands()

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -162,6 +162,15 @@ server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
 
 
 @server_config
+def test_item_types(qtile):
+    qtile.test_window("one")
+    wid = qtile.c.window.info()["id"]
+    assert type(wid) == int
+    assert qtile.c.window[wid].info()["id"] == wid
+    assert qtile.c.window[str(wid)].info()["id"] == wid
+
+
+@server_config
 def test_cmd_commands(qtile):
     assert qtile.c.commands()
     assert qtile.c.layout.commands()

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2020 Guangwang Huang
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+import libqtile.confreader
+import libqtile.config
+import libqtile.layout
+import libqtile.bar
+import libqtile.widget
+from libqtile.ipc import Client
+from libqtile.command_client import InteractiveCommandClient
+from libqtile.command_interface import IPCCommandInterface
+from libqtile.scripts.qtile_cmd import get_object, run_function
+
+
+class ServerConfig:
+    auto_fullscreen = True
+    keys = []
+    mouse = []
+    groups = [
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
+        libqtile.config.Group("c"),
+    ]
+    layouts = [
+        libqtile.layout.Stack(num_stacks=1),
+        libqtile.layout.Stack(num_stacks=2),
+        libqtile.layout.Stack(num_stacks=3),
+    ]
+    floating_layout = libqtile.layout.floating.Floating()
+    screens = [
+        libqtile.config.Screen(
+            bottom=libqtile.bar.Bar(
+                [
+                    libqtile.widget.TextBox(name="one"),
+                ],
+                20
+            ),
+        ),
+        libqtile.config.Screen(
+            bottom=libqtile.bar.Bar(
+                [
+                    libqtile.widget.TextBox(name="two"),
+                ],
+                20
+            ),
+        )
+    ]
+    main = None
+
+
+server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
+
+
+@server_config
+def test_qtile_cmd(qtile):
+
+    def _qtile_cmd(obj_spec, function, args):
+        "Imitate the behavior of qtile_cmd"
+        ipc_client = Client(qtile.sockfile)
+        cmd_object = IPCCommandInterface(ipc_client)
+        cmd_client = InteractiveCommandClient(cmd_object)
+
+        obj = get_object(cmd_client, obj_spec)
+        return run_function(obj, function, args)
+
+    qtile.test_window("foo")
+    wid = qtile.c.window.info()["id"]
+
+    # e.g. qtile-cmd -o screen -f info
+    for obj in ["window", "layout", "group", "screen"]:
+        assert _qtile_cmd([obj], 'info', [])
+
+    # e.g. qtile-cmd -o group a -f info
+    assert _qtile_cmd(['window', wid], 'info', [])
+    assert _qtile_cmd(['group', 'a'], 'info', [])
+    assert _qtile_cmd(['screen', 0], 'info', [])
+    assert _qtile_cmd(['bar', 'bottom'], 'info', [])
+

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -94,4 +94,3 @@ def test_qtile_cmd(qtile):
     assert _qtile_cmd(['group', 'a'], 'info', [])
     assert _qtile_cmd(['screen', 0], 'info', [])
     assert _qtile_cmd(['bar', 'bottom'], 'info', [])
-


### PR DESCRIPTION
This fixes the failure of qtile-cmd as described in #1410, it excludes the initial object of `CommandGraphRoot` type, which has no meaningful children in qtile manager.