### PR TITLE
Fix Slice.add and make it use Match-object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ qtile X.X.X, released XXXX-XX-XX:
     !!! Config breakage !!!
 	- Pacman widget has been removed. Use CheckUpdates instead.
 	- property "masterWindows" of Tile layout renamed to master_length
+	- properties wname, wmclass and role of Slice-layout replaced by Match-
+	  type property "match"
 
 qtile 0.16.1, released 2020-08-11:
     !!! Config breakage !!!

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -95,23 +95,16 @@ class Slice(Delegate):
     """
 
     defaults = [
-        ("width", 256, "Slice width"),
-        ("side", "left", "Side of the slice (left, right, top, bottom)"),
+        ("width", 256, "Slice width."),
+        ("side", "left", "Position of the slice (left, right, top, bottom)."),
         ("name", "slice", "Name of this layout."),
-        ("wname", None, "WM_NAME to match"),
-        ("wmclass", None, "WM_CLASS to match"),
-        ("role", None, "WM_WINDOW_ROLE to match"),
-        ("fallback", Max(), "Fallback layout"),
+        ("match", None, "Match-object describing which window(s) to move to the slice."),
+        ("fallback", Max(), "Layout to be used for the non-slice area."),
     ]
 
     def __init__(self, **config):
         Delegate.__init__(self, **config)
         self.add_defaults(Slice.defaults)
-        self.match = {
-            'wname': self.wname,
-            'wmclass': self.wmclass,
-            'role': self.role,
-        }
         self._slice = Single()
 
     def clone(self, group):
@@ -158,7 +151,7 @@ class Slice(Delegate):
         return (win, sub)
 
     def add(self, win):
-        if self._slice.empty() and win.match(**self.match):
+        if self._slice.empty() and self.match and self.match.compare(win):
             self._slice.add(win)
             self.layouts[win] = self._slice
         else:

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -29,6 +29,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.config import Match
 from libqtile.confreader import Config
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import (
@@ -44,13 +45,13 @@ class SliceConfig(Config):
         libqtile.config.Group("a"),
     ]
     layouts = [
-        layout.Slice(side='left', width=200, wname='slice',
+        layout.Slice(side='left', width=200, match=Match(title=['slice']),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='right', width=200, wname='slice',
+        layout.Slice(side='right', width=200, match=Match(title=['slice']),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='top', width=200, wname='slice',
+        layout.Slice(side='top', width=200, match=Match(title=['slice']),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='bottom', width=200, wname='slice',
+        layout.Slice(side='bottom', width=200, match=Match(title=['slice']),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
     ]
     floating_layout = libqtile.layout.floating.Floating()


### PR DESCRIPTION
Inspired by #1470, since failing to pass in any matching criteria caused problems. As mentioned in that issue, I would prefer to use a proper `Match`-object here, but I could remove it again if it seemed unsuitable.

Replaces wname, wmclass and role properties with "match" (Match object).
Change a few comments.
Make `add` check whether `match` has been set up. (this is the "fix" for #1470)