### PR TITLE
Restructuring float rules

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -68,6 +68,7 @@ class Floating(Layout):
             float_rules = {
                 "wmclass": ["Wine", "vlc"],
                 "role": ["About"],
+                "wmtype": ["notification", "toolbar"],
             }
         The follwing keys are possible. (With corresponding X property)
             "wmname"    (WM_NAME)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -113,7 +113,6 @@ class Floating(Layout):
         """Compares a window's properties with the `float_rules`.
         Returns `True` if window should float.
         """
-        print(win.window.get_wm_type())
         if (win.name in self.float_rules['wmname'] or
                 win.window.get_wm_window_role() in self.float_rules['role'] or
                 set(win.window.get_wm_class()) & self.float_rules['wmclass'] or

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -31,14 +31,16 @@
 from collections import defaultdict
 
 from libqtile.layout.base import Layout
+from libqtile.log_utils import logger
 
 # sensible floating defaults like in i3
 # https://github.com/i3/i3/blob/ae757c6848b49d7a0423973a39791ba6eca29308/src/manage.c#L449
 # except `A__NET_WM_STATE_MODAL` windows (couldn't figure this one out)
-DEFAULT_FLOAT_RULES  = defaultdict(set, {
-    "wmtype": {"dialog" ,"utility", "toolbar", "splash"},
+DEFAULT_FLOAT_RULES = defaultdict(set, {
+    "wmtype": {"dialog", "utility", "toolbar", "splash"},
     "wmhint": {"fixed_size"},
 })
+
 
 class Floating(Layout):
     """
@@ -95,11 +97,11 @@ class Floating(Layout):
             self.float_rules = DEFAULT_FLOAT_RULES
         # provide support for deprecated `auto_float_types` argument
         if self.auto_float_types:
-            # TODO: deprecated warning
+            logger.warning("`auto_float_types` is deprecated. Use `float_rules` for this.")
             self.float_rules["wmtype"].update(self.auto_float_types)
         # provide support for the deprecated list-structure of `float_rules`
         if isinstance(float_rules, list):
-            # TODO: deprecated warning
+            logger.warning("The list structure of `float_rules` is deprecated. Use a dictionary instead")
             for rule_dict in float_rules:
                 key, val = tuple(rule_dict.items())[0]
                 self.float_rules[key].add(val)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -59,23 +59,21 @@ class Floating(Layout):
     ]
 
     def __init__(self, float_rules={}, no_reposition_match=None, override_default_float_rules=False, **config):
-        # TODO: update docstring
         """
-        If you have certain apps that you always want to float you can provide
-        ``float_rules`` to do so. ``float_rules`` is a list of
-        dictionaries containing some or all of the keys::
+        There is a preset of rules for windows which most users want to float by
+        default. Additionally, you can set your own rules in your config when
+        specifying the `floating_layout` with the `float_rules` parameter. E.g.
+            float_rules = {
+                "wmclass": ["Wine", "vlc"],
+                "role": ["About"],
+            }
+        The follwing keys are possible. (With corresponding X property)
+            "wmname"    (WM_NAME)
+            "role"      (WM_WINDOW_ROLE)
+            "wmclass"   (WM_CLASS)
+            "wmtype"    (see here: https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm45408774024288)
 
-            {'wname': WM_NAME, 'wmclass': WM_CLASS, 'role': WM_WINDOW_ROLE}
-
-        The keys must be specified as above.  You only need one, but
-        you need to provide the value for it.  When a new window is
-        opened it's ``match`` method is called with each of these
-        rules.  If one matches, the window will float.  The following
-        will float gimp and skype::
-
-            float_rules=[dict(wmclass="skype"), dict(wmclass="gimp")]
-
-        Specify these in the ``floating_layout`` in your config.
+        If you don't want to use the preset rules, you can override them with `override_default_float_rules=True`.
 
         Floating layout will try to center most of floating windows by
         default (until hints are properly implemented), but if you don't
@@ -113,6 +111,7 @@ class Floating(Layout):
         """Compares a window's properties with the `float_rules`.
         Returns `True` if window should float.
         """
+        print(win.window.get_wm_type())
         if (win.name in self.float_rules['wmname'] or
                 win.window.get_wm_window_role() in self.float_rules['role'] or
                 set(win.window.get_wm_class()) & self.float_rules['wmclass'] or

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -145,23 +145,19 @@ main = None
 follow_mouse_focus = True
 bring_front_click = False
 cursor_warp = False
-floating_layout = layout.Floating(float_rules=[
+floating_layout = layout.Floating(float_rules={
     # Run the utility of `xprop` to see the wm class and name of an X client.
-    {'wmclass': 'confirm'},
-    {'wmclass': 'dialog'},
-    {'wmclass': 'download'},
-    {'wmclass': 'error'},
-    {'wmclass': 'file_progress'},
-    {'wmclass': 'notification'},
-    {'wmclass': 'splash'},
-    {'wmclass': 'toolbar'},
-    {'wmclass': 'confirmreset'},  # gitk
-    {'wmclass': 'makebranch'},  # gitk
-    {'wmclass': 'maketag'},  # gitk
-    {'wname': 'branchdialog'},  # gitk
-    {'wname': 'pinentry'},  # GPG key password entry
-    {'wmclass': 'ssh-askpass'},  # ssh-askpass
-])
+    'wmclass': [
+        'confirmreset',  # gitk
+        'makebranch',  # gitk
+        'maketag',  # gitk
+        'ssh-askpass',  # ssh-askpass
+    ],
+    'wmname': [
+        'branchdialog',  # gitk
+        'pinentry',  # GPG key password entry
+    ],
+})
 auto_fullscreen = True
 focus_on_window_activation = "smart"
 


### PR DESCRIPTION
The Floating Layout has currently two parameters to specify the rules for floating windows. I think this is a bit confusing. Also it is not possible to have no floating windows all (Issue #1275).

This is a proposal to change this and let the user specify the different rules for floating with a single dictionary, e.g. like this.
```python
float_rules = {
    "wmclass": ["Wine", "vlc"],
    "role": ["About"],
    "wmtype": ["notification", "toolbar"],
    "wmname": ["appname"],
}
```
However, the current structure of `float_rules` is different, so this requires extra code to prevent old configs from breaking. If you don't like this, I will reconsider this. This is just the way that I find is the prettiest.

Also, I made another default rule which addresses issue  #1518. This is similar to what i3 uses.

If a user specifies `float_rules`, they are appended to preset rules. But the user can also override these.