### PR TITLE
fix no attribute pixbuf

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -41,6 +41,7 @@ from collections import OrderedDict
 from itertools import chain, repeat
 
 import cairocffi
+import cairocffi.pixbuf
 import cairocffi.xcb
 import xcffib
 import xcffib.randr


### PR DESCRIPTION
File "/home/dakaizou/.local/lib/python3.8/site-packages/libqtile/backend/x11/xcbq.py", line 1007, in paint
    image, _ = cairocffi.pixbuf.decode_to_image_surface(f.read())
AttributeError: module 'cairocffi' has no attribute 'pixbuf'