### PR TITLE
Continued: Implement AND-match semantics for Match objects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,8 @@ qtile X.X.X, released XXXX-XX-XX:
           were made explicit and added to the default config
         - using `dict`s for `layout.Floating`'s `float_rules` is now deprecated, please
           use `config.Match` objects instead
+        - `no_reposition_match` in `layout.Floating` has been removed; use the list of
+          `config.Match`-objects `no_reposition_rules` instead
     * features
 	- new restart and shutdown hooks
         - rules specified in `layout.Floating`'s `float_rules` are now evaluated with

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,20 +4,20 @@ qtile X.X.X, released XXXX-XX-XX:
 	- property "masterWindows" of Tile layout renamed to master_length
 	- properties wname, wmclass and role of Slice-layout replaced by Match-
 	  type property "match"
-        - rules specified in `layout.Floating`'s `float_rules` are now evaluated with
-          AND-semantics instead of OR-semantics, i.e. if you specify 2 different
-          property rules, both have to match
-        - check the new `float_rules` for `floating_layout` in the default config and
-          extend your own rules appropriately: some non-configurable auto-floating rules
-          were made explicit and added to the default config
-        - using `dict`s for `layout.Floating`'s `float_rules` is now deprecated, please
-          use `config.Match` objects instead
-        - `no_reposition_match` in `layout.Floating` has been removed; use the list of
-          `config.Match`-objects `no_reposition_rules` instead
+	- rules specified in `layout.Floating`'s `float_rules` are now evaluated with
+	  AND-semantics instead of OR-semantics, i.e. if you specify 2 different
+	  property rules, both have to match
+	- check the new `float_rules` for `floating_layout` in the default config and
+	  extend your own rules appropriately: some non-configurable auto-floating rules
+	  were made explicit and added to the default config
+	- using `dict`s for `layout.Floating`'s `float_rules` is now deprecated, please
+	  use `config.Match` objects instead
+	- `no_reposition_match` in `layout.Floating` has been removed; use the list of
+	  `config.Match`-objects `no_reposition_rules` instead
     * features
 	- new restart and shutdown hooks
-        - rules specified in `layout.Floating`'s `float_rules` are now evaluated with
-          AND-semantics, allowing for more complex and specific rules
+	- rules specified in `layout.Floating`'s `float_rules` are now evaluated with
+	  AND-semantics, allowing for more complex and specific rules
 
 qtile 0.16.1, released 2020-08-11:
     !!! Config breakage !!!

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,18 @@ qtile X.X.X, released XXXX-XX-XX:
 	- property "masterWindows" of Tile layout renamed to master_length
 	- properties wname, wmclass and role of Slice-layout replaced by Match-
 	  type property "match"
+        - rules specified in `layout.Floating`'s `float_rules` are now evaluated with
+          AND-semantics instead of OR-semantics, i.e. if you specify 2 different
+          property rules, both have to match
+        - check the new `float_rules` for `floating_layout` in the default config and
+          extend your own rules appropriately: some non-configurable auto-floating rules
+          were made explicit and added to the default config
+        - using `dict`s for `layout.Floating`'s `float_rules` is now deprecated, please
+          use `config.Match` objects instead
     * features
 	- new restart and shutdown hooks
+        - rules specified in `layout.Floating`'s `float_rules` are now evaluated with
+          AND-semantics, allowing for more complex and specific rules
 
 qtile 0.16.1, released 2020-08-11:
     !!! Config breakage !!!

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -547,83 +547,91 @@ class ScratchPad(Group):
 class Match:
     """Match for dynamic groups
 
-    It can match by title, class or role.
+    It can match by title, wm_class, role, wm_type, wm_instance_class or
+    net_wm_pid.
 
     ``Match`` supports both regular expression objects (i.e. the result of
-    ``re.compile()``) or strings (match as a "include" match). If a window
-    matches any of the things in any of the lists, it is considered a match.
+    ``re.compile()``) or strings (match as an "include"-match). If a window
+    matches all specified values, it is considered a match.
 
     Parameters
     ==========
     title:
-        things to match against the title (WM_NAME)
+        matches against the title (WM_NAME)
     wm_class:
-        things to match against the second string in WM_CLASS atom
+        matches against the second string in WM_CLASS atom
     role:
-        things to match against the WM_ROLE atom
+        matches against the WM_ROLE atom
     wm_type:
-        things to match against the WM_TYPE atom
+        matches against the WM_TYPE atom
     wm_instance_class:
-        things to match against the first string in WM_CLASS atom
+        matches against the first string in WM_CLASS atom
     net_wm_pid:
-        things to match against the _NET_WM_PID atom (only int allowed in this
+        matches against the _NET_WM_PID atom (only int allowed for this
         rule)
     """
     def __init__(self, title=None, wm_class=None, role=None, wm_type=None,
                  wm_instance_class=None, net_wm_pid=None):
