### PR TITLE
Move setup of qtile object within try/finally test block

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -944,7 +944,10 @@ class Connection:
         return Window(self, wid)
 
     def disconnect(self):
-        self.conn.disconnect()
+        try:
+            self.conn.disconnect()
+        except xcffib.ConnectionException:
+            logger.error("Failed to disconnect, connection already failed?")
         self._connected = False
 
     def flush(self):

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -179,8 +179,8 @@ class XCore(base.Core):
         """
         logger.debug("Adding io watch")
         self.qtile = qtile
-        fd = self.conn.conn.get_file_descriptor()
-        eventloop.add_reader(fd, self._xpoll)
+        self.fd = self.conn.conn.get_file_descriptor()
+        eventloop.add_reader(self.fd, self._xpoll)
 
     def remove_listener(self, eventloop: asyncio.AbstractEventLoop) -> None:
         """Remove the listener from the given event loop
@@ -189,8 +189,7 @@ class XCore(base.Core):
             The eventloop that had been setup for listening.
         """
         logger.debug("Removing io watch")
-        fd = self.conn.conn.get_file_descriptor()
-        eventloop.remove_reader(fd)
+        eventloop.remove_reader(self.fd)
         self.qtile = None
         self.conn.finalize()
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -287,6 +287,7 @@ class Qtile(CommandObject):
             self.graceful_shutdown()
 
         logger.debug('Stopping qtile')
+        self.core.remove_listener(self._eventloop)
         self._stopped_event.set()
 
     async def finalize(self):
@@ -314,8 +315,6 @@ class Qtile(CommandObject):
                 for bar in [screen.top, screen.bottom, screen.left, screen.right]:
                     if bar is not None:
                         bar.finalize()
-
-            self.core.remove_listener(self._eventloop)
         except:  # noqa: E722
             logger.exception('exception during finalize')
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -186,7 +186,7 @@ class Xephyr:
     def __enter__(self):
         try:
             self.start_xephyr()
-        except:
+        except:  # noqa: E722
             self.stop_xephyr()
             raise
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,6 +81,8 @@ class Retry:
                     return fn(*args, **kwargs)
                 except ignore_exceptions:
                     pass
+                except AssertionError:
+                    break
                 time.sleep(dt)
                 dt *= 1.5
             if self.return_on_fail:
@@ -91,14 +93,20 @@ class Retry:
 
 
 @Retry(ignore_exceptions=(xcffib.ConnectionException,), return_on_fail=True)
-def can_connect_x11(disp=':0'):
+def can_connect_x11(disp=':0', *, ok=None):
+    if ok is not None and not ok():
+        raise AssertionError()
+
     conn = xcffib.connect(display=disp)
     conn.disconnect()
     return True
 
 
 @Retry(ignore_exceptions=(ipc.IPCError,), return_on_fail=True)
-def can_connect_qtile(socket_path):
+def can_connect_qtile(socket_path, *, ok=None):
+    if ok is not None and not ok():
+        raise AssertionError()
+
     ipc_client = ipc.Client(socket_path)
     ipc_command = command_interface.IPCCommandInterface(ipc_client)
     client = command_client.InteractiveCommandClient(ipc_command)
@@ -176,7 +184,11 @@ class Xephyr:
         self.display = None
 
     def __enter__(self):
-        self.start_xephyr()
+        try:
+            self.start_xephyr()
+        except:
+            self.stop_xephyr()
+            raise
 
         return self
 
@@ -212,11 +224,13 @@ class Xephyr:
 
         self.proc = subprocess.Popen(args)
 
-        if can_connect_x11(self.display):
+        if can_connect_x11(self.display, ok=lambda: self.proc.poll() is None):
             return
+
+        # we wern't able to get a display up
+        if self.proc.poll() is None:
+            raise AssertionError("Unable to conncet to running Xephyr")
         else:
-            # we wern't able to get a display up
-            self.display = None
             raise AssertionError("Unable to start Xephyr, quit with return code {:d}".format(
                 self.proc.returncode
             ))
@@ -275,7 +289,7 @@ class Qtile:
         self.proc.start()
 
         # First, wait for socket to appear
-        if can_connect_qtile(self.sockfile):
+        if can_connect_qtile(self.sockfile, ok=lambda: not rpipe.poll()):
             ipc_client = ipc.Client(self.sockfile)
             ipc_command = command_interface.IPCCommandInterface(ipc_client)
             self.c = command_client.InteractiveCommandClient(ipc_command)
@@ -310,6 +324,7 @@ class Qtile:
             self.proc.join(10)
 
             if self.proc.is_alive():
+                print("Killing qtile forcefully", file=sys.stderr)
                 # desperate times... this probably messes with multiprocessing...
                 try:
                     os.kill(self.proc.pid, 9)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -464,8 +464,8 @@ def qtile(request, xephyr):
 
     with tempfile.NamedTemporaryFile() as f:
         sockfile = f.name
-        q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
         try:
+            q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
             q.start(config)
 
             yield q
@@ -477,9 +477,8 @@ def qtile(request, xephyr):
 def qtile_nospawn(request, xephyr):
     with tempfile.NamedTemporaryFile() as f:
         sockfile = f.name
-        q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
-
         try:
+            q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
             yield q
         finally:
             q.terminate()


### PR DESCRIPTION
Occasionally, when ctrl-C'ing the running test suite, it will cause the tests to hang and have to be killed manually. This seems to improve this behavior and better cleans up when the qtile object setup is cancelled.