### PR TITLE
fix image test

### DIFF
--- a/test/test_images.py
+++ b/test/test_images.py
@@ -8,6 +8,7 @@ from glob import glob
 from os import path
 
 import cairocffi
+import cairocffi.pixbuf
 import pytest
 
 from libqtile import images
@@ -54,7 +55,7 @@ def test_get_cairo_surface(path_n_bytes_image):
 
 
 def test_get_cairo_surface_bad_input():
-    with pytest.raises(images.LoadingError):
+    with pytest.raises(cairocffi.pixbuf.ImageLoadingError):
         images.get_cairo_surface(b'asdfasfdi3')
 
 


### PR DESCRIPTION
330f0434acf5 ("images: don't swallow image decoding errors") changed the
exception this throws, but didn't update the test. Let's do that.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>