### PR TITLE
Add optional preferences to utils.guess_terminal

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -24,6 +24,7 @@ import os
 import sys
 import traceback
 import warnings
+from collections.abc import Sequence
 from shutil import which
 
 from libqtile.log_utils import logger
@@ -236,9 +237,14 @@ def send_notification(title, message, urgent=False, timeout=10000):
         logger.error(exception)
 
 
-def guess_terminal():
+def guess_terminal(preference=None):
     """Try to guess terminal."""
-    test_terminals = [
+    test_terminals = []
+    if isinstance(preference, str):
+        test_terminals += [preference]
+    elif isinstance(preference, Sequence):
+        test_terminals += list(preference)
+    test_terminals += [
         'roxterm',
         'sakura',
         'hyper',

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -20,6 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
 from libqtile import utils
 
 
@@ -57,3 +62,28 @@ def test_shuffle():
     assert test_l != list(range(3))
     utils.shuffle_down(test_l)
     assert test_l == list(range(3))
+
+
+def test_guess_terminal_accepts_a_preference(path):
+    term = 'shitty'
+    Path(path, term).touch(mode=0o777)
+    assert utils.guess_terminal(term) == term
+
+
+def test_guess_terminal_accepts_a_list_of_preferences(path):
+    term = 'shitty'
+    Path(path, term).touch(mode=0o777)
+    assert utils.guess_terminal(['nutty', term]) == term
+
+
+def test_guess_terminal_falls_back_to_defaults(path):
+    Path(path, 'kitty').touch(mode=0o777)
+    assert utils.guess_terminal(['nutty', 'witty', 'petty']) == 'kitty'
+
+
+@pytest.fixture
+def path(monkeypatch):
+    "Create a TemporaryDirectory as the PATH"
+    with TemporaryDirectory() as d:
+        monkeypatch.setenv('PATH', d)
+        yield d


### PR DESCRIPTION
This makes it a tiny bit easier to have a portable config that works on
machines where your favourite terminal isn't available.