### PR TITLE
base: remove incorrect comment

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -83,8 +83,7 @@ class _Widget(CommandObject, configurable.Configurable):
 
     If length is set to the special value `bar.STRETCH`, the bar itself will
     set the length to the maximum remaining space, after all other widgets have
-    been configured. Only ONE widget per bar can have the `bar.STRETCH` length
-    set.
+    been configured.
 
     In horizontal bars, 'length' corresponds to the width of the widget; in
     vertical bars, it corresponds to the widget's height.


### PR DESCRIPTION
This has been out of date 431f947591ad ("Allow more than one STRETCH
widget.") aka over 10 years, and I never noticed.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>