### PR TITLE
Use additional async functionality in setup

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -236,18 +236,20 @@ class Qtile(CommandObject):
             logger.warning("importing dbus/gobject failed, dbus will not work.")
             self._glib_loop = None
 
-    async def async_loop(self):
+    async def async_loop(self) -> None:
+        """Run the event loop
+
+        Finalizes the Qtile instance on exit.
+        """
         try:
             await self._stopped_event.wait()
         finally:
             await self.finalize()
 
-    def loop(self):
-        self._eventloop.run_until_complete(self.async_loop())
+        self._eventloop.stop()
 
-        self._eventloop.close()
-        self._eventloop = None
-
+    def maybe_restart(self) -> None:
+        """If set, restart the qtile instance"""
         if self._restart:
             logger.warning('Restarting Qtile with os.execv(...)')
             os.execv(*self._restart)


### PR DESCRIPTION
Move more of the setup functionality into async. I think it'd be great if nothing needed to be passed a loop in the constructor and all of the async initialization could be called in async tasks, which would then be able to automatically get the running loop. Some additional refactoring could help with this. This may set us on a path that the Qtile object can be easily re-made from within the session manager if we can pull out enough of the direct loop handling from that.