### PR TITLE
Spawn terminal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+qtile X.X.X, released XXXX-XX-XX:
+    * features
+        - added `guess_terminal` in utils
+        - added keybinding cheet sheet image generator
+
 qtile 0.15.0, released 2020-04-12:
     !!! Config breakage !!!
         - removed the mpd widget, which depended on python-mpd.

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -50,7 +50,7 @@ key. The basic operation is:
 * ``mod + <ctrl> + r``: restart qtile with new config
 * ``mod + <group name>``: switch to that group
 * ``mod + <shift> + <group name>``: send a window to that group
-* ``mod + <enter>``: start xterm
+* ``mod + <enter>``: start terminal guessed by ``libqtile.utils.guess_terminal``
 * ``mod + r``: start a little prompt in the bar so users can run arbitrary
   commands
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -29,8 +29,10 @@ from typing import List  # noqa: F401
 from libqtile import bar, layout, widget
 from libqtile.config import Click, Drag, Group, Key, Screen
 from libqtile.lazy import lazy
+from libqtile.utils import guess_terminal
 
 mod = "mod4"
+terminal = guess_terminal()
 
 keys = [
     # Switch between windows in current stack pane
@@ -59,7 +61,7 @@ keys = [
     # multiple stack panes
     Key([mod, "shift"], "Return", lazy.layout.toggle_split(),
         desc="Toggle between split and unsplit sides of stack"),
-    Key([mod], "Return", lazy.spawn("xterm"), desc="Launch xterm"),
+    Key([mod], "Return", lazy.spawn(terminal), desc="Launch terminal"),
 
     # Toggle between different layouts as defined below
     Key([mod], "Tab", lazy.next_layout(), desc="Toggle between layouts"),

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -23,6 +23,7 @@ import importlib
 import os
 import traceback
 import warnings
+from shutil import which
 
 from libqtile.log_utils import logger
 
@@ -209,3 +210,39 @@ def send_notification(title, message, urgent=False, timeout=10000):
         notifier.show()
     except Exception as exception:
         logger.error(exception)
+
+
+def guess_terminal():
+    """Try to guess terminal."""
+    test_terminals = [
+            'x-terminal-emulator',
+            'roxterm',
+            'sakura',
+            'hyper',
+            'alacritty',
+            'terminator',
+            'termite',
+            'gnome-terminal',
+            'konsole',
+            'xfce4-terminal',
+            'lxterminal',
+            'mate-terminal',
+            'kitty',
+            'yakuake',
+            'tilda',
+            'guake',
+            'eterm',
+            'st',
+            'urxvt',
+            'xterm',
+            ]
+
+    for terminal in test_terminals:
+        logger.debug('Guessing terminal: {}'.format(terminal))
+        if not which(terminal, os.X_OK):
+            continue
+
+        logger.info('Terminal found: {}'.format(terminal))
+        return terminal
+
+    logger.error('Default terminal has not been found.')


### PR DESCRIPTION
Version 3
`guess_terminal` in utils

Now in config it could be used:
```python
from libqtile.utils import get_duess_terminal
terminal = guess_terminal()
<...>
    Key([mod], "Return", lazy.spawn(terminal), desc="Launch terminal"),
<...>
```
or if you want some app inside
`Key([mod], "t", lazy.spawn([terminal, '-e', 'htop']), desc="Launch htop")`

Part of https://github.com/qtile/qtile/issues/1582