### PR TITLE
Use python3 rather than python

### DIFF
--- a/bin/qshell
+++ b/bin/qshell
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2008, Aldo Cortesi. All rights reserved.
 #

--- a/bin/qtile
+++ b/bin/qtile
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2008, Aldo Cortesi. All rights reserved.
 # Copyright (c) 2011, Florian Mounier

--- a/bin/qtile-cmd
+++ b/bin/qtile-cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/bin/qtile-run
+++ b/bin/qtile-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/bin/qtile-top
+++ b/bin/qtile-top
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/docs/manual/commands/shell/iqshell.rst
+++ b/docs/manual/commands/shell/iqshell.rst
@@ -33,7 +33,7 @@ running:
 
 .. code-block:: bash
 
-    $ python -m libqtile.interactive.iqshell_kernel
+    $ python3 -m libqtile.interactive.iqshell_kernel
 
 However, this will merely spawn a kernel instance, you will have to run a
 separate frontend that connects to this kernel.
@@ -43,7 +43,7 @@ Jupyter.  To register the kernel itself, run:
 
 .. code-block:: bash
 
-    $ python -m libqtile.interactive.iqshell_install
+    $ python3 -m libqtile.interactive.iqshell_install
 
 If you run this as a non-root user, or pass the ``--user`` flag, this will
 install to the user Jupyter kernel directory.  You can now invoke the kernel

--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -120,7 +120,7 @@ system for user ``foo``, it should work on other Linux systems too.
        #!/bin/bash
 
        source ~/local/qtile/venv/bin/activate
-       python ~/local/qtile/bin/qtile $*
+       python3 ~/local/qtile/bin/qtile $*
        EOF
 
 #. Create an xsession file.

--- a/libqtile/scripts/qtile_cmd.py
+++ b/libqtile/scripts/qtile_cmd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017, Piotr Przymus
 #

--- a/scripts/ffibuild
+++ b/scripts/ffibuild
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "building pango"
-python ./libqtile/pango_ffi_build.py
+python3 ./libqtile/pango_ffi_build.py
 echo "building xcursors"
-python ./libqtile/backend/x11/xcursors_ffi_build.py
+python3 ./libqtile/backend/x11/xcursors_ffi_build.py
 echo "building pulseaudio volume control"
-python ./libqtile/widget/pulseaudio_ffi.py
+python3 ./libqtile/widget/pulseaudio_ffi.py

--- a/scripts/gen-keybinding-img
+++ b/scripts/gen-keybinding-img
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #######################################
 #  Qtile keybindings image generator  #

--- a/scripts/genkeysyms
+++ b/scripts/genkeysyms
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     This script is used to generate xkeysyms.py from the X keysymdef.h definition
     header file.

--- a/scripts/qtb
+++ b/scripts/qtb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Command-line interaction with Qtile TextBox widgets.
 """

--- a/scripts/take-screenshots
+++ b/scripts/take-screenshots
@@ -11,10 +11,10 @@ BORDER_NORMAL=${BORDER_NORMAL:-#000000}
 BORDER_WIDTH=${BORDER_WIDTH:-8}
 MARGIN=${MARGIN:-10}
 if [[ -z "${PYTHON}" ]]; then
-  if [[ -f "${PROJECT_DIR}/venv/bin/python" ]]; then
-    PYTHON="${PROJECT_DIR}/venv/bin/python"
+  if [[ -f "${PROJECT_DIR}/venv/bin/python3" ]]; then
+    PYTHON="${PROJECT_DIR}/venv/bin/python3"
   else
-    PYTHON=python
+    PYTHON=python3
   fi
 fi
 

--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -6,7 +6,7 @@ XDISPLAY=${XDISPLAY:-:1}
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 APP=${APP:-xterm}
 if [[ -z $PYTHON ]]; then
-    PYTHON=python
+    PYTHON=python3
 fi
 
 Xephyr +extension RANDR -screen ${SCREEN_SIZE} ${XDISPLAY} -ac &

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2008 Aldo Cortesi
 # Copyright (c) 2011 Mounier Florian

--- a/test/scripts/tkwindow.py
+++ b/test/scripts/tkwindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017 Dario Giovannetti
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/scripts/window.py
+++ b/test/scripts/window.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2011 Florian Mounier
 # Copyright (c) 2014 Sean Vig
 #

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     setuptools >= 40.5.0
     xcffib >= 0.8.1
 commands =
-    python setup.py pytest --addopts "-Wall --cov libqtile --cov-report term-missing {posargs}"
+    python3 setup.py pytest --addopts "-Wall --cov libqtile --cov-report term-missing {posargs}"
 
 [testenv:packaging]
 deps =
@@ -34,8 +34,8 @@ deps =
     twine
 commands =
     check-manifest
-    python setup.py check -m -s
-    python setup.py sdist
+    python3 setup.py check -m -s
+    python3 setup.py sdist
     twine check dist/*
 
 [testenv:format]
@@ -63,4 +63,4 @@ commands =
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt
-commands = python setup.py build_sphinx -W
+commands = python3 setup.py build_sphinx -W


### PR DESCRIPTION
On Ubuntu 20.04 /usr/bin/python is a symlink to python2, not python3.

PEP 394 suggests the "python3" binary should be available on any system with
Python 3. Verified for Ubuntu and Arch Linux.

Using "python" rather than "python3" should not usually be a problem, since venv
may make "python" Python 3 even if the system version is Python 2. But this way
seems more correct, and allows developing and running Qtile outside of a virtual
env if desired.