### PR TITLE
Move un/grab methods to core

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -1,6 +1,8 @@
 import typing
 from abc import ABCMeta, abstractmethod
 
+from libqtile import config
+
 
 class Core(metaclass=ABCMeta):
     @property
@@ -15,3 +17,31 @@ class Core(metaclass=ABCMeta):
     @abstractmethod
     def get_modifiers(self) -> typing.List[str]:
         pass
+
+    @abstractmethod
+    def grab_key(self, key: config.Key) -> typing.Tuple[int, int]:
+        """Configure the backend to grab the key event"""
+
+    @abstractmethod
+    def ungrab_key(self, key: config.Key) -> typing.Tuple[int, int]:
+        """Release the given key event"""
+
+    @abstractmethod
+    def ungrab_keys(self) -> None:
+        """Release the grabbed key events"""
+
+    @abstractmethod
+    def grab_button(self, mouse: config.Mouse) -> None:
+        """Configure the backend to grab the mouse event"""
+
+    @abstractmethod
+    def ungrab_buttons(self) -> None:
+        """Release the grabbed button events"""
+
+    @abstractmethod
+    def grab_pointer(self) -> None:
+        """Configure the backend to grab mouse events"""
+
+    @abstractmethod
+    def ungrab_pointer(self) -> None:
+        """Release grabbed pointer events"""

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -746,63 +746,6 @@ class Window:
     def get_attributes(self):
         return self.conn.conn.core.GetWindowAttributes(self.wid).reply()
 
-    def ungrab_key(self, key, modifiers):
-        """Passing None means any key, or any modifier"""
-        if key is None:
-            key = xcffib.xproto.Atom.Any
-        if modifiers is None:
-            modifiers = xcffib.xproto.ModMask.Any
-        self.conn.conn.core.UngrabKey(key, self.wid, modifiers)
-
-    def grab_key(self, key, modifiers, owner_events,
-                 pointer_mode, keyboard_mode):
-        self.conn.conn.core.GrabKey(
-            owner_events,
-            self.wid,
-            modifiers,
-            key,
-            pointer_mode,
-            keyboard_mode
-        )
-
-    def ungrab_button(self, button, modifiers):
-        """Passing None means any key, or any modifier"""
-        if button is None:
-            button = xcffib.xproto.Atom.Any
-        if modifiers is None:
-            modifiers = xcffib.xproto.ModMask.Any
-        self.conn.conn.core.UngrabButton(button, self.wid, modifiers)
-
-    def grab_button(self, button, modifiers, owner_events,
-                    event_mask, pointer_mode, keyboard_mode):
-        self.conn.conn.core.GrabButton(
-            owner_events,
-            self.wid,
-            event_mask,
-            pointer_mode,
-            keyboard_mode,
-            xcffib.xproto.Atom._None,
-            xcffib.xproto.Atom._None,
-            button,
-            modifiers,
-        )
-
-    def grab_pointer(self, owner_events, event_mask, pointer_mode,
-                     keyboard_mode, cursor=None):
-        self.conn.conn.core.GrabPointer(
-            owner_events,
-            self.wid,
-            event_mask,
-            pointer_mode,
-            keyboard_mode,
-            xcffib.xproto.Atom._None,
-            cursor or xcffib.xproto.Atom._None,
-            xcffib.xproto.Atom._None,
-        )
-
-    def ungrab_pointer(self):
-        self.conn.conn.core.UngrabPointer(xcffib.xproto.Atom._None)
-
     def query_tree(self):
         q = self.conn.conn.core.QueryTree(self.wid).reply()
         root = None


### PR DESCRIPTION
Setup the core with abstract (un)grab methods for the keys, buttons, and
pointer.  Move the functionality which performed this grabbing from the
xcbq window into the X core.  The use of a root window is somewhat
X-specific, so exposing this instead in the core with the calls made
using the X root window id is easier to extend to Wayland.