### PR TITLE
floating: mark windows as mapped after configuring them

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -209,6 +209,10 @@ class Floating(Layout):
         return above
 
     def configure(self, client, screen):
+        # After this, the client will be mapped. Either this will do it, or the
+        # client has already done it.
+        client.hidden = False
+
         # 'sun-awt-X11-XWindowPeer' is a dropdown used in Java application,
         # don't reposition it anywhere, let Java app to control it
         cls = client.window.get_wm_class() or ''


### PR DESCRIPTION
We have some internal self.hidden checks in window.py:focus() which we
should probably just get rid of entirely. But until now, let's mark windows
as mapped if they're going through the floating process. They've either
mapped themselves, or this will map them at the end of the function.

I think this fixes #1737