### PR TITLE
manager: focus root if nothing is focused

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -977,6 +977,20 @@ class Connection:
             for i in self.conn.core.ListExtensions().reply().names
         )
 
+    def fixup_focus(self):
+        """
+        If the X11 focus is set to None, all keypress events are discarded,
+        which makes our hotkeys not work. This fixes up the focus so it is not
+        None.
+        """
+        window = self.conn.core.GetInputFocus().reply().focus
+        if window == xcffib.xproto.InputFocus._None:
+            self.conn.core.SetInputFocus(
+                xcffib.xproto.InputFocus.PointerRoot,
+                xcffib.xproto.InputFocus.PointerRoot,
+                xcffib.xproto.Time.CurrentTime,
+            )
+
 
 class Painter:
     def __init__(self, display):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -574,6 +574,8 @@ class Qtile(CommandObject):
                 c.group.remove(c)
             del self.windows_map[win]
             self.update_client_list()
+        if self.current_window is None:
+            self.conn.fixup_focus()
 
     def graceful_shutdown(self):
         """


### PR DESCRIPTION
X11 has various focus reversion modes: RevertToPointerRoot is the most
common, but some applications set RevertToParent (that seems most polite,
after all). Except that when one of these windows doesn't have a parent,
focus is reverted to None, which:

"If focus is None, all keyboard events are discarded until a new focus
window is set, and the revert_to argument is ignored."

then discards all qtile's hotkey presses to e.g. spawn a new window or
switch to a different desktop. This effectively jails the user on the
desktop until they click on the bar or mouse over something else.

Let's fix this by focusing the root window if focus is None.

Note that we check to see if the focus is None first to avoid sending
gratuitous root window focus requests, since most windows don't set
revert-to-parent, and there is a small race by sending CurrentTime where we
might focus the root window if someone kills the last window in a group and
spawns a new window really fast.

Naturally, we can't actually send anything besides CurrentTime, because
DestroyNotify events don't come with a timestamp. Whee.

I experience this issue with spotify, but there are presumably other
windows out there that do the same thing.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>