### PR TITLE
x11 backend: use extmap for XFixes

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -834,6 +834,7 @@ class Connection:
     _extmap = {
         "xinerama": Xinerama,
         "randr": RandR,
+        "xfixes": XFixes,
     }
 
     def __init__(self, display):
@@ -845,7 +846,6 @@ class Connection:
         self.screens = [Screen(self, i) for i in self.setup.roots]
         self.default_screen = self.screens[self.conn.pref_screen]
 
-        self.xfixes = XFixes(self)
         for i in extensions:
             if i in self._extmap:
                 setattr(self, i, self._extmap[i](self))


### PR DESCRIPTION
In case some X server doesn't have support for XFixes, we don't want to set
up the XFixes extension. Let's just use the same mechanism as we do for
randr and xinerama.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>