### PR TITLE
#1671: Notice about Ubuntu 20.04 lacking the qtile package.

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -18,8 +18,11 @@ running something else, please see `Installing From Source`_.
     Slackware <slackware>
     FreeBSD <freebsd>
 
+.. _installing-from-source:
+
 Installing From Source
 ======================
+
 
 First, you need to install all of Qtile's dependencies (although some are
 optional/not needed depending on your Python version, as noted below).

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -2,7 +2,9 @@
 Installing on Debian or Ubuntu
 ==============================
 
-On recent Ubuntu (17.04 or greater) and Debian unstable versions, there are
+Note: As of Ubuntu 20.04 (Focal Fossa), the package has been outdated and removed from the Ubuntu's official package list. Users are advised to follow the instructions of :ref:`installing-from-source`.
+
+On other recent Ubuntu (17.04 or greater) and Debian unstable versions, there are
 Qtile packages available via:
 
 .. code-block:: bash

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -2,10 +2,12 @@
 Installing on Debian or Ubuntu
 ==============================
 
-Note: As of Ubuntu 20.04 (Focal Fossa), the package has been outdated and removed from the Ubuntu's official package list. Users are advised to follow the instructions of :ref:`installing-from-source`.
+Note: As of Ubuntu 20.04 (Focal Fossa), the package has been outdated
+and removed from the Ubuntu's official package list.
+Users are advised to follow the instructions of :ref:`installing-from-source`.
 
-On other recent Ubuntu (17.04 or greater) and Debian unstable versions, there are
-Qtile packages available via:
+On other recent Ubuntu (17.04 or greater) and Debian unstable versions,
+there are Qtile packages available via:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Updated the docs to reflect the lack of an package in Ubuntu's official package list. #1671