### PR TITLE
Provide in depth docs on the structure and design of the command interfaces

### DIFF
--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -167,9 +167,9 @@ Digging Deeper: Command Objects
 
 If you just want to script your Qtile window manager the above information, in
 addition to the documentation on the :doc:`various scripting
-commands<manual/ref/commands>` should be enough to get started.  To develop the
-Qtile manager itself, we can dig into how Qtile represents these objects, which
-will lead to the way the commands are dispatched.
+commands </manual/ref/commands>` should be enough to get started.  To develop
+the Qtile manager itself, we can dig into how Qtile represents these objects,
+which will lead to the way the commands are dispatched.
 
 All of the configured objects setup by Qtile are ``CommandObject`` subclasses.
 These objects are so named because we can issue commands against them using the

--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -20,8 +20,8 @@ the API using the ``qshell`` command shell. Command lists and detailed
 documentation can be accessed from its built-in help command.
 
 
-Object Graph
-============
+Introduction: Object Graph
+==========================
 
 The objects in Qtile's object graph come in seven flavours, matching the seven
 basic components of the window manager: ``layouts``, ``windows``, ``groups``,
@@ -40,36 +40,61 @@ the bar they are attached to.
 
 Lets look at an example, starting at the root node. The following script runs
 the ``status`` command on the root node, which, in this case, is represented by
-the ``CommandClient`` object:
+the ``InteractiveCommandClient`` object:
+
+.. code-block:: python
+
+    from libqtile.command_client import InteractiveCommandClient
+    c = InteractiveCommandClient()
+    print(c.status())
+
+The ``InteractiveCommandClient`` is a class that allows us to traverse the
+command graph using attributes to select child nodes or commands.  In this
+example, we have resolved the ``status()`` command on the root object.  The
+interactive command client will automatically find and connect to a running
+Qtile instance, and which it will use to dispatch the call and print out the
+return.
+
+An alternative is to use the ``CommandClient``, which allows for a more precise
+resolution of command graph objects, but is not as easy to interact with from a
+REPL:
 
 .. code-block:: python
 
     from libqtile.command_client import CommandClient
     c = CommandClient()
-    print(c.status())
+    print(c.call("status")())
 
-From the graph, we can see that the root node holds a reference to
-``group`` nodes. We can access the "info" command on the current group like
-so:
+Like the interactive client, the command client will automatically connect to a
+running Qtile instance.  Here, we first resolve the ``status()`` command with
+the ``.call("status")``, which simply located the function, then we can invoke
+the call with no arguments.
+
+For the rest of this example, we will use the interactive command client.  From
+the graph, we can see that the root node holds a reference to ``group`` nodes.
+We can access the "info" command on the current group like so:
 
 .. code-block:: python
 
     c.group.info()
 
 To access a specific group, regardless of whether or not it is current, we use
-the Python containment syntax. This command sends group "b" to screen 1 (by the
-:meth:`libqtile.config.Group.to_screen` method):
+the Python mapping lookup syntax. This command sends group "b" to screen 1 (by
+the :meth:`libqtile.config.Group.to_screen` method):
 
 .. code-block:: python
 
     c.group["b"].to_screen(1)
 
-The current ``group``, ``layout``, ``screen`` and ``window`` can be
-accessed by simply leaving the key specifier out. The key specifier is
-mandatory for ``widget`` and ``bar`` nodes.
+In different contexts, it is possible to access a default object, where in
+other contexts a key is required.  From the root of the graph, the current
+``group``, ``layout``, ``screen`` and ``window`` can be accessed by simply
+leaving the key specifier out. The key specifier is mandatory for ``widget``
+and ``bar`` nodes.
 
-We can now drill down deeper in the graph. To access the screen
-currently displaying group "b", we can do this:
+With this context, we can now drill down deeper in the graph, following the
+edges in the graphic above. To access the screen currently displaying group
+"b", we can do this:
 
 .. code-block:: python
 
@@ -90,6 +115,9 @@ specifies the group belonging to the screen that belongs to group "b":
 .. code-block:: python
 
     c.group["b"].screen.group
+
+This amout of connectivity makes it easy to reach out from a given object when
+callbacks and events fire on that object to related objects.
 
 Keys
 ====
@@ -132,3 +160,145 @@ The key specifier for the various object types are as follows:
       - Yes
       - | c.window[123456]
         | c.window
+
+
+Digging Deeper: Command Objects
+===============================
+
+If you just want to script your Qtile window manager the above information, in
+addition to the documentation on the :doc:`various scripting
+commands<manual/ref/commands>` should be enough to get started.  To develop the
+Qtile manager itself, we can dig into how Qtile represents these objects, which
+will lead to the way the commands are dispatched.
+
+All of the configured objects setup by Qtile are ``CommandObject`` subclasses.
+These objects are so named because we can issue commands against them using the
+command scripting API.  Looking through the code, the commands that are exposed
+are commands named ``cmd_*``.  When writing custom layouts, widgets, or any
+other object, you can add your own custom ``cmd_`` functions and they will be
+callable using the standard command infrastructure.  An available command can
+be extracted by calling ``.command()`` with the name of the command.
+
+In addition to having a set of associated commands, each command object also
+has a collection of items associated with it.  This is what forms the graph
+that is shown above.  For a given object type, the ``items()`` method returns
+all of the names of the associated objects of that type and whether or not
+there is a defaultable value.  For example, from the root, ``.items("group")``
+returns the name of all of the groups and that there is a default value, the
+currently focused group.
+
+To navigate from one command object to the next, the ``.select()`` method is
+used.  This method resolves a requested object from the command graph by
+iteratively selecting objects.  A selector like ``[("group", "b"), ("screen",
+None)]`` would be to first resolve group "b", then the screen associated to the
+group.
+
+The Command Graph
+=================
+
+In order to help in specifying command objects, there is the abstract command
+graph structure.  The command graph structure allows us to address any valid
+command object and issue any command against it without needing to have any
+Qtile instance running or have anything to resolve the objects to.  This is
+particularly useful when constructing lazy calls, where the Qtile instance does
+not exist to specify the path that will be resolved when the command is
+executed.  The only limitation of traversing the command graph is that it must
+follow the allowed edges specified in the first section above.
+
+Every object in the command graph is represented by a ``CommandGraphNode``.
+Any call can be resolved from a given node.  In addition, each node knows about
+all of the children objects that can be reached from it and have the ability to
+``.navigate()`` to the other nodes in the command graph.  Each of the object
+types are represented as ``CommandGraphObject`` types and the root node of the
+graph, the ``CommandGraphRoot`` reresents the Qtile instance.  When a call is
+performed on an object, it returns a ``CommandGraphCall``.  Each call will know
+its own name as well as be able to resolve the path through the command graph
+to be able to find itself.
+
+Note that the command graph itself can standalone, there is no other
+functionality within Qtile that it relies on.  While we could have started here
+and built up, it is helpful to understand the objects that the graph is meant
+to represent, as the graph is just a representation of a traversal of the real
+objects in a running Qtile window manager.  In order to tie the running Qtile
+instance to the abstract command graph, we move on to the command interface.
+
+Executing graph commands: Command Interface
+===========================================
+
+The ``CommandInterface`` is what lets us take an abstract call on the command
+graph and resolve it against a running command object.  Put another way, this
+is what takes the graph traversal ``.group["b"].screen.info()`` and executes
+the ``info()`` command against the addressed ``screen`` object.  Additional
+functionality can be used to check that a given traversal resolves to actual
+objcets and that the requested command actually exists.  Note that by
+construction of the command graph, the traversals here must be feasible, even
+if they cannot be resolved for a given configuration state.  For example, it is
+possible to check the screen assoctiated to a group, even though the group may
+not be on a screen, but it is not possible to check the widget associated to a
+group.
+
+The simplest form of the command interface is the ``QtileCommandInterface``,
+which can take an in-process ``Qtile`` instance as the root ``CommandObject``
+and execute requested commands.  This is typically how we run the unit tests
+for qtile.
+
+The other primary example of this is the ``IPCCommandInterface`` which is able
+to then route all calls through an IPC client connected to a running qtile
+instance.  In this case, the command graph call can be constructed on the
+client side without having to dispatch to qtile and once the call is
+constructed and deemed valid, the call can be executed.
+
+In both of these cases, executing a command on a command interface will return
+the result of executing the command on a running qtile instance.  To support
+lazy execution, the ``LazyCommandInterface`` instead returns a ``LazyCall``
+which is able to be resolved later by the running qtile instance when it is
+configured to fire.
+
+Tying it together: Command Client
+=================================
+
+So far, we have our running Command Objects and the Command Interface to
+dispatch commands against these objects as well as the Command Graph structure
+itself which encodes how to traverse the connections between the objects.  The
+final component which ties everything together is the Command Client, which
+allows us to navigate through the graph to resolve objects, find their
+associated commands, and execute the commands against the held command
+interface.
+
+The idea of the command client is that it is created with a reference into the
+command graph and a command interface.  All navigation can be done against the
+command graph, and traversal is done by creating a new command client starting
+from the new node.  When a command is executed against a node, that command is
+dispatched to the held command interface.  The key decision here is how to
+perform the traversal.  The command client exists in two different flavors: the
+standard ``ComandClient`` which is useful for handling more programatic
+traversal of the graph, calling methods to traverse the graph, and the
+``InteractiveCommandClient`` which behaves more like a standard Python object,
+traversing by accessing properties and performing key lookups.
+
+Returning to our examples above, we now have the full context to see what is
+going on when we call:
+
+.. code-block:: python
+
+    from libqtile.command_client import CommandClient
+    c = CommandClient()
+    print(c.call("status")())
+    from libqtile.command_client import InteractiveCommandClient
+    c = InteractiveCommandClient()
+    print(c.status())
+
+In both cases, the command clients are constructed with the default command
+interface, which sets up an IPC connection to the running qtile instance, and
+starts the client at the graph root.  When we call ``c.call("status")`` or
+``c.status``, we navigate the command client to the ``status`` command on the
+root graph object.  When these are invoked, the commands graph calls are
+dispatched via the IPC command interface and the results then sent back and
+printed on the local command line.
+
+The power that can be realized by separating out the traversal and resolution
+of objects in the command graph from actually invoking or looking up any
+objects within the graph can be seen in the ``lazy`` module.  By creating a
+lazy evaluated command client, we can expose the graph traversal and object
+resolution functionality via the same ``InteractiveCommandClient`` that is used
+to perform live command execution in the qtile prompt.

--- a/docs/manual/commands/scripting.rst
+++ b/docs/manual/commands/scripting.rst
@@ -8,13 +8,14 @@ Client-Server Scripting Model
 Qtile has a client-server control model - the main Qtile instance listens on a
 named pipe, over which marshalled command calls and response data is passed.
 This allows Qtile to be controlled fully from external scripts. Remote
-interaction occurs through an instance of the ``libqtile.command_client.CommandClient``
-class. This class establishes a connection to the currently running instance of
-Qtile, and sources the user's configuration file to figure out which commands
-should be exposed. Commands then appear as methods with the appropriate
-signature on the ``CommandClient`` object.  The object hierarchy is described in the
-:doc:`/manual/commands/index` section of this manual. Full command
-documentation is available through the :doc:`Qtile Shell
+interaction occurs through an instance of the
+``libqtile.command_interface.IPCCommandInterface`` class. This class
+establishes a connection to the currently running instance of Qtile.  A
+``libqtile.command_client.CommandClient`` can use this connection to dispatch
+commands to the running instance.  Commands then appear as methods with the
+appropriate signature on the ``CommandClient`` object.  The object hierarchy is
+described in the :doc:`/manual/commands/index` section of this manual. Full
+command documentation is available through the :doc:`Qtile Shell
 </manual/commands/qshell>`.
 
 

