### PR TITLE
Option to warp cursor to bottom right before drag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ qtile X.X.X, released XXXX-XX-XX:
         - added `guess_terminal` in utils
         - added keybinding cheet sheet image generator
         - custom keyboardlayout display 
+        - added option to warp cursor to bottom right of window before drag
 
 qtile 0.15.1, released 2020-04-14
     * bugfixes

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -114,9 +114,10 @@ class Drag(Mouse):
     To position the mouse cursor at the bottom right of the window before
     dragging, pass `cursor_warp=True` as argument
     """
-    def __init__(self, *args, start=False, **kwargs):
+    def __init__(self, *args, start=False, cursor_warp=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.start = start
+        self.cursor_warp = cursor_warp
 
     def __repr__(self):
         return "<Drag (%s, %s)>" % (self.modifiers, self.button)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -110,6 +110,9 @@ class Drag(Mouse):
 
     It focuses clicked window by default.  If you want to prevent it pass,
     `focus=None` as an argument
+
+    To position the mouse cursor at the bottom right of the window before
+    dragging, pass `cursor_warp=True` as argument
     """
     def __init__(self, *args, start=False, **kwargs):
         super().__init__(*args, **kwargs)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -779,6 +779,14 @@ class Qtile(CommandObject):
                     i = m.start
                     if m.focus == "before":
                         self.cmd_focus_by_click(event)
+
+                    if hasattr(m, 'cursor_warp') and m.cursor_warp:
+                        # warp cursor to bottom right of window before dragging
+                        new_x = self.current_window.width + self.current_window.x
+                        new_y = self.current_window.height + self.current_window.y
+                        self.current_window.window.warp_pointer(self.current_window.width, self.current_window.height)
+                        self.mouse_position = (new_x, new_y)
+
                     status, val = self.server.call(
                         (i.selectors, i.name, i.args, i.kwargs))
                     if status in (command_interface.ERROR, command_interface.EXCEPTION):
@@ -790,7 +798,7 @@ class Qtile(CommandObject):
                     val = (0, 0)
                 if m.focus == "after":
                     self.cmd_focus_by_click(event)
-                self._drag = (x, y, val[0], val[1], m.commands)
+                self._drag = (self.mouse_position[0], self.mouse_position[1], val[0], val[1], m.commands)
                 self.core.grab_pointer()
 
     def process_button_release(self, button_code):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -780,7 +780,7 @@ class Qtile(CommandObject):
                     if m.focus == "before":
                         self.cmd_focus_by_click(event)
 
-                    if hasattr(m, 'cursor_warp') and m.cursor_warp:
+                    if m.cursor_warp:
                         # warp cursor to bottom right of window before dragging
                         new_x = self.current_window.width + self.current_window.x
                         new_y = self.current_window.height + self.current_window.y


### PR DESCRIPTION
Added option to warp cursor to bottom right of window before drag. This
allows one to fully shrink a floating window, even when the mouse was
positioned in the top left of the window before dragging.

Rationale:
I made the transition from Xmonad to qtile a short while ago. I also muddle around sometimes with floating windows (shame). The the default window dragging behavior of qtile seems a bit odd to me compared to XMonad. When resizing a floating window, XMonad warps the mouse cursor to the bottom right of the window that is being warped. In this way the entire window can be shrunk entirely (down to a 1x1 window).
In Qtile, the mouse position is not warped to the bottom right of the window. Therefore, if the mouse reaches the top left of the screen when dragging, the window can not be shrunk any more, since the cursor can not leave the top left of the screen. This is annoying to me, since I don't want to move the mouse manually to the bottom right to shrink windows to my liking... :(

It was not possible for me to configure the Drag-directive to my liking, so I added a few lines of code. Feel free to reject this PR if it is possible to configure Qtile to warp the mouse before dragging (I would be happy to get a configuration hint).

I can make a screencast if the above explanation is not clear enough.