### PR TITLE
add callback functions to textbox widget

### DIFF
--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -23,12 +23,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Any, List, Tuple
+
 from .. import bar
 from . import base
 
 
 class TextBox(base._TextBox):
-    """A flexible textbox that can be updated from bound keys, scripts, and qshell"""
+    """A flexible textbox that can be updated from bound keys, scripts, and qshell
+
+    Callback functions can be assigned to button presses by passing a dict to the
+    'callbacks' kwarg. For example: {'Button1': func} will execute func when the widget
+    receives a button 1 press. The Qtile instance of passed as the only argument to the
+    callback functions.
+
+    """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("font", "sans", "Text font"),
@@ -36,7 +45,8 @@ class TextBox(base._TextBox):
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
         ("padding", None, "Padding left and right. Calculated if None."),
         ("foreground", "#ffffff", "Foreground colour."),
-    ]
+        ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
+    ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, text=text, width=width, **config)
@@ -44,6 +54,11 @@ class TextBox(base._TextBox):
     def update(self, text):
         self.text = text
         self.bar.draw()
+
+    def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
 
     def cmd_update(self, text):
         """Update the text in a TextBox widget"""


### PR DESCRIPTION
This commit lets you pass a dictionary to the textbox widget mapping mouse buttons to callback functions. Callbacks are passed the Qtile instance. Example config:
```
def myfunc(qtile):
    something_useful()

texbox = widget.TextBox('text', callbacks={1: myfunc})
```
It supports any value for `button` that is passed to `TextBox.button_press` because `button` is used directly to get the callback from the dictionary.

An alternative to this might be to add `callbacks` as a default parameter in the base class for all widgets, leaving their use up to the widget itself in its `button_press` method. This could then be used by any widgets that aren't already interactive, or to unused buttons on those that are.