### PR TITLE
add window to Screen when centre window is dragged across

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -958,7 +958,9 @@ class Window(_Window):
         if self.width < 0:
             self.width = 0
 
-        screen = self.qtile.find_closest_screen(self.x, self.y)
+        screen = self.qtile.find_closest_screen(
+            self.x + self.width // 2, self.y + self.height // 2
+        )
         if self.group and screen is not None and screen != self.group.screen:
             self.group.remove(self, force=True)
             screen.group.add(self, force=True)


### PR DESCRIPTION
Currently, the top left corner of a window (self.x and self.y) are used
when dragging a window between screens. Using the centre-point of the
window makes the window's screen-switching behave more naturally when
dragging between screens. The annoyance is most apparent when, for
example, a window is dragged from left to right across screens and 1
pixel of the left edge remains on the left screen. When switching groups
on either screen, the window follows the left screen('s group) when it
seems like it ought to be on the right('s group).