### PR TITLE
Make MonadTall, MonadWide, and TreeTab work together with Slice

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -270,7 +270,7 @@ class Delegate(Layout):
     def delegate_layout(self, windows, mapping):
         """Delegates layouting actual windows
 
-        Parameterer
+        Parameters
         ===========
         windows:
             windows to layout
@@ -297,6 +297,22 @@ class Delegate(Layout):
                 idx += 1
                 focus = layouts[idx].focus_first()
         return focus
+
+    @abstractmethod
+    def show(self, screen):
+        """Tells the layout to show itself on the given ScreenRect"""
+        pass
+
+    def hide(self):
+        for lay in self._get_layouts():
+            lay.hide()
+
+    def focus(self, win):
+        self.layouts[win].focus(win)
+
+    def blur(self):
+        for lay in self._get_layouts():
+            lay.blur()
 
     def focus_first(self):
         layouts = self._get_layouts()

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -122,6 +122,30 @@ class Slice(Delegate):
         return res
 
     def layout(self, windows, screen):
+        win, sub = self._get_screens(screen)
+        self.delegate_layout(
+            windows,
+            {
+                self._slice: win,
+                self.fallback: sub,
+            }
+        )
+
+    def show(self, screen):
+        win, sub = self._get_screens(screen)
+        self._slice.show(win)
+        self.fallback.show(sub)
+
+    def configure(self, win, screen):
+        raise NotImplementedError("Should not be called")
+
+    def _get_layouts(self):
+        return (self._slice, self.fallback)
+
+    def _get_active_layout(self):
+        return self.fallback  # always
+
+    def _get_screens(self, screen):
         if self.side == 'left':
             win, sub = screen.hsplit(self.width)
         elif self.side == 'right':
@@ -132,22 +156,7 @@ class Slice(Delegate):
             sub, win = screen.vsplit(screen.height - self.width)
         else:
             raise NotImplementedError(self.side)
-        self.delegate_layout(
-            windows,
-            {
-                self._slice: win,
-                self.fallback: sub,
-            }
-        )
-
-    def configure(self, win, screen):
-        raise NotImplementedError("Should not be called")
-
-    def _get_layouts(self):
-        return (self._slice, self.fallback)
-
-    def _get_active_layout(self):
-        return self.fallback  # always
+        return (win, sub)
 
     def add(self, win):
         if self._slice.empty() and win.match(**self.match):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -455,15 +455,15 @@ class TreeTab(Layout):
         del self._nodes[win]
         self.draw_panel()
 
-    def _create_panel(self):
+    def _create_panel(self, screen):
         self._panel = window.Internal.create(
             self.group.qtile,
-            0,
-            0,
+            screen.x,
+            screen.y,
             self.panel_width,
             100
         )
-        self._create_drawer()
+        self._create_drawer(screen)
         self._panel.handle_Expose = self._handle_Expose
         self._panel.handle_ButtonPress = self._handle_ButtonPress
         self.group.qtile.windows_map[self._panel.window.wid] = self._panel
@@ -547,7 +547,7 @@ class TreeTab(Layout):
 
     def show(self, screen):
         if not self._panel:
-            self._create_panel()
+            self._create_panel(screen)
         panel, body = screen.hsplit(self.panel_width)
         self._resize_panel(panel)
         self._panel.unhide()
@@ -714,13 +714,13 @@ class TreeTab(Layout):
         self.panel_width -= 10
         self.group.layout_all()
 
-    def _create_drawer(self):
+    def _create_drawer(self, rect):
         if self._drawer is None:
             self._drawer = drawer.Drawer(
                 self.group.qtile,
                 self._panel.window.wid,
                 self.panel_width,
-                self.group.screen.dheight
+                rect.height
             )
         self._drawer.clear(self.bg_color)
         self._layout = self._drawer.textlayout(
@@ -745,5 +745,5 @@ class TreeTab(Layout):
                 0,
                 None
             )
-            self._create_drawer()
+            self._create_drawer(rect)
             self.draw_panel()

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -176,22 +176,24 @@ class MonadTall(_SimpleLayoutBase):
         if self.single_margin is None:
             self.single_margin = self.margin
         self.relative_sizes = []
+        self.screen_rect = None
 
     @property
     def focused(self):
         return self.clients.current_index
 
     def _get_relative_size_from_absolute(self, absolute_size):
-        return absolute_size / self.group.screen.dheight
+        return absolute_size / self.screen_rect.height
 
     def _get_absolute_size_from_relative(self, relative_size):
-        return int(relative_size * self.group.screen.dheight)
+        return int(relative_size * self.screen_rect.height)
 
     def clone(self, group):
         "Clone layout for other groups"
         c = _SimpleLayoutBase.clone(self, group)
         c.sizes = []
         c.relative_sizes = []
+        c.rect = group.screen.get_rect() if group.screen else None
         c.ratio = self.ratio
         c.align = self.align
         return c
@@ -210,7 +212,7 @@ class MonadTall(_SimpleLayoutBase):
         "Evenly distribute screen-space among secondary clients"
         n = len(self.clients) - 1  # exclude main client, 0
         # if secondary clients exist
-        if n > 0 and self.group.screen is not None:
+        if n > 0 and self.screen_rect is not None:
             self.relative_sizes = [1.0 / n] * n
         # reset main pane ratio
         if redraw:
@@ -267,6 +269,8 @@ class MonadTall(_SimpleLayoutBase):
 
     def configure(self, client, screen):
         "Position client based on order and sizes"
+        self.screen_rect = screen
+
         # if no sizes or normalize flag is set, normalize
         if not self.relative_sizes or self.do_normalize:
             self.cmd_normalize(False)
@@ -285,10 +289,10 @@ class MonadTall(_SimpleLayoutBase):
         # single client - fullscreen
         if len(self.clients) == 1:
             client.place(
-                self.group.screen.dx,
-                self.group.screen.dy,
-                self.group.screen.dwidth - 2 * self.single_border_width,
-                self.group.screen.dheight - 2 * self.single_border_width,
+                self.screen_rect.x,
+                self.screen_rect.y,
+                self.screen_rect.width - 2 * self.single_border_width,
+                self.screen_rect.height - 2 * self.single_border_width,
                 self.single_border_width,
                 px,
                 margin=self.single_margin,
@@ -301,32 +305,34 @@ class MonadTall(_SimpleLayoutBase):
 
     def _configure_specific(self, client, screen, px, cidx):
         """Specific configuration for xmonad tall."""
+        self.screen_rect = screen
+
         # calculate main/secondary pane size
-        width_main = int(self.group.screen.dwidth * self.ratio)
-        width_shared = self.group.screen.dwidth - width_main
+        width_main = int(self.screen_rect.width * self.ratio)
+        width_shared = self.screen_rect.width - width_main
 
         # calculate client's x offset
         if self.align == self._left:  # left or up orientation
             if cidx == 0:
                 # main client
-                xpos = self.group.screen.dx
+                xpos = self.screen_rect.x
             else:
                 # secondary client
-                xpos = self.group.screen.dx + width_main
+                xpos = self.screen_rect.x + width_main
         else:  # right or down orientation
             if cidx == 0:
                 # main client
-                xpos = self.group.screen.dx + width_shared - self.margin
+                xpos = self.screen_rect.x + width_shared - self.margin
             else:
                 # secondary client
-                xpos = self.group.screen.dx
+                xpos = self.screen_rect.x
 
         # calculate client height and place
         if cidx > 0:
             # secondary client
             width = width_shared - 2 * self.border_width
             # ypos is the sum of all clients above it
-            ypos = self.group.screen.dy + \
+            ypos = self.screen_rect.y + \
                 self._get_absolute_size_from_relative(
                     sum(self.relative_sizes[:cidx - 1])
                 )
@@ -353,10 +359,9 @@ class MonadTall(_SimpleLayoutBase):
             width = width_main - 2 * self.border_width
             client.place(
                 xpos + self.margin,
-                self.group.screen.dy + self.margin,
+                self.screen_rect.y + self.margin,
                 width - self.margin,
-                (self.group.screen.dheight -
-                    2 * self.border_width - 2 * self.margin),
+                (self.screen_rect.height - 2 * self.border_width - 2 * self.margin),
                 self.border_width,
                 px,
             )
@@ -671,7 +676,7 @@ class MonadTall(_SimpleLayoutBase):
         """Get closest window to a point x,y"""
         target = min(
             clients,
-            key=lambda c: math.hypot(c.info()['x'] - x, c.info()['y'] - y)
+            key=lambda c: math.hypot(c.info()["x"] - x, c.info()["y"] - y)
         )
         return target
 
@@ -708,7 +713,7 @@ class MonadTall(_SimpleLayoutBase):
         """Focus on the closest window to the left of the current window"""
         win = self.clients.current_client
         x, y = win.x, win.y
-        candidates = [c for c in self.clients if c.info()['x'] < x]
+        candidates = [c for c in self.clients if c.info()["x"] < x]
         self.clients.current_client = self._get_closest(x, y, candidates)
         self.group.focus(self.clients.current_client)
 
@@ -716,7 +721,7 @@ class MonadTall(_SimpleLayoutBase):
         """Focus on the closest window to the right of the current window"""
         win = self.clients.current_client
         x, y = win.x, win.y
-        candidates = [c for c in self.clients if c.info()['x'] > x]
+        candidates = [c for c in self.clients if c.info()["x"] > x]
         self.clients.current_client = self._get_closest(x, y, candidates)
         self.group.focus(self.clients.current_client)
 
@@ -831,10 +836,10 @@ class MonadWide(MonadTall):
     _down = 1
 
     def _get_relative_size_from_absolute(self, absolute_size):
-        return absolute_size / self.group.screen.dwidth
+        return absolute_size / self.screen_rect.width
 
     def _get_absolute_size_from_relative(self, relative_size):
-        return int(relative_size * self.group.screen.dwidth)
+        return int(relative_size * self.screen_rect.width)
 
     def _maximize_secondary(self):
         """Toggle the focused secondary pane between min and max size."""
@@ -843,7 +848,7 @@ class MonadWide(MonadTall):
         collapsed_size = self.min_secondary_size * n
         nidx = self.focused - 1  # focused size index
         # total width of maximized secondary
-        maxed_size = self.group.screen.dwidth - collapsed_size
+        maxed_size = self.screen_rect.width - collapsed_size
         # if maximized or nearly maximized
         if abs(
             self._get_absolute_size_from_relative(self.relative_sizes[nidx]) -
@@ -861,32 +866,34 @@ class MonadWide(MonadTall):
 
     def _configure_specific(self, client, screen, px, cidx):
         """Specific configuration for xmonad wide."""
+        self.screen_rect = screen
+
         # calculate main/secondary column widths
-        height_main = int(self.group.screen.dheight * self.ratio)
-        height_shared = self.group.screen.dheight - height_main
+        height_main = int(self.screen_rect.height * self.ratio)
+        height_shared = self.screen_rect.height - height_main
 
         # calculate client's x offset
         if self.align == self._up:  # up orientation
             if cidx == 0:
                 # main client
-                ypos = self.group.screen.dy
+                ypos = self.screen_rect.y
             else:
                 # secondary client
-                ypos = self.group.screen.dy + height_main
+                ypos = self.screen_rect.y + height_main
         else:  # right or down orientation
             if cidx == 0:
                 # main client
-                ypos = self.group.screen.dy + height_shared - self.margin
+                ypos = self.screen_rect.y + height_shared - self.margin
             else:
                 # secondary client
-                ypos = self.group.screen.dy
+                ypos = self.screen_rect.y
 
         # calculate client height and place
         if cidx > 0:
             # secondary client
             height = height_shared - 2 * self.border_width
             # xpos is the sum of all clients left of it
-            xpos = self.group.screen.dx + \
+            xpos = self.screen_rect.x + \
                 self._get_absolute_size_from_relative(
                     sum(self.relative_sizes[:cidx - 1])
                 )
@@ -912,10 +919,9 @@ class MonadWide(MonadTall):
             # main client
             height = height_main - 2 * self.border_width
             client.place(
-                self.group.screen.dx + self.margin,
+                self.screen_rect.x + self.margin,
                 ypos + self.margin,
-                (self.group.screen.dwidth -
-                    2 * self.border_width - 2 * self.margin),
+                (self.screen_rect.width - 2 * self.border_width - 2 * self.margin),
                 height - self.margin,
                 self.border_width,
                 px,
@@ -961,7 +967,7 @@ class MonadWide(MonadTall):
         """Swap current window with closest window to the down"""
         win = self.clients.current_client
         x, y = win.x, win.y
-        candidates = [c for c in self.clients.clients if c.info()['y'] > y]
+        candidates = [c for c in self.clients.clients if c.info()["y"] > y]
         target = self._get_closest(x, y, candidates)
         self.cmd_swap(win, target)
 
@@ -969,7 +975,7 @@ class MonadWide(MonadTall):
         """Swap current window with closest window to the up"""
         win = self.clients.current_client
         x, y = win.x, win.y
-        candidates = [c for c in self.clients if c.info()['y'] < y]
+        candidates = [c for c in self.clients if c.info()["y"] < y]
         target = self._get_closest(x, y, candidates)
         self.cmd_swap(win, target)
 

--- a/test/layouts/layout_utils.py
+++ b/test/layouts/layout_utils.py
@@ -40,8 +40,19 @@ def assert_dimensions(self, x, y, w, h, win=None):
     info = win.info()
     assert info['x'] == x, info
     assert info['y'] == y, info
-    assert info['width'] == w, info  # why?
+    assert info['width'] == w, info
     assert info['height'] == h, info
+
+
+def assert_dimensions_fit(self, x, y, w, h, win=None):
+    """Asserts that window is within the given bounds"""
+    if win is None:
+        win = self.c.window
+    info = win.info()
+    assert info['x'] >= x, info
+    assert info['y'] >= y, info
+    assert info['width'] <= w, info
+    assert info['height'] <= h, info
 
 
 def assert_focus_path(self, *names):

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -24,6 +24,7 @@ import libqtile.config
 import libqtile.hook
 from libqtile import layout
 from test.layouts.layout_utils import (
+    assert_dimensions_fit,
     assert_focus_path_unordered,
     assert_focused,
 )
@@ -70,6 +71,24 @@ class AllLayoutsConfig:
                 for layout_name, layout_cls in cls.iter_layouts()]
 
 
+class AllDelegateLayoutsConfig(AllLayoutsConfig):
+
+    @classmethod
+    def generate(cls):
+        """
+        Generate a Slice configuration for each layout currently in the repo.
+        Each layout is made a delegate/fallback layout of the Slice layout.
+        Each configuration has only the tested layout (i.e. 1 item) in the
+        'layouts' variable.
+        """
+        return [
+            type(layout_name, (cls, ), {
+                'layouts': [
+                    layout.slice.Slice(
+                        wname='nevermatch', fallback=layout_cls())]})
+            for layout_name, layout_cls in cls.iter_layouts()]
+
+
 class AllLayouts(AllLayoutsConfig):
     """
     Like AllLayoutsConfig, but all the layouts in the repo are installed
