### PR TITLE
set _NET_DESKTOP_VIEWPORT

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `place_right` option in the TreeTab layout to place the tab panel on the right side
+        - X11: Add support for _NET_DESKTOP_VIEWPORT. E.g. can be used by rofi to map on current output.
     * bugfixes
         - Remove non-commandable windows from IPC. Fixes bug where IPC would fail when trying to get info
           on all windows but Systray has icons (which are non-commandable `_Window`s.)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -429,6 +429,10 @@ class Core(base.Core):
         self._root.set_property("_NET_NUMBER_OF_DESKTOPS", len(groups))
         self._root.set_property("_NET_DESKTOP_NAMES", "\0".join(i.name for i in groups))
         self._root.set_property("_NET_CURRENT_DESKTOP", index)
+        viewport = []
+        for group in groups:
+            viewport += [group.screen.x, group.screen.y] if group.screen else [0, 0]
+        self._root.set_property("_NET_DESKTOP_VIEWPORT", viewport)
 
     def lookup_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Find the keysym and the modifier mask for the given key"""

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -164,6 +164,7 @@ PropertyMap = {
     "_NET_NUMBER_OF_DESKTOPS": ("CARDINAL", 32),
     "_NET_CURRENT_DESKTOP": ("CARDINAL", 32),
     "_NET_DESKTOP_NAMES": ("UTF8_STRING", 8),
+    "_NET_DESKTOP_VIEWPORT": ("CARDINAL", 32),
     "_NET_WORKAREA": ("CARDINAL", 32),
     "_NET_ACTIVE_WINDOW": ("WINDOW", 32),
     "_NET_WM_DESKTOP": ("CARDINAL", 32),
@@ -192,6 +193,7 @@ SUPPORTED_ATOMS = [
     "_NET_CLIENT_LIST",
     "_NET_CLIENT_LIST_STACKING",
     "_NET_CURRENT_DESKTOP",
+    "_NET_DESKTOP_VIEWPORT",
     "_NET_ACTIVE_WINDOW",
     "_NET_SUPPORTING_WM_CHECK",
     # From http://standards.freedesktop.org/wm-spec/latest/ar01s05.html


### PR DESCRIPTION
This is an attempt at dealing with #1419, but simply setting _NET_DESKTOP_VIEWPORT does not fix the problem annoyingly.

With these changes, the viewport is being changed (correctly) each time I focus a different screen both by moving the mouse or by focussing to a window on that screen with a keybinding.

However, when I run `rofi -monitor -1 -show combi -no-config`, focus moves to the screen where the mouse is and the rofi window opens there, which is fallback behaviour, but the rofi window should instead open on the current screen. I'll continue debugging.