### PR TITLE
x11: use either WM_TAKE_FOCUS or SetInputFocus(), not both

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -569,7 +569,7 @@ class _Window(CommandObject):
                 self.window.send_event(e)
 
             # Never send FocusIn to java windows
-            if not is_java and self.hints['input']:
+            elif not is_java and self.hints['input']:
                 self.window.set_input_focus()
             try:
                 if warp and self.qtile.config.cursor_warp:


### PR DESCRIPTION
Idea for the fix stolen from:

https://github.com/i3/i3/commit/21a2971b2442ab0881cf79553cc6b65bbb44afa7

Hopefully this fixes the last of the java focus issues.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>