### PR TITLE
Allow keysym to be mapped to multiple keycodes

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1135,7 +1135,7 @@ class Qtile(CommandObject):
             pass
 
         d = DummyEv()
-        d.detail = self.conn.first_sym_to_code[keysym]
+        d.detail = self.conn.keysym_to_keycode(keysym)[0]
         d.state = modmasks
         self.core.handle_KeyPress(d)
 

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -678,7 +678,7 @@ class Prompt(base._TextBox):
             pass
         d = Dummy()
         keysym = xcbq.keysyms[key]
-        d.detail = self.qtile.conn.keysym_to_keycode(keysym)
+        d.detail = self.qtile.conn.keysym_to_keycode(keysym)[0]
         d.state = 0
         self.handle_KeyPress(d)
 


### PR DESCRIPTION
Each keycode can be mapped to multiple keysyms by X11, and qtile could
already handle the lookup in that direction. However, looking up a
keysym only ever returned the first keycode it had been mapped to,
which made it difficult to map buttons of e.g. different devices to the
same function.

This is related to #1867. The main effect of this PR is that one can now make use of buttons with different keycodes/same keysyms to trigger stuff in qtile - in particular I can now use a bluetooth-device to play/pause media, while my keyboard has a similar button that does the same.