### PR TITLE
Focus screen when moving mouse between screens and into window (#1735)

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -726,9 +726,13 @@ class Qtile(CommandObject):
         return closest_screen
 
     def enter_event(self, event) -> Optional[bool]:
-        if event.event in self.windows_map:
-            return True
-        screen = self.find_screen(event.root_x, event.root_y)
+        win = self.windows_map.get(event.event, None)
+        if win is None:
+            screen = self.find_screen(event.root_x, event.root_y)
+        else:
+            if win.group.screen is self.current_screen:
+                return True
+            screen = win.group.screen
         if screen:
             self.focus_screen(screen.index, warp=False)
         return None


### PR DESCRIPTION
Fix for #1735

This bug was happening because `qtile.enter_event` is not called when the mouse goes between screens, only when the mouse enters a window. This makes it so that when you move the mouse into a different screen and then above one of its windows, it will focus that screen.