### PR TITLE
exclude libqtile/backend/x11/_ffi_xcursors.py from flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ source-dir = docs
 build-dir = docs/_build
 
 [flake8]
-exclude = libqtile/_ffi*.py,libqtile/core/_ffi*.py
+exclude = libqtile/_ffi*.py,libqtile/backend/x11/_ffi*.py
 max-line-length = 120
 
 [tool:pytest]


### PR DESCRIPTION
I seem to be bombarding you with PRs at the minute... it's the lockdown.

This one just updates the flake8 config to exclude `libqtile/backend/x11/_ffi*.py`. I think this file used to be in `libqtile/core` before the backend stuff was created, so I've changed that path.