### PR TITLE
let Bars have margins for more control over position

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -153,6 +153,7 @@ class Bar(Gap, configurable.Configurable):
     defaults = [
         ("background", "#000000", "Background colour."),
         ("opacity", 1, "Bar window opacity."),
+        ("margin", 0, "Space around bar as int or list of ints [N E S W]."),
     ]
 
     def __init__(self, widgets, size, **config):
@@ -166,6 +167,28 @@ class Bar(Gap, configurable.Configurable):
 
     def _configure(self, qtile, screen):
         Gap._configure(self, qtile, screen)
+
+        if self.margin:
+            if isinstance(self.margin, int):
+                self.margin = [self.margin] * 4
+            if self.horizontal:
+                self.x += self.margin[3]
+                self.width -= self.margin[1] + self.margin[3]
+                self.length = self.width
+                self.size += self.margin[0] + self.margin[2]
+                if self.screen.top is self:
+                    self.y += self.margin[0]
+                else:
+                    self.y -= self.margin[2]
+            else:
+                self.y += self.margin[0]
+                self.height -= self.margin[0] + self.margin[2]
+                self.length = self.height
+                self.size += self.margin[1] + self.margin[3]
+                if self.screen.left is self:
+                    self.x += self.margin[3]
+                else:
+                    self.x -= self.margin[1]
 
         stretches = 0
         for w in self.widgets:


### PR DESCRIPTION
Hello!

This small commit gives `bar.Bar` a `margin` parameter that as the name suggests can be used to give the bar some margins, making that 'detached' bar style. Margins can either be an `int` or a `list` of 4 `int`s corresponding to [North East South West]. For example:

```
Screen(
    top=bar.Bar(
	[
	    widget.GroupBox(),
	    widget.Spacer(),
	    widget.Clock(),
	],
	40,
	margin=[10, 10, 0, 10],
    ),
)
```

Would give all sides but South a margin of 10px. If margin was instead just `10` then all sides would get the 10px margin (equivalent to `[10, 10, 10, 10]`).

This works with all configurations of single or multiple bars on any edges of the screen.