-        if not title:
-            title = []
-        if not wm_class:
-            wm_class = []
-        if not role:
-            role = []
-        if not wm_type:
-            wm_type = []
-        if not wm_instance_class:
-            wm_instance_class = []
-        if not net_wm_pid:
-            net_wm_pid = []
+        self._rules = {}
 
-        try:
-            net_wm_pid = list(map(int, net_wm_pid))
-        except ValueError:
-            error = 'Invalid rule for net_wm_pid: "%s" '\
-                    'only ints allowed' % str(net_wm_pid)
-            raise utils.QtileError(error)
+        if title is not None:
+            self._rules["title"] = title
+        if wm_class is not None:
+            self._rules["wm_class"] = wm_class
+        if role is not None:
+            self._rules["role"] = role
+        if wm_type is not None:
+            self._rules["wm_type"] = wm_type
+        if wm_instance_class is not None:
+            self._rules["wm_instance_class"] = wm_instance_class
+        if net_wm_pid is not None:
+            try:
+                self._rules["net_wm_pid"] = int(net_wm_pid)
+            except ValueError:
+                error = 'Invalid rule for net_wm_pid: "%s" only int allowed' % \
+                        str(net_wm_pid)
+                raise utils.QtileError(error)
 
-        self._rules = [('title', t) for t in title]
-        self._rules += [('wm_class', w) for w in wm_class]
-        self._rules += [('role', r) for r in role]
-        self._rules += [('wm_type', r) for r in wm_type]
-        self._rules += [('wm_instance_class', w) for w in wm_instance_class]
-        self._rules += [('net_wm_pid', w) for w in net_wm_pid]
+    @staticmethod
+    def _get_property_predicate(name, value):
+        if name == 'net_wm_pid':
+            return lambda other: other == value
+        elif name == 'wm_class':
+            def predicate(other):
+                # match as an "include"-match on any of the received classes
+                match = getattr(other, 'match', lambda v: other in v)
+                return value and any(match(v) for v in value)
+            return predicate
+        else:
+            def predicate(other):
+                # match as an "include"-match
+                match = getattr(other, 'match', lambda v: other in v)
+                return match(value)
+            return predicate
 
     def compare(self, client):
-        for _type, rule in self._rules:
-            # get value
-            if _type == "title":
+        for property_name, rule_value in self._rules.items():
+            if property_name == 'title':
                 value = client.name
-            elif _type == "wm_instance_class":
-                value = client.window.get_wm_class() and client.window.get_wm_class()[0]
-            elif _type == "role":
+            elif property_name == "wm_instance_class":
+                wm_class = client.window.get_wm_class()
+                if not wm_class:
+                    return False
+                value = wm_class[0]
+            elif property_name == 'role':
                 value = client.window.get_wm_window_role()
             else:
-                value = getattr(client.window, 'get_' + _type)()
+                value = getattr(client.window, 'get_' + property_name)()
 
-            # compare
-            if _type == "net_wm_pid":
-                if rule == value:
-                    return True
-                else:
-                    continue
-            match = getattr(rule, 'match', None) or getattr(rule, 'count')
+            # Some of the window.get_...() functions can return None
+            if value is None:
+                return False
 
-            if _type == "wm_class":
-                if any(match(v) for v in value):
-                    return True
-            elif value is not None and match(value):
-                return True
-        return False
+            match = self._get_property_predicate(property_name, value)
+            if not match(rule_value):
+                return False
+
+        return True
 
     def map(self, callback, clients):
         """Apply callback to each client that matches this Match"""

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -129,7 +129,7 @@ class DGroups:
                     spawns = group.spawn
                 for spawn in spawns:
                     pid = self.qtile.cmd_spawn(spawn)
-                    self.add_rule(Rule(Match(net_wm_pid=[pid]), group.name))
+                    self.add_rule(Rule(Match(net_wm_pid=pid), group.name))
 
     def _setup_hooks(self):
         libqtile.hook.subscribe.addgroup(self._addgroup)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -48,7 +48,7 @@ class Floating(Layout):
         ("name", "floating", "Name of this layout."),
     ]
 
