### PR TITLE
use mirror widgets to paint duplicate widgets

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -222,7 +222,10 @@ class Bar(Gap, configurable.Configurable):
         qtile.windows_map[self.window.window.wid] = self.window
         self.window.unhide()
 
-        for i in self.widgets:
+        for idx, i in enumerate(self.widgets):
+            if i.configured:
+                i = i.create_mirror()
+                self.widgets[idx] = i
             qtile.register_widget(i)
             i._configure(qtile, self)
         self._resize(self.length, self.widgets)

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -25,6 +25,7 @@ from .import_error import make_error
 
 # only directly import widgets that do not have any third party dependencies
 # other than those required by qtile, otherwise use the same import function
+from .base import Mirror  # noqa: F401
 from .clock import Clock  # noqa: F401
 from .currentlayout import CurrentLayout, CurrentLayoutIcon  # noqa: F401
 from .groupbox import AGroupBox, GroupBox  # noqa: F401


### PR DESCRIPTION
re: #1579

This adds a `Mirror` class in `widget.base`. Instances take the place of widgets that have already been passed to a `Bar` and configured, and hook into their `draw` operations to copy the contents of the original widget's `drawer`. Mouse clicks are forwarded to the original. This lets you do this:

```python
cpu = widget.CPUGraph()
mpd = widget.Mpd2()
battery = widget.Battery()
clock = widget.Clock()

screens = [
    Screen(
	top=bar.Bar(
	    [
		widget.GroupBox(),
		cpu, mpd, battery, clock,
	    ],
	),
    ),
    Screen(
	top=bar.Bar(
	    [
		widget.GroupBox(),
		cpu, mpd, battery, clock,
	    ],
	),
    ),
]
```
Widgets can be passed to more than one bar, so that there don't need to be any duplicates executing the same code all the time, and they'll always be visually identical.

This works for all widgets that use `drawers` (and nothing else) to display their contents. Currently this is all widgets except for `Systray`, which looks like it actually just manages tiny windows hoving over the bar or something.