### PR TITLE
session manager: set_event_loop() to our event loop

### DIFF
--- a/libqtile/core/session_manager.py
+++ b/libqtile/core/session_manager.py
@@ -25,6 +25,7 @@ class SessionManager:
             The state to restart the qtile instance with.
         """
         eventloop = asyncio.new_event_loop()
+        asyncio.set_event_loop(eventloop)
 
         self.qtile = Qtile(kore, config, eventloop, no_spawn=no_spawn, state=state)
 


### PR DESCRIPTION
This will enable widgets to do things using our event loop if they want.

Closes #1046

Signed-off-by: Tycho Andersen <tycho@tycho.ws>