-    def __init__(self, float_rules=None, no_reposition_match=None, **config):
+    def __init__(self, float_rules=None, no_reposition_rules=None, **config):
         """
         If you have certain apps that you always want to float you can provide
         ``float_rules`` to do so. ``float_rules`` are a list of
@@ -68,7 +68,7 @@ class Floating(Layout):
 
         Floating layout will try to center most of floating windows by default,
         but if you don't want this to happen for certain windows that are
-        centered by mistake, you can use ``no_reposition_match`` option to
+        centered by mistake, you can use ``no_reposition_rules`` option to
         specify them and layout will rely on windows to position themselves in
         correct location on the screen.
         """
@@ -76,7 +76,6 @@ class Floating(Layout):
         self.clients = []
         self.focused = None
         self.group = None
-        self.no_reposition_match = no_reposition_match
         self.float_rules = float_rules or []
 
         warned = False
@@ -99,6 +98,7 @@ class Floating(Layout):
 
             self.float_rules[index] = match
 
+        self.no_reposition_rules = no_reposition_rules or []
         self.add_defaults(Floating.defaults)
 
     def match(self, win):
@@ -239,7 +239,7 @@ class Floating(Layout):
 
         # ok, it's not java and the window itself didn't position it, but users
         # may still have asked us not to mess with it
-        if self.no_reposition_match is not None and self.no_reposition_match.compare(client):
+        if any(m.compare(client) for m in self.no_reposition_rules):
             client.user_placed_window_setup(bc, bw)
             return
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -28,20 +28,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import warnings
+
+from libqtile.config import Match
 from libqtile.layout.base import Layout
-
-DEFAULT_FLOAT_WM_TYPES = set([
-    'utility',
-    'notification',
-    'toolbar',
-    'splash',
-    'dialog',
-])
-
-DEFAULT_FLOAT_RULES = [
-    {"role": "About"},
-    {"wmclass": "file_progress"},
-]
+from libqtile.log_utils import logger
 
 
 class Floating(Layout):
@@ -55,28 +46,23 @@ class Floating(Layout):
         ("max_border_width", 0, "Border width for maximize."),
         ("fullscreen_border_width", 0, "Border width for fullscreen."),
         ("name", "floating", "Name of this layout."),
