### PR TITLE
Improve closing of X connection file descriptor

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -287,7 +287,6 @@ class Qtile(CommandObject):
             self.graceful_shutdown()
 
         logger.debug('Stopping qtile')
-        self.core.remove_listener(self._eventloop)
         self._stopped_event.set()
 
     async def finalize(self):
@@ -304,7 +303,6 @@ class Qtile(CommandObject):
                 pass
 
         try:
-
             for w in self.widgets_map.values():
                 w.finalize()
 
@@ -317,6 +315,7 @@ class Qtile(CommandObject):
                         bar.finalize()
         except:  # noqa: E722
             logger.exception('exception during finalize')
+            self.core.remove_listener()
 
     def _process_fake_screens(self):
         """


### PR DESCRIPTION
The X connection file descriptor should be kept open when closing qtile
normally until the very end.  When we catch an error in the poll loop
and there is a connection error, then we should immediately remove the
watch on the file.