### PR TITLE
add notify_below option to battery widget

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -333,6 +333,7 @@ class Battery(base.ThreadedPollText):
         self.add_defaults(self.defaults)
 
         self._battery = self._load_battery(**config)
+        self._has_notified = False
 
     @staticmethod
     def _load_battery(**config):
@@ -358,7 +359,11 @@ class Battery(base.ThreadedPollText):
         if self.notify_below:
             percent = int(status.percent * 100)
             if percent < self.notify_below:
-                send_notification("Warning", "Battery at {0}%".format(percent), urgent=True)
+                if not self._has_notified:
+                    send_notification("Warning", "Battery at {0}%".format(percent), urgent=True)
+                    self._has_notified = True
+            elif self._has_notified:
+                self._has_notified = False
 
         return self.build_string(status)
 

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -42,8 +42,8 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 from libqtile import bar, configurable, images
 from libqtile.images import Img
 from libqtile.log_utils import logger
-from libqtile.widget import base
 from libqtile.utils import send_notification
+from libqtile.widget import base
 
 
 @unique
@@ -358,7 +358,7 @@ class Battery(base.ThreadedPollText):
         if self.notify_below:
             percent = int(status.percent * 100)
             if percent < self.notify_below:
-                send_notification("Warning", f"Battery at {percent}%", urgent=True)
+                send_notification("Warning", "Battery at {0}%".format(percent), urgent=True)
 
         return self.build_string(status)
 

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -43,6 +43,7 @@ from libqtile import bar, configurable, images
 from libqtile.images import Img
 from libqtile.log_utils import logger
 from libqtile.widget import base
+from libqtile.utils import send_notification
 
 
 @unique
@@ -319,6 +320,7 @@ class Battery(base.ThreadedPollText):
         ('low_foreground', 'FF0000', 'Font color on low battery'),
         ('update_interval', 60, 'Seconds between status updates'),
         ('battery', 0, 'Which battery should be monitored (battery number or name)'),
+        ('notify_below', None, 'Send a notification below this battery level.'),
     ]
 
     def __init__(self, **config) -> None:
@@ -352,6 +354,11 @@ class Battery(base.ThreadedPollText):
             status = self._battery.update_status()
         except RuntimeError as e:
             return 'Error: {}'.format(e)
+
+        if self.notify_below:
+            percent = int(status.percent * 100)
+            if percent < self.notify_below:
+                send_notification("Warning", f"Battery at {percent}%", urgent=True)
 
         return self.build_string(status)
 


### PR DESCRIPTION
The notify_below option passed to the Battery widget will make the
widget send a system notification during `poll()` if the battery
percentage is below the notify_below value.