### PR TITLE
Correctly respond to _NET_CURRENT_DESKTOP messages by switch group

### DIFF
--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -535,7 +535,7 @@ class XCore(base.Core):
         if atoms["_NET_CURRENT_DESKTOP"] == opcode:
             index = data.data32[0]
             try:
-                self.qtile.cmd_to_layout_index(index)
+                self.qtile.groups[index].cmd_toscreen()
             except IndexError:
                 logger.info("Invalid Desktop Index: %s" % index)
 


### PR DESCRIPTION
This message incorrectly switches layout, when it should switch to the
specified desktop. Fixes #1968.