### PR TITLE
ci: do an apt update before apt install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
             - run: |
+                sudo apt update
                 sudo apt install graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev
                 pip install tox tox-gh-actions
               name: install dependencies


### PR DESCRIPTION
github's images may get out of date slightly with the apt mirrors; let's
ensure our apt cache is correct before trying to install things.

This prevents failures like:

2020-11-24T19:11:44.8125949Z Reading package lists...
2020-11-24T19:11:45.9021866Z Building dependency tree...
2020-11-24T19:11:45.9044139Z Reading state information...
2020-11-24T19:11:46.0365022Z imagemagick is already the newest version (8:6.9.10.23+dfsg-2.1ubuntu11.1).
2020-11-24T19:11:46.0368852Z xvfb is already the newest version (2:1.20.8-2ubuntu2.4).
2020-11-24T19:11:46.0370959Z The following additional packages will be installed:
2020-11-24T19:11:46.0374091Z   libann0 libasyncns0 libcdt5 libcgraph6 libflac8 libgts-0.7-5 libgts-bin
2020-11-24T19:11:46.0377133Z   libgvc6 libgvpr2 liblab-gamut1 libpathplan4 libpulse-mainloop-glib0
2020-11-24T19:11:46.0380245Z   libpulse0 libsndfile1 libvorbisenc2 libxcb-icccm4 libxcb-image0
2020-11-24T19:11:46.0385194Z   libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-util1 libxcb-xkb1
2020-11-24T19:11:46.0393620Z   libxcb-xv0 xbitmaps
2020-11-24T19:11:46.0394632Z Suggested packages:
2020-11-24T19:11:46.0396273Z   graphviz-doc pulseaudio mesa-utils xfonts-cyrillic
2020-11-24T19:11:46.0816683Z The following NEW packages will be installed:
2020-11-24T19:11:46.0832751Z   graphviz libann0 libasyncns0 libcdt5 libcgraph6 libflac8 libgts-0.7-5
2020-11-24T19:11:46.0845509Z   libgts-bin libgvc6 libgvpr2 liblab-gamut1 libpathplan4 libpulse-dev
2020-11-24T19:11:46.0846879Z   libpulse-mainloop-glib0 libpulse0 libsndfile1 libvorbisenc2 libxcb-icccm4
2020-11-24T19:11:46.0848367Z   libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-util1
2020-11-24T19:11:46.0849616Z   libxcb-xkb1 libxcb-xv0 x11-apps xbitmaps xserver-xephyr xterm
2020-11-24T19:11:46.1070255Z 0 upgraded, 29 newly installed, 0 to remove and 0 not upgraded.
2020-11-24T19:11:46.1071184Z Need to get 5054 kB of archives.
2020-11-24T19:11:46.1072049Z After this operation, 20.8 MB of additional disk space will be used.
2020-11-24T19:11:46.1074121Z Get:1 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libann0 amd64 1.1.2+doc-7build1 [26.0 kB]
2020-11-24T19:11:46.1104812Z Get:2 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libcdt5 amd64 2.42.2-3build2 [18.7 kB]
2020-11-24T19:11:46.1118564Z Get:3 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libcgraph6 amd64 2.42.2-3build2 [41.3 kB]
2020-11-24T19:11:46.1128699Z Get:4 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgts-0.7-5 amd64 0.7.6+darcs121130-4 [150 kB]
2020-11-24T19:11:46.1159012Z Get:5 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libpathplan4 amd64 2.42.2-3build2 [21.9 kB]
2020-11-24T19:11:46.1168219Z Get:6 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgvc6 amd64 2.42.2-3build2 [647 kB]
2020-11-24T19:11:46.1257197Z Get:7 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgvpr2 amd64 2.42.2-3build2 [167 kB]
2020-11-24T19:11:46.1276270Z Get:8 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 liblab-gamut1 amd64 2.42.2-3build2 [177 kB]
2020-11-24T19:11:46.1308996Z Get:9 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 graphviz amd64 2.42.2-3build2 [590 kB]
2020-11-24T19:11:46.1394662Z Get:10 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libasyncns0 amd64 0.8-6 [12.1 kB]
2020-11-24T19:11:46.1400826Z Get:11 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libflac8 amd64 1.3.3-1build1 [103 kB]
2020-11-24T19:11:46.1428348Z Get:12 http://azure.archive.ubuntu.com/ubuntu focal/universe amd64 libgts-bin amd64 0.7.6+darcs121130-4 [41.3 kB]
2020-11-24T19:11:46.1442058Z Get:13 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libvorbisenc2 amd64 1.3.6-2ubuntu1 [70.7 kB]
2020-11-24T19:11:46.1458859Z Get:14 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libsndfile1 amd64 1.0.28-7 [170 kB]
2020-11-24T19:11:46.4420302Z Err:15 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse0 amd64 1:13.99.1-1ubuntu3.7
2020-11-24T19:11:46.4421667Z   404  Not Found [IP: 52.250.76.244 80]
2020-11-24T19:11:46.4423162Z Err:16 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse-mainloop-glib0 amd64 1:13.99.1-1ubuntu3.7
2020-11-24T19:11:46.4424459Z   404  Not Found [IP: 52.250.76.244 80]
2020-11-24T19:11:46.4425800Z Err:17 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpulse-dev amd64 1:13.99.1-1ubuntu3.7
2020-11-24T19:11:46.4427034Z   404  Not Found [IP: 52.250.76.244 80]

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>