### PR TITLE
propagate pointer events to bar and widget enter/leave to widgets

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -43,7 +43,6 @@ _IGNORED_EVENTS = {
     xcffib.xproto.FocusInEvent,
     xcffib.xproto.FocusOutEvent,
     xcffib.xproto.KeyReleaseEvent,
-    xcffib.xproto.LeaveNotifyEvent,
     # DWM handles this to help "broken focusing windows".
     xcffib.xproto.MapNotifyEvent,
     xcffib.xproto.NoExposureEvent,
@@ -295,6 +294,8 @@ class XCore(base.Core):
         # Certain events expose the affected window id as an "event" attribute.
         event_events = [
             "EnterNotify",
+            "LeaveNotify",
+            "MotionNotify",
             "ButtonPress",
             "ButtonRelease",
             "KeyPress",

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -161,6 +161,7 @@ class Bar(Gap, configurable.Configurable):
         self.add_defaults(Bar.defaults)
         self.widgets = widgets
         self.saved_focus = None
+        self.cursor_in = None
 
         self.queued_draws = 0
 
@@ -214,6 +215,9 @@ class Bar(Gap, configurable.Configurable):
         self.window.handle_Expose = self.handle_Expose
         self.window.handle_ButtonPress = self.handle_ButtonPress
         self.window.handle_ButtonRelease = self.handle_ButtonRelease
+        self.window.handle_EnterNotify = self.handle_EnterNotify
+        self.window.handle_LeaveNotify = self.handle_LeaveNotify
+        self.window.handle_MotionNotify = self.handle_MotionNotify
         qtile.windows_map[self.window.window.wid] = self.window
         self.window.unhide()
 
@@ -303,6 +307,32 @@ class Bar(Gap, configurable.Configurable):
                 e.event_y - widget.offsety,
                 e.detail
             )
+
+    def handle_EnterNotify(self, e):  # noqa: N802
+        widget = self.get_widget_in_position(e)
+        if widget:
+            widget.mouse_enter(
+                e.event_x - widget.offsetx,
+                e.event_y - widget.offsety,
+            )
+        self.cursor_in = widget
+
+    def handle_LeaveNotify(self, e):  # noqa: N802
+        if self.cursor_in:
+            self.cursor_in.mouse_leave(
+                e.event_x - self.cursor_in.offsetx,
+                e.event_y - self.cursor_in.offsety,
+            )
+            self.cursor_in = None
+
+    def handle_MotionNotify(self, e):  # noqa: N802
+        widget = self.get_widget_in_position(e)
+        if widget and widget is not self.cursor_in:
+            widget.mouse_enter(
+                e.event_x - widget.offsetx,
+                e.event_y - widget.offsety,
+            )
+        self.cursor_in = widget
 
     def widget_grab_keyboard(self, widget):
         """

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -296,6 +296,12 @@ class _Widget(CommandObject, configurable.Configurable):
     def create_mirror(self):
         return Mirror(self)
 
+    def mouse_enter(self, x, y):
+        pass
+
+    def mouse_leave(self, x, y):
+        pass
+
 
 UNSPECIFIED = bar.Obj("UNSPECIFIED")
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -672,6 +672,8 @@ class Internal(_Window):
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
         EventMask.EnterWindow | \
+        EventMask.LeaveWindow | \
+        EventMask.PointerMotion | \
         EventMask.FocusChange | \
         EventMask.Exposure | \
         EventMask.ButtonPress | \


### PR DESCRIPTION
EnterNotify, LeaveNotify and MotionNotify events are propagated to bars,
and bars use this information to calculate when the pointer enters and
leaves widgets then inform widgets when the pointer enters or leaves
them. Widgets can then override the mouse_enter and mouse_leave methods
to subscribe actions to these events, e.g. tooltips (#1441).

Co-authored-by: Tycho Andersen <tycho@tycho.ws>