### PR TITLE
Ensure that libqtile.qtile is never None from the user perspective

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -81,9 +81,7 @@ class Config:
     @classmethod
     def from_file(cls, path: str, kore: Optional[base.Core] = None):
         "Create a Config() object from the python file located at path."
-        cnf = cls(file_path=path, kore=kore)
-        cnf.load()
-        return cnf
+        return cls(file_path=path, kore=kore)
 
     def load(self):
         name = os.path.splitext(os.path.basename(self.file_path))[0]

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -76,6 +76,9 @@ class Config:
             setattr(self, key, value)
 
     def load(self):
+        if not self.file_path:
+            return
+
         name = os.path.splitext(os.path.basename(self.file_path))[0]
 
         # Make sure we'll import the latest version of the config

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -24,9 +24,6 @@
 # SOFTWARE.
 import os
 import sys
-from typing import Optional
-
-from libqtile.backend import base
 
 
 class ConfigError(Exception):
@@ -77,11 +74,6 @@ class Config:
             except KeyError:
                 value = getattr(self, key, default[key])
             setattr(self, key, value)
-
-    @classmethod
-    def from_file(cls, path: str, kore: Optional[base.Core] = None):
-        "Create a Config() object from the python file located at path."
-        return cls(file_path=path, kore=kore)
 
     def load(self):
         name = os.path.splitext(os.path.basename(self.file_path))[0]

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -37,7 +37,7 @@ import xcffib.xinerama
 import xcffib.xproto
 
 import libqtile
-from libqtile import command_interface, hook, utils, window
+from libqtile import command_interface, confreader, hook, utils, window
 from libqtile.backend.x11 import xcbq
 from libqtile.command_client import InteractiveCommandClient
 from libqtile.command_interface import IPCCommandServer, QtileCommandInterface
@@ -106,6 +106,16 @@ class Qtile(CommandObject):
         self.current_chord = False
 
         self.numlock_mask, self.valid_mask = self.core.masks
+
+        if hasattr(self.config, "load"):
+            try:
+                self.config.load()
+            except Exception as e:
+                logger.exception('Error while reading config file (%s)', e)
+                self.config = confreader.Config()
+                from libqtile.widget import TextBox
+                widgets = self.config.screens[0].bottom.widgets
+                widgets.insert(0, TextBox('Config Err!'))
 
         self.core.wmname = getattr(self.config, "wmname", "qtile")
         if config.main:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -107,15 +107,14 @@ class Qtile(CommandObject):
 
         self.numlock_mask, self.valid_mask = self.core.masks
 
-        if hasattr(self.config, "load"):
-            try:
-                self.config.load()
-            except Exception as e:
-                logger.exception('Error while reading config file (%s)', e)
-                self.config = confreader.Config()
-                from libqtile.widget import TextBox
-                widgets = self.config.screens[0].bottom.widgets
-                widgets.insert(0, TextBox('Config Err!'))
+        try:
+            self.config.load()
+        except Exception as e:
+            logger.exception('Error while reading config file (%s)', e)
+            self.config = confreader.Config()
+            from libqtile.widget import TextBox
+            widgets = self.config.screens[0].bottom.widgets
+            widgets.insert(0, TextBox('Config Err!'))
 
         self.core.wmname = getattr(self.config, "wmname", "qtile")
         if config.main:

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -109,28 +109,21 @@ def make_qtile():
     init_log(log_level=log_level)
     kore = xcore.XCore()
 
-    try:
-        if not path.isfile(options.configfile):
-            try:
-                makedirs(path.dirname(options.configfile), exist_ok=True)
-                from shutil import copyfile
-                default_config_path = path.join(path.dirname(__file__),
-                                                "..",
-                                                "resources",
-                                                "default_config.py")
-                copyfile(default_config_path, options.configfile)
-                logger.info('Copied default_config.py to %s', options.configfile)
-            except Exception as e:
-                logger.exception('Failed to copy default_config.py to %s: (%s)',
-                                 options.configfile, e)
+    if not path.isfile(options.configfile):
+        try:
+            makedirs(path.dirname(options.configfile), exist_ok=True)
+            from shutil import copyfile
+            default_config_path = path.join(path.dirname(__file__),
+                                            "..",
+                                            "resources",
+                                            "default_config.py")
+            copyfile(default_config_path, options.configfile)
+            logger.info('Copied default_config.py to %s', options.configfile)
+        except Exception as e:
+            logger.exception('Failed to copy default_config.py to %s: (%s)',
+                             options.configfile, e)
 
-        config = confreader.Config.from_file(options.configfile, kore=kore)
-    except Exception as e:
-        logger.exception('Error while reading config file (%s)', e)
-        config = confreader.Config()
-        from libqtile.widget import TextBox
-        widgets = config.screens[0].bottom.widgets
-        widgets.insert(0, TextBox('Config Err!'))
+    config = confreader.Config.from_file(options.configfile, kore=kore)
 
     # XXX: the import is here because we need to call init_log
     # before start importing stuff

