### PR TITLE
Revert "core: properly shutdown event loop"

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -32,7 +32,6 @@ import traceback
 import time
 import warnings
 from typing import Optional
-from concurrent.futures import CancelledError
 
 import xcffib
 import xcffib.xinerama
@@ -237,10 +236,7 @@ class Qtile(CommandObject):
             await self.finalize()
 
     def loop(self):
-        try:
-            self._eventloop.run_until_complete(self.async_loop())
-        except CancelledError:
-            pass
+        self._eventloop.run_until_complete(self.async_loop())
 
         self._eventloop.close()
         self._eventloop = None
@@ -287,9 +283,6 @@ class Qtile(CommandObject):
             self.core.remove_listener(self._eventloop)
         except:  # noqa: E722
             logger.exception('exception during finalize')
-
-        for task in asyncio.all_tasks(self._eventloop):
-            task.cancel()
 
     def _process_fake_screens(self):
         """


### PR DESCRIPTION
This reverts commit 8e249464572b34f88dc78ca420f864baf726690d.

Closes #1566

Seems like something with this is wrong, so let's revert it until someone
has time to look at it further.