### PR TITLE
start: only log in color mode when stdout is a tty

### DIFF
--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -24,7 +24,7 @@
 import locale
 import logging
 from os import getenv, makedirs, path
-from sys import exit
+from sys import exit, stdout
 
 from libqtile import confreader
 from libqtile.backend.x11 import xcore
@@ -49,7 +49,7 @@ def rename_process():
 
 def make_qtile(options):
     log_level = getattr(logging, options.log_level)
-    init_log(log_level=log_level)
+    init_log(log_level=log_level, log_color=stdout.isatty())
     kore = xcore.XCore()
 
     if not path.isfile(options.configfile):


### PR DESCRIPTION
For the most part, people are looking at logs in ~/.xsession-errors, which
is not a tty. let's not spew a bunch of color changing control codes there.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>