### PR TITLE
WM_TAKE_FOCUS: use the valid timestamp got from X server.

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -84,6 +84,8 @@ class XCore(base.Core):
             "_NET_SUPPORTED", [self.conn.atoms[x] for x in xcbq.SUPPORTED_ATOMS]
         )
 
+        self._last_event_timestamp = xcffib.CurrentTime
+
         wmname = "qtile"
         self._supporting_wm_check_window = self.conn.create_window(-1, -1, 1, 1)
         self._supporting_wm_check_window.set_property("_NET_WM_NAME", wmname)
@@ -273,6 +275,9 @@ class XCore(base.Core):
         """
         assert self.qtile is not None
 
+        if hasattr(event, "time") and event.time > 0:
+            self._last_event_timestamp = event.time
+
         handler = "handle_{event_type}".format(event_type=event_type)
         # Certain events expose the affected window id as an "event" attribute.
         event_events = [
@@ -300,6 +305,12 @@ class XCore(base.Core):
         if not chain:
             logger.info("Unhandled event: {event_type}".format(event_type=event_type))
         return chain
+
+    def get_valid_timestamp(self):
+        """Get a valid timestamp, i.e. not CurrentTime, for X server.
+
+        It may be used in cases where CurrentTime is unacceptable for X server."""
+        return self._last_event_timestamp
 
     @property
     def display_name(self) -> str:

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -21,7 +21,6 @@ import array
 import contextlib
 import inspect
 import traceback
-import time
 import warnings
 from xcffib.xproto import EventMask, StackMode, SetMode
 import xcffib.xproto
@@ -558,7 +557,7 @@ class _Window(CommandObject):
                     # > window manager (as described in section 4.2.8) with
                     # > WM_TAKE_FOCUS in its data[0] field and a valid timestamp
                     # > (i.e. not *CurrentTime* ) in its data[1] field.
-                    int(time.time()),
+                    self.qtile.core.get_valid_timestamp(),
                     0,
                     0,
                     0


### PR DESCRIPTION
This tries to fix #1542 and #755 (again) properly.

[The Timestamp definition in X11 protocol](https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#id2616329) is the following:
> A timestamp is a time value, expressed in milliseconds. It typically is the time since the last server reset. Timestamp values wrap around (after about 49.7 days). The server, given its current time is represented by timestamp T, always interprets timestamps from clients by treating half of the timestamp space as being earlier in time than T and half of the timestamp space as being later in time than T. One timestamp value (named CurrentTime) is never generated by the server. This value is reserved for use in requests to represent the current server time.

It seems like that it is a relative time offset since the server reset, so we don't know what it is by WM itself. In this PR, I take the approach of i3wm (grep `last_timestamp` in the i3 codebase), that keep the event timestamp from the X server, and take it in `WM_TAKE_FOCUS` ClientMessage event.

Though it fixes both #1542 and #755 on my side, I'm not sure if it breaks other things, and if there are better solutions, I'm open to hearing your opinions!