### PR TITLE
Makefile: don't delete coveragerc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 
 .PHONY: clean
 clean:
-	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/ .coverage*
+	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/
 
 # This is a little ugly: we want to be able to have users just run
 # 'python setup.py install' to install qtile, but we would also like to install


### PR DESCRIPTION
Now that we're doing all this stuff inside tox, we don't need to clean
up .coverage files at all anyway, and this deleted .coveragerc which we
probably don't want.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>