### PR TITLE
Fix missing key in song_info for mpd2 widget

### DIFF
--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -341,7 +341,7 @@ class Mpd2(base.ThreadPoolText):
         if not isinstance(fmt, str):
             fmt = str(fmt)
 
-        formatted = fmt.format(**song_info)
+        formatted = fmt.format_map(song_info)
 
         if self.color_progress and status['state'] != 'stop':
             try:


### PR DESCRIPTION
When a key is not in `song_info` it results in the following error:
```
2020-05-01 10:39:18,485 ERROR libqtile base.py:on_done():L522 poll() raised exceptions, not rescheduling
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/libqtile/widget/base.py", line 519, in on_done
    result = future.result()
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3/dist-packages/libqtile/widget/mpd2widget.py", line 232, in poll
    return self.update_status()
  File "/usr/lib/python3/dist-packages/libqtile/widget/mpd2widget.py", line 243, in update_status
    return self.formatter(status, current_song)
  File "/usr/lib/python3/dist-packages/libqtile/widget/mpd2widget.py", line 343, in formatter
    formatted = fmt.format(**song_info)
KeyError: 'artist'
```
`song_info` should already handle missing keys since it is a `collections.defaultdict` but `str.format_map` must be used to not copy it to a new dict.