### PR TITLE
Prevent libqtile/scripts/top.py from breaking things on pypy

### DIFF
--- a/libqtile/scripts/top.py
+++ b/libqtile/scripts/top.py
@@ -26,10 +26,19 @@ import curses
 import linecache
 import os
 import time
-import tracemalloc
-from tracemalloc import Snapshot
 
 from libqtile import command_client, command_interface, ipc
+
+""" These imports are here because they are not supported in pypy
+having them at the top of the file causes problems when running any
+of the other scripts.
+"""
+try:
+    import tracemalloc
+    from tracemalloc import Snapshot
+    ENABLED = True
+except ModuleNotFoundError:
+    ENABLED = False
 
 
 class TraceNotStarted(Exception):
@@ -130,6 +139,8 @@ def raw_stats(client, group_by='lineno', limit=10, force_start=False):
 
 
 def top(opts):
+    if not ENABLED:
+        raise Exception('Could not import tracemalloc')
     lines = opts.lines
     seconds = opts.seconds
     force_start = opts.force_start


### PR DESCRIPTION
Ran into an issue where a recently moved script isn't compatible with pypy(libqtile/scripts/top.py). This allows me to continue using pypy for now.

The specific error this causes on pypy when invoking libqtile/scripts/main.py (from bin/qtile) is
```
Traceback (most recent call last):
  File "bin/qtile", line 31, in <module>
    from libqtile.scripts.main import main
  File "/home/dditthardt/src/qtile/libqtile/scripts/main.py", line 4, in <module>
    from libqtile.scripts import cmd_obj, run_cmd, shell, start, top
  File "/home/dditthardt/src/qtile/libqtile/scripts/top.py", line 29, in <module>
    import tracemalloc
  File "/usr/lib/pypy3.7/lib-python/3/tracemalloc.py", line 9, in <module>
    from _tracemalloc import *
ModuleNotFoundError: No module named '_tracemalloc'
```

I don't know how to fix ^, but at least it doesn't break when I'm just trying to run qtile anymore, only when I run top.