### PR TITLE
tests: port to xcffib's new find_display() api

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -15,7 +15,7 @@ pip install -U pip setuptools wheel
 
 # https://github.com/qtile/qtile/issues/994#issuecomment-497984551
 echo "Installing xcffib then cairocffi..."
-pip install 'xcffib >= 0.5.0' && pip install --no-cache-dir 'cairocffi >= 0.9.0'
+pip install 'xcffib >= 0.10.1' && pip install --no-cache-dir 'cairocffi >= 0.9.0'
 
 echo "Installing other required packages..."
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cairocffi >= 0.9.0
 cffi >= 1.1.0
-xcffib >= 0.5.0
+xcffib >= 0.10.1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -182,6 +182,7 @@ class Xephyr:
 
         self.proc = None  # Handle to Xephyr instance, subprocess.Popen object
         self.display = None
+        self.display_file = None
 
     def __enter__(self):
         try:
@@ -202,7 +203,8 @@ class Xephyr:
         which is used to setup the instance.
         """
         # get a new display
-        self.display = ":{}".format(xcffib.testing.find_display())
+        display, self.display_file = xcffib.testing.find_display()
+        self.display = ":{}".format(display)
 
         # build up arguments
         args = [
@@ -251,6 +253,7 @@ class Xephyr:
 
         # clean up the lock file for the display we allocated
         try:
+            self.display_file.close()
             os.remove(xcffib.testing.lock_path(int(self.display[1:])))
         except OSError:
             pass


### PR DESCRIPTION
later versions of xcffib (>= 0.10.1) use flocks to make super sure they
don't stomp on other things. However, that required an API change, which
qtile needs a small patch for. Let's add this patch, and then require
xcffib >= 0.10.1 so that people have this same API.

Note that this only affects running the tests, users actually using qtile
don't need to upgrade.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>