### PR TITLE
accept any number of spacer widgets

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -256,7 +256,8 @@ class Bar(Gap, configurable.Configurable):
                     else:
                         i.length = int(interval - blocks[idx] / 2 - blocks[idx + 1] / 2)
                     stretchspace -= i.length
-                i.length += stretchspace
+                stretches[0].length += stretchspace // 2
+                stretches[-1].length += stretchspace - stretchspace // 2
 
         offset = 0
         if self.horizontal:

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -188,15 +188,12 @@ class Bar(Gap, configurable.Configurable):
                 else:
                     self.x -= self.margin[1]
 
-        stretches = 0
         for w in self.widgets:
             # Executing _test_orientation_compatibility later, for example in
             # the _configure() method of each widget, would still pass
             # test/test_bar.py but a segfault would be raised when nosetests is
             # about to exit
             w._test_orientation_compatibility(self.horizontal)
-            if w.length_type == STRETCH:
-                stretches += 1
 
         self.window = window.Internal.create(
             self.qtile,

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import configurable, confreader, drawer, window
+from libqtile import configurable, drawer, window
 from libqtile.command_object import CommandObject
 
 

--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -62,8 +62,9 @@ class Spacer(base._Widget):
         self.add_defaults(Spacer.defaults)
 
     def draw(self):
-        self.drawer.clear(self.background or self.bar.background)
-        if self.bar.horizontal:
-            self.drawer.draw(offsetx=self.offset, width=self.length)
-        else:
-            self.drawer.draw(offsety=self.offset, height=self.length)
+        if self.length > 0:
+            self.drawer.clear(self.background or self.bar.background)
+            if self.bar.horizontal:
+                self.drawer.draw(offsetx=self.offset, width=self.length)
+            else:
+                self.drawer.draw(offsety=self.offset, height=self.length)

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -342,40 +342,16 @@ def test_incompatible_widget(qtile_nospawn):
         qtile_nospawn.create_manager(config)
 
 
-class MultiStretchConf:
-    main = None
-    keys = []
-    mouse = []
-    groups = [libqtile.config.Group("a")]
-    layouts = [libqtile.layout.stack.Stack(num_stacks=1)]
-    floating_layout = libqtile.layout.floating.Floating()
-    screens = [
-        libqtile.config.Screen(
-            top=libqtile.bar.Bar(
-                [
-                    libqtile.widget.Spacer(libqtile.bar.STRETCH),
-                    libqtile.widget.Spacer(libqtile.bar.STRETCH),
-                ],
-                10
-            ),
-        )
-    ]
-
-
-def test_multiple_stretches(qtile_nospawn):
-    config = MultiStretchConf
-
-    # Ensure that adding two STRETCH widgets to the same bar raises ConfigError
-    with pytest.raises(libqtile.confreader.ConfigError):
-        qtile_nospawn.create_manager(config)
-
-
 def test_basic(qtile_nospawn):
     config = GeomConf
     config.screens = [
         libqtile.config.Screen(
             bottom=libqtile.bar.Bar(
                 [
+                    ExampleWidget(),
+                    libqtile.widget.Spacer(libqtile.bar.STRETCH),
+                    ExampleWidget(),
+                    libqtile.widget.Spacer(libqtile.bar.STRETCH),
                     ExampleWidget(),
                     libqtile.widget.Spacer(libqtile.bar.STRETCH),
                     ExampleWidget()
@@ -390,8 +366,14 @@ def test_basic(qtile_nospawn):
     i = qtile_nospawn.c.bar["bottom"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][1]["offset"] == 10
-    assert i["widgets"][1]["width"] == 780
-    assert i["widgets"][2]["offset"] == 790
+    assert i["widgets"][1]["width"] == 252
+    assert i["widgets"][2]["offset"] == 262
+    assert i["widgets"][3]["offset"] == 272
+    assert i["widgets"][3]["width"] == 256
+    assert i["widgets"][4]["offset"] == 528
+    assert i["widgets"][5]["offset"] == 538
+    assert i["widgets"][5]["width"] == 252
+    assert i["widgets"][6]["offset"] == 790
     libqtile.hook.clear()
 
 


### PR DESCRIPTION
This lets a bar accept any number of `widget.Spacer` widgets, allowing for any number of blocks of widgets in the bar. These blocks are distributed so that the first (left) and last (right) are up against the ends of the bar (as usual) and the rest of these blocks have their centrepoint at regular intervals across the bar. E.g. 2 spacers will put the centre of the second block right in the centre of the bar.