### PR TITLE
Enh: widget/maildir: conditional colored display, custom subfolder format, hide when empty

### DIFF
--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -61,7 +61,7 @@ class Maildir(base.ThreadedPollText):
                 for folder in self.sub_folders
             ]
 
-    def poll(self) -> str:
+    def poll(self):
         """Scans the mailbox for new messages
 
         Returns

--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -26,6 +26,7 @@
 
 import mailbox
 import os.path
+from typing import Dict
 
 from libqtile.widget import base
 
@@ -60,7 +61,7 @@ class Maildir(base.ThreadedPollText):
                 for folder in self.sub_folders
             ]
 
-    def poll(self):
+    def poll(self) -> str:
         """Scans the mailbox for new messages
 
         Returns
@@ -85,7 +86,7 @@ class Maildir(base.ThreadedPollText):
 
         return self.format_text(state)
 
-    def _format_one(self, label, value):
+    def _format_one(self, label: str, value: int) -> str:
         if value == 0 and self.hide_when_empty:
             return ""
 
@@ -98,7 +99,7 @@ class Maildir(base.ThreadedPollText):
         return s.join(('<span foreground="{}">'.format(color),
                        '</span>'))
 
-    def format_text(self, state):
+    def format_text(self, state: Dict[str, int]) -> str:
         """Converts the state of the subfolders to a string
 
         Parameters

--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -40,6 +40,12 @@ class Maildir(base.ThreadedPollText):
         ("separator", " ", "the string to put between the subfolder strings."),
         ("total", False, "Whether or not to sum subfolders into a grand \
             total. The first label will be used."),
+        ("hide_when_empty", False, "Whether not to display anything if "
+         "the subfolder has no new mail"),
+        ("empty_color", None, "Display color when no new mail is available"),
+        ("nonempty_color", None, "Display color when new mail is available"),
+        ("subfolder_fmt", "{label}: {value}",
+         "Display format for one subfolder"),
     ]
 
     def __init__(self, **config):
@@ -79,24 +85,35 @@ class Maildir(base.ThreadedPollText):
 
         return self.format_text(state)
 
+    def _format_one(self, label, value):
+        if value == 0 and self.hide_when_empty:
+            return ""
+
+        s = self.subfolder_fmt.format(label=label, value=value)
+        color = self.empty_color if value == 0 else self.nonempty_color
+
+        if color is None:  # default to self.foreground
+            return s
+
+        return s.join(('<span foreground="{}">'.format(color),
+                       '</span>'))
+
     def format_text(self, state):
         """Converts the state of the subfolders to a string
 
         Parameters
         ==========
-        state:
-            a dictionary as returned by mailbox_state
+        state: Dict[str, int]
+            a dictionary mapping subfolder labels to new mail values
 
         Returns
         =======
         a string representation of the given state
         """
         if self.total:
-            return self.separator.join([
-                self.sub_folders[0]["label"],
-                str(sum(state.values()))
-            ])
+            return self._format_one(self.sub_folders[0]["label"],
+                                    sum(state.values()))
         else:
             return self.separator.join(
-                "{0}: {1}".format(*item) for item in state.items()
+                self._format_one(*item) for item in state.items()
             )


### PR DESCRIPTION
This patch is a proposal for enhancement of the ``Maildir`` widget. It adds support for the following options:

  - ``subfolder_fmt``: custom format string for a single subfolder. Defaults to ``{label}: {value}`` to match current behaviour;
  - ``empty_color`` and ``nonempty_color``: foreground colors applied to the formatted string depending on the whether the subfolder (sum of subfolders if ``total=True``) is empty (i.e. no new mail) or not. Both default to ``None``, using the default;
  - ``hide_when_empty``: flag to disable the display of the subfolder(s) if it is empty.

The patch also adds type hints for methods in ``widget.maildir.Maildir``.

Discussion:
  - ``_TextBox.foreground`` and ``_TextBox.background`` already manage foreground and background color for the whole widget but independently from the maildir state. This patch allows conditional colors depending on the most basic status of the maildir;
  - this is a minimal extension: more advanced/flexible options would be possible. For example: apply color only to value (or defined by ``subfolder_fmt``), define multi-color thresholds (less crude than empty or not), adjusting the background color, font weight, etc. However, all these enter the area of templating and are always possible by subclassing ``widget.Maildir`` in the user's own config. The balance here is to provide more options to the average user;
  - ``subfolder_fmt`` can be used to hide labels if wanted, which is not supported by ``_TextBox.fmt``;
  - a natural extension is to support similar options for ``GmailChecker`` and ``ImapWidget``.

Opiniated feedback is most welcome.