### PR TITLE
avoid some exceptions in bsp layout

### DIFF
--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -210,14 +210,15 @@ class Bsp(Layout):
         color = self.group.qtile.color_pixel(
             self.border_focus if client.has_focus else self.border_normal)
         border = 0 if node is self.root else self.border_width
-        client.place(
-            node.x,
-            node.y,
-            node.w - 2 * border,
-            node.h - 2 * border,
-            border,
-            color,
-            margin=self.margin)
+        if node is not None:
+            client.place(
+                node.x,
+                node.y,
+                node.w - 2 * border,
+                node.h - 2 * border,
+                border,
+                color,
+                margin=self.margin)
         client.unhide()
 
     def cmd_toggle_split(self):


### PR DESCRIPTION
I have it relatively often, I didn't check which operations are triggering this but I think it's also a matter of application in use. I can try to find what is inducing it, I wanted to first know if this is something valid (node == None) or not.

```
 Traceback (most recent call last):
  File "/home/fab/dev/qtile/libqtile/group.py", line 159, in layout_all
    self.layout.layout(normal, screen)
  File "/home/fab/dev/qtile/libqtile/layout/base.py", line 57, in layout
    self.configure(i, screen)
  File "/home/fab/dev/qtile/libqtile/layout/bsp.py", line 214, in configure
    node.x,
 AttributeError: 'NoneType' object has no attribute 'x'
```