-        (
-            "auto_float_types",
-            DEFAULT_FLOAT_WM_TYPES,
-            "default wm types to automatically float"
-        ),
     ]
 
     def __init__(self, float_rules=None, no_reposition_match=None, **config):
         """
         If you have certain apps that you always want to float you can provide
-        ``float_rules`` to do so. ``float_rules`` is a list of
-        dictionaries containing some or all of the keys::
+        ``float_rules`` to do so. ``float_rules`` are a list of
+        Match objects::
 
-            {'wname': WM_NAME, 'wmclass': WM_CLASS, 'role': WM_WINDOW_ROLE}
+            from libqtile.config import Match
+            Match(title=WM_NAME, wm_class=WM_CLASS, role=WM_WINDOW_ROLE)
 
-        The keys must be specified as above.  You only need one, but
-        you need to provide the value for it.  When a new window is
-        opened it's ``match`` method is called with each of these
-        rules.  If one matches, the window will float.  The following
-        will float gimp and skype::
+        When a new window is opened its ``match`` method is called with each of
+        these rules.  If one matches, the window will float.  The following
+        will float GIMP and Skype::
 
-            float_rules=[dict(wmclass="skype"), dict(wmclass="gimp")]
+            from libqtile.config import Match
+            float_rules=[Match(wm_class="skype"), Match(wm_class="gimp")]
 
         Specify these in the ``floating_layout`` in your config.
 
@@ -90,18 +76,34 @@ class Floating(Layout):
         self.clients = []
         self.focused = None
         self.group = None
-        self.float_rules = float_rules or DEFAULT_FLOAT_RULES
         self.no_reposition_match = no_reposition_match
+        self.float_rules = float_rules or []
+
+        warned = False
+        for index, rule in enumerate(self.float_rules):
+            if isinstance(rule, Match):
+                continue
+
+            if not warned:
+                message = "Non-config.Match objects in float_rules are " \
+                          "deprecated"
+                warnings.warn(message, DeprecationWarning)
+                logger.warning(message)
+                warned = True
+
+            match = Match(
+                title=rule.get("wname"), wm_class=rule.get("wmclass"),
+                role=rule.get("role"), wm_type=rule.get("wm_type"),
+                wm_instance_class=rule.get("wm_instance_class"),
+                net_wm_pid=rule.get("net_wm_pid"))
+
+            self.float_rules[index] = match
+
         self.add_defaults(Floating.defaults)
 
     def match(self, win):
         """Used to default float some windows"""
-        if win.window.get_wm_type() in self.auto_float_types:
-            return True
-        for rule_dict in self.float_rules:
-            if win.match(**rule_dict):
-                return True
-        return False
+        return any(win.match(rule) for rule in self.float_rules)
 
     def find_clients(self, group):
         """Find all clients belonging to a given group"""

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -27,7 +27,7 @@
 from typing import List  # noqa: F401
 
 from libqtile import bar, layout, widget
-from libqtile.config import Click, Drag, Group, Key, Screen
+from libqtile.config import Click, Drag, Group, Key, Match, Screen
 from libqtile.lazy import lazy
 from libqtile.utils import guess_terminal
 
@@ -164,20 +164,25 @@ bring_front_click = False
 cursor_warp = False
 floating_layout = layout.Floating(float_rules=[
     # Run the utility of `xprop` to see the wm class and name of an X client.
-    {'wmclass': 'confirm'},
-    {'wmclass': 'dialog'},
-    {'wmclass': 'download'},
-    {'wmclass': 'error'},
-    {'wmclass': 'file_progress'},
-    {'wmclass': 'notification'},
-    {'wmclass': 'splash'},
-    {'wmclass': 'toolbar'},
-    {'wmclass': 'confirmreset'},  # gitk
-    {'wmclass': 'makebranch'},  # gitk
-    {'wmclass': 'maketag'},  # gitk
-    {'wname': 'branchdialog'},  # gitk
-    {'wname': 'pinentry'},  # GPG key password entry
-    {'wmclass': 'ssh-askpass'},  # ssh-askpass
+    Match(wm_type='utility'),
+    Match(wm_type='notification'),
+    Match(wm_type='toolbar'),
+    Match(wm_type='splash'),
+    Match(wm_type='dialog'),
+    Match(wm_class='file_progress'),
+    Match(wm_class='confirm'),
+    Match(wm_class='dialog'),
+    Match(wm_class='download'),
+    Match(wm_class='error'),
+    Match(wm_class='notification'),
+    Match(wm_class='splash'),
+    Match(wm_class='toolbar'),
+    Match(wm_class='confirmreset'),  # gitk
+    Match(wm_class='makebranch'),  # gitk
+    Match(wm_class='maketag'),  # gitk
+    Match(wm_class='ssh-askpass'),  # ssh-askpass
+    Match(title='branchdialog'),  # gitk
+    Match(title='pinentry'),  # GPG key password entry
 ])
 auto_fullscreen = True
 focus_on_window_activation = "smart"

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1053,38 +1053,18 @@ class Window(_Window):
                 raise CommandError('No such screen: %d' % index)
         self.togroup(screen.group.name)
 
-    def match(self, wname=None, wmclass=None, role=None):
+    def match(self, match):
         """Match window against given attributes.
 
         Parameters
         ==========
