### PR TITLE
include tests in release tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,11 +16,11 @@ exclude logo.png
 
 graft libqtile/resources
 graft resources
+graft test
 
 prune bin
 prune docs
 prune scripts
-prune test
 prune rpm
 include bin/dqtile-cmd
 include bin/iqshell

--- a/setup.py
+++ b/setup.py
@@ -93,4 +93,5 @@ setup(
     use_scm_version=True,
     cffi_modules=get_cffi_modules(),
     install_requires=["cffi>=1.0.0"],
+    include_package_data=True,
 )


### PR DESCRIPTION
Distro packagers are asking for us to include the tests in release tarballs so
they can run the tests, which seems very reasonable. Let's not prune these.
Looks like everything is included on this test result:

copying test/__init__.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/conftest.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_bar.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_command.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_command_graph.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_config.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_configurable.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_fakescreen.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_hook.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_images.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_images2.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_manager.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_popup.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_qtile_cmd.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_scratchpad.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_sh.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/test_utils.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test
copying test/configs/basic.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/configs
copying test/configs/syntaxerr.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/configs
copying test/data/comparison_images/audio-volume-muted_bad.png -> qtile-0.16.1.dev0+g340a8386.d20200723/test/data/comparison_images
copying test/data/comparison_images/audio-volume-muted_good.png -> qtile-0.16.1.dev0+g340a8386.d20200723/test/data/comparison_images
copying test/data/png/audio-volume-muted.png -> qtile-0.16.1.dev0+g340a8386.d20200723/test/data/png
copying test/data/png/battery-caution-charging.png -> qtile-0.16.1.dev0+g340a8386.d20200723/test/data/png
copying test/data/svg/audio-volume-muted.svg -> qtile-0.16.1.dev0+g340a8386.d20200723/test/data/svg
copying test/layouts/__init__.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/layout_utils.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_bsp.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_columns.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_common.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_floating.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_matrix.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_max.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_ratiotile.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_slice.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_stack.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_tile.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_treetab.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_verticaltile.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_xmonad.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/layouts/test_zoomy.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/layouts
copying test/scripts/tkwindow.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/scripts
copying test/scripts/window.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/scripts
copying test/widgets/__init__.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/widgets/conftest.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/widgets/test_battery.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/widgets/test_chord.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/widgets/test_misc.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/widgets/test_volume.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/widgets
copying test/x11/__init__.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/x11
copying test/x11/test_xcbq.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/x11
copying test/x11/test_xcore.py -> qtile-0.16.1.dev0+g340a8386.d20200723/test/x11

Closes #1828

Signed-off-by: Tycho Andersen <tycho@tycho.ws>