### PR TITLE
Allow Match-list to be passed into config.Rule

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -644,15 +644,15 @@ class Match:
 
 
 class Rule:
-    """How to act on a Match
+    """How to act on a match
 
-    A Rule contains a Match object, and a specification about what to do when
-    that object is matched.
+    A Rule contains a list of Match objects, and a specification about what to
+    do when any of them is matched.
 
     Parameters
     ==========
     match :
-        ``Match`` object associated with this ``Rule``
+        ``Match`` object or a list of such associated with this ``Rule``
     float :
         auto float this window?
     intrusive :
@@ -662,18 +662,21 @@ class Rule:
     """
     def __init__(self, match, group=None, float=False, intrusive=False,
                  break_on_match=True):
-        self.match = match
+        if isinstance(match, Match):
+            self.matches = [match]
+        else:
+            self.matches = match
         self.group = group
         self.float = float
         self.intrusive = intrusive
         self.break_on_match = break_on_match
 
     def matches(self, w):
-        return self.match.compare(w)
+        return any(w.match(m) for m in self.matches)
 
     def __repr__(self):
         actions = utils.describe_attributes(self, ['group', 'float', 'intrusive', 'break_on_match'])
-        return '<Rule match=%r actions=(%s)>' % (self.match, actions)
+        return '<Rule match=%r actions=(%s)>' % (self.matches, actions)
 
 
 class DropDown(configurable.Configurable):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1489,14 +1489,14 @@ class Qtile(CommandObject):
         rule_args :
             config.Rule arguments
         min_priorty :
-            If the rule is added with minimum prioriry (last) (default: False)
+            If the rule is added with minimum priority (last) (default: False)
         """
         if not self.dgroups:
             logger.warning('No dgroups created')
             return
 
         match = Match(**match_args)
-        rule = Rule(match, **rule_args)
+        rule = Rule([match], **rule_args)
         return self.dgroups.add_rule(rule, min_priorty)
 
     def cmd_remove_rule(self, rule_id):

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -113,8 +113,8 @@ class DGroups:
 
     def add_dgroup(self, group, start=False):
         self.groups_map[group.name] = group
-        rules = [Rule(m, group=group.name) for m in group.matches]
-        self.rules.extend(rules)
+        rule = Rule(group.matches, group=group.name)
+        self.rules.append(rule)
         if start:
             self.qtile.add_group(group.name, group.layout, group.layouts, group.label)
 

--- a/libqtile/scripts/qtile_run.py
+++ b/libqtile/scripts/qtile_run.py
@@ -77,7 +77,7 @@ def main() -> None:
     root = command_graph.CommandGraphRoot()
 
     proc = subprocess.Popen(opts.cmd)
-    match_args = {"net_wm_pid": [proc.pid]}
+    match_args = {"net_wm_pid": proc.pid}
     rule_args = {"float": opts.float, "intrusive": opts.intrusive,
                  "group": opts.group, "break_on_match": not opts.dont_break}
 


### PR DESCRIPTION
As mentioned [here](https://github.com/qtile/qtile/pull/1937#issuecomment-719271950), `config.Rule` needed a little change to make better use of the recent changes to `config.Match`.

@tych0 : You also mentioned that a bit of documentation would be nice. As far as I can see, `config.Rule` is exclusively used in conjunction with `DGroups`, which aren't documented at all right now (as far as I can see). I haven't played with adding documentation outside of what's usually written in a classes header, and I haven't used `DGroups` so far (although that's partially due to the lacking documentation).
I could extend the documentation for `config.Match` a little so it includes an example or two, but that doesn't really fit this PR, I think. Also, it isn't too difficult to figure out how `config.Match` works - especially since it is actually used in various places.