--- a/libqtile/command.py
+++ b/libqtile/command.py
@@ -25,7 +25,7 @@ The deprecated lazy command objects
 import warnings
 
 from libqtile.command_client import InteractiveCommandClient
-from libqtile.lazy import LazyCommandObject
+from libqtile.lazy import LazyCommandInterface
 
 
 class _LazyTree(InteractiveCommandClient):
@@ -35,4 +35,4 @@ class _LazyTree(InteractiveCommandClient):
         return super().__getattr__(name)
 
 
-lazy = _LazyTree(LazyCommandObject())
+lazy = _LazyTree(LazyCommandInterface())

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -86,7 +86,7 @@ class LazyCall:
         return True
 
 
-class LazyCommandObject(CommandInterface):
+class LazyCommandInterface(CommandInterface):
     """A lazy loading command object
 
     Allows all commands and items to be resolved at run time, and returns
@@ -106,4 +106,4 @@ class LazyCommandObject(CommandInterface):
         return True
 
 
-lazy = InteractiveCommandClient(LazyCommandObject())
+lazy = InteractiveCommandClient(LazyCommandInterface())


### PR DESCRIPTION
Fix up some of the current docs and provide additional information on
the structure and design of the various components that underlie the
command graph structure.  This is a developer-centric overview of how
these component slot together and how the command graph itself relates
back to the qtile objects.