### PR TITLE
Adjust X and Y when adjusting maximised dimensions using increment hints

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1007,10 +1007,14 @@ class Window(_Window):
             height = max(self.height, self.hints.get('min_height', 0))
 
             if self.hints['base_width'] and self.hints['width_inc']:
-                width -= (width - self.hints['base_width']) % self.hints['width_inc']
+                width_adjustment = (width - self.hints['base_width']) % self.hints['width_inc']
+                width -= width_adjustment
+                self.x += int(width_adjustment / 2)
 
             if self.hints['base_height'] and self.hints['height_inc']:
-                height -= (height - self.hints['base_height']) % self.hints['height_inc']
+                height_adjustment = (height - self.hints['base_height']) % self.hints['height_inc']
+                height -= height_adjustment
+                self.y += int(height_adjustment / 2)
 
             self.place(
                 self.x, self.y,


### PR DESCRIPTION
When a window is maximised and it gives height and width increment hints, the width and height of the window is decreased to the nearest multiple of these increments. This can leave asymmetric gaps at the right and bottom edges that look like an unintentional bug (which I sought out to fix until I discovered that this was intentionally to follow increment hints!). This change adjusts the window's X and Y position to position any maximised windows following these hints so that it is centred, removing the weird cut edge effect.