### PR TITLE
confreader: do basic type checking of top level items

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -74,6 +74,10 @@ class Config:
         for key in self.settings_keys:
             try:
                 value = settings[key]
+                if not isinstance(value, type(default[key])):
+                    from libqtile.log_utils import logger
+                    logger.error("bad type for {}: got {}, expected {}".format(key,
+                                 type(value), type(default[key])))
             except KeyError:
                 value = getattr(self, key, default[key])
             setattr(self, key, value)


### PR DESCRIPTION
I still think that getting type checking for config object arguments (like
those annotated in 98927b7b9f1f532d35f4e6b9abf80802d4a4d24b) is a good path
forward, but because of the way we do configs (via __import__), there's no
good way to type check top level variables.

So let's add some code that does a little bit of that. This doesn't recurse
into anything (so we don't get deep checking of e.g. lists of groups or
screens), but we do get checking of the top level boolean/string flags at
least, and basic sanity "this is a list" checking.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>