### PR TITLE
Revert "send MapNotify to auto positioned windows too"

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -209,24 +209,25 @@ class Floating(Layout):
         return above
 
     def configure(self, client, screen):
+        # After this, the client will be mapped. Either this will do it, or the
+        # client has already done it.
+        client.hidden = False
+
         # 'sun-awt-X11-XWindowPeer' is a dropdown used in Java application,
         # don't reposition it anywhere, let Java app to control it
         cls = client.window.get_wm_class() or ''
         is_java_dropdown = 'sun-awt-X11-XWindowPeer' in cls
         if is_java_dropdown:
-            client.unhide()
             return
 
         # similar to above but the X11 version, the client may have already
         # placed itself. let's respect that
         if client.has_user_set_position():
-            client.unhide()
             return
 
         # ok, it's not java and the window itself didn't position it, but users
         # may still have asked us not to mess with it
         if self.no_reposition_match is not None and self.no_reposition_match.compare(client):
-            client.unhide()
             return
 
         if client.has_focus:


### PR DESCRIPTION
This reverts commit db0f044f8968f4bccad006fb001a87a98742c9a0.

I believe this commit is not necessary. I added it and it seemed to fix
some things for some people, but there were a lot of other fundamental
focus bugs still in the code. Now that these are all fixed, I think we can
drop this.

There's a reason to drop it too: MapNotify causes the window to re-draw
itself, so sending these when they're not necessary can result in screen
flicker.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>