### PR TITLE
Fix docs

### DIFF
--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -182,8 +182,8 @@ class QtileModule(SimpleDirectiveMixin, Directive):
 
         for item in dir(module):
             obj = import_object(self.arguments[0], item)
-            if not inspect.isclass(obj) and (BaseClass and
-                not isinstance(obj, BaseClass)):
+            if not inspect.isclass(obj) or (BaseClass and
+                not issubclass(obj, BaseClass)):
                 continue
 
             context = {

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -21,6 +21,7 @@
 import functools
 import importlib
 import os
+import sys
 import traceback
 import warnings
 from shutil import which
@@ -197,6 +198,9 @@ def safe_import(module_names, class_name, globals_, fallback=None):
 
     The globals are filled with a proxy function so that the module is imported
     only if the class is being instanciated.
+
+    An exception is made when the documentation is being built with Sphinx, in
+    which case the class is eagerly imported, for inspection.
     """
     module_path = '.'.join(module_names)
     if type(class_name) is list:
@@ -208,7 +212,10 @@ def safe_import(module_names, class_name, globals_, fallback=None):
         cls = import_class(module_path, class_name, fallback)
         return cls(*args, **kwargs)
 
-    globals_[class_name] = class_proxy
+    if "sphinx" in sys.modules:
+        globals_[class_name] = import_class(module_path, class_name, fallback)
+    else:
+        globals_[class_name] = class_proxy
 
 
 def send_notification(title, message, urgent=False, timeout=10000):


### PR DESCRIPTION
The first commit fixes the `:baseclass:` logic, which I think never actually worked.

The second one fixes #1731: since we're now importing widgets (and extensions) lazily through a function proxy, Sphinx can not inspect the classes behind the proxies. I'm not fond of looking into `sys.modules`, but I couldn't find a simpler solution. If anyone has a better idea, I'm all ears! 