### PR TITLE
Match: Allow any class of a client to match

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -610,32 +610,26 @@ class Match:
 
     def compare(self, client):
         for _type, rule in self._rules:
-            if _type == "net_wm_pid":
-                def match_func(value):
-                    return rule == value
-            else:
-                match_func = getattr(rule, 'match', None) or \
-                    getattr(rule, 'count')
-
-            if _type == 'title':
+            # get value
+            if _type == "title":
                 value = client.name
-            elif _type == 'wm_class':
-                value = None
-                _value = client.window.get_wm_class()
-                if _value and len(_value) > 1:
-                    value = _value[1]
-            elif _type == 'wm_instance_class':
-                value = client.window.get_wm_class()
-                if value:
-                    value = value[0]
-            elif _type == 'wm_type':
-                value = client.window.get_wm_type()
-            elif _type == 'net_wm_pid':
-                value = client.window.get_net_wm_pid()
-            else:
+            elif _type == "wm_instance_class":
+                value = client.window.get_wm_class() and client.window.get_wm_class()[0]
+            elif _type == "role":
                 value = client.window.get_wm_window_role()
+            else:
+                value = getattr(client.window, 'get_' + _type)()
 
-            if value and match_func(value):
+            # compare
+            if _type == "net_wm_pid":
+                if rule == value:
+                    return True
+            match = getattr(rule, 'match', None) or getattr(rule, 'count')
+
+            if _type == "wm_class":
+                if any(match(v) for v in value):
+                    return True
+            elif match(value):
                 return True
         return False
 


### PR DESCRIPTION
I wondered why `Match` was considering only the 2nd WM_CLASS if there are many.
Why not all of them?
To me it looks more convenient, but maybe it was like this for a good reason.