### PR TITLE
fix caption

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -208,7 +208,7 @@ create your own ``~/.xsession``. There are several examples of user defined
 
 If there is no display manager such as SDDM, LightDM or other and there is need
 to start Qtile directly from `~/.xinitrc` suggestion would be to do that
-through a custom sessions cript to save running applications.
+through a custom sessions script to save running applications.
 
 Finally, if you're a gnome user, you can start integrate Qtile into Gnome's
 session manager and use gnome as usual.

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -207,8 +207,15 @@ create your own ``~/.xsession``. There are several examples of user defined
 <https://github.com/qtile/qtile-examples>`_ repository.
 
 If there is no display manager such as SDDM, LightDM or other and there is need
-to start Qtile directly from `~/.xinitrc` suggestion would be to do that
-through a custom sessions script to save running applications.
+to start Qtile directly from ``~/.xinitrc`` do that by adding ``exec qtile`` at
+the end.
+
+In very special cases, ex. Qtile crashing during session, then suggestion would
+be to start through a loop to save running applications::
+
+    while true; do
+        qtile
+    done
 
 Finally, if you're a gnome user, you can start integrate Qtile into Gnome's
 session manager and use gnome as usual.

--- a/docs/manual/config/without-dm.rst
+++ b/docs/manual/config/without-dm.rst
@@ -10,10 +10,8 @@ Automatic login to virtual console
 ----------------------------------
 
 To get login into virtual console as an example edit `getty` service by running
-`systemctl edit getty@tty1` and add instructions:
-
-::
-    :caption: /etc/systemd/system/getty@tty1.service.d/override.conf
+`systemctl edit getty@tty1` and add instructions to
+`/etc/systemd/system/getty@tty1.service.d/override.conf`::
 
     [Service]
     ExecStart=

--- a/docs/manual/config/without-dm.rst
+++ b/docs/manual/config/without-dm.rst
@@ -21,13 +21,6 @@ To get login into virtual console as an example edit `getty` service by running
 
 Check more for other `examples <https://wiki.archlinux.org/index.php/Getty#Automatic_login_to_virtual_console>`_.
 
-Qtile session
--------------
-
-Starting Qtile directly will not preserve running applications on Qtile
-restarts by `qtile-cmd -o cmd -f restart` or other ways in Qtile itself. This
-can be solved by starting simple script loop.
-
 Autostart X session
 -------------------
 
@@ -57,6 +50,4 @@ And to start Qtile itself `.xinitrc` should be fixed:
     #
     #   source ~/.xsession
 
-    while true; do
-        qtile
-    done
+    exec qtile


### PR DESCRIPTION
still getting error in docs generation:
```
(qtile)  arnas@zordmachine  ~/out/qtile/docs   patch-6  make html
sphinx-build -E -W -b html -d _build/doctrees   . _build/html
Running Sphinx v3.0.1
Unmet dependencies for optional Widget: '.widget.pulse_volume.PulseVolume', No module named '_cffi_backend'
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 46 source files that are out of date
updating environment: [new config] 46 added, 0 changed, 0 removed
reading sources... [100%] qtile/lib/python3.8/site-packages/sphinx/ext/autosummary/templates/autosummary/module

Warning, treated as error:
/home/arnas/out/qtile/docs/qtile/lib/python3.8/site-packages/sphinx/ext/autosummary/templates/autosummary/base.rst:3:Error in "currentmodule" directive:
maximum 1 argument(s) allowed, 3 supplied.

.. currentmodule:: {{ module }}
make: *** [Makefile:46: html] Error 2
```