### PR TITLE
Allow to selectively synchronize fullscreen

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -110,6 +110,10 @@ configuration variables that control specific aspects of Qtile's behavior:
       - If a window requests to be fullscreen, it is automatically
         fullscreened. Set this to false if you only want windows to be
         fullscreen if you ask them to be.
+    * - auto_fullscreen_exceptions
+      - []
+      - Changes the behavior of ``auto_fullscreen`` for windows corresponding
+        to one of the :class:`~libqtile.config.Match` object of this list.
     * - bring_front_click
       - False
       - When clicked, should the window be brought to the front or not. (This

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -112,8 +112,8 @@ configuration variables that control specific aspects of Qtile's behavior:
         fullscreen if you ask them to be.
     * - auto_fullscreen_exceptions
       - []
-      - Changes the behavior of ``auto_fullscreen`` for windows corresponding
-        to one of the :class:`~libqtile.config.Match` object of this list.
+      - Invert the behavior of ``auto_fullscreen`` for windows corresponding
+        to one of the listed :class:`~libqtile.config.Match`.
     * - bring_front_click
       - False
       - When clicked, should the window be brought to the front or not. (This

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -48,7 +48,7 @@ class Config:
         "screens",
         "main",
         "auto_fullscreen",
-        "no_auto_fullscreen_windows",
+        "auto_fullscreen_exceptions",
         "widget_defaults",
         "extension_defaults",
         "bring_front_click",

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -48,6 +48,7 @@ class Config:
         "screens",
         "main",
         "auto_fullscreen",
+        "no_auto_fullscreen_windows",
         "widget_defaults",
         "extension_defaults",
         "bring_front_click",

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -171,7 +171,7 @@ floating_layout = layout.Floating(float_rules=[
     {'wmclass': 'ssh-askpass'},  # ssh-askpass
 ])
 auto_fullscreen = True
-no_auto_fullscreen_windows = False # Set a list of windows ignored by auto fs
+no_auto_fullscreen_windows = False  # Set a list of windows ignored by auto fs
 focus_on_window_activation = "smart"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -27,7 +27,7 @@
 from typing import List  # noqa: F401
 
 from libqtile import bar, layout, widget
-from libqtile.config import Click, Drag, Group, Key, Screen
+from libqtile.config import Click, Drag, Group, Key, Screen, Match
 from libqtile.lazy import lazy
 from libqtile.utils import guess_terminal
 
@@ -171,7 +171,7 @@ floating_layout = layout.Floating(float_rules=[
     {'wmclass': 'ssh-askpass'},  # ssh-askpass
 ])
 auto_fullscreen = True
-auto_fullscreen_exceptions = []  # Set a list of Match to be ignored
+auto_fullscreen_exceptions = []  # type: List[Match]  # Set a list of Match to be ignored
 focus_on_window_activation = "smart"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -171,7 +171,7 @@ floating_layout = layout.Floating(float_rules=[
     {'wmclass': 'ssh-askpass'},  # ssh-askpass
 ])
 auto_fullscreen = True
-no_auto_fullscreen_windows = False  # Set a list of windows ignored by auto fs
+auto_fullscreen_exceptions = None  # Set a list of Match to be ignored
 focus_on_window_activation = "smart"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -171,7 +171,7 @@ floating_layout = layout.Floating(float_rules=[
     {'wmclass': 'ssh-askpass'},  # ssh-askpass
 ])
 auto_fullscreen = True
-auto_fullscreen_exceptions = None  # Set a list of Match to be ignored
+auto_fullscreen_exceptions = []  # Set a list of Match to be ignored
 focus_on_window_activation = "smart"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -171,6 +171,7 @@ floating_layout = layout.Floating(float_rules=[
     {'wmclass': 'ssh-askpass'},  # ssh-askpass
 ])
 auto_fullscreen = True
+no_auto_fullscreen_windows = False # Set a list of windows ignored by auto fs
 focus_on_window_activation = "smart"
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -27,7 +27,7 @@
 from typing import List  # noqa: F401
 
 from libqtile import bar, layout, widget
-from libqtile.config import Click, Drag, Group, Key, Screen, Match
+from libqtile.config import Click, Drag, Group, Key, Match, Screen
 from libqtile.lazy import lazy
 from libqtile.utils import guess_terminal
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -321,7 +321,12 @@ class _Window(CommandObject):
         triggered = ['urgent']
 
         if self.qtile.config.auto_fullscreen:
-            triggered.append('fullscreen')
+            if self.qtile.config.no_auto_fullscreen_windows:
+                if not any(match.compare(self) \
+                        for match in self.qtile.config.no_auto_fullscreen_windows):
+                    triggered.append('fullscreen')
+            else:
+                triggered.append('fullscreen')
 
         state = self.window.get_net_wm_state()
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -321,7 +321,7 @@ class _Window(CommandObject):
         triggered = ['urgent']
 
         is_exception = any(match.compare(self)
-                           for match in self.qtile.config.auto_fullscreen_exceptions or [])
+                           for match in self.qtile.config.auto_fullscreen_exceptions)
 
         if self.qtile.config.auto_fullscreen != is_exception:
             triggered.append('fullscreen')

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -322,7 +322,7 @@ class _Window(CommandObject):
 
         if self.qtile.config.auto_fullscreen:
             if self.qtile.config.no_auto_fullscreen_windows:
-                if not any(match.compare(self) \
+                if not any(match.compare(self)
                         for match in self.qtile.config.no_auto_fullscreen_windows):
                     triggered.append('fullscreen')
             else:

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -320,13 +320,11 @@ class _Window(CommandObject):
     def update_state(self):
         triggered = ['urgent']
 
-        if self.qtile.config.auto_fullscreen:
-            if self.qtile.config.no_auto_fullscreen_windows:
-                if not any(match.compare(self)
-                           for match in self.qtile.config.no_auto_fullscreen_windows):
-                    triggered.append('fullscreen')
-            else:
-                triggered.append('fullscreen')
+        is_exception = any(match.compare(self)
+                           for match in self.qtile.config.auto_fullscreen_exceptions or [])
+
+        if self.qtile.config.auto_fullscreen != is_exception:
+            triggered.append('fullscreen')
 
         state = self.window.get_net_wm_state()
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -323,7 +323,7 @@ class _Window(CommandObject):
         if self.qtile.config.auto_fullscreen:
             if self.qtile.config.no_auto_fullscreen_windows:
                 if not any(match.compare(self)
-                        for match in self.qtile.config.no_auto_fullscreen_windows):
+                           for match in self.qtile.config.no_auto_fullscreen_windows):
                     triggered.append('fullscreen')
             else:
                 triggered.append('fullscreen')


### PR DESCRIPTION
I wondered if it wasn't simpler to re-use the auto_fullscreen variable and allow it to be polymorphic, but I kept it separated.

config.py to avoid browsers to get fullscreen automatically:

```python
no_auto_fullscreen_windows = (
     Match(wm_class=['firefox']),
     Match(wm_class=['google-chrome']),
)
```