### PR TITLE
Revamp config and restart

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 import os
 import sys
+from typing import Optional
 
 from libqtile.backend import base
 
@@ -78,7 +79,7 @@ class Config:
             setattr(self, key, value)
 
     @classmethod
-    def from_file(cls, kore: base.Core, path: str):
+    def from_file(cls, path: str, kore: Optional[base.Core] = None):
         "Create a Config() object from the python file located at path."
         cnf = cls(file_path=path, kore=kore)
         cnf.load()
@@ -104,7 +105,8 @@ class Config:
             raise ConfigError(tb)
 
         self.update(**vars(config))
-        self.validate()
+        if self.kore:
+            self.validate()
 
     def validate(self) -> None:
         """

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -53,15 +53,21 @@ class Config:
         "wmname",
     ]
 
-    def __init__(self, file_path=None, **settings):
+    def __init__(self, file_path=None, kore=None, **settings):
         """Create a Config() object from settings
 
         Only attributes found in Config.settings_keys will be added to object.
         config attribute precedence is 1.) **settings 2.) self 3.) default_config
         """
+        self.file_path = file_path
+        self.kore = kore
+        self.update(**settings)
+
+    def update(self, *, fake_screens=None, **settings):
         from libqtile.resources import default_config
 
-        self.file_path = file_path
+        if fake_screens:
+            self.fake_screens = fake_screens
 
         default = vars(default_config)
         for key in self.settings_keys:
@@ -70,20 +76,16 @@ class Config:
             except KeyError:
                 value = getattr(self, key, default[key])
             setattr(self, key, value)
-        self._init_fake_screens(**settings)
-
-    def _init_fake_screens(self, **settings):
-        " Initiaize fake_screens if they are set."
-        try:
-            value = settings['fake_screens']
-            setattr(self, 'fake_screens', value)
-        except KeyError:
-            pass
 
     @classmethod
     def from_file(cls, kore: base.Core, path: str):
         "Create a Config() object from the python file located at path."
-        name = os.path.splitext(os.path.basename(path))[0]
+        cnf = cls(file_path=path, kore=kore)
+        cnf.load()
+        return cnf
+
+    def load(self):
+        name = os.path.splitext(os.path.basename(self.file_path))[0]
 
         # Make sure we'll import the latest version of the config
         try:
@@ -92,24 +94,24 @@ class Config:
             pass
 
         try:
-            sys.path.insert(0, os.path.dirname(path))
+            sys.path.insert(0, os.path.dirname(self.file_path))
             config = __import__(name)  # noqa: F811
         except Exception:
             import traceback
             from libqtile.log_utils import logger
-            logger.exception('Could not import config file %r', path)
+            logger.exception('Could not import config file %r', self.file_path)
             tb = traceback.format_exc()
             raise ConfigError(tb)
-        cnf = cls(file_path=path, **vars(config))
-        cnf.validate(kore)
-        return cnf
 
-    def validate(self, kore: base.Core) -> None:
+        self.update(**vars(config))
+        self.validate()
+
+    def validate(self) -> None:
         """
             Validate the configuration against the core.
         """
-        valid_keys = kore.get_keys()
-        valid_mods = kore.get_modifiers()
+        valid_keys = self.kore.get_keys()
+        valid_mods = self.kore.get_modifiers()
         # we explicitly do not want to set self.keys and self.mouse above,
         # because they are dynamically resolved from the default_config. so we
         # need to ignore the errors here about missing attributes.

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1088,7 +1088,7 @@ class Qtile(CommandObject):
             self.config.load()
         except Exception as error:
             logger.error("Preventing restart because of a configuration error: {}".format(error))
-            send_notification("Configuration error", str(error))
+            send_notification("Configuration error", str(error.__context__))
             return
 
         argv = [sys.executable] + sys.argv

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1082,6 +1082,14 @@ class Qtile(CommandObject):
         d.state = modmasks
         self.core.handle_KeyPress(d)
 
+    def cmd_validate_config(self):
+        try:
+            self.config.load()
+        except Exception as error:
+            send_notification("Configuration check", str(error.__context__))
+        else:
+            send_notification("Configuration check", "No error found!")
+
     def cmd_restart(self):
         """Restart qtile"""
         try:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -38,7 +38,6 @@ import xcffib.xproto
 
 from libqtile import command_interface, hook, utils, window
 from libqtile.backend.x11 import xcbq
-from libqtile.backend.x11.xcore import XCore
 from libqtile.command_client import InteractiveCommandClient
 from libqtile.command_interface import IPCCommandServer, QtileCommandInterface
 from libqtile.command_object import (
@@ -49,7 +48,6 @@ from libqtile.command_object import (
 from libqtile.config import Click, Drag, Match, Rule
 from libqtile.config import ScratchPad as ScratchPadConfig
 from libqtile.config import Screen
-from libqtile.confreader import Config, ConfigError
 from libqtile.dgroups import DGroups
 from libqtile.extension.base import _Extension
 from libqtile.group import _Group
@@ -59,32 +57,6 @@ from libqtile.scratchpad import ScratchPad
 from libqtile.state import QtileState
 from libqtile.utils import get_cache_dir, send_notification
 from libqtile.widget.base import _Widget
-
-
-def validate_config(file_path):
-    """
-    Validate a configuration file.
-
-    This function reloads and imports the given configuration file.
-    It re-raises a ConfigError with a detailed message for any caught exception.
-    """
-    output = [
-        "The configuration file '",
-        file_path,
-        "' generated the following error:\n\n",
-    ]
-
-    try:
-        Config.from_file(XCore(), file_path)
-
-    except ConfigError as error:
-        output.append(str(error))
-        raise ConfigError("".join(output))
-
-    except Exception as error:
-        # Handle SyntaxError and the likes
-        output.append("{}: {}".format(sys.exc_info()[0].__name__, str(error)))
-        raise ConfigError("".join(output))
 
 
 def _import_module(module_name, dir_path):
@@ -1113,9 +1085,9 @@ class Qtile(CommandObject):
     def cmd_restart(self):
         """Restart qtile"""
         try:
-            validate_config(self.config.file_path)
-        except ConfigError as error:
-            logger.error("Preventing restart because of a configuration error: " + str(error))
+            self.config.load()
+        except Exception as error:
+            logger.error("Preventing restart because of a configuration error: {}".format(error))
             send_notification("Configuration error", str(error))
             return
 

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -107,8 +107,8 @@ def make_qtile():
     options = parser.parse_args()
     log_level = getattr(logging, options.log_level)
     init_log(log_level=log_level)
-
     kore = xcore.XCore()
+
     try:
         if not path.isfile(options.configfile):
             try:
@@ -124,7 +124,7 @@ def make_qtile():
                 logger.exception('Failed to copy default_config.py to %s: (%s)',
                                  options.configfile, e)
 
-        config = confreader.Config.from_file(kore, options.configfile)
+        config = confreader.Config.from_file(options.configfile, kore=kore)
     except Exception as e:
         logger.exception('Error while reading config file (%s)', e)
         config = confreader.Config()

--- a/scripts/gen-keybinding-img
+++ b/scripts/gen-keybinding-img
@@ -356,12 +356,11 @@ class MInfo(KInfo):
 
 
 def get_kb_map(config_path=None):
-    from libqtile.backend.x11.xcore import XCore
     from libqtile.confreader import Config
 
-    c = Config()
-    if config_path is not None:
-        c = Config.from_file(XCore(), config_path)
+    c = Config(config_path)
+    if config_path:
+        c.load()
 
     kb_map = {}
     for key in c.keys:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -32,14 +32,14 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 
 def test_validate():
     xc = xcore.XCore()
-    f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
     f.validate()
     f.keys[0].key = "nonexistent"
     with pytest.raises(confreader.ConfigError):
         f.validate()
 
     f.keys[0].key = "x"
-    f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
     f.keys[0].modifiers = ["nonexistent"]
     with pytest.raises(confreader.ConfigError):
         f.validate()
@@ -47,20 +47,17 @@ def test_validate():
 
 
 def test_syntaxerr():
-    xc = xcore.XCore()
     with pytest.raises(confreader.ConfigError):
-        confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "syntaxerr.py"))
+        confreader.Config.from_file(os.path.join(tests_dir, "configs", "syntaxerr.py"))
 
 
 def test_basic():
-    xc = xcore.XCore()
-    f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
     assert f.keys
 
 
 def test_falls_back():
-    xc = xcore.XCore()
-    f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
 
     # We just care that it has a default, we don't actually care what the
     # default is; don't assert anything at all about the default in case

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -33,16 +33,16 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 def test_validate():
     xc = xcore.XCore()
     f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
-    f.validate(xc)
+    f.validate()
     f.keys[0].key = "nonexistent"
     with pytest.raises(confreader.ConfigError):
-        f.validate(xc)
+        f.validate()
 
     f.keys[0].key = "x"
     f = confreader.Config.from_file(xc, os.path.join(tests_dir, "configs", "basic.py"))
     f.keys[0].modifiers = ["nonexistent"]
     with pytest.raises(confreader.ConfigError):
-        f.validate(xc)
+        f.validate()
     f.keys[0].modifiers = ["shift"]
 
 


### PR DESCRIPTION
The context of this PR is that for some reason, validating the config for each `cmd_restart` isn't a good idea with my config, as it used `cmd_restart` as a screen change hook, and it made qtile enter into an infinite restart loop. The easy way would have been to just merge the last commit of this PR, or to add a `force` argument to `cmd_restart`, but I really wanted also to simplify the validation mechanism and add a `cmd_validate_config` also.

The PR could have been separated in three PR:
* Revamp confreader
* Add cmd_validate_config
* Decouple the cmd_restart from the actual restart

I decided to make it a single PR because the last two points depend on the first one. I highly recommend to any potential reviewer to go through all commits one by one rather than looking at the overall changes.