### PR TITLE
Add support for Python 3.9, drop 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,21 @@ jobs:
           env: TOXENV=py37
         - python: 3.8
           env: TOXENV=py38
+        - python: 3.9
+          env: TOXENV=py39
         - python: pypy3
           env: TOXENV=pypy3
         - python: nightly
           env: TOXENV=py-nightly
-        - python: 3.8
+        - python: 3.9
           env: TOXENV=packaging
-        - python: 3.8
+        - python: 3.9
           env: TOXENV=docs
         - python: 3.7
           env: TOXENV=pep8
-        - python: 3.8
+        - python: 3.9
           env: TOXENV=pep8
-        - python: 3.8
+        - python: 3.9
           env: TOXENV=mypy
 
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: python
 
 jobs:
     include:
-        - python: 3.5
-          env: TOXENV=py35
-        - python: 3.6
-          env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
         - python: 3.8
@@ -20,7 +16,7 @@ jobs:
           env: TOXENV=packaging
         - python: 3.8
           env: TOXENV=docs
-        - python: 3.5
+        - python: 3.7
           env: TOXENV=pep8
         - python: 3.8
           env: TOXENV=pep8

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ qtile X.X.X, released XXXX-XX-XX:
 	- new restart and shutdown hooks
 	- rules specified in `layout.Floating`'s `float_rules` are now evaluated with
 	  AND-semantics, allowing for more complex and specific rules
+	- Python 3.9 support
 
 qtile 0.16.1, released 2020-08-11:
     !!! Config breakage !!!

--- a/docs/manual/install/funtoo.rst
+++ b/docs/manual/install/funtoo.rst
@@ -2,8 +2,7 @@
 Installing on Funtoo
 ====================
 
-Latest versions of Qtile are available on Funtoo with Python 2.7, 3.4, and 3.5
-implementations. To install it, run:
+Latest versions of Qtile are available on Funtoo. To install it, run:
 
 .. code-block:: bash
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
   Programming Language :: Python :: 3 :: Only
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
   Programming Language :: Python :: Implementation :: CPython
   Programming Language :: Python :: Implementation :: PyPy
   Topic :: Desktop Environment :: Window Managers

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,6 @@ classifiers =
   Operating System :: POSIX :: BSD :: FreeBSD
   Operating System :: POSIX :: Linux
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.5
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: Implementation :: CPython
@@ -36,7 +34,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires >= 3.6
+python_requires >= 3.7
 setup_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 0.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ skip_missing_interpreters = True
 skipsdist=True
 minversion = 1.8
 envlist =
-    py35,
-    py36,
     py37,
     py38,
     py-nightly

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 1.8
 envlist =
     py37,
     py38,
+    py39,
     py-nightly
     docs,
     pep8,


### PR DESCRIPTION
Support for Python 3.5 had actually been dropped before, but the tests were still available.

I also found a doc string for funtoo which mentioned some Python versions.

@ramnes wants to add more stuff to this PR.