### PR TITLE
Fetch layout names from config instead of folder when searching icons

### DIFF
--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -159,12 +159,7 @@ class CurrentLayoutIcon(base._TextBox):
         """
         Returns the list of lowercased strings for each available layout name.
         """
-        return [
-            layout_class_name.lower()
-            for layout_class, layout_class_name
-            in map(lambda x: (getattr(layout_module, x), x), dir(layout_module))
-            if inspect.isclass(layout_class) and issubclass(layout_class, Layout)
-        ]
+        return [l.__class__.__name__.lower() for l in self.qtile.config.layouts]
 
     def _update_icon_paths(self):
         self.icon_paths = []

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -25,14 +25,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import inspect
 import os
 
 import cairocffi
 
 from libqtile import bar, hook
-from libqtile import layout as layout_module
-from libqtile.layout.base import Layout
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -159,7 +156,7 @@ class CurrentLayoutIcon(base._TextBox):
         """
         Returns the list of lowercased strings for each available layout name.
         """
-        return [l.__class__.__name__.lower() for l in self.qtile.config.layouts]
+        return [layout.__class__.__name__.lower() for layout in self.qtile.config.layouts]
 
     def _update_icon_paths(self):
         self.icon_paths = []


### PR DESCRIPTION
I have been using a custom layout for a long time now, and the code for that layout sits somewhere in my home-folder instead of the qtile directory. I also created an icon for said layout and provided the path in my config as follows:

```python
widget.CurrentLayoutIcon(custom_icon_paths=[home + '/.config/qtile/icons'])
```

The problem with the current code is that icons can only be searched and found for _default_ layouts (stuff in qtiles layout-folder, to be more precise), which results in a warning message whenever a group with that layout is activated (my log gets quite long over the day). Also, I don't see why we have to load all icons for all the layouts if there are only a few of them available anyway.

This is a very small change, but there might be a reason things are set up as they are at the moment. If I overlooked something (maybe layouts can be added dynamically?), please let me know. I guess one could always combine the current code and this small fix to get all existing layouts.