### PR TITLE
Focus should not follow mouse across screens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@ qtile X.X.X, released XXXX-XX-XX:
           Running `qtile` without arguments will continue to work for the
           forseeable future, but will be eventually deprecated. qtile prints a
           warning when run in this configuration.
+        - Qtile.cmd_focus_by_click is no longer an available command.
     * features
         - new WidgetBox widget
         - new restart and shutdown hooks

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -534,11 +534,6 @@ class XCore(base.Core):
             self._selection[name]["selection"] = value
             hook.fire("selection_change", name, self._selection[name])
 
-    def handle_EnterNotify(self, event) -> Optional[bool]:  # noqa: N802
-        assert self.qtile is not None
-
-        return self.qtile.enter_event(event)
-
     def handle_ClientMessage(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1064,13 +1064,11 @@ class Window(_Window):
 
     def handle_EnterNotify(self, e):  # noqa: N802
         hook.fire("client_mouse_enter", self)
-        if self.qtile.config.follow_mouse_focus and \
-                self.group.current_window != self:
-            self.group.focus(self, False)
-        if self.group.screen and \
-                self.qtile.current_screen != self.group.screen and \
-                self.qtile.config.follow_mouse_focus:
-            self.qtile.focus_screen(self.group.screen.index, False)
+        if self.qtile.config.follow_mouse_focus:
+            if self.group.current_window != self:
+                self.group.focus(self, False)
+            if self.group.screen and self.qtile.current_screen != self.group.screen:
+                self.qtile.focus_screen(self.group.screen.index, False)
         return True
 
     def handle_ConfigureRequest(self, e):  # noqa: N802


### PR DESCRIPTION
Currently, enter events on non-focussed screens cause the focus to shift
to that screen. This behaviour is similar in behaviour to what is
expected with the follow_mouse_focus config option, but happens in this
situation even when that is set to false. Instead, when
follow_mouse_focus is False, a different screen should only be focussed
upon a click of a window in that screen, or the root window within that
screen.