### PR TITLE
Replace Window.user_placed_window_setup() with paint_borders()

### DIFF
--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -228,40 +228,41 @@ class Floating(Layout):
         cls = client.window.get_wm_class() or ''
         is_java_dropdown = 'sun-awt-X11-XWindowPeer' in cls
         if is_java_dropdown:
-            client.user_placed_window_setup(bc, bw)
-            return
+            client.paint_borders(bc, bw)
+            client.cmd_bring_to_front()
 
         # similar to above but the X11 version, the client may have already
         # placed itself. let's respect that
-        if client.has_user_set_position():
-            client.user_placed_window_setup(bc, bw)
-            return
+        elif client.has_user_set_position():
+            client.paint_borders(bc, bw)
+            client.cmd_bring_to_front()
 
         # ok, it's not java and the window itself didn't position it, but users
         # may still have asked us not to mess with it
-        if any(m.compare(client) for m in self.no_reposition_rules):
-            client.user_placed_window_setup(bc, bw)
-            return
+        elif any(m.compare(client) for m in self.no_reposition_rules):
+            client.paint_borders(bc, bw)
+            client.cmd_bring_to_front()
 
-        above = False
+        else:
+            above = False
 
-        # We definitely have a screen here, so let's be sure we'll float on screen
-        try:
-            client.float_x
-            client.float_y
-        except AttributeError:
-            # this window hasn't been placed before, let's put it in a sensible spot
-            above = self.compute_client_position(client, screen_rect)
+            # We definitely have a screen here, so let's be sure we'll float on screen
+            try:
+                client.float_x
+                client.float_y
+            except AttributeError:
+                # this window hasn't been placed before, let's put it in a sensible spot
+                above = self.compute_client_position(client, screen_rect)
 
-        client.place(
-            client.x,
-            client.y,
-            client.width,
-            client.height,
-            bw,
-            bc,
-            above,
-        )
+            client.place(
+                client.x,
+                client.y,
+                client.width,
+                client.height,
+                bw,
+                bc,
+                above,
+            )
         client.unhide()
 
     def add(self, client):

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -474,31 +474,27 @@ class _Window(CommandObject):
         self.y = y
         self.width = width
         self.height = height
-        self.borderwidth = borderwidth
-        self.bordercolor = bordercolor
 
         kwarg = dict(
             x=x,
             y=y,
             width=width,
             height=height,
-            borderwidth=borderwidth,
         )
         if above:
             kwarg['stackmode'] = StackMode.Above
 
         self.window.configure(**kwarg)
-        self.window.paint_borders(bordercolor)
+        self.paint_borders(bordercolor, borderwidth)
 
         if send_notify:
             self.send_configure_notify(x, y, width, height)
 
-    def user_placed_window_setup(self, borderpixel, borderwidth):
+    def paint_borders(self, borderpixel, borderwidth):
         self.borderwidth = borderwidth
         self.bordercolor = borderpixel
-        self.window.configure(borderwidth=borderwidth, stackmode=StackMode.Above)
+        self.window.configure(borderwidth=borderwidth)
         self.window.paint_borders(borderpixel)
-        self.unhide()
 
     def send_configure_notify(self, x, y, width, height):
         """Send a synthetic ConfigureNotify"""


### PR DESCRIPTION
Window.user_placed_window_setup implies an alternative route to similar
functionality seen within Window.place. It is neater and more clear if
Window.place is seen as The One True way to place and show windows.
Where Window.user_placed_window_setup is used, the only functionality
needed is to reconfigure the window borders. This indicates the need to
set window borders without touching the window's geometry (i.e. when
window set it directly), so a Window.paint_borders method can be used
instead where user_placed_window_setup was.