### PR TITLE
widget: add Configurable to *Mixin widgets

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -545,7 +545,7 @@ class ThreadPoolText(_TextBox):
 # these two classes below look SUSPICIOUSLY similar
 
 
-class PaddingMixin:
+class PaddingMixin(configurable.Configurable):
     """Mixin that provides padding(_x|_y|)
 
     To use it, subclass and add this to __init__:
@@ -563,7 +563,7 @@ class PaddingMixin:
     padding_y = configurable.ExtraFallback('padding_y', 'padding')
 
 
-class MarginMixin:
+class MarginMixin(configurable.Configurable):
     """Mixin that provides margin(_x|_y|)
 
     To use it, subclass and add this to __init__:


### PR DESCRIPTION
our doc generator looks for subclasses of configurable.Configurable in
order to figure out what to detect defaults from. let's add
configurable.Configurable to these classes so that their defaults also get
added to the list of widget options.

Closes #1545

Signed-off-by: Tycho Andersen <tycho@tycho.ws>