@@ -99,6 +118,7 @@ class AllLayoutsConfigEvents(AllLayoutsConfig):
 each_layout_config = pytest.mark.parametrize("qtile", AllLayoutsConfig.generate(), indirect=True)
 all_layouts_config = pytest.mark.parametrize("qtile", [AllLayouts], indirect=True)
 each_layout_config_events = pytest.mark.parametrize("qtile", AllLayoutsConfigEvents.generate(), indirect=True)
+each_delegate_layout_config = pytest.mark.parametrize("qtile", AllDelegateLayoutsConfig.generate(), indirect=True)
 
 
 @each_layout_config
@@ -399,6 +419,14 @@ def test_desktop_notifications(qtile):
     qtile.kill_window(notif7)
     qtile.kill_window(notif8)
     assert qtile.c.group.info()['focus_history'] == ["two", "dialog3", "three"]
+
+
+@each_delegate_layout_config
+def test_only_uses_delegated_screen_rect(qtile):
+    qtile.test_window("one")
+    qtile.c.group.focus_by_name("one")
+    assert_focused(qtile, "one")
+    assert_dimensions_fit(qtile, 256, 0, 800-256, 600)
 
 
 @all_layouts_config


### PR DESCRIPTION
Using Slice means the delegate layout's available ScreenRect is smaller
than the Group's ScreenRect.

MonadTall and MonadWide store the size of the screen. Get the ScreenRect
from the call to configure, and store that instead.

TreeTab assumes its panel should be placed at (0, 0). Get the ScreenRect
from the call to show, and use it as the origin instead.

Slice was also not forwarding focus, show, and hide calls to it sub
layouts. TreeTab needs to receive show and hide events to show and hide
its panel. And without receiving the focus call, it would never place
or unhide its clients.

Fixes #1811