### PR TITLE
Export QTILE_XEPHYR so configs can tell when they're run under Xephyr

### DIFF
--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -13,7 +13,7 @@ Xephyr +extension RANDR -screen ${SCREEN_SIZE} ${XDISPLAY} -ac &
 XEPHYR_PID=$!
 (
   sleep 1
-  env DISPLAY=${XDISPLAY} ${PYTHON} "${HERE}"/../bin/qtile -l ${LOG_LEVEL} $@ &
+  env DISPLAY=${XDISPLAY} QTILE_XEPHYR=1 ${PYTHON} "${HERE}"/../bin/qtile -l ${LOG_LEVEL} $@ &
   QTILE_PID=$!
   env DISPLAY=${XDISPLAY} ${APP} &
   wait $QTILE_PID


### PR DESCRIPTION
For example, I plan to do:

    if os.environ.get("QTILE_XEPHYR"):
        width = 480
        mod = "mod1"

So I can more easily test under Xephyr using only part of the screen,
and using a different mod key.