### PR TITLE
keyboard: don't set keyboard every second

### DIFF
--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -97,7 +97,7 @@ class KeyboardLayout(base.InLoopPollText):
         Examples: "us", "us dvorak".  In case of error returns "unknown".
         """
         try:
-            command = 'setxkbmap -verbose 10'
+            command = 'setxkbmap -verbose 10 -query'
             setxkbmap_output = self.call_process(command.split(' '))
             keyboard = self.get_keyboard_layout(setxkbmap_output)
             return str(keyboard)


### PR DESCRIPTION
Without the -query parameter, setxkbmap causes a cascade of X events that
cause problems in other applications. Additionally, it re-sets custom
keyboard layouts, which is annoying :)

Closes #1616
Closes #1446

Signed-off-by: Tycho Andersen <tycho@tycho.ws>