### PR TITLE
bars should use initial_size when (re)configuring window size

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -63,27 +63,27 @@ class Gap(CommandObject):
             self.y = screen.y
             self.length = screen.width
             self.width = self.length
-            self.height = self.size
+            self.height = self.initial_size
             self.horizontal = True
         elif screen.bottom is self:
             self.x = screen.x
             self.y = screen.dy + screen.dheight
             self.length = screen.width
             self.width = self.length
-            self.height = self.size
+            self.height = self.initial_size
             self.horizontal = True
         elif screen.left is self:
             self.x = screen.x
             self.y = screen.dy
             self.length = screen.dheight
-            self.width = self.size
+            self.width = self.initial_size
             self.height = self.length
             self.horizontal = False
         else:  # right
             self.x = screen.dx + screen.dwidth
             self.y = screen.dy
             self.length = screen.dheight
-            self.width = self.size
+            self.width = self.initial_size
             self.height = self.length
             self.horizontal = False
 
@@ -172,7 +172,8 @@ class Bar(Gap, configurable.Configurable):
                 self.x += self.margin[3]
                 self.width -= self.margin[1] + self.margin[3]
                 self.length = self.width
-                self.size += self.margin[0] + self.margin[2]
+                if self.size == self.initial_size:
+                    self.size += self.margin[0] + self.margin[2]
                 if self.screen.top is self:
                     self.y += self.margin[0]
                 else:


### PR DESCRIPTION
I came across a bug where if a bar that has margins is re-configured, the size is increased each time (to add the margins to its `self.size`) and upon reconfiguring, the height takes its value from the now greater size. This creates a black window growing out of the bar that grows each time they are re-configured. These changes make the height get its value from the initial size, which never changes, and stops the size from growing more than once.