### PR TITLE
replace cgi.escape with html.escape in mpd2 widget

### DIFF
--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -9,7 +9,7 @@ from libqtile.log_utils import logger
 from socket import error as socket_error
 from mpd import MPDClient, ConnectionError, CommandError
 from collections import defaultdict
-from cgi import escape
+from html import escape
 
 # Mouse Interaction
 # TODO: Volume inc/dec support


### PR DESCRIPTION
`cgi.escape` is [deprecated](https://docs.python.org/3.5/library/cgi.html) and at somepoint (I think Python 3.8) was removed. `html.escape` is recommended as a drop-in replacement.