### PR TITLE
Revert "Revert "send MapNotify to auto positioned windows too""

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -209,25 +209,24 @@ class Floating(Layout):
         return above
 
     def configure(self, client, screen):
-        # After this, the client will be mapped. Either this will do it, or the
-        # client has already done it.
-        client.hidden = False
-
         # 'sun-awt-X11-XWindowPeer' is a dropdown used in Java application,
         # don't reposition it anywhere, let Java app to control it
         cls = client.window.get_wm_class() or ''
         is_java_dropdown = 'sun-awt-X11-XWindowPeer' in cls
         if is_java_dropdown:
+            client.unhide()
             return
 
         # similar to above but the X11 version, the client may have already
         # placed itself. let's respect that
         if client.has_user_set_position():
+            client.unhide()
             return
 
         # ok, it's not java and the window itself didn't position it, but users
         # may still have asked us not to mess with it
         if self.no_reposition_match is not None and self.no_reposition_match.compare(client):
+            client.unhide()
             return
 
         if client.has_focus:


### PR DESCRIPTION
This reverts commit df621b9a8ec19e7207b61789bb58274e8ba9e639.

It seems my analysis in the above commit is wrong: we *do* need this for
some applications. In particular, since we unmap things when changing to a
different group, we do need to send a remap hint when it is floating.

Now, this may cause a flicker the *first* time a user-positioned window
appears, because it'll map twice: once the first user time, and once when
we do this map. This is better than leaving it unmapped, and I think is
less confusing than adding a boolean that is a once-mapped flag. If it
really bothers someone, they can fix it (and indeed, some windows may even
be smart enough to ignore it).

Closes #1784

Signed-off-by: Tycho Andersen <tycho@tycho.ws>