### PR TITLE
tests: fix deprecation warning

### DIFF
--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -45,7 +45,7 @@ class Call:
         self.val = val
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def hook_fixture():
     class Dummy:
         pass


### PR DESCRIPTION
2020-12-18T23:58:24.5373141Z test/test_hook.py:49
2020-12-18T23:58:24.5374172Z   /home/runner/work/qtile/qtile/test/test_hook.py:49: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
2020-12-18T23:58:24.5375326Z   Use @pytest.fixture instead; they are the same.
2020-12-18T23:58:24.5375985Z     def hook_fixture():

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>