### PR TITLE
copy default args for Window.static to Window.cmd_static

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -582,7 +582,7 @@ class Qtile(CommandObject):
                     return
 
                 if w.get_wm_type() == "dock" or c.strut:
-                    c.static(self.current_screen.index)
+                    c.cmd_static(self.current_screen.index)
                 else:
                     hook.fire("client_new", c)
 

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -182,7 +182,7 @@ class Subscribe:
                 if c.name == "xterm":
                     c.togroup("a")
                 elif c.name == "dzen":
-                    c.static(0)
+                    c.cmd_static(0)
         """
         return self._subscribe("client_new", func)
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -955,7 +955,7 @@ class Window(_Window):
         warnings.warn("toggleminimize is deprecated, use toggle_minimize", DeprecationWarning)
         self.toggle_minimize()
 
-    def static(self, screen, x=None, y=None, width=None, height=None):
+    def cmd_static(self, screen, x=None, y=None, width=None, height=None):
         """Makes this window a static window, attached to a Screen
 
         If any of the arguments are left unspecified, the values given by the
@@ -1308,9 +1308,6 @@ class Window(_Window):
 
     def __repr__(self):
         return "Window(%r)" % self.name
-
-    def cmd_static(self, screen, x, y, width, height):
-        self.static(screen, x, y, width, height)
 
     def cmd_kill(self):
         """Kill this window

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -970,7 +970,6 @@ class Window(_Window):
         s = Static(self.window, self.qtile, screen, x, y, width, height)
         self.qtile.windows_map[self.window.wid] = s
         hook.fire("client_managed", s)
-        return s
 
     def tweak_float(self, x=None, y=None, dx=0, dy=0,
                     w=None, h=None, dw=0, dh=0):

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1079,7 +1079,7 @@ class ClientNewStaticConfig(_Config):
     @staticmethod
     def main(c):
         def client_new(c):
-            c.static(0)
+            c.cmd_static(0)
         libqtile.hook.subscribe.client_new(client_new)
 
 


### PR DESCRIPTION
`Window.static` has default values of `None` for x, y, width and height, so it makes sense that `Window.cmd_static` would also pass these as defaults and only require the index of the screen to make a window static.