### PR TITLE
Fix use of CommandClient in docs

### DIFF
--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -40,13 +40,13 @@ the bar they are attached to.
 
 Lets look at an example, starting at the root node. The following script runs
 the ``status`` command on the root node, which, in this case, is represented by
-the Client object:
+the ``CommandClient`` object:
 
 .. code-block:: python
 
-    from libqtile.command import Client
-    c = Client()
-    print c.status()
+    from libqtile.command_client import CommandClient
+    c = CommandClient()
+    print(c.status())
 
 From the graph, we can see that the root node holds a reference to
 ``group`` nodes. We can access the "info" command on the current group like

--- a/docs/manual/commands/scripting.rst
+++ b/docs/manual/commands/scripting.rst
@@ -8,11 +8,11 @@ Client-Server Scripting Model
 Qtile has a client-server control model - the main Qtile instance listens on a
 named pipe, over which marshalled command calls and response data is passed.
 This allows Qtile to be controlled fully from external scripts. Remote
-interaction occurs through an instance of the ``libqtile.command.Client``
+interaction occurs through an instance of the ``libqtile.command_client.CommandClient``
 class. This class establishes a connection to the currently running instance of
 Qtile, and sources the user's configuration file to figure out which commands
 should be exposed. Commands then appear as methods with the appropriate
-signature on the ``Client`` object.  The object hierarchy is described in the
+signature on the ``CommandClient`` object.  The object hierarchy is described in the
 :doc:`/manual/commands/index` section of this manual. Full command
 documentation is available through the :doc:`Qtile Shell
 </manual/commands/qshell>`.
@@ -26,6 +26,6 @@ instance, and returns the integer offset of the current screen.
 
 .. code-block:: python
 
-    from libqtile.command import Client
-    c = Client()
-    print c.screen.info()["index"]
+    from libqtile.command_client import CommandClient
+    c = CommandClient()
+    print(c.screen.info()["index"])


### PR DESCRIPTION
For issue #1409, part 2.

Not sure if we should tell about `CommandClient` or `InteractiveCommandClient` (I don't know the difference).