### PR TITLE
Adds group...toscreen() toggle documentation.

### DIFF
--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -73,7 +73,10 @@ Group functions
     * - ``lazy.screen.toggle_group()``
       - Move to the last visited group
     * - ``lazy.group["group_name"].toscreen()``
-      - Move to the group called ``group_name``
+      - Move to the group called ``group_name``.
+        Takes an optional ``toggle`` parameter (defaults to True).
+        If this group is already on the screen, then the group is toggled 
+        with last used
     * - ``lazy.layout.increase_ratio()``
       - Increase the space for master window at the expense of slave windows
     * - ``lazy.layout.decrease_ratio()``

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -364,7 +364,8 @@ class _Group(CommandObject):
         screen :
             Screen offset. If not specified, we assume the current screen.
         toggle :
-            If this group is already on the screen, then toggle group.
+            If this group is already on the screen, then the group is toggled
+            with last used
 
         Examples
         ========


### PR DESCRIPTION
Adds a small bit of text to the lazy.group["group_name"].toscreen() toggle documentation, explaining the toggle.