### PR TITLE
WidgetBox widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ qtile X.X.X, released XXXX-XX-XX:
           forseeable future, but will be eventually deprecated. qtile prints a
           warning when run in this configuration.
     * features
+        - new WidgetBox widget
         - new restart and shutdown hooks
         - rules specified in `layout.Floating`'s `float_rules` are now evaluated with
           AND-semantics, allowing for more complex and specific rules

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -36,6 +36,7 @@ from libqtile.widget.prompt import Prompt  # noqa: F401
 from libqtile.widget.quick_exit import QuickExit  # noqa: F401
 from libqtile.widget.systray import Systray  # noqa: F401
 from libqtile.widget.textbox import TextBox  # noqa: F401
+from libqtile.widget.widgetbox import WidgetBox  # noqa: F401
 from libqtile.widget.window_count import WindowCount  # noqa: F401
 from libqtile.widget.windowname import WindowName  # noqa: F401
 
@@ -103,3 +104,4 @@ safe_import("quick_exit", "QuickExit")
 safe_import("pulse_volume", "PulseVolume")
 safe_import("chord", "Chord")
 safe_import("window_count", "WindowCount")
+safe_import("widgetbox", "WidgetBox")

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2020 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from collections import namedtuple
+
+from libqtile import bar
+from libqtile.log_utils import logger
+from libqtile.widget import base
+
+BoxedWidget = namedtuple("Widget", ["widget", "draw"])
+
+
+def _no_draw(*args, **kwargs):
+    pass
+
+
+class WidgetBox(base._Widget):
+    """A widget to declutter your bar.
+
+    WidgetBox is a widget that hides widgets by default but shows them when
+    the box is opened.
+
+    Widgets that are hidden will still update etc. as if they were on the main
+    bar.
+
+    Button clicks are passed to widgets when they are visible so callbacks will
+    work.
+
+    Widgets in the box alsos remain accessible via command interfaces.
+
+    Widgets can only be added to the box via the configuration file. The widget
+    is conigured by adding widgets to the "widgets" parameter as follows:
+
+        widget.WidgetBox(widgets=[
+            widget.TextBox(text="This widget is in the box"),
+            widget.Memory(),
+            ]),
+    """
+    orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [
+        (
+            "font",
+            "sans",
+            "Text font"
+        ),
+        (
+            "fontsize",
+            None,
+            "Font pixel size. Calculated if None."
+        ),
+        (
+            "fontshadow",
+            None,
+            "font shadow color, default is None(no shadow)"
+        ),
+        (
+            "foreground",
+            "#ffffff",
+            "Foreground colour."
+        ),
+        (
+            "close_button_location",
+            "left",
+            "Location of close button when box open ('left' or 'right')"
+        ),
+        (
+            "text_closed",
+            "[<]",
+            "Text when box is closed"
+        ),
+        (
+            "text_open",
+            "[>]",
+            "Text when box is open"
+        ),
+    ]
+
+    def __init__(self, widgets=list(), **config):
+        base._Widget.__init__(self, bar.CALCULATED, **config)
+        self.add_defaults(WidgetBox.defaults)
+        self.box_is_open = False
+        self._widgets = widgets
+        self.add_callbacks({"Button1": self.cmd_toggle})
+
+        if self.close_button_location not in ["left", "right"]:
+            val = self.close_button_location
+            msg = "Invalid value for 'close_button_location': {}".format(val)
+            logger.warning(msg)
+            self.close_button_location = "left"
+
+    def _configure(self, qtile, bar):
+        base._Widget._configure(self, qtile, bar)
+
+        self.layout = self.drawer.textlayout(
+            self.text_closed,
+            self.foreground,
+            self.font,
+            self.fontsize,
+            self.fontshadow,
+            markup=False,
+        )
+
+        for idx, w in enumerate(self._widgets):
+            if w.configured:
+                w = w.create_mirror()
+                self._widgets[idx] = w
+            self.qtile.register_widget(w)
+            w._configure(self.qtile, self.bar)
+
+            # In case the widget is mirrored, we need to draw it once so the
+            # mirror can copy the surface but draw it off screen
+            w.offsetx = self.bar.width
+            self.qtile.call_soon(w.draw)
+
+        # We need to stop hidden widgets from drawing while hidden
+        # (e.g. draw could be triggered by a timer) so we take a reference to
+        # the widget's drawer.draw method
+        self.widgets = [BoxedWidget(w, w.drawer.draw) for w in self._widgets]
+
+        # # Overwrite the current drawer.draw method with a no-op
+        for w in self.widgets:
+            w.widget.drawer.draw = _no_draw
+
+    def calculate_length(self):
+        return self.layout.width
+
+    def set_box_label(self):
+        self.layout.text = (self.text_open if self.box_is_open
+                            else self.text_closed)
+
+    def toggle_widgets(self):
+        for item in self.widgets:
+            try:
+                self.bar.widgets.remove(item.widget)
+                # Override drawer.drawer with a no-op
+                item.widget.drawer.draw = _no_draw
+            except ValueError:
+                continue
+
+        index = self.bar.widgets.index(self)
+
+        if self.close_button_location == "left":
+            index += 1
+
+        if self.box_is_open:
+
+            # Need to reverse list as widgets get added in front of eachother.
+            for item in self.widgets[::-1]:
+                # Restore the original drawer.draw method
+                item.widget.drawer.draw = item.draw
+                self.bar.widgets.insert(index, item.widget)
+
+    def draw(self):
+        self.drawer.clear(self.background or self.bar.background)
+
+        self.layout.draw(0,
+                         int(self.bar.height / 2.0 -
+                             self.layout.height / 2.0) + 1)
+
+        self.drawer.draw(offsetx=self.offsetx, width=self.width)
+
+    def button_press(self, x, y, button):
+        name = "Button{}".format(button)
+        if name in self.mouse_callbacks:
+            self.mouse_callbacks[name]()
+
+    def cmd_toggle(self):
+        """Toggle box state"""
+        self.box_is_open = not self.box_is_open
+        self.toggle_widgets()
+        self.set_box_label()
+        self.bar.draw()

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -1,0 +1,81 @@
+import pytest
+
+from libqtile.backend.x11 import xcbq
+from libqtile.bar import Bar
+from libqtile.widget import TextBox, WidgetBox
+from test.conftest import BareConfig
+
+
+def no_op(*args, **kwargs):
+    pass
+
+
+class FakeWindow:
+    class _NestedWindow:
+        wid = 10
+
+    window = _NestedWindow()
+
+
+widget_config = pytest.mark.parametrize("qtile", [BareConfig], indirect=True)
+
+
+@widget_config
+def test_widgetbox_widget(qtile):
+    qtile.conn = xcbq.Connection(qtile.display)
+
+    # We need to trick the widgets into thinking this is libqtile.qtile so
+    # we add some methods that are called when the widgets are configured
+    qtile.call_soon = no_op
+    qtile.register_widget = no_op
+
+    tb_one = TextBox(name="tb_one", text="TB ONE")
+    tb_two = TextBox(name="tb_two", text="TB TWO")
+
+    # Give widgetbox invalid value for button location
+    widget_box = WidgetBox([tb_one, tb_two],
+                           close_button_location="middle",
+                           fontsize=10)
+
+    # Create a bar and set attributes needed to run widget
+    fakebar = Bar([widget_box], 24)
+    fakebar.window = FakeWindow()
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = no_op
+
+    # Configure the widget box
+    widget_box._configure(qtile, fakebar)
+
+    # Invalid value should be corrected to default
+    assert widget_box.close_button_location == "left"
+
+    # Check only widget in bar is widgetbox
+    assert fakebar.widgets == [widget_box]
+
+    # Open box
+    widget_box.cmd_toggle()
+
+    # Check it's open
+    assert widget_box.box_is_open
+
+    # Default text position is left
+    assert fakebar.widgets == [widget_box, tb_one, tb_two]
+
+    # Close box
+    widget_box.cmd_toggle()
+
+    # Check it's closed
+    assert not widget_box.box_is_open
+
+    # Check widgets have been removed
+    assert fakebar.widgets == [widget_box]
+
+    # Move button to right-hand side
+    widget_box.close_button_location = "right"
+
+    # Re-open box with new layout
+    widget_box.cmd_toggle()
+
+    # Now widgetbox is on the right
+    assert fakebar.widgets == [tb_one, tb_two, widget_box]


### PR DESCRIPTION
I've made a new widget that can take other widgets as children. The widgets are hidden by default but shown when the widget is clicked.

The idea was to have a means to hide non-essential widgets by default to reduce clutter on the bar.

The gif below shows how it looks:
![widgetbox](https://user-images.githubusercontent.com/946265/100140082-5d427b00-2e88-11eb-9106-ebc25377975d.gif)

I'm still relatively new when looking at qtile's inner workings but I think I've got this set up correctly. I made sure the child widget are still passed to `qtile.register_widget` so they're still accessible to command interfaces.

Button clicks should also be passed to the appropriate child widget.