### PR TITLE
core: don't resize 0th screen on ConfigureNotify

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -558,13 +558,6 @@ class XCore(base.Core):
 
         self.qtile.process_button_motion(event.event_x, event.event_y)
 
-    def handle_ConfigureNotify(self, event) -> None:  # noqa: N802
-        """Handle xrandr events"""
-        assert self.qtile is not None
-
-        if event.window == self._root.wid:
-            self.qtile.process_configure(event.width, event.height)
-
     def handle_ConfigureRequest(self, event):  # noqa: N802
         # It's not managed, or not mapped, so we just obey it.
         cw = xcffib.xproto.ConfigWindow

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -348,10 +348,6 @@ class Qtile(CommandObject):
     def paint_screen(self, screen, image_path, mode=None):
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_configure(self, width: int, height: int) -> None:
-        screen = self.current_screen
-        screen.resize(0, 0, width, height)
-
     def process_key_event(self, keysym: int, mask: int) -> None:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -26,7 +26,6 @@
 # SOFTWARE.
 
 import logging
-import subprocess
 
 import pytest
 import xcffib.xproto
@@ -877,58 +876,6 @@ def test_screens(qtile):
     self = qtile
 
     assert len(self.c.screens())
-
-
-@manager_config
-@no_xinerama
-def test_rotate(qtile):
-    self = qtile
-
-    self.test_window("one")
-    s = self.c.screens()[0]
-    height, width = s["height"], s["width"]
-    subprocess.call(
-        [
-            "xrandr",
-            "--output", "default",
-            "-display", self.display,
-            "--rotate", "left"
-        ],
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE
-    )
-
-    @Retry(ignore_exceptions=(AssertionError,), fail_msg="Screen did not rotate")
-    def run():
-        s = self.c.screens()[0]
-        assert s['width'] == height
-        assert s['height'] == width
-        return True
-    run()
-
-
-# TODO: see note on test_resize
-@manager_config
-@no_xinerama
-def test_resize_(qtile):
-    self = qtile
-
-    self.test_window("one")
-    subprocess.call(
-        [
-            "xrandr",
-            "-s", "480x640",
-            "-display", self.display
-        ]
-    )
-
-    @Retry(ignore_exceptions=(AssertionError,), fail_msg="Screen did not resize")
-    def run():
-        d = self.c.screen.info()
-        assert d['width'] == 480
-        assert d['height'] == 640
-        return True
-    run()
 
 
 @manager_config


### PR DESCRIPTION
First, the comment """ Handle xrandr events """ is incorrect, since
ConfigureNotify doesn't come from the randr extension. (People can handle
randr events by subscribing to the ScreenChangeNotify hook.)

Second, it is incorrect to change the 0th screen's size on ConfigureNotify
for the root window, since the root window spans all current screens, not
just the 0th one. When we do this, it makes the one group span both
screens, which is a bug. This event happens on e.g. fullscreen exit
from some games, resume from suspend or hibernate, etc.

This does mean that we don't really handle the root window changing sizes
(e.g. when someone adds or deletes a monitor), but we already didn't do
that, so let's not try and pretend and introduce bugs.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>