### PR TITLE
images: don't swallow image decoding errors

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -53,11 +53,7 @@ def get_cairo_surface(bytes_img, width=None, height=None):
         return _SurfaceInfo(surf, 'png')
     except (MemoryError, OSError):
         pass
-    try:
-        return _decode_to_image_surface(bytes_img, width, height)
-    except cairocffi.pixbuf.ImageLoadingError:
-        pass
-    raise LoadingError("Couldn't load image!")
+    return _decode_to_image_surface(bytes_img, width, height)
 
 
 def get_cairo_pattern(surface, width=None, height=None, theta=0.0):


### PR DESCRIPTION
In #1352, we see the test failing like:

    def get_cairo_surface(bytes_img, width=None, height=None):
        try:
            surf = cairocffi.ImageSurface.create_from_png(io.BytesIO(bytes_img))
            return _SurfaceInfo(surf, 'png')
        except (MemoryError, OSError):
            pass
        try:
            return _decode_to_image_surface(bytes_img, width, height)
        except cairocffi.pixbuf.ImageLoadingError:
            pass
>       raise LoadingError("Couldn't load image!")
E       libqtile.images.LoadingError: Couldn't load image!

but that exception gives us exactly zero useful info about why image loading
failed. It looks to me like the first try is a try at decoding a PNG before we
decode the SVG, so we could/should probably do that better so we don't swallow
unnecessary exceptions. But at least this will help us not swallow the
exception from that test.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>