### PR TITLE
qtile binary: don't fail if we can't set the locale

### DIFF
--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -29,7 +29,11 @@ from libqtile.log_utils import init_log, logger
 from libqtile import confreader
 from libqtile.backend.x11 import xcore
 
-locale.setlocale(locale.LC_ALL, locale.getdefaultlocale())  # type: ignore
+try:
+    locale.setlocale(locale.LC_ALL, locale.getdefaultlocale())  # type: ignore
+except locale.Error:
+    pass
+
 
 try:
     import pkg_resources


### PR DESCRIPTION
This isn't really fatal, so let's nto make it that way.

Fixes #1577

Signed-off-by: Tycho Andersen <tycho@tycho.ws>