### PR TITLE
libqtile/lazy: fix 'when' filter

### DIFF
--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -72,6 +72,7 @@ class LazyCall:
     def when(self, layout=None, when_floating=True):
         self._layout = layout
         self._when_floating = when_floating
+        return self
 
     def check(self, q) -> bool:
         if self._layout is not None:


### PR DESCRIPTION
Fixes #1629

Was apparently broken during refactoring in 877e684 and 85f95a5. Tested with Xephyr, seems to work. A test case would be nice but I can't do this now. Merging this would at least bring back the functionality.