### PR TITLE
drop various python < 3.7 version tests

### DIFF
--- a/libqtile/core/session_manager.py
+++ b/libqtile/core/session_manager.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import sys
 
 from libqtile import ipc
 from libqtile.backend import base
@@ -49,8 +48,7 @@ class SessionManager:
             # replace with asyncio.run(...) on Python 3.7+
             self.eventloop.run_until_complete(self.async_loop())
         finally:
-            if sys.version_info >= (3, 6):
-                self.eventloop.run_until_complete(self.eventloop.shutdown_asyncgens())
+            self.eventloop.run_until_complete(self.eventloop.shutdown_asyncgens())
             self.eventloop.close()
 
         self.qtile.maybe_restart()

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -31,7 +31,6 @@ import marshal
 import os.path
 import socket
 import struct
-import sys
 from typing import Any, Optional, Tuple
 
 from libqtile.log_utils import logger
@@ -158,10 +157,7 @@ class Client:
         finally:
             # see the note in Server._server_callback()
             writer.close()
-            if sys.version_info >= (3, 7):
-                await writer.wait_closed()
-            else:
-                await asyncio.sleep(0)
+            await writer.wait_closed()
 
         data, _ = _IPC.unpack(read_data, is_json=self.is_json)
 
@@ -213,15 +209,8 @@ class Server:
             logger.debug("Closing connection on receive EOF")
             writer.write_eof()
         finally:
-            # the resoure isn't closed immediately on the close call, but is on
-            # the next loop iteration, this is exposed as the wait_closed
-            # method in 3.7, but requires a manual loop iteration in earlier
-            # versions
             writer.close()
-            if sys.version_info >= (3, 7):
-                await writer.wait_closed()
-            else:
-                await asyncio.sleep(0)
+            await writer.wait_closed()
 
     async def __aenter__(self) -> "Server":
         """Start and return the server"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,7 +119,7 @@ include_trailing_comma = true
 
 [mypy]
 mypy_path = stubs
-python_version = 3.5
+python_version = 3.7
 [mypy-_cffi_backend]
 ignore_missing_imports = True
 [mypy-cairocffi._generated.ffi]


### PR DESCRIPTION
Now that we only support >= 3.7, let's drop a bunch of version tests.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>