-        wname :
-            matches against the window name or title, that is, either
-            ``_NET_WM_VISIBLE_NAME``, ``_NET_WM_NAME``, ``WM_NAME``.
-        wmclass :
-            matches against any of the two values in the ``WM_CLASS`` property
-        role :
-            matches against the ``WM_WINDOW_ROLE`` property
+        match:
+            a config.Match object
         """
-        if not (wname or wmclass or role):
-            raise TypeError(
-                "Either a name, a wmclass or a role must be specified"
-            )
-        if wname and wname == self.name:
-            return True
-
         try:
-            cliclass = self.window.get_wm_class()
-            if wmclass and cliclass and wmclass in cliclass:
-                return True
-
-            clirole = self.window.get_wm_window_role()
-            if role and clirole and role == clirole:
-                return True
+            return match.compare(self)
         except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
             return False
-
-        return False
 
     def handle_EnterNotify(self, e):  # noqa: N802
         hook.fire("client_mouse_enter", self)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -138,7 +138,7 @@ class BareConfig(Config):
         libqtile.layout.stack.Stack(num_stacks=1),
         libqtile.layout.stack.Stack(num_stacks=2)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = [
         libqtile.config.Key(
             ["control"],

--- a/test/layouts/test_bsp.py
+++ b/test/layouts/test_bsp.py
@@ -37,7 +37,7 @@ class BspConfig(Config):
     layouts = [
         layout.Bsp(),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -37,7 +37,7 @@ class ColumnsConfig(Config):
     layouts = [
         layout.Columns(),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -42,7 +42,7 @@ class AllLayoutsConfig(Config):
         libqtile.config.Group("d"),
     ]
     follow_mouse_focus = False
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = []
 
     @staticmethod

--- a/test/layouts/test_floating.py
+++ b/test/layouts/test_floating.py
@@ -35,7 +35,7 @@ class FloatingConfig(Config):
     layouts = [
         layout.Floating()
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_matrix.py
+++ b/test/layouts/test_matrix.py
@@ -45,7 +45,7 @@ class MatrixConfig(Config):
     layouts = [
         layout.Matrix(columns=2)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -45,7 +45,7 @@ class MaxConfig(Config):
     layouts = [
         layout.Max()
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_ratiotile.py
+++ b/test/layouts/test_ratiotile.py
@@ -48,7 +48,7 @@ class RatioTileConfig(Config):
         layout.RatioTile(ratio=.5),
         layout.RatioTile(),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -44,17 +44,18 @@ class SliceConfig(Config):
     groups = [
         libqtile.config.Group("a"),
     ]
+
     layouts = [
-        layout.Slice(side='left', width=200, match=Match(title=['slice']),
+        layout.Slice(side='left', width=200, match=Match(title='slice'),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='right', width=200, match=Match(title=['slice']),
+        layout.Slice(side='right', width=200, match=Match(title='slice'),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='top', width=200, match=Match(title=['slice']),
+        layout.Slice(side='top', width=200, match=Match(title='slice'),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
-        layout.Slice(side='bottom', width=200, match=Match(title=['slice']),
+        layout.Slice(side='bottom', width=200, match=Match(title='slice'),
                      fallback=layout.Stack(num_stacks=1, border_width=0)),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -46,7 +46,7 @@ class StackConfig(Config):
         layout.Stack(num_stacks=2),
         layout.Stack(num_stacks=1),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -46,7 +46,7 @@ class TileConfig(Config):
         layout.Tile(),
         layout.Tile(master_length=2)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -38,7 +38,7 @@ class TreeTabConfig(Config):
     layouts = [
         layout.TreeTab(sections=["Foo", "Bar"]),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_verticaltile.py
+++ b/test/layouts/test_verticaltile.py
@@ -49,7 +49,7 @@ class VerticalTileConfig(Config):
     layouts = [
         layout.VerticalTile(columns=2)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -39,7 +39,7 @@ class MonadTallConfig(Config):
     layouts = [
         layout.MonadTall()
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []
@@ -58,7 +58,7 @@ class MonadTallMarginsConfig(Config):
     layouts = [
         layout.MonadTall(margin=4)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []
@@ -77,7 +77,7 @@ class MonadWideConfig(Config):
     layouts = [
         layout.MonadWide()
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []
@@ -96,7 +96,7 @@ class MonadWideMarginsConfig(Config):
     layouts = [
         layout.MonadWide(margin=4)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/layouts/test_zoomy.py
+++ b/test/layouts/test_zoomy.py
@@ -46,7 +46,7 @@ class ZoomyConfig(Config):
     layouts = [
         layout.Zoomy(columnwidth=200),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     screens = []

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -46,7 +46,7 @@ class GBConfig(libqtile.confreader.Config):
         libqtile.config.Group("Pppy")
     ]
     layouts = [libqtile.layout.stack.Stack(num_stacks=1)]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             top=libqtile.bar.Bar(
@@ -189,7 +189,7 @@ class GeomConf(libqtile.confreader.Config):
         libqtile.config.Group("d")
     ]
     layouts = [libqtile.layout.stack.Stack(num_stacks=1)]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             top=libqtile.bar.Bar([], 10),
@@ -316,7 +316,7 @@ class IncompatibleWidgetConf(libqtile.confreader.Config):
     mouse = []
     groups = [libqtile.config.Group("a")]
     layouts = [libqtile.layout.stack.Stack(num_stacks=1)]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             left=libqtile.bar.Bar(

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -54,7 +54,7 @@ class CallConfig(Config):
         libqtile.layout.Stack(num_stacks=1),
         libqtile.layout.Max(),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             bottom=libqtile.bar.Bar(
@@ -136,7 +136,7 @@ class ServerConfig(Config):
         libqtile.layout.Stack(num_stacks=2),
         libqtile.layout.Stack(num_stacks=3),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             bottom=libqtile.bar.Bar(

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -71,7 +71,7 @@ class FakeScreenConfig(Config):
         layout.RatioTile(),
         layout.Tile(),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
     fake_screens = [

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -41,6 +41,7 @@ import libqtile.widget
 from libqtile.backend.x11 import xcbq
 from libqtile.command_client import SelectError
 from libqtile.command_interface import CommandError, CommandException
+from libqtile.config import Match
 from libqtile.confreader import Config
 from libqtile.lazy import lazy
 from test.conftest import BareConfig, Retry, no_xinerama
@@ -61,7 +62,7 @@ class ManagerConfig(Config):
         libqtile.layout.max.Max()
     ]
     floating_layout = libqtile.layout.floating.Floating(
-        float_rules=[dict(wmclass="xclock")])
+        float_rules=[Match(wm_class='xclock')])
     keys = [
         libqtile.config.Key(
             ["control"],
@@ -232,7 +233,7 @@ class _ChordsConfig(Config):
     layouts = [
         libqtile.layout.max.Max()
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = [
         libqtile.config.Key(
             [],
@@ -539,8 +540,8 @@ def test_match(qtile):
     self = qtile
 
     self.test_xeyes()
-    assert self.c.window.match(wname="xeyes")
-    assert not self.c.window.match(wname="nonexistent")
+    assert self.c.window.info()['name'] == 'xeyes'
+    assert not self.c.window.info()['name'] == 'nonexistent'
 
 
 @manager_config
@@ -1067,7 +1068,7 @@ class _Config(Config):
         libqtile.layout.stack.Stack(num_stacks=1),
         libqtile.layout.stack.Stack(num_stacks=2)
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = [
         libqtile.config.Key(
             ["control"],

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -44,7 +44,7 @@ class ServerConfig(Config):
         libqtile.layout.Stack(num_stacks=2),
         libqtile.layout.Stack(num_stacks=3),
     ]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     screens = [
         libqtile.config.Screen(
             bottom=libqtile.bar.Bar(

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -42,7 +42,7 @@ class ScratchPadBaseConfic(Config):
         libqtile.config.Group("b"),
     ]
     layouts = [libqtile.layout.max.Max()]
-    floating_layout = libqtile.layout.floating.Floating()
+    floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
 

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -22,10 +22,10 @@
 
 import pytest
 
-from libqtile import config, ipc
+from libqtile import config, ipc, resources
 from libqtile.command_interface import IPCCommandInterface
 from libqtile.confreader import Config
-from libqtile.layout import Max, floating
+from libqtile.layout import Max
 from libqtile.sh import QSh
 
 
@@ -39,7 +39,7 @@ class ShConfig(Config):
     layouts = [
         Max(),
     ]
-    floating_layout = floating.Floating()
+    floating_layout = resources.default_config.floating_layout
     screens = [
         config.Screen()
     ]


### PR DESCRIPTION
This is (at the moment) just a rebase of PR #1805, since the author stopped working on it:

@cryzed originally wrote:

>Currently values in the float_rules for the Float layout are matched using "any" (OR) semantics, while it is more sensible to match them as "all" (AND). Creating a float rule that requires multiple properties to match at the same time is currently impossible, while recreating the old "any"-behavior is still possible, by simply creating a new rule for each property that used to be in the dict after this change.

>Window.match now uses config.Match instead of only partially reimplementing its logic. This change also allows to match against three new properties: wm_type, wm_instance_class and net_wm_pid in the float rules, and anywhere else that Window.match might be used. The changes should hopefully all be backwards-compatible, except obviously the changed semantics of Window.match.

>I tested this locally with the use-case I mentioned on IRC ({"wname": "win0", "wmclass": "jetbrains-pycharm-ce"}), i.e. matching the PyCharm splash dialog more specifically, which worked. Negating the match by using a bogus value for some property also seemed to work successfully. Otherwise Qtile seems to behave pretty normally while using it, so I am somewhat optimistic that I didn't break things too badly. Please look this over with a critical eye, I'm not very familiar with Qtile's code otherwise.

I have yet to fix some tests and clean up the commit history without changing the original author.