### PR TITLE
docs: fix a deprecation warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -304,4 +304,4 @@ graphviz_dot_args = ['-Lg']
 
 # A workaround for the responsive tables always having annoying scrollbars.
 def setup(app):
-    app.add_stylesheet("no_scrollbars.css")
+    app.add_css_file("no_scrollbars.css")


### PR DESCRIPTION
/home/tycho/packages/qtile/docs/conf.py:307: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet("no_scrollbars.css")

Signed-off-by: Tycho Andersen <tycho@tycho.ws>