### PR TITLE
Type annotations config

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -28,6 +28,7 @@
 import os.path
 import sys
 import warnings
+from typing import List
 
 from . import configurable
 from . import hook
@@ -51,7 +52,7 @@ class Key:
     kwargs:
         A dictionary containing "desc", allowing a description to be added
     """
-    def __init__(self, modifiers, key, *commands, **kwargs):
+    def __init__(self, modifiers: List[str], key: str, *commands, **kwargs):
         self.modifiers = modifiers
         self.key = key
         self.commands = commands

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -49,14 +49,14 @@ class Key:
     commands:
         A list of lazy command objects generated with the lazy.lazy helper.
         If multiple Call objects are specified, they are run in sequence.
-    kwargs:
-        A dictionary containing "desc", allowing a description to be added
+    desc:
+        description to be added to the key binding
     """
-    def __init__(self, modifiers: List[str], key: str, *commands, **kwargs):
+    def __init__(self, modifiers: List[str], key: str, *commands, desc: str = ""):
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
-        self.desc = kwargs.get("desc", "")
+        self.desc = desc
 
     def __repr__(self):
         return "<Key (%s, %s)>" % (self.modifiers, self.key)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -63,7 +63,7 @@ class Key:
 
 
 class Mouse:
-    def __init__(self, modifiers, button, *commands, **kwargs):
+    def __init__(self, modifiers: List[str], button: str, *commands, **kwargs):
         self.focus = kwargs.pop("focus", "before")
         self.modifiers = modifiers
         self.button = button

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -96,9 +96,6 @@ class Click(Mouse):
     It focuses clicked window by default.  If you want to prevent it, pass
     `focus=None` as an argument
     """
-    def __init__(self, modifiers, button, *commands, **kwargs):
-        super().__init__(modifiers, button, *commands, **kwargs)
-
     def __repr__(self):
         return "<Click (%s, %s)>" % (self.modifiers, self.button)
 


### PR DESCRIPTION
Here's some type annotations on config. Unfortunately I couldn't get these to actually *work* with pytype on my own config, but they'll be useful when we can actually figure it out :)