### PR TITLE
move mouse_callbacks into base widget

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -92,11 +92,19 @@ class _Widget(CommandObject, configurable.Configurable):
 
     The offsetx and offsety attributes are set by the Bar after all widgets
     have been configured.
+
+    Callback functions can be assigned to button presses by passing a dict to the
+    'callbacks' kwarg. For example: {'Button1': func} will execute func when the widget
+    receives a button 1 press. The Qtile instance of passed as the only argument to the
+    callback functions.
     """
     orientations = ORIENTATION_BOTH
     offsetx = None
     offsety = None
-    defaults = [("background", None, "Widget background color")]  # type: List[Tuple[str, Any, str]]
+    defaults = [
+        ("background", None, "Widget background color"),
+        ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
+    ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, length, **config):
         """
@@ -204,7 +212,9 @@ class _Widget(CommandObject, configurable.Configurable):
         )
 
     def button_press(self, x, y, button):
-        pass
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
 
     def button_release(self, x, y, button):
         pass
@@ -445,6 +455,7 @@ class InLoopPollText(_TextBox):
 
     def button_press(self, x, y, button):
         self.tick()
+        _TextBox.button_press(self, x, y, button)
 
     def poll(self):
         return 'N/A'

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -30,14 +30,7 @@ from . import base
 
 
 class TextBox(base._TextBox):
-    """A flexible textbox that can be updated from bound keys, scripts, and qshell
-
-    Callback functions can be assigned to button presses by passing a dict to the
-    'callbacks' kwarg. For example: {'Button1': func} will execute func when the widget
-    receives a button 1 press. The Qtile instance of passed as the only argument to the
-    callback functions.
-
-    """
+    """A flexible textbox that can be updated from bound keys, scripts, and qshell."""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("font", "sans", "Text font"),
@@ -45,7 +38,6 @@ class TextBox(base._TextBox):
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
         ("padding", None, "Padding left and right. Calculated if None."),
         ("foreground", "#ffffff", "Foreground colour."),
-        ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -54,11 +46,6 @@ class TextBox(base._TextBox):
     def update(self, text):
         self.text = text
         self.bar.draw()
-
-    def button_press(self, x, y, button):
-        name = 'Button{0}'.format(button)
-        if name in self.mouse_callbacks:
-            self.mouse_callbacks[name](self.qtile)
 
     def cmd_update(self, text):
         """Update the text in a TextBox widget"""


### PR DESCRIPTION
Follow on from #1573. I moved the logic for widget mouse_callbacks into the base class and it seems to be working well. The base button_press method calls these callbacks by default and is then overriden by widgets that have pre-existing interactivity. The callbacks dict can be put into the config's `widget_defaults` and it then applies to all widgets that haven't overriden button_press.