### PR TITLE
window.togroup(): don't toggle groups if switch_group=True

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1073,7 +1073,7 @@ class Window(_Window):
                 self.x += group.screen.x
             group.add(self)
             if switch_group:
-                group.cmd_toscreen()
+                group.cmd_toscreen(toggle=False)
 
     def toscreen(self, index=None):
         """Move window to a specified screen, or the current screen."""


### PR DESCRIPTION
With the addition of the toggle feature, togroup(switch_group=True) changed
semantics in a bad way: if you were already on the current group, it will
toggle back to your previous group, instead of staying on the one you just
wanted to switch to.

Let's pass toggle=False here, since switch_group=True implies you want to
be on the group you just sent the window to.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>