### PR TITLE
Add format recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 
 .PHONY: lint
 lint:
-	TOXENV=pep8 tox
+	TOXENV=format,pep8 tox
 
 .PHONY: clean
 clean:

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,12 @@ commands =
     python setup.py sdist
     twine check dist/*
 
+[testenv:format]
+deps =
+    isort
+commands =
+    isort -y -rc {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test
+
 [testenv:pep8]
 deps =
     flake8


### PR DESCRIPTION
- This adds a `format` tox env and makefile rule.
- `make format` actually runs `TOXENV=format tox` to be consistent with the other rules

For #1625