### PR TITLE
remove already defined `install_requires` from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,5 @@ setup(
     cmdclass={'install': CheckCairoXcb},
     use_scm_version=True,
     cffi_modules=get_cffi_modules(),
-    install_requires=["cffi>=1.0.0"],
     include_package_data=True,
 )


### PR DESCRIPTION
The `install_requires` definition inside setup.py is redundant and also differs from the one in `setup.cfg`.