### PR TITLE
Multiple borders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Qtile xxxxxx, released xxxxxxxxxx:
+    * features
+        - All layouts will accept a list of colors for border_* options with which
+          they will draw multiple borders on the appropriate windows.
+
 Qtile 0.18.0, released 2021-07-04:
     !!! Config breakage !!!
         - The `qtile` entry point doesn't run `qtile start` by default anymore

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ MOCK_MODULES = [
     'xcffib',
     'xcffib.randr',
     'xcffib.render',
+    'xcffib.wrappers',
     'xcffib.xfixes',
     'xcffib.xinerama',
     'xcffib.xproto',

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -271,8 +271,8 @@ class Window(_Window, metaclass=ABCMeta):
     def get_pid(self) -> int:
         """Return the PID that owns the window."""
 
-    def paint_borders(self, color, width) -> None:
-        """Paint the window borders with the given color and width"""
+    def paint_borders(self, color: Union[ColorType, List[ColorType]], width: int) -> None:
+        """Paint the window borders with the given color(s) and width"""
 
     @abstractmethod
     def cmd_focus(self, warp: bool = True) -> None:

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -160,30 +160,36 @@ class Output(HasListeners):
         transform_matrix = self.transform_matrix
 
         if window.borderwidth:
-            bw = window.borderwidth * scale
+            bw = int(window.borderwidth * scale)
 
             if surface == window.surface.surface:
-                bc = window.bordercolor
-                border = Box(
-                    int(x),
-                    int(y),
-                    int(width + bw * 2),
-                    int(bw),
-                )
-                x += bw
-                y += bw
-                self.renderer.render_rect(border, bc, transform_matrix)  # Top border
-                border.y = int(y + height)
-                self.renderer.render_rect(border, bc, transform_matrix)  # Bottom border
-                border.y = int(y - bw)
-                border.width = int(bw)
-                border.height = int(height + bw * 2)
-                self.renderer.render_rect(border, bc, transform_matrix)  # Left border
-                border.x = int(x + width)
-                self.renderer.render_rect(border, bc, transform_matrix)  # Right border
-            else:
-                x += bw
-                y += bw
+                outer_w = width + bw * 2
+                outer_h = height + bw * 2
+                num = len(window.bordercolor)
+                bws = [bw // num] * num
+                for i in range(bw % num):
+                    bws[i] += 1
+                coord = 0
+                for i, bc in enumerate(window.bordercolor):
+                    border = Box(
+                        int(x + coord),
+                        int(y + coord),
+                        int(outer_w - coord * 2),
+                        int(bws[i]),
+                    )
+                    self.renderer.render_rect(border, bc, transform_matrix)  # Top border
+                    border.y = int(y + outer_h - bws[i] - coord)
+                    self.renderer.render_rect(border, bc, transform_matrix)  # Bottom border
+                    border.y = int(y + coord)
+                    border.width = int(bws[i])
+                    border.height = int(outer_h - coord * 2)
+                    self.renderer.render_rect(border, bc, transform_matrix)  # Left border
+                    border.x = int(x + outer_w - bws[i] - coord)
+                    self.renderer.render_rect(border, bc, transform_matrix)  # Right border
+                    coord += bws[i]
+
+            x += bw
+            y += bw
 
         box = Box(
             int(x),

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -83,7 +83,7 @@ class Window(base.Window, HasListeners):
         self._mapped: bool = False
         self.x = 0
         self.y = 0
-        self.bordercolor: ffi.CData = _rgb((0, 0, 0, 1))
+        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self.opacity: float = 1.0
         self._outputs: List[Output] = []
 
@@ -294,9 +294,14 @@ class Window(base.Window, HasListeners):
             if switch_group:
                 group.cmd_toscreen(toggle=False)
 
-    def paint_borders(self, color: ColorType, width) -> None:
+    def paint_borders(self, color: Union[ColorType, List[ColorType]], width) -> None:
         if color:
-            self.bordercolor = _rgb(color)
+            if isinstance(color, list):
+                if len(color) > width:
+                    color = color[:width]
+                self.bordercolor = [_rgb(c) for c in color]
+            else:
+                self.bordercolor = [_rgb(color)]
         self.borderwidth = width
 
     @property
@@ -720,7 +725,7 @@ class Static(base.Static, Window):
         self.x = 0
         self.y = 0
         self.borderwidth: int = 0
-        self.bordercolor: ffi.CData = _rgb((0, 0, 0, 1))
+        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self.opacity: float = 1.0
         self._outputs: List[Output] = []
         self._float_state = FloatStates.FLOATING

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -148,8 +148,8 @@ class Bsp(Layout):
         Key([mod], "Return", lazy.layout.toggle_split()),
     """
     defaults = [
-        ("border_focus", "#881111", "Border colour for the focused window."),
-        ("border_normal", "#220000", "Border colour for un-focused windows."),
+        ("border_focus", "#881111", "Border colour(s) for the focused window."),
+        ("border_normal", "#220000", "Border colour(s) for un-focused windows."),
         ("border_width", 2, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])."),
         ("ratio", 1.6,

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -111,12 +111,12 @@ class Columns(Layout):
         Key([mod], "n", lazy.layout.normalize()),
     """
     defaults = [
-        ("border_focus", "#881111", "Border colour for the focused window."),
-        ("border_normal", "#220000", "Border colour for un-focused windows."),
+        ("border_focus", "#881111", "Border colour(s) for the focused window."),
+        ("border_normal", "#220000", "Border colour(s) for un-focused windows."),
         ("border_focus_stack", "#881111",
-         "Border colour for the focused window in stacked columns."),
+         "Border colour(s) for the focused window in stacked columns."),
         ("border_normal_stack", "#220000",
-         "Border colour for un-focused windows in stacked columns."),
+         "Border colour(s) for un-focused windows in stacked columns."),
         ("border_width", 2, "Border width."),
         ("border_on_single", False, "Draw a border when there is one only window."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])."),

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -58,8 +58,8 @@ class Floating(Layout):
     ]
 
     defaults = [
-        ("border_focus", "#0000ff", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("max_border_width", 0, "Border width for maximize."),
         ("fullscreen_border_width", 0, "Border width for fullscreen."),

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -37,8 +37,8 @@ class Matrix(_SimpleLayoutBase):
     """
 
     defaults = [
-        ("border_focus", "#0000ff", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
     ]

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -207,8 +207,8 @@ class GridInfo:
 class RatioTile(_SimpleLayoutBase):
     """Tries to tile all windows in the width/height ratio passed in"""
     defaults = [
-        ("border_focus", "#0000ff", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("ratio", GOLDEN_RATIO, "Ratio of the tiles"),

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -55,8 +55,8 @@ class Stack(Layout):
     Unlike the columns layout the number of stacks is fixed.
     """
     defaults = [
-        ("border_focus", "#0000ff", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -45,8 +45,8 @@ class Tile(_SimpleLayoutBase):
     """
 
     defaults = [
-        ("border_focus", "#0000ff", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("ratio", 0.618,

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -84,8 +84,8 @@ class VerticalTile(_SimpleLayoutBase):
     """
 
     defaults = [
-        ('border_focus', '#FF0000', 'Border color for the focused window.'),
-        ('border_normal', '#FFFFFF', 'Border color for un-focused windows.'),
+        ('border_focus', '#FF0000', 'Border color(s) for the focused window.'),
+        ('border_normal', '#FFFFFF', 'Border color(s) for un-focused windows.'),
         ('border_width', 1, 'Border width.'),
         ('margin', 0, 'Border margin (int or list of ints [N E S W]).'),
     ]

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -145,8 +145,8 @@ class MonadTall(_SimpleLayoutBase):
     _med_ratio = 0.5
 
     defaults = [
-        ("border_focus", "#ff0000", "Border colour for the focused window."),
-        ("border_normal", "#000000", "Border colour for un-focused windows."),
+        ("border_focus", "#ff0000", "Border colour(s) for the focused window."),
+        ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 2, "Border width."),
         ("single_border_width", None, "Border width for single window"),
         ("single_margin", None, "Margin size for single window"),

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -100,7 +100,7 @@ for i in groups:
     ])
 
 layouts = [
-    layout.Columns(border_focus_stack='#d75f5f'),
+    layout.Columns(border_focus_stack=['#d75f5f', '#8f3d3d'], border_width=4),
     layout.Max(),
     # Try more layouts by unleashing below layouts.
     # layout.Stack(num_stacks=2),

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ setup_requires =
 install_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 0.9.0
-  xcffib >= 0.8.1
+  xcffib >= 0.10.1
 tests_require =
   flake8
   pep8-naming

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -452,3 +452,25 @@ def test_cycle_layouts(manager):
         # Use manager.c.layout.info()['name'] in the assertion message, so we
         # know which layout is buggy
         assert manager.c.window.info()['name'] == "three", manager.c.layout.info()['name']
+
+
+class AllLayoutsMultipleBorders(AllLayoutsConfig):
+    """
+    Like AllLayouts, but all the layouts have border_focus set to a list of colors.
+    """
+    layouts = [
+        layout_cls(border_focus=['#000' '#111', '#222', '#333', '#444'])
+        for layout_name, layout_cls in AllLayoutsConfig.iter_layouts()
+    ]
+
+
+@pytest.mark.parametrize("manager", [AllLayoutsMultipleBorders], indirect=True)
+def test_multiple_borders(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+
+    initial_layout_name = manager.c.layout.info()['name']
+    while True:
+        manager.c.next_layout()
+        if manager.c.layout.info()['name'] == initial_layout_name:
+            break

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     pytest >= 6.2.1
     pytest-cov >= 2.10.1
     setuptools >= 40.5.0
-    xcffib >= 0.8.1
+    xcffib >= 0.10.1
     bowler
     xkbcommon >= 0.3
     pywayland >= 0.4.4
@@ -85,7 +85,7 @@ commands =
 deps =
     mypy
     bowler
-    xcffib >= 0.8.1
+    xcffib >= 0.10.1
     pytest >= 6.2.1
     types-python-dateutil
     types-pytz


### PR DESCRIPTION
This PR lets qtile draw multiple borders on windows. Changes:

`xcbq.Window` does all border handling itself rather than `libqtile.window.Window` in a `paint_borders` method, and it gets a `set_borderpixmap` method which accepts a pixmap which will be used to draw window borders. A fun side effect of this is that the `paint_borders` method can be overriden for alternative border styles ([proof of concept](https://github.com/m-col/qtools/blob/master/qtools/borders/borders.py)).

Multiple borders can be painted by passing a layout with "border_width" parameter a list/tuple of ints and the same number of colours to any colour parameters the layout has (i.e. any other "border_*" parameter). Borders can therefore be different widths. The parameters correspond to borders from outside inward. As before, layouts will accept an int width or str colour so configs are not broken; they are always converted to tuples when the layout is instantiated. Tuples are used so that `Qtile.color_pixel` will accept them (lru_cache needs hashable args).

All layouts that use borders have been updated to allow for multiple borders.