### PR TITLE
Fixed YahooWeather-widget.

### DIFF
--- a/libqtile/widget/yahoo_weather.py
+++ b/libqtile/widget/yahoo_weather.py
@@ -160,14 +160,10 @@ class YahooWeather(GenPollUrl):
     def __init__(self, **config):
         GenPollUrl.__init__(self, **config)
         self.add_defaults(YahooWeather.defaults)
-        self._url = None
         self.headers.update(HEADER)
 
     @property
     def url(self):
-        if self._url:
-            return self._url
-
         if not self.woeid and not self.location and not self.coordinates:
             return None
 
@@ -194,8 +190,7 @@ class YahooWeather(GenPollUrl):
         }
         params.update(oauth)
 
-        self._url = QUERY_URL + urlencode(params) + '%26'
-        return self._url
+        return QUERY_URL + urlencode(params) + '%26'
 
     def flatten_json(self, obj):
         out = {}

--- a/libqtile/widget/yahoo_weather.py
+++ b/libqtile/widget/yahoo_weather.py
@@ -26,10 +26,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import requests
 import json
-from requests_oauthlib import OAuth1
 from urllib.parse import urlencode
+
+import requests
+from requests_oauthlib import OAuth1
 
 from libqtile.widget import base
 

--- a/libqtile/widget/yahoo_weather.py
+++ b/libqtile/widget/yahoo_weather.py
@@ -212,21 +212,58 @@ class YahooWeather(GenPollUrl):
         data['units_temperature'] = 'C' if self.metric else 'F'
 
         # symbols: https://unicode-search.net/unicode-namesearch.pl?term=RAIN
-        # TODO: There are 47 different conditions (see Yahoos documentation).
         condition_mapping = {
-            'Clear': '🌞',  # Sun
-            'Overcast clouds': '🌥',  # Sun behind cloud
-            'Few clouds': '🌤',  # Sun with small cloud
-            'Light rain': '🌧',  # Cloud with rain
-
-            'Cloud with snow': '🌨',
-            'Cloud with lightning': '🌩',
-            'Thundercloid and rain': '⛈',
-            'Sun behind cloud with rain': '🌦',
-            'Sun behind cloud': '🌥',
+            0: '🌪',  # tornado
+            #  1: '',  # tropical storm
+            #  2: '',  # hurricane
+            3: '⛈',  # severe thunderstorms
+            4: '⛈',  # thunderstorms
+            #  5: '',  # mixed rain and snow
+            #  6: '',  # mixed rain and sleet
+            #  7: '',  # mixed snow and sleet
+            #  8: '',  # freezing drizzle
+            #  9: '',  # drizzle
+            # 10: '',  # freezing rain
+            11: '🌧',  # showers
+            12: '🌧',  # rain
+            # 13: '',  # snow flurries
+            # 14: '',  # light snow showers
+            # 15: '',  # blowing snow
+            16: '❄',  # snow
+            # 17: '',  # hail
+            # 18: '',  # sleet
+            # 19: '',  # dust
+            20: '🌫',  # foggy
+            # 21: '',  # haze
+            # 22: '',  # smoky
+            # 23: '',  # blustery
+            24: '🍃',  # windy
+            # 25: '',  # cold
+            26: '☁',  # cloudy
+            27: '⛅',  # mostly cloudy (night)
+            28: '⛅',  # mostly cloudy (day)
+            29: '🌤',  # partly cloudy (night)
+            30: '🌤',  # partly cloudy (day)
+            31: '🌑',  # clear (night)
+            32: '☼',  # sunny
+            33: '🌑',  # fair (night)
+            34: '☼',  # fair (day)
+            # 35: '',  # mixed rain and hail
+            # 36: '',  # hot
+            37: '⛈',  # isolated thunderstorms
+            38: '⛈',  # scattered thunderstorms
+            # 39: '',  # scattered showers (day)
+            40: '⛆',  # heavy rain
+            # 41: '',  # scattered snow showers (day)
+            # 42: '',  # heavy snow
+            # 43: '',  # blizzard
+            # 44: '',  # not available
+            # 45: '',  # scattered showers (night)
+            # 46: '',  # scattered snow showers (night)
+            47: '⛈',  # scattered thundershowers
         }
         data['current_observation_condition_symbol'] = condition_mapping.get(
-            data['current_observation_condition_text'],
+            data['current_observation_condition_code'],
             data['current_observation_condition_text']
         )
 


### PR DESCRIPTION
This is a rework of the YahooWeather-widget. Since I had never interacted with Yahoos API before, I used the Cinnamon weather-applet by [@mockturtl](https://github.com/linuxmint/cinnamon-spices-applets/tree/master/weather%40mockturtl) as a reference.

The format options have mostly changed since the widget has last been worked on, but I didn't want to map old and new but instead just have the keys be auto-generated from the received json-data in the hopes of keeping the widget work as long as possible.

There is a caveat here: I am new to Qtiles code (I have only switched to Qtile four days ago) *and* PyCharm doesn't really work with the current release (#1548), so there will be code conventions I haven't fully adhered to. Also, I saw that the latest changes to the file included a reordering of the imports - it is very likely that I have ordered them wrong, but I didn't see any guidelines for this.

Any kind of feedback is welcome!

Fixes: #899