### PR TITLE
manager: fire setgroup hook when changing screens

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,3 +27,4 @@ include bin/iqshell
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude stubs *

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -822,6 +822,7 @@ class Qtile(CommandObject):
         self.current_screen = self.screens[n]
         if old != self.current_screen:
             hook.fire("current_screen_change")
+            hook.fire("setgroup")
             old.group.layout_all()
             self.current_group.focus(self.current_window, warp)
 


### PR DESCRIPTION
When changing screens, the group has necessarily changed to something else,
since we can't display the same group in two places. So let's fire the
setgroup hook.

We need to do this, since update_net_desktops() is subscribed to setgroup,
and it's the thing that updates the X atom state to indicate to other
clients what group is currently focused. This means we'll get the correct
state on restart after re-focusing with a mouse, and also that clients that
query this state will get the right information.

Closes #1712

Signed-off-by: Tycho Andersen <tycho@tycho.ws>