### PR TITLE
add config example on how to use widget mouse_callbacks

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -105,7 +105,6 @@ class _Widget(CommandObject, configurable.Configurable):
     When the clock widget receives a click with button 1, the ``open_calendar`` function
     will be executed. Callbacks can be assigned to other buttons by adding more entries
     to the passed dictionary.
-
     """
     orientations = ORIENTATION_BOTH
     offsetx = None

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -93,9 +93,19 @@ class _Widget(CommandObject, configurable.Configurable):
     have been configured.
 
     Callback functions can be assigned to button presses by passing a dict to the
-    'callbacks' kwarg. For example: {'Button1': func} will execute func when the widget
-    receives a button 1 press. The Qtile instance of passed as the only argument to the
-    callback functions.
+    'callbacks' kwarg.
+
+    For example::
+
+        def open_calendar(qtile):
+            qtile.cmd_spawn('gsimplecal next_month')
+
+        clock = widget.Clock(mouse_callbacks={'Button1': open_calendar})
+
+    When the clock widget receives a click with button 1, the open_calendar function
+    will be executed. Callbacks can be assigned to other buttons by adding more entries
+    to the passed dictionary.
+
     """
     orientations = ORIENTATION_BOTH
     offsetx = None

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -102,7 +102,7 @@ class _Widget(CommandObject, configurable.Configurable):
 
         clock = widget.Clock(mouse_callbacks={'Button1': open_calendar})
 
-    When the clock widget receives a click with button 1, the open_calendar function
+    When the clock widget receives a click with button 1, the ``open_calendar`` function
     will be executed. Callbacks can be assigned to other buttons by adding more entries
     to the passed dictionary.
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -95,7 +95,9 @@ class _Widget(CommandObject, configurable.Configurable):
     Callback functions can be assigned to button presses by passing a dict to the
     'callbacks' kwarg.
 
-    For example::
+    For example:
+
+    .. code-block:: python
 
         def open_calendar(qtile):
             qtile.cmd_spawn('gsimplecal next_month')


### PR DESCRIPTION
re: #1713 

This just expands the Widget docstring slightly to show an example of how to use `mouse_callbacks` in one's config.py.