### PR TITLE
Reconfigure screens upon screen_change events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,11 @@ Qtile 0.x.x, released xxxx-xx-xx:
         - memory widget can now be displayed with decimal values
         - new "qtile migrate" command, which will attempt to upgrade previous
           configs to the current version in the case of qtile API breaks.
+        - A new `reconfigure_screens` config setting. When `True` (default) it
+          hooks `Qtile.reconfigure_screens` to the `screen_change` hook,
+          reconfiguring qtile's screens in response to randr events. This
+          removes the need to restart qtile when adding/removing external
+          monitors.
     * bugfixes
         - fix KeyboardLayout widget (xkb-switch is new dependency)
 

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -164,6 +164,10 @@ configuration variables that control specific aspects of Qtile's behavior:
              fontsize=12,
              padding=3)
       - Default settings for bar widgets.
+    * - reconfigure_screens
+      - True
+      - Controls whether or not to automatically reconfigure screens when there
+        are changes in randr output configuration.
     * - wmname
       - "LG3D"
       - Gasp! We're lying here. In fact, nobody really uses or cares

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -779,28 +779,6 @@ class Connection:
             if i in self._extmap:
                 setattr(self, i, self._extmap[i](self))
 
-        self.pseudoscreens = []
-        if "xinerama" in extensions:
-            for i, s in enumerate(self.xinerama.query_screens()):
-                scr = PseudoScreen(
-                    self,
-                    s.x_org,
-                    s.y_org,
-                    s.width,
-                    s.height,
-                )
-                self.pseudoscreens.append(scr)
-        elif "randr" in extensions:
-            for i in self.randr.query_crtcs(self.screens[0].root.wid):
-                scr = PseudoScreen(
-                    self,
-                    i["x"],
-                    i["y"],
-                    i["width"],
-                    i["height"],
-                )
-                self.pseudoscreens.append(scr)
-
         self.atoms = AtomCache(self)
 
         self.code_to_syms = {}
@@ -809,6 +787,31 @@ class Connection:
 
         self.modmap = None
         self.refresh_modmap()
+
+    @property
+    def pseudoscreens(self):
+        pseudoscreens = []
+        if hasattr(self, "xinerama"):
+            for i, s in enumerate(self.xinerama.query_screens()):
+                scr = PseudoScreen(
+                    self,
+                    s.x_org,
+                    s.y_org,
+                    s.width,
+                    s.height,
+                )
+                pseudoscreens.append(scr)
+        elif hasattr(self, "randr"):
+            for i in self.randr.query_crtcs(self.screens[0].root.wid):
+                scr = PseudoScreen(
+                    self,
+                    i["x"],
+                    i["y"],
+                    i["width"],
+                    i["height"],
+                )
+                pseudoscreens.append(scr)
+        return pseudoscreens
 
     def finalize(self):
         self.cursors.finalize()

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -58,6 +58,7 @@ class Config:
         ("widget_defaults", "Dict[str, Any]"),
         ("extension_defaults", "Dict[str, Any]"),
         ("bring_front_click", "bool"),
+        ("reconfigure_screens", "bool"),
         ("wmname", "str"),
     ]
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -195,6 +195,9 @@ class Qtile(CommandObject):
         self.update_net_desktops()
         hook.subscribe.setgroup(self.update_net_desktops)
 
+        if self.config.reconfigure_screens:
+            hook.subscribe.screen_change(self.cmd_reconfigure_screens)
+
         hook.fire("startup_complete")
 
     def _prepare_socket_path(
@@ -299,6 +302,7 @@ class Qtile(CommandObject):
             self.screens.append(s)
 
     def _process_screens(self) -> None:
+        self.screens = []
         if hasattr(self.config, 'fake_screens'):
             self._process_fake_screens()
             return
@@ -324,6 +328,23 @@ class Qtile(CommandObject):
 
             scr._configure(self, i, x, y, w, h, grp)
             self.screens.append(scr)
+
+    def cmd_reconfigure_screens(self, ev=None):
+        """
+        This can be used to set up screens again during run time. Intended usage is to
+        be called when the screen_change hook is fired, responding to changes in
+        physical monitor setup by configuring qtile.screens accordingly. The ev kwarg is
+        ignored; it is here in case this function is hooked directly to screen_change.
+        """
+        logger.info("Reconfiguring screens.")
+        self._process_screens()
+
+        for group in self.groups:
+            if group.screen:
+                if group.screen in self.screens:
+                    group.layout_all()
+                else:
+                    group.hide()
 
     def paint_screen(self, screen, image_path, mode=None):
         self.core.painter.paint(screen, image_path, mode)

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -295,21 +295,10 @@ class Subscribe:
     def screen_change(self, func):
         """Called when a screen is added or screen configuration is changed (via xrandr)
 
-        Common usage is simply to call ``qtile.cmd_restart()`` on each event
-        (to restart qtile when there is a new monitor):
-
         **Arguments**
 
             * ``xproto.randr.ScreenChangeNotify`` event
 
-        Examples
-        --------
-
-        ::
-
-            @libqtile.hook.subscribe.screen_change
-            def restart_on_randr(ev):
-                libqtile.qtile.cmd_restart()
         """
         return self._subscribe("screen_change", func)
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -174,6 +174,7 @@ floating_layout = layout.Floating(float_rules=[
 ])
 auto_fullscreen = True
 focus_on_window_activation = "smart"
+reconfigure_screens = True
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the


### PR DESCRIPTION
This makes Qtile internally respond to changes in physical monitor setup
by reconfiguring screens, making it unnecessary to fully restart Qtile
to match the setup. Fixes #1874.