### PR TITLE
windowname: escape text

### DIFF
--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -24,7 +24,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import bar, hook
+from libqtile import bar, hook, pangocffi
 from libqtile.widget import base
 
 
@@ -64,5 +64,6 @@ class WindowName(base._TextBox):
                 state = '_ '
             elif w.floating:
                 state = 'V '
-        self.text = "%s%s" % (state, w.name if w and w.name else " ")
+        unescaped = "%s%s" % (state, w.name if w and w.name else " ")
+        self.text = pangocffi.markup_escape_text(unescaped)
         self.bar.draw()


### PR DESCRIPTION
This is parsed as pango markup, so we need to escape it.

Closes #1685

Signed-off-by: Tycho Andersen <tycho@tycho.ws>