### PR TITLE
setup: use setuptools_scm to get git hash in version number

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 
 import os
-import pkg_resources
+import setuptools_scm
 import sys
 from unittest.mock import MagicMock
 
@@ -98,7 +98,7 @@ copyright = u'2008-2020, Aldo Cortesi and contributers'
 # built documents.
 #
 # The short X.Y version.
-version = pkg_resources.get_distribution("qtile").version
+version = setuptools_scm.get_version(root="..")
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import os
+import pkg_resources
 import sys
 from unittest.mock import MagicMock
 
@@ -97,7 +98,7 @@ copyright = u'2008-2020, Aldo Cortesi and contributers'
 # built documents.
 #
 # The short X.Y version.
-version = '0.15.0'
+version = pkg_resources.get_distribution("qtile").version
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+setuptools_scm
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-seqdiag

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = qtile
-version = 0.15.0
 url = http://qtile.org
 license = MIT
 license_file = LICENSE
@@ -42,6 +41,7 @@ setup_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 0.9.0
   setuptools >= 40.5.0
+  setuptools_scm >= 3.2.0
 install_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 0.9.0

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ def get_cffi_modules():
 
 setup(
     cmdclass={'install': CheckCairoXcb},
+    use_scm_version=True,
     cffi_modules=get_cffi_modules(),
     install_requires=["cffi>=1.0.0"],
 )


### PR DESCRIPTION
Fixes #1681.

Rationale:

  - use [setuptools_scm](https://pypi.org/project/setuptools-scm), stick to [PEP-0440](https://www.python.org/dev/peps/pep-0440) format

  - in sphinx, use version number [from metadata](https://github.com/pypa/setuptools_scm#usage-from-sphinx). If this turns out not to be what one wants, we can set the version [in setup.py](https://www.sphinx-doc.org/en/master/usage/advanced/setuptools.html).