### PR TITLE
Use /usr/bin/env bash in scripts that rely on bash features

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright (c) 2012 dmpayton
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,11 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#!/bin/sh
-
 rm -rf _build/*
 
-while [ true ]; do
+while true; do
     make html
     sleep 5
 done

--- a/scripts/take-screenshots
+++ b/scripts/take-screenshots
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # environment variables
 PROJECT_DIR=$(dirname "$(dirname "$(readlink -f "$0")")")
 XDISPLAY=${XDISPLAY:-:1}

--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 HERE=$(dirname $(readlink -f $0))
 SCREEN_SIZE=${SCREEN_SIZE:-800x600}


### PR DESCRIPTION
And fix some minor issues in `docs/build.sh`.

Without this, a default Ubuntu system prints

    scripts/xephyr: 8: [[: not found

when trying to run `scripts/xephyr`.

Normally I'd just use `#!/bin/bash` but I guess using env is more portable, and is the approach already used in `bin/dqtile-cmd`.