### PR TITLE
core: make exception handling slightly more sane

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -119,6 +119,13 @@ def _import_module(module_name, dir_path):
     return module
 
 
+def handle_exception(loop, context):
+    if "exception" in context:
+        logger.error(context["exception"], exc_info=True)
+    else:
+        logger.error("exception in event loop: %s", context)
+
+
 class Qtile(CommandObject):
     """This object is the `root` of the command graph"""
     def __init__(
@@ -246,9 +253,7 @@ class Qtile(CommandObject):
     def setup_eventloop(self) -> None:
         self._eventloop.add_signal_handler(signal.SIGINT, self.stop)
         self._eventloop.add_signal_handler(signal.SIGTERM, self.stop)
-        self._eventloop.set_exception_handler(
-            lambda x, y: logger.exception("Got an exception in poll loop")
-        )
+        self._eventloop.set_exception_handler(handle_exception)
 
         logger.debug('Adding io watch')
         self.core.setup_listener(self, self._eventloop)


### PR DESCRIPTION
Before, this did:

2020-04-18 09:32:08,818 libqtile manager.py:<lambda>():L250  Got an exception in poll loop
NoneType: None

Now it does:

2020-04-18 09:42:05,627 libqtile manager.py:handle_exception():L124  [Errno 2] No such file or directory: 'xbacklight'

It would be better if we could get a stack trace, but I don't see a good
way of doing that right now. Hopefully they'll add it in the future, but at
least this prints the exception :)

Signed-off-by: Tycho Andersen <tycho@tycho.ws>