### PR TITLE
core: fix multiscreen restart

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -186,6 +186,9 @@ class Qtile(CommandObject):
                 logger.exception("failed restoring state")
 
         self.core.scan()
+        if state:
+            for screen in self.screens:
+                screen.group.layout_all()
         self.update_net_desktops()
         hook.subscribe.setgroup(self.update_net_desktops)
 


### PR DESCRIPTION
We have a bug where windows not on the screen with focus don't get drawn
correctly after multiscreen restart. This is because they don't realize
they're mapped any more. When qtile does a restart, it does:

1. apply all the state (i.e. which groups are in which screens)
2. focus the right screen
3. grab all the existing windows and throw them in a layout

The problem is that screens which aren't focused don't get another layout
event which means they don't realize they're being displayed.

Since state now relies on this ordering (viz. the scratchpad code, which
expects windows to be added after it has run), let's keep this ordering but
just add a:

4. for all screens, make sure they do one final layout so that groups know
   to map their windows if they're visible

Note that we explicitly don't have to do any focus dancing, since we don't
warp the cursor or otherwise change focus here, just map the right windows
at the right places.

Closes #1790

Signed-off-by: Tycho Andersen <tycho@tycho.ws>