### PR TITLE
Make detection of __xcb_proto_version__ more robust.

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -623,7 +623,7 @@ class Window:
         mask, values = ConfigureMasks(**kwargs)
         # older versions of xcb pack everything into unsigned ints "=I"
         # since 1.12, uses switches to pack things sensibly
-        if float(xcffib.__xcb_proto_version__) < 1.12:
+        if float(".".join(xcffib.__xcb_proto_version__.split(".")[0: 2])) < 1.12:
             values = [i & 0xffffffff for i in values]
         return self.conn.conn.core.ConfigureWindow(self.wid, mask, values)
 


### PR DESCRIPTION
libqtile/backend/x11/xcbq.py:
Only use major and minor version of `xcffib.__xcb_proto_version__` for
comparison in `Window.configure()`.
Previously the comparison would raise `ValueError` on a version string
also including a patch level.

Fixes #1962