### PR TITLE
tests: turn warnings into errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     setuptools >= 40.5.0
     xcffib >= 0.8.1
 commands =
-    python setup.py pytest --addopts "--cov libqtile --cov-report term-missing {posargs}"
+    python setup.py pytest --addopts "-Wall --cov libqtile --cov-report term-missing {posargs}"
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
Recently, we saw some raciness in the tests where they would pass sometimes
and fail others. The test suite was actually telling us there was a problem
even when things passed, with warnings like:

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/selectors.py:74: ResourceWarning: unclosed <socket.socket fd=28, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/tmpmi0mlzq0>
    raise KeyError("{!r} is not registered".format(fileobj)) from None

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py:666: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=28 read=idle write=<idle, bufsize=0>>
    source=self)

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/selectors.py:74: ResourceWarning: unclosed <socket.socket fd=29, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/tmpmi0mlzq0>
    raise KeyError("{!r} is not registered".format(fileobj)) from None

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py:666: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=29 read=idle write=<idle, bufsize=0>>
    source=self)

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/selectors.py:74: ResourceWarning: unclosed <socket.socket fd=30, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/tmp60gc8deo>
    raise KeyError("{!r} is not registered".format(fileobj)) from None

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py:666: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=30 read=idle write=<idle, bufsize=0>>
    source=self)

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/selectors.py:74: ResourceWarning: unclosed <socket.socket fd=31, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/tmp/tmp60gc8deo>
    raise KeyError("{!r} is not registered".format(fileobj)) from None

test/test_hook.py::test_can_call_by_selection_notify
  /opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py:666: ResourceWarning: unclosed transport <_SelectorSocketTransport fd=31 read=idle write=<idle, bufsize=0>>
    source=self)

about races closing and leaking the XCB connection. Let's make these types of
things errors, since they usually are.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>