### PR TITLE
base.deprecated does not come up in the logs

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -31,7 +31,6 @@
 
 import subprocess
 import threading
-import warnings
 from typing import Any, List, Tuple
 
 from libqtile import bar, configurable, confreader, drawer
@@ -627,7 +626,3 @@ class Mirror(_Widget):
 
     def button_press(self, x, y, button):
         self.reflects.button_press(x, y, button)
-
-
-def deprecated(msg):
-    warnings.warn(msg, DeprecationWarning)

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -23,6 +23,7 @@ import os
 
 from libqtile import bar
 from libqtile.images import Img
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -39,8 +40,8 @@ class Image(base._Widget, base.MarginMixin):
         # 'width' was replaced by 'length' since the widget can be installed in
         # vertical bars
         if width is not None:
-            base.deprecated('width kwarg or positional argument is '
-                            'deprecated. Please use length.')
+            logger.warning('width kwarg or positional argument is '
+                           'deprecated. Please use length.')
             length = width
 
         base._Widget.__init__(self, length, **config)

--- a/libqtile/widget/pacman.py
+++ b/libqtile/widget/pacman.py
@@ -17,6 +17,7 @@
 
 import subprocess
 
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -34,7 +35,7 @@ class Pacman(base.ThreadedPollText):
     ]
 
     def __init__(self, **config):
-        base.deprecated("Pacman is deprecated, please use CheckUpdates")
+        logger.warning("Pacman is deprecated, please use CheckUpdates")
         base.ThreadedPollText.__init__(self, **config)
         self.add_defaults(Pacman.defaults)
 

--- a/libqtile/widget/sep.py
+++ b/libqtile/widget/sep.py
@@ -23,6 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -44,8 +45,8 @@ class Sep(base._Widget):
         # 'height_percent' was replaced by 'size_percent' since the widget can
         # be installed in vertical bars
         if height_percent is not None:
-            base.deprecated('height_percent kwarg or positional argument is '
-                            'deprecated. Please use size_percent.')
+            logger.warning('height_percent kwarg or positional argument is '
+                           'deprecated. Please use size_percent.')
             config["size_percent"] = height_percent
 
         length = config.get("padding", 2) * 2 + config.get("linewidth", 1)

--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -25,6 +25,7 @@
 # SOFTWARE.
 
 from libqtile import bar
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -53,8 +54,8 @@ class Spacer(base._Widget):
         # 'width' was replaced by 'length' since the widget can be installed in
         # vertical bars
         if width is not None:
-            base.deprecated('width kwarg or positional argument is '
-                            'deprecated. Please use length.')
+            logger.warning('width kwarg or positional argument is '
+                           'deprecated. Please use length.')
             length = width
 
         base._Widget.__init__(self, length, **config)


### PR DESCRIPTION
Not sure why, but I figured out that I had deprecation errors due to my config, but they weren't showing up in my logs. @tych0 I know you made the `base.deprecated` function in the first place, do you think it's still needed? Or can we use `logger.warning` directly, as I'm doing here? Another option would be to use `logger.warning` inside `base.deprecated`, but using `logger.warning` directly sounds like a more intuitive option to me.