### PR TITLE
Add more documentation for debugging and writing tests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Getting started
 
     manual/install/index
     manual/config/index
+    manual/troubleshooting
     manual/commands/shell/index
 
 

--- a/docs/manual/contributing.rst
+++ b/docs/manual/contributing.rst
@@ -2,6 +2,8 @@
 Contributing
 ============
 
+.. _reporting:
+
 Reporting bugs
 ==============
 
@@ -20,6 +22,9 @@ has two qualities:
    point. Try to summarize the problem in minimum words yet in effective way.
    Do not combine multiple problems even they seem to be similar. Write
    different reports for each problem.
+
+Ensure to include any appropriate log entries from
+``~/.local/share/qtile/qtile.log`` and/or ``~/.xsession-errors``!
 
 Writing code
 ============
@@ -40,8 +45,28 @@ to our `issue tracker <https://github.com/qtile/qtile/issues>`_ on GitHub.
     following:
 
     * **Code** that conforms to PEP8.
-    * **Unit tests** that pass locally and in our CI environment.
+    * **Unit tests** that pass locally and in our CI environment (More below).
     * **Documentation** updates on an as needed basis.
 
 Feel free to add your contribution (no matter how small) to the appropriate
 place in the CHANGELOG as well!
+
+Unit testing
+------------
+
+We must test each *unit* of code to ensure that new changes to the code do not
+break existing functionality. The framework we use to test Qtile is `pytest
+<https://docs.pytest.org>`_. How pytest works is outside of the scope of this
+documentation, but there are tutorials online that explain how it is used.
+
+Our tests are written inside the ``test`` folder at the top level of the
+repository. Reading through these, you can get a feel for the approach we take
+to test a given unit. Most of the tests involve an object called ``qtile``
+(note that this is distinct from ``libqtile.qtile``).  This exposes a command
+client at ``qtile.c`` that we use to test a Qtile instance running in a
+separate thread as if we were using a command client from within a running
+Qtile session.
+
+For any Qtile-specific question on testing, feel free to ask on our `issue
+tracker <https://github.com/qtile/qtile/issues>`_ or on IRC (#qtile on
+irc.oftc.net).

--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -168,22 +168,6 @@ launching X with:
 Examples of custom X startup scripts are available in `qtile-examples
 <https://github.com/qtile/qtile-examples>`_.
 
-Capturing an ``xtrace``
-=======================
-
-Occasionally, a bug will be low level enough to require an ``xtrace`` of
-Qtile's conversations with the X server. To capture one of these, create an
-``xinitrc`` or similar file with:
-
-.. code-block:: bash
-
-  exec xtrace qtile >> ~/qtile.log
-
-This will put the xtrace output in Qtile's logfile as well. You can then
-demonstrate the bug, and paste the contents of this file into the bug report.
-
-Note that xtrace may be named ``x11trace`` on some platforms, for example, on Fedora.
-
 Debugging in PyCharm
 ====================
 

--- a/docs/manual/troubleshooting.rst
+++ b/docs/manual/troubleshooting.rst
@@ -1,0 +1,50 @@
+===============
+Troubleshooting
+===============
+
+So something has gone wrong... what do you do?
+==============================================
+
+When Qtile is running, it logs error messages (and other messages) to its log
+file. This is found at ``~/.local/share/qtile/qtile.log``. This is the first
+place to check to see what is going on. If you are getting unexpected errors
+from normal usage or your configuration (and you're not doing something wacky)
+and believe you have found a bug, then please :ref:`report a bug <reporting>`.
+
+If you are :ref:`hacking on Qtile <hacking>` and you want to debug your
+changes, this log is your best friend. You can send messages to the log from
+within libqtile by using the ``logger``:
+
+.. code-block:: python
+
+   from libqtile.log_utils import logger
+
+   logger.warning("Your message here")
+   logger.warning(variable_you_want_to_print)
+
+   try:
+       # some changes here that might error
+   raise Exception as e:
+       logger.exception(e)
+
+``logger.warning`` is convenient because its messages will always be visibile
+in the log. ``logger.exception`` is helpful because it will print the full
+traceback of an error to the log. By sticking these amongst your changes you
+can look more closely at the effects of any changes you made to Qtile's
+internals.
+
+Capturing an ``xtrace``
+=======================
+
+Occasionally, a bug will be low level enough to require an ``xtrace`` of
+Qtile's conversations with the X server. To capture one of these, create an
+``xinitrc`` or similar file with:
+
+.. code-block:: bash
+
+  exec xtrace qtile >> ~/qtile.log
+
+This will put the xtrace output in Qtile's logfile as well. You can then
+demonstrate the bug, and paste the contents of this file into the bug report.
+
+Note that xtrace may be named ``x11trace`` on some platforms, for example, on Fedora.


### PR DESCRIPTION
There have been some comments about a lack of mention in the docs about
where the logs are and how they are/can be used as well as what our unit
testing entails for contributions. This brings a small and general
troubleshooting page near the start of our docs that aims to make this
more explicit, and a section later giving a brief intro to our unit
testing.