### PR TITLE
it happended I have windows with no group...

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -865,7 +865,7 @@ class Window(_Window):
                 self.window.set_property('_NET_WM_STATE', list(new_state))
 
         if do_full:
-            screen = self.group.screen or \
+            screen = (self.group and self.group.screen) or \
                 self.qtile.find_closest_screen(self.x, self.y)
 
             self._enablefloating(


### PR DESCRIPTION
That was to avoid some trace:
`None has no attribute "screen"`

As far as I remember it happened during reload scenarios, but not only.

- are reload scenarios to be considered ?
  - then we can consider having a bit more tolerant code while reloading
- else I'll run without the patch & try to figure what is triggering it 
