### PR TITLE
WindowList should not include ScratchPad-windows

### DIFF
--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 from libqtile.extension.dmenu import Dmenu
+from libqtile.scratchpad import ScratchPad
 
 
 class WindowList(Dmenu):
@@ -49,7 +50,7 @@ class WindowList(Dmenu):
             windows = self.qtile.current_group.windows
 
         for win in windows:
-            if win.group:
+            if win.group and not isinstance(win.group, ScratchPad):
                 item = self.item_format.format(
                     group=win.group.label or win.group.name, id=id, window=win.name)
                 self.item_to_win[item] = win


### PR DESCRIPTION
I noticed that when switching windows via `WindowList`, possibly existing `ScratchPad`-windows are included in the shown list as well. When selected, the corresponding `ScratchPad`-group is opened up with all the usual clients layed out at once. Interaction now happens in the same way as with normal groups, not `ScratchPad`-windows.

I am not entirely sure whether this is an actual bug or a feature, but since I found the experience very much confusing (it took me a minute to realize that Qtile was indeed still running normally), I wanted to get rid of those scratchpad-windows. There doesn't seem to be much point in having them in a quick-switch list anyway.