--- a/libqtile/scripts/qtile.py
+++ b/libqtile/scripts/qtile.py
@@ -123,7 +123,7 @@ def make_qtile():
             logger.exception('Failed to copy default_config.py to %s: (%s)',
                              options.configfile, e)
 
-    config = confreader.Config.from_file(options.configfile, kore=kore)
+    config = confreader.Config(options.configfile, kore=kore)
 
     # XXX: the import is here because we need to call init_log
     # before start importing stuff

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,6 +39,7 @@ import xcffib.xproto
 import libqtile.config
 from libqtile import command_client, command_interface, ipc
 from libqtile.backend.x11 import xcore
+from libqtile.confreader import Config
 from libqtile.core.session_manager import SessionManager
 from libqtile.lazy import lazy
 from libqtile.log_utils import init_log
@@ -125,7 +126,7 @@ def whereis(program):
     return None
 
 
-class BareConfig:
+class BareConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_bsp.py
+++ b/test/layouts/test_bsp.py
@@ -21,11 +21,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class BspConfig:
+class BspConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -21,11 +21,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class ColumnsConfig:
+class ColumnsConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -23,6 +23,7 @@ import pytest
 import libqtile.config
 import libqtile.hook
 from libqtile import layout
+from libqtile.confreader import Config
 from test.layouts.layout_utils import (
     assert_dimensions_fit,
     assert_focus_path_unordered,
@@ -30,7 +31,7 @@ from test.layouts.layout_utils import (
 )
 
 
-class AllLayoutsConfig:
+class AllLayoutsConfig(Config):
     """
     Ensure that all layouts behave consistently in some common scenarios.
     """

--- a/test/layouts/test_floating.py
+++ b/test/layouts/test_floating.py
@@ -22,11 +22,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focused
 
 
-class FloatingConfig:
+class FloatingConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_matrix.py
+++ b/test/layouts/test_matrix.py
@@ -29,11 +29,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class MatrixConfig:
+class MatrixConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -29,11 +29,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class MaxConfig:
+class MaxConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_ratiotile.py
+++ b/test/layouts/test_ratiotile.py
@@ -31,11 +31,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class RatioTileConfig:
+class RatioTileConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -29,6 +29,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import (
     assert_dimensions,
@@ -37,7 +38,7 @@ from test.layouts.layout_utils import (
 )
 
 
-class SliceConfig:
+class SliceConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -29,11 +29,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class StackConfig:
+class StackConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -29,11 +29,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class TileConfig:
+class TileConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -22,11 +22,12 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class TreeTabConfig:
+class TreeTabConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_verticaltile.py
+++ b/test/layouts/test_verticaltile.py
@@ -29,6 +29,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import (
     assert_dimensions,
@@ -37,7 +38,7 @@ from test.layouts.layout_utils import (
 )
 
 
-class VerticalTileConfig:
+class VerticalTileConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -22,6 +22,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import (
     assert_dimensions,
@@ -30,7 +31,7 @@ from test.layouts.layout_utils import (
 )
 
 
-class MonadTallConfig:
+class MonadTallConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a")
@@ -49,7 +50,7 @@ def monadtall_config(x):
     return no_xinerama(pytest.mark.parametrize("qtile", [MonadTallConfig], indirect=True)(x))
 
 
-class MonadTallMarginsConfig:
+class MonadTallMarginsConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a")
@@ -68,7 +69,7 @@ def monadtallmargins_config(x):
     return no_xinerama(pytest.mark.parametrize("qtile", [MonadTallMarginsConfig], indirect=True)(x))
 
 
-class MonadWideConfig:
+class MonadWideConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a")
@@ -87,7 +88,7 @@ def monadwide_config(x):
     return no_xinerama(pytest.mark.parametrize("qtile", [MonadWideConfig], indirect=True)(x))
 
 
-class MonadWideMarginsConfig:
+class MonadWideMarginsConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a")

--- a/test/layouts/test_zoomy.py
+++ b/test/layouts/test_zoomy.py
@@ -29,6 +29,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import (
     assert_dimensions,
@@ -37,7 +38,7 @@ from test.layouts.layout_utils import (
 )
 
 
-class ZoomyConfig:
+class ZoomyConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -34,7 +34,7 @@ import libqtile.layout
 import libqtile.widget
 
 
-class GBConfig:
+class GBConfig(libqtile.confreader.Config):
     auto_fullscreen = True
     keys = []
     mouse = []
@@ -178,7 +178,7 @@ def test_groupbox_button_press(qtile):
     assert qtile.c.groups()["a"]["screen"] == 0
 
 
-class GeomConf:
+class GeomConf(libqtile.confreader.Config):
     auto_fullscreen = False
     keys = []
     mouse = []
@@ -311,7 +311,7 @@ class ExampleWidget(libqtile.widget.base._Widget):
         pass
 
 
-class IncompatibleWidgetConf:
+class IncompatibleWidgetConf(libqtile.confreader.Config):
     keys = []
     mouse = []
     groups = [libqtile.config.Group("a")]

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -30,10 +30,11 @@ import libqtile.layout
 import libqtile.widget
 from libqtile.command_interface import CommandError
 from libqtile.command_object import CommandObject
+from libqtile.confreader import Config
 from libqtile.lazy import lazy
 
 
-class CallConfig:
+class CallConfig(Config):
     keys = [
         libqtile.config.Key(
             ["control"], "j",
@@ -121,7 +122,7 @@ def test_command():
     assert not c.command("nonexistent")
 
 
-class ServerConfig:
+class ServerConfig(Config):
     auto_fullscreen = True
     keys = []
     mouse = []

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -32,14 +32,14 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 
 def test_validate():
     xc = xcore.XCore()
-    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
+    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
     f.load()
     f.keys[0].key = "nonexistent"
     with pytest.raises(confreader.ConfigError):
         f.validate()
 
     f.keys[0].key = "x"
-    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
+    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
     f.load()
     f.keys[0].modifiers = ["nonexistent"]
     with pytest.raises(confreader.ConfigError):
@@ -48,19 +48,19 @@ def test_validate():
 
 
 def test_syntaxerr():
-    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "syntaxerr.py"))
+    f = confreader.Config(os.path.join(tests_dir, "configs", "syntaxerr.py"))
     with pytest.raises(confreader.ConfigError):
         f.load()
 
 
 def test_basic():
-    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"))
     f.load()
     assert f.keys
 
 
 def test_falls_back():
-    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
+    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"))
     f.load()
 
     # We just care that it has a default, we don't actually care what the

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -33,13 +33,14 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 def test_validate():
     xc = xcore.XCore()
     f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
-    f.validate()
+    f.load()
     f.keys[0].key = "nonexistent"
     with pytest.raises(confreader.ConfigError):
         f.validate()
 
     f.keys[0].key = "x"
     f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"), xc)
+    f.load()
     f.keys[0].modifiers = ["nonexistent"]
     with pytest.raises(confreader.ConfigError):
         f.validate()
@@ -47,17 +48,20 @@ def test_validate():
 
 
 def test_syntaxerr():
+    f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "syntaxerr.py"))
     with pytest.raises(confreader.ConfigError):
-        confreader.Config.from_file(os.path.join(tests_dir, "configs", "syntaxerr.py"))
+        f.load()
 
 
 def test_basic():
     f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
+    f.load()
     assert f.keys
 
 
 def test_falls_back():
     f = confreader.Config.from_file(os.path.join(tests_dir, "configs", "basic.py"))
+    f.load()
 
     # We just care that it has a default, we don't actually care what the
     # default is; don't assert anything at all about the default in case

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -28,6 +28,7 @@ import pytest
 import libqtile.config
 from libqtile import bar, layout, widget
 from libqtile.config import Screen
+from libqtile.confreader import Config
 
 LEFT_ALT = 'mod1'
 WINDOWS = 'mod4'
@@ -57,7 +58,7 @@ GRAPH_KW = dict(line_width=1,
 # also D goes down below the others
 
 
-class FakeScreenConfig:
+class FakeScreenConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -40,11 +40,12 @@ import libqtile.layout
 import libqtile.widget
 from libqtile.backend.x11 import xcbq
 from libqtile.command_interface import CommandError, CommandException
+from libqtile.confreader import Config
 from libqtile.lazy import lazy
 from test.conftest import BareConfig, Retry, no_xinerama
 
 
-class ManagerConfig:
+class ManagerConfig(Config):
     auto_fullscreen = True
     groups = [
         libqtile.config.Group("a"),
@@ -223,7 +224,7 @@ def test_keypress(qtile):
     assert self.c.groups()["a"]["focus"] == "one"
 
 
-class _ChordsConfig:
+class _ChordsConfig(Config):
     groups = [
         libqtile.config.Group("a")
     ]
@@ -1091,7 +1092,7 @@ def test_dheight():
     assert s.dheight == 80
 
 
-class _Config:
+class _Config(Config):
     groups = [
         libqtile.config.Group("a"),
         libqtile.config.Group("b"),

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -27,9 +27,10 @@ import libqtile.bar
 import libqtile.config
 import libqtile.layout
 import libqtile.widget
+from libqtile.confreader import Config
 
 
-class ServerConfig:
+class ServerConfig(Config):
     auto_fullscreen = True
     keys = []
     mouse = []

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -23,11 +23,12 @@ import pytest
 import libqtile.config
 import libqtile.layout
 import libqtile.widget
+from libqtile.confreader import Config
 from test.conftest import Retry, no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
 
-class ScratchPadBaseConfic:
+class ScratchPadBaseConfic(Config):
     auto_fullscreen = True
     screens = []
     groups = [

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -24,11 +24,12 @@ import pytest
 
 from libqtile import config, ipc
 from libqtile.command_interface import IPCCommandInterface
+from libqtile.confreader import Config
 from libqtile.layout import Max, floating
 from libqtile.sh import QSh
 
 
-class ShConfig:
+class ShConfig(Config):
     keys = []
     mouse = []
     groups = [


### PR DESCRIPTION
`libqtile.qtile` is `None` until `libqtile.init` is called, which is made in `Qtile.__init__`. Let's defer configuration loading after that step to make sure that an user importing `libqtile.qtile` will never get `None` instead of a manager instance.