### PR TITLE
window: user placed windows should go on top of other windows

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -501,7 +501,7 @@ class _Window(CommandObject):
         self.borderwidth = borderwidth
         self.bordercolor = borderpixel
         self.window.set_attribute(borderpixel=borderpixel)
-        self.window.configure(borderwidth=borderwidth)
+        self.window.configure(borderwidth=borderwidth, stackmode=StackMode.Above)
         self.unhide()
 
     def send_configure_notify(self, x, y, width, height):


### PR DESCRIPTION
Before 0f886606e1f3 ("floating: respect size hints from client/user") we
would always window.place() these windows, so they would be placed above.
Now that we don't call place() any more, we still need to tell these
windows to be above others.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>