### PR TITLE
Unmap withdrawn windows when (re)starting Qtile

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -209,6 +209,7 @@ class XCore(base.Core):
             if attrs and attrs.map_state == xcffib.xproto.MapState.Unmapped:
                 continue
             if state and state[0] == window.WithdrawnState:
+                item.unmap()
                 continue
             self.qtile.manage(item)
 


### PR DESCRIPTION
Currently windows in the withdrawn state are untouched when scanning for
windows upon start or restarting, but at some point they appear to be
mapped and then stay present on the screen. When we scan for windows and
find withdrawn windows, these should be unmapped. Fixes #1861, and
possibly #1379