### PR TITLE
Fix libqtile/lazy:LazyCall.check, add type hints and doc to LazyCall.when

### DIFF
--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -69,7 +69,19 @@ class LazyCall:
         """The kwargs to the given call"""
         return self._kwargs
 
-    def when(self, layout=None, when_floating=True):
+    def when(self, layout: Optional[str] = None,
+             when_floating: bool = True) -> 'LazyCall':
+        """Filter call activation per layout or floating state
+
+        Parameters
+        ----------
+        layout : str or None
+            Restrict call to given layout name. If None, call for all layouts.
+            If 'floating', call if, and only if the current window is floating,
+            ``when_floating`` is ignored in this case.
+        when_floating : bool
+            Call if the current window is floating.
+        """
         self._layout = layout
         self._when_floating = when_floating
         return self

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -75,14 +75,17 @@ class LazyCall:
         return self
 
     def check(self, q) -> bool:
-        if self._layout is not None:
-            if self._layout == 'floating':
-                if q.current_window.floating:
-                    return True
-                return False
-            if q.current_layout.name != self._layout:
-                if q.current_window and q.current_window.floating and not self._when_floating:
-                    return False
+        cur_win_floating = q.current_window and q.current_window.floating
+
+        if self._layout == 'floating':  # ignore _when_floating
+            return cur_win_floating
+
+        if cur_win_floating and not self._when_floating:
+            return False
+
+        if self._layout and q.current_layout.name != self._layout:
+            return False
+
         return True
 
 

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -76,18 +76,13 @@ class LazyCall:
         Parameters
         ----------
         layout : str, Iterable[str], or None
-            Restrict call to given layout names. If None, enable call
-            for all layouts.
-            Can be a single name, a string of comma-separated names, or any
-            iterable yielding layout names.
+            Restrict call to one or more layouts.
+            If None, enable the call for all layouts.
         when_floating : bool
             Enable call when the current window is floating.
         """
         if layout is not None:
-            if isinstance(layout, str):
-                self._layouts = set(l.strip() for l in layout.split(","))
-            else:
-                self._layouts = set(layout)
+            self._layouts = {layout} if isinstance(layout, str) else set(layout)
 
         self._when_floating = when_floating
         return self

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union  # noqa: F401
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from libqtile.command_client import InteractiveCommandClient
 from libqtile.command_graph import (


### PR DESCRIPTION
Follow-up to: #1645  add type annotations and documentation to ``LazyCall.when``
Fixes: #1646 simplify and fix logic according to issue reported.

Both changes are in the same PR because the documentation for ``LazyCall.when`` depends on the behavior of ``LazyCall.check``.

The proposed logic sticks to the [previously working one](https://github.com/qtile/qtile/blob/a3ae3c623859b247813fc1876b188c4d40e84df0/libqtile/command.py#L293), only simplifying the code. Some discussion points:

  - the check for ``self._floating == 'floating'`` is pretty restrictive. If there are no windows left but the last one was floating, the current layout is still ``floating`` but the call will not be evaluated. This might be surprising because ``lazy.something.when(layout="floating")`` does not seem to assume that there has to be a floating window;

  - the previous point also conflicts with ``when_floating`` (it ignores the latter). This is probably unproblematic since the following is weird: ``lazy.something.when(layout="floating", when_floating=False)``. The only use case is that of floating layout with no window, as previously;

  - AFAICT, there's no support for restricting a command to multiple layouts (chaining ``.when``s would overwrite ``self._layout`` wouldn't it?). Extending ``layout`` to ``Union[List[str], None]`` or even ``Union[List[str], str, None]`` is relatively straightforward (the latter would not break legacy code). One could also stick to ``Optional[str]`` with a comma separated list of layouts as parameter. Relevance? Opinions?

