### PR TITLE
Makefile: some basic cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,26 +8,15 @@ default:
 
 .PHONY: check
 check:
-	pytest --verbose
-
-.PHONY: check-cov
-check-cov:
-	pytest --verbose --with-cov libqtile --cov-report term-missing
+	TOXENV=py38 tox
 
 .PHONY: lint
 lint:
-	flake8 ./libqtile bin/q* ./test
-
-.PHONY: static_check
-static_check:
-	mypy -p libqtile
-
-.PHONY: ckpatch
-ckpatch: lint check static_check
+	TOXENV=pep8 tox
 
 .PHONY: clean
 clean:
-	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/
+	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/ .coverage*
 
 # This is a little ugly: we want to be able to have users just run
 # 'python setup.py install' to install qtile, but we would also like to install


### PR DESCRIPTION
We've migrated to tox for linting/testing, and now that we do a bunch of
additional linting on imports, etc., we should probably use the same thing
for the make targets that we do for CI. (Am I the only one that uses the
Makefile? :D)

We can drop ckpatch, as that was originally the entry point for travis. I
just tend to run individual things manually.

Also, let's clean up some of the new coverage reports that tox generates.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>