### PR TITLE
Create generic util to find files within a folder recursively

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2020, Matt Colligan. All rights reserved.
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -18,11 +20,12 @@
 
 import io
 import os
-import re
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict, namedtuple
 
 import cairocffi
 import cairocffi.pixbuf
+
+from libqtile.utils import scan_files
 
 
 class LoadingError(Exception):
@@ -300,69 +303,38 @@ class Img:
         return s0 == s1
 
 
-def get_matching_files(dirpath='.', explicit_filetype=False, *names):
-    """Search dirpath recursively for files matching the names
-
-    Return a dict with keys equal to entries in names
-    and values a list of matching paths.
-    """
-    def match_files_in_dir(dirpath, regex_pattern):
-        for dpath, dnames, fnames in os.walk(dirpath):
-            matches = (regex_pattern.match(x) for x in fnames)
-            for match in (x for x in matches if x):
-                d = match.groupdict()
-                d['directory'] = dpath
-                yield d
-
-    pat_str = '(?P<name>' + '|'.join(map(re.escape, names)) + ')'
-    if explicit_filetype:
-        pat_str += '$'
-    else:
-        pat_str += r'\.(?P<suffix>\w+)$'
-    regex_pattern = re.compile(pat_str, flags=re.IGNORECASE)
-
-    d_total = defaultdict(list)
-    join_path = os.path.join
-    for d_match in match_files_in_dir(dirpath, regex_pattern):
-        name, directory = d_match['name'], d_match['directory']
-        try:
-            suffix = d_match['suffix']
-            filename = '.'.join((name, suffix))
-        except KeyError:
-            filename = name
-        d_total[name].append(join_path(directory, filename))
-    return d_total
-
-
 class Loader:
     """Loader - create Img() instances from image names
 
     load icons with Loader e.g.,
     >>> ldr = Loader('/usr/share/icons/Adwaita/24x24', '/usr/share/icons/Adwaita')
-    >>> d_loaded_images = ldr.icons('audio-volume-muted', 'audio-volume-low')
+    >>> d_loaded_images = ldr('audio-volume-muted', 'audio-volume-low')
     """
     def __init__(self, *directories, **kwargs):
-        self.explicit_filetype = False
         for k, v in kwargs.items():
             setattr(self, k, v)
         self.directories = list(directories)
 
     def __call__(self, *names):
-        d = dict(self._get_images(names))
-        return OrderedDict(((x, d[x]) for x in names))
-
-    def _get_images(self, names):
+        d = OrderedDict()
         seen = set()
-        set_names = set(names)
+        set_names = set()
+        for n in names:
+            root, ext = os.path.splitext(n)
+            if ext:
+                set_names.add(n)
+            else:
+                set_names.add(n + '.*')
 
-        explicit = self.explicit_filetype
-        matching = get_matching_files
-        from_path = Img.from_path
         for directory in self.directories:
-            d_matches = matching(directory, explicit, *(set_names - seen))
+            d_matches = scan_files(directory, *(set_names - seen))
             for name, paths in d_matches.items():
-                yield (name, from_path(paths[0]))
-                seen.add(name)
+                if paths:
+                    d[name if name in names else name[:-2]] = Img.from_path(paths[0])
+                    seen.add(name)
+
         if seen != set_names:
             msg = "Wasn't able to find images corresponding to the names: {}"
             raise LoadingError(msg.format(set_names - seen))
+
+        return d

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2008, Aldo Cortesi. All rights reserved.
+# Copyright (c) 2020, Matt Colligan. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -19,11 +20,13 @@
 # SOFTWARE.
 
 import functools
+import glob
 import importlib
 import os
 import sys
 import traceback
 import warnings
+from collections import defaultdict
 from collections.abc import Sequence
 from random import randint
 from shutil import which
@@ -293,3 +296,23 @@ def guess_terminal(preference=None):
         return terminal
 
     logger.error('Default terminal has not been found.')
+
+
+def scan_files(dirpath, *names):
+    """
+    Search a folder recursively for files matching those passed as arguments, with
+    globbing. Returns a dict with keys equal to entries in names, and values a list of
+    matching paths. E.g.:
+
+    >>> scan_files('/wallpapers', '*.png', '*.jpg')
+    defaultdict(<class 'list'>, {'*.png': ['/wallpapers/w1.png'], '*.jpg':
+    ['/wallpapers/w2.jpg', '/wallpapers/w3.jpg']})
+
+    """
+    files = defaultdict(list)
+
+    for name in names:
+        found = glob.glob(os.path.join(dirpath, '**', name), recursive=True)
+        files[name].extend(found)
+
+    return files

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -3,7 +3,6 @@ test_images.py contains unittests for libqtile.images.Img
 and its supporting code.
 """
 import os
-from collections import OrderedDict
 from glob import glob
 from os import path
 
@@ -206,42 +205,6 @@ class TestImgResize:
         assert (png_img.width / png_img.height) == pytest.approx(ratio)
 
 
-class TestGetMatchingFiles:
-    def test_audio_volume_muted(self):
-        name = 'audio-volume-muted'
-        dfiles = images.get_matching_files(
-            DATA_DIR,
-            False,
-            name,
-        )
-        result = dfiles[name]
-        assert len(result) == 2
-        png = path.join(DATA_DIR, 'png', 'audio-volume-muted.png')
-        assert png in result
-        svg = path.join(DATA_DIR, 'svg', 'audio-volume-muted.svg')
-        assert svg in result
-
-    def test_only_svg(self):
-        name = 'audio-volume-muted.svg'
-        dfiles = images.get_matching_files(
-            DATA_DIR,
-            True,
-            name,
-        )
-        result = dfiles[name]
-        assert len(result) == 1
-        svg = path.join(DATA_DIR, 'svg', 'audio-volume-muted.svg')
-        assert svg in result
-
-    def test_multiple(self):
-        names = OrderedDict()
-        names['audio-volume-muted'] = 2
-        names['battery-caution-charging'] = 1
-        dfiles = images.get_matching_files(DATA_DIR, False, *names)
-        for name, length in names.items():
-            assert len(dfiles[name]) == length
-
-
 class TestLoader:
     @pytest.fixture(scope='function')
     def loader(self):
@@ -257,7 +220,6 @@ class TestLoader:
 
     def test_audio_volume_muted_png(self, loader):
         name = 'audio-volume-muted.png'
-        loader.explicit_filetype = True
         result = loader(name)
         assert isinstance(result[name], images.Img)
         assert result[name].path.endswith('.png')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2008, 2010 Aldo Cortesi
 # Copyright (c) 2011 Florian Mounier
 # Copyright (c) 2011 Anshuman Bhaduri
+# Copyright (c) 2020 Matt Colligan
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import os
+from collections import OrderedDict
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -95,3 +98,35 @@ def path(monkeypatch):
     with TemporaryDirectory() as d:
         monkeypatch.setenv('PATH', d)
         yield d
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, 'data')
+
+
+class TestScanFiles:
+    def test_audio_volume_muted(self):
+        name = 'audio-volume-muted.*'
+        dfiles = utils.scan_files(DATA_DIR, name)
+        result = dfiles[name]
+        assert len(result) == 2
+        png = os.path.join(DATA_DIR, 'png', 'audio-volume-muted.png')
+        assert png in result
+        svg = os.path.join(DATA_DIR, 'svg', 'audio-volume-muted.svg')
+        assert svg in result
+
+    def test_only_svg(self):
+        name = 'audio-volume-muted.svg'
+        dfiles = utils.scan_files(DATA_DIR, name)
+        result = dfiles[name]
+        assert len(result) == 1
+        svg = os.path.join(DATA_DIR, 'svg', 'audio-volume-muted.svg')
+        assert svg in result
+
+    def test_multiple(self):
+        names = OrderedDict()
+        names['audio-volume-muted.*'] = 2
+        names['battery-caution-charging.*'] = 1
+        dfiles = utils.scan_files(DATA_DIR, *names)
+        for name, length in names.items():
+            assert len(dfiles[name]) == length


### PR DESCRIPTION
This utility function replaces equivalent logic in images.Loader, and
can be used elsewhere for other purposes, for instance in #2016.