### PR TITLE
Let widgets send notifications during cmd_s with notify=True

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -25,9 +25,21 @@ import sys
 import traceback
 import warnings
 from collections.abc import Sequence
+from random import randint
 from shutil import which
 
 from libqtile.log_utils import logger
+
+_can_notify = False
+try:
+    import gi
+    gi.require_version("Notify", "0.7")  # type: ignore
+    from gi.repository import Notify  # type: ignore
+    Notify.init("Qtile")
+    if Notify.get_server_info()[0]:
+        _can_notify = True
+except Exception:
+    pass
 
 
 class QtileError(Exception):
@@ -219,22 +231,19 @@ def safe_import(module_names, class_name, globals_, fallback=None):
         globals_[class_name] = class_proxy
 
 
-def send_notification(title, message, urgent=False, timeout=10000):
+def send_notification(title, message, urgent=False, timeout=10000, id=None):
     """Send a notification."""
-    try:
-        import gi
-        gi.require_version("Notify", "0.7")
-        from gi.repository import Notify
-        Notify.init("Qtile")
-        info = Notify.get_server_info()
-        if info[0]:
-            notifier = Notify.Notification.new(title, message)
-            notifier.set_timeout(timeout)
-            if urgent:
-                notifier.set_urgency(Notify.Urgency.CRITICAL)
-            notifier.show()
-    except Exception as exception:
-        logger.error(exception)
+    if _can_notify:
+        notifier = Notify.Notification.new(title, message)
+        notifier.set_timeout(timeout)
+        if urgent:
+            notifier.set_urgency(Notify.Urgency.CRITICAL)
+        notifier.set_timeout(timeout)
+        if id is None:
+            id = randint(10, 1000)
+        notifier.set_property('id', id)
+        notifier.show()
+        return id
 
 
 def guess_terminal(preference=None):

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -28,6 +28,7 @@ from functools import partial
 from typing import Dict
 
 from libqtile.log_utils import logger
+from libqtile.utils import send_notification
 from libqtile.widget import base
 
 BACKLIGHT_DIR = '/sys/class/backlight'
@@ -87,6 +88,7 @@ class Backlight(base.InLoopPollText):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(Backlight.defaults)
         self._future = None
+        self._notify_id = None
 
         self.brightness_file = os.path.join(
             BACKLIGHT_DIR, self.backlight_name, self.brightness_file,
@@ -145,5 +147,12 @@ class Backlight(base.InLoopPollText):
             new = max(now - step, 0)
         elif direction is ChangeDirection.UP:
             new = min(now + step, 100)
+        if self.notify:
+            self._notify_id = send_notification(
+                "Backlight",
+                "{:n}%".format(new),
+                timeout=self.notify_timeout,
+                id=self._notify_id,
+            )
         if new != now:
             self._future = self.qtile.run_in_executor(self._change_backlight, new)

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -114,6 +114,8 @@ class _Widget(CommandObject, configurable.Configurable):
     defaults = [
         ("background", None, "Widget background color"),
         ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
+        ("notify", False, "Enable notifications upon status change, if supported."),
+        ("notify_timeout", 10000, "Milliseconds before notifications disappear."),
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, length, **config):

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from libqtile.utils import send_notification
 from libqtile.widget._pulse_audio import ffi, lib
 from libqtile.widget.volume import Volume
 
@@ -177,6 +178,8 @@ class PulseVolume(Volume):
         )
         if op:
             self.wait_for_operation(op)
+        if self.notify:
+            self._notify()
 
     def cmd_mute(self):
         op = lib.pa_context_set_sink_mute_by_index(
@@ -188,6 +191,8 @@ class PulseVolume(Volume):
         )
         if op:
             self.wait_for_operation(op)
+        if self.notify:
+            self._notify()
 
     def cmd_increase_vol(self, value=None):
         if value is None:
@@ -258,3 +263,8 @@ class PulseVolume(Volume):
             self.timeout_add(self.update_interval, self.timer_setup)
         if self.theme_path:
             self.setup_images()
+
+    def _notify(self):
+        volume = self.get_volume()
+        message = "Muted" if volume <= 0 else "{:n}%".format(volume)
+        send_notification("Volume", message, timeout=self.notify_timeout)

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -34,6 +34,7 @@ import re
 import subprocess
 
 from libqtile import bar
+from libqtile.utils import send_notification
 from libqtile.widget import base
 
 __all__ = [
@@ -75,6 +76,7 @@ class Volume(base._TextBox):
             self.length = 0
         self.surfaces = {}
         self.volume = None
+        self._notify_id = None
 
         self.add_callbacks({
             'Button1': self.cmd_mute,
@@ -195,6 +197,9 @@ class Volume(base._TextBox):
                                                        'sset',
                                                        self.channel,
                                                        '{}%+'.format(self.step)))
+        self.update()
+        if self.notify:
+            self._notify()
 
     def cmd_decrease_vol(self):
         if self.volume_down_command is not None:
@@ -204,6 +209,9 @@ class Volume(base._TextBox):
                                                        'sset',
                                                        self.channel,
                                                        '{}%-'.format(self.step)))
+        self.update()
+        if self.notify:
+            self._notify()
 
     def cmd_mute(self):
         if self.mute_command is not None:
@@ -213,7 +221,18 @@ class Volume(base._TextBox):
                                                        'sset',
                                                        self.channel,
                                                        'toggle'))
+        self.update()
+        if self.notify:
+            self._notify()
 
     def cmd_run_app(self):
         if self.volume_app is not None:
             subprocess.Popen(self.volume_app, shell=True)
+
+    def _notify(self):
+        self._notify_id = send_notification(
+            "Volume",
+            "{:n}%".format(self.volume),
+            timeout=self.notify_timeout,
+            id=self._notify_id,
+        )


### PR DESCRIPTION
This introduces two options for all widgets, 'notify' and
'notify_timeout', which will be used by supporting widgets to send
notifications upon status changes. For example, currently the backlight
and volume widgets will, if notify=True is passed, send notifications
when the backlight and volume changes. The send_notifications has been
updated to allow for optional passing of an 'id', which by the
notification service spec should make notifications replace visible
notifications of the same id, so e.g. if you bind
Backlight.cmd_increase_backlight to a key and hit it many times, only
one notification should appear, and it should get replaced/updated
instead of loads of separate notifications appearing.