### PR TITLE
Adjust Bar margin/Gap size for struts without duplicating windows (#1654, #1810)

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -754,8 +754,8 @@ class Static(_Window):
             "_NET_WM_STRUT",
             unpack=int
         )
-        strut = strut or (0, 0, 0, 0)
-        self.qtile.update_gaps(strut, self.strut)
+        if strut:
+            self.qtile.add_strut(strut)
         self.strut = strut
 
     def handle_PropertyNotify(self, e):  # noqa: N802


### PR DESCRIPTION
New static windows make bars reconfigure; currently reconfiguring bars
creates a new window each time, and makes widgets re-register with qtile
and erroneously get turned into Mirror widgets. Instead, this just
adjusts the bar's outside margin with the new strut value, which can be
negative in the case that static windows are becoming unmanaged. In the
absence of a bar on the corresponding screen edge, a Gap is either added
or adjusted in size.