### PR TITLE
Pass qtile object to mouse callbacks

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -229,7 +229,7 @@ class _Widget(CommandObject, configurable.Configurable):
     def button_press(self, x, y, button):
         name = 'Button{0}'.format(button)
         if name in self.mouse_callbacks:
-            self.mouse_callbacks[name]()
+            self.mouse_callbacks[name](self.qtile)
 
     def button_release(self, x, y, button):
         pass


### PR DESCRIPTION
The mouse callbacks need qtile object to do anything
worth while. This seems to work in current release.
But 1.6 seems to throw exceptions.

Signed-off-by: Himanshu Chauhan <hschauhan@nulltrace.org>