### PR TITLE
use mouse_callbacks in all widgets

### DIFF
--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -96,6 +96,10 @@ class Backlight(base.InLoopPollText):
         self.call_process(shlex.split(self.change_command.format(value)))
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if self.future and not self.future.done():
             return
         info = self._get_info()

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -97,6 +97,9 @@ class CheckUpdates(base.ThreadedPollText):
 
     def button_press(self, x, y, button):
         # type: (int, int, int) -> None
-        base.ThreadedPollText.button_press(self, x, y, button)
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1 and self.execute is not None:
             Popen(self.execute, shell=True)

--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -123,6 +123,10 @@ class Cmus(base.ThreadPoolText):
             - skip forward in playlist on scroll up;
             - skip backward in playlist on scroll down.
         """
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             if self.status in ('playing', 'paused'):
                 subprocess.Popen(['cmus-remote', '-u'])

--- a/libqtile/widget/crashme.py
+++ b/libqtile/widget/crashme.py
@@ -58,6 +58,10 @@ class _CrashMe(base._TextBox):
         )
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             1 / 0
         elif button == 3:

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -58,6 +58,10 @@ class CurrentLayout(base._TextBox):
         hook.subscribe.layout_change(hook_response)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             self.qtile.cmd_next_layout()
         elif button == 2:

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -132,6 +132,10 @@ class AGroupBox(_GroupBase):
         self.add_defaults(AGroupBox.defaults)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         self.bar.screen.cmd_next_group()
 
     def calculate_length(self):

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -52,6 +52,10 @@ class KeyboardLayout(base.InLoopPollText):
         self.add_defaults(KeyboardLayout.defaults)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             self.next_keyboard()
 

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -177,6 +177,10 @@ class LaunchBar(base._Widget):
 
     def button_press(self, x, y, button):
         """ Launch the associated command to the clicked icon. """
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             icon = self.get_icon_in_position(x, y)
             if icon is not None:

--- a/libqtile/widget/moc.py
+++ b/libqtile/widget/moc.py
@@ -121,6 +121,10 @@ class Moc(base.ThreadPoolText):
             - skip forward in playlist on scroll up;
             - skip backward in playlist on scroll down.
         """
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             if self.status in ('PLAY', 'PAUSE'):
                 subprocess.Popen(['mocp', '-G'])

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -240,6 +240,11 @@ class Mpd2(base.ThreadPoolText):
     # TODO: Resolve timeouts on the method call.
     def button_press(self, x, y, button):
         """handle click event on widget."""
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
+
         self.try_reconnect()
         m_name = self.mouse_buttons[button]
         self_has_attr = hasattr(self, m_name)

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -114,6 +114,10 @@ class Notify(base._TextBox):
             self.display()
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             self.clear()
         elif button == 4:

--- a/libqtile/widget/pacman.py
+++ b/libqtile/widget/pacman.py
@@ -50,6 +50,9 @@ class Pacman(base.ThreadedPollText):
         return str(len(pacman.splitlines()))
 
     def button_press(self, x, y, button):
-        base.ThreadedPollText.button_press(self, x, y, button)
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1 and self.execute is not None:
             subprocess.Popen([self.execute], shell=True)

--- a/libqtile/widget/pomodoro.py
+++ b/libqtile/widget/pomodoro.py
@@ -175,9 +175,11 @@ class Pomodoro(base.ThreadPoolText):
         RIGHT BUTTON: toggle activity
 
         """
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             self._toggle_break()
         elif button == 3:
             self._toggle_active()
-
-        base.ThreadedPollText.button_press(self, x, y, button)

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -218,6 +218,10 @@ class PulseVolume(Volume):
         self.change_volume(volume)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if self.default_sink and button == BUTTON_DOWN:
             self.decrease_volume(self.step)
         elif self.default_sink and button == BUTTON_UP:

--- a/libqtile/widget/quick_exit.py
+++ b/libqtile/widget/quick_exit.py
@@ -66,7 +66,10 @@ class QuickExit(base._TextBox):
             return
 
     def button_press(self, x, y, button):
-
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if not self.is_counting:
             self.is_counting = True
             self.update()

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -363,6 +363,10 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         return None
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         window = None
         current_win = self.bar.screen.group.current_window
 

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -98,6 +98,11 @@ class Volume(base._TextBox):
         return cmd
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
+
         if button == BUTTON_DOWN:
             if self.volume_down_command is not None:
                 subprocess.call(self.volume_down_command, shell=True)

--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -89,6 +89,10 @@ class Wallpaper(base._TextBox):
             self.qtile.paint_screen(self.bar.screen, cur_image, self.option)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         if button == 1:
             if self.random_selection:
                 self.index = random.randint(0, len(self.images) - 1)

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -51,6 +51,10 @@ class WindowTabs(base._TextBox):
         hook.subscribe.float_change(self.update)
 
     def button_press(self, x, y, button):
+        name = 'Button{0}'.format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name](self.qtile)
+            return
         self.bar.screen.group.cmd_next_window()
 
     def update(self, *args):


### PR DESCRIPTION
The sequel to #1575 : mouse_callbacks dict used by all widgets.

The widgets that re-implement `button_press` have been updated to perform the same lookup in `mouse_callbacks`, and if they find a callback then they execute it and return. If they do not find a callback for a given button then they continue as normal. This means that any button can be given a callback for any widget, and any code that would normally be executed upon a button press is overriden if the user provides a callback for that button.