### PR TITLE
Exclude new _ffi modules location from flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ source-dir = docs
 build-dir = docs/_build
 
 [flake8]
-exclude = libqtile/_ffi*.py,libqtile/core/_ffi*.py
+exclude = libqtile/_ffi*.py,libqtile/backend/x11/_ffi*.py
 max-line-length = 120
 
 [tool:pytest]


### PR DESCRIPTION
The configuration was still excluding _ffi modules in `libqtie/core`