### PR TITLE
Add missing instruction to build docs in hacking.rst

### DIFF
--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -57,7 +57,9 @@ Activate your virtualenv, and install the ``graphviz`` Python package:
 
     pip install graphviz
     
-Go into the ``docs/`` directory and run ``make html``.
+Go into the ``docs/`` directory and run ``pip install -r requirements.txt``.
+
+Build the documentation with ``make html``.
 
 Check the result by opening ``_build/html/index.html`` in your browser.
 


### PR DESCRIPTION
I forgot this instruction in the previous PR, sorry :sweat_smile: 

`pip install -r requirements.txt` in the docs folder.