### PR TITLE
Fixes #1867: Avoid problems after failing to map keys.

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -408,7 +408,11 @@ class XCore(base.Core):
                     xcffib.xproto.GrabMode.Async,
                 )
         else:
-            logger.warning("Keysym could not be mapped: {keysym}, mask: {modmask}".format(keysym=keysym, modmask=modmask))
+            logger.warning(
+                "Keysym could not be mapped: {keysym}, mask: {modmask}".format(
+                    keysym=hex(keysym), modmask=modmask
+                )
+            )
 
         return keysym, modmask & self._valid_mask
 

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -397,15 +397,18 @@ class XCore(base.Core):
         keysym, modmask = self.lookup_key(key)
         code = self.conn.keysym_to_keycode(keysym)
 
-        for amask in self._auto_modmasks():
-            self.conn.conn.core.GrabKey(
-                True,
-                self._root.wid,
-                modmask | amask,
-                code,
-                xcffib.xproto.GrabMode.Async,
-                xcffib.xproto.GrabMode.Async,
-            )
+        if code != 0:
+            for amask in self._auto_modmasks():
+                self.conn.conn.core.GrabKey(
+                    True,
+                    self._root.wid,
+                    modmask | amask,
+                    code,
+                    xcffib.xproto.GrabMode.Async,
+                    xcffib.xproto.GrabMode.Async,
+                )
+        else:
+            logger.warning("Keysym could not be mapped: {keysym}, mask: {modmask}".format(keysym=keysym, modmask=modmask))
 
         return keysym, modmask & self._valid_mask
 


### PR DESCRIPTION
This is supposed to fix the problems described in #1867 (a mostly unusable keyboard after mapping a key that is not available on the primary hardware).

This would be the minimal fix; I would much prefer if it *was* possible to map whatever keys I want to, especially if they were spread out over multiple devices. But so far I don't know if that's possible.