### PR TITLE
Fixing bar.handle_MotionNotify: calling mouse_leave on previous widget

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -336,6 +336,10 @@ class Bar(Gap, configurable.Configurable):
     def handle_MotionNotify(self, e):  # noqa: N802
         widget = self.get_widget_in_position(e)
         if widget and widget is not self.cursor_in:
+            self.cursor_in.mouse_leave(
+                e.event_x - self.cursor_in.offsetx,
+                e.event_y - self.cursor_in.offsety,
+            )
             widget.mouse_enter(
                 e.event_x - widget.offsetx,
                 e.event_y - widget.offsety,


### PR DESCRIPTION
The bar.handle_MotionNotify method does not call mouse_leave on previously hovered widget. This commit fixes it.