### PR TITLE
ci: add lm-sensors to runtime environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
             - run: |
                 sudo apt update
-                sudo apt install graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev
+                sudo apt install graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors
                 pip install tox tox-gh-actions
               name: install dependencies
             - name: run tests

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -152,8 +152,8 @@ def catch_exception_and_warn(warning=Warning, return_on_exception=None,
             try:
                 return_value = func(*args, **kwargs)
             except excepts as err:
-                logger.warning(err.strerror)
-                warnings.warn(err.strerror, warning)
+                logger.warning(str(err))
+                warnings.warn(str(err), warning)
             return return_value
         return wrapper
     return decorator


### PR DESCRIPTION
That way we can get rid of this warning:

test/widgets/test_misc.py::test_thermalsensor_regex_compatibility
  /home/runner/work/qtile/qtile/libqtile/utils.py:156: UnixCommandNotFound: No such file or directory
    warnings.warn(err.strerror, warning)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>