### PR TITLE
focus_on_window_activation: promote "never" to a real setting

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -150,6 +150,8 @@ configuration variables that control specific aspects of Qtile's behavior:
         - focus: automatically focus the window
 
         - smart: automatically focus if the window is in the current group
+
+        - never: never automatically focus any window that requests it
     * - follow_mouse_focus
       - True
       - Controls whether or not focus follows the mouse around as it moves

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1230,8 +1230,10 @@ class Window(_Window):
                 elif focus_behavior == "urgent" or (focus_behavior == "smart" and not self.group.screen):
                     logger.info("Setting urgent flag for window")
                     self.urgent = True
-                else:
+                elif focus_behavior == "never":
                     logger.info("Ignoring focus request")
+                else:
+                    logger.warning("Invalid value for focus_on_window_activation: {}".format(focus_behavior))
 
     def handle_PropertyNotify(self, e):  # noqa: N802
         name = self.qtile.conn.atoms.get_name(e.atom)


### PR DESCRIPTION
I've used "never" in my config for this for a long time, which was mostly a
hack because we didn't have an explicit value for this.

Let's promote "never" to a real value, and warn people when they have
something that we don't recognize.

Closes #1756

Signed-off-by: Tycho Andersen <tycho@tycho.ws>