### PR TITLE
screen: add type annotations

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Union
+
 from libqtile import configurable, drawer, window
 from libqtile.command_object import CommandObject
 
@@ -376,3 +378,6 @@ class Bar(Gap, configurable.Configurable):
         fake.event_y = y
         fake.detail = button
         self.handle_ButtonPress(fake)
+
+
+BarType = Union[Bar, Gap]

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -28,9 +28,10 @@
 import os.path
 import sys
 import warnings
-from typing import List
+from typing import List, Optional
 
 from libqtile import configurable, hook, utils
+from libqtile.bar import BarType
 from libqtile.command_object import CommandObject
 from libqtile.lazy import lazy
 
@@ -252,21 +253,12 @@ class Screen(CommandObject):
     dimensions. If the mode is 'fill', the image will be centred on the screen and
     resized to fill it. If the mode is 'stretch', the image is stretched to fit all of
     it into the screen.
-
-    Parameters
-    ==========
-    top: Gap/Bar object, or None.
-    bottom: Gap/Bar object, or None.
-    left: Gap/Bar object, or None.
-    right: Gap/Bar object, or None.
-    wallpaper: Dict, or None.
-    x : int or None
-    y : int or None
-    width : int or None
-    height : int or None
     """
-    def __init__(self, top=None, bottom=None, left=None, right=None, wallpaper=None,
-                 wallpaper_mode=None, x=None, y=None, width=None, height=None):
+    def __init__(self, top: Optional[BarType] = None, bottom: Optional[BarType] = None,
+                 left: Optional[BarType] = None, right: Optional[BarType] = None,
+                 wallpaper: Optional[str] = None, wallpaper_mode: Optional[str] = None,
+                 x: Optional[int] = None, y: Optional[int] = None, width: Optional[int] = None,
+                 height: Optional[int] = None):
         self.group = None
         self.previous_group = None
 


### PR DESCRIPTION
The type annotations in the docs were wrong (wallpaper is a str not a dict,
and wallpaper_mode didn't exist), so let's drop those and really add type
annotations.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>