### PR TITLE
fix ci

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
 
 [testenv:format]
 deps =
-    isort
+    isort < 5.0
 commands =
     isort -y -rc {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test
 


### PR DESCRIPTION
This pins isort to a < 5.0 version, since it's no longer API compatible and
flake8 is broken with >= 5.0.

See https://github.com/timothycrosley/isort/issues/1273

Signed-off-by: Tycho Andersen <tycho@tycho.ws>