### PR TITLE
MANIFEST: include scripts/ffibuild in release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,7 @@ prune scripts
 prune rpm
 include bin/dqtile-cmd
 include bin/iqshell
+include scripts/ffibuild
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Per #1828, scripts/ffibuild should be included in the release tarball to
run the tests.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>