### PR TITLE
Feature: z-layering of windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,11 @@ Qtile X.X.X, released XXXX-XX-XX:
           AND-semantics, allowing for more complex and specific rules
         - Python 3.9 support
         - switch to Github Actions for CI
+        - added `cmd_keep_above` and `cmd_keep_below` to Windows so they can be
+          kept above/below other windows permanently; calling the functions
+          twice removes the flag
+        - added `cmd_raise_client` and `cmd_lower_client` to Windows so they
+          can be shifted along z 
     !!! warning !!!
         - When (re)starting, Qtile passes its state to the new process in a
           file now, where previously it passed state directly as a string. This

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -227,7 +227,7 @@ class XCore(base.Core):
             if state and state[0] == window.WithdrawnState:
                 item.unmap()
                 continue
-            self.qtile.manage(item)
+            self.qtile.manage(item, assume_correct_layering=True)
 
     def convert_selection(self, selection_atom, _type="UTF8_STRING") -> None:
         type_atom = self.conn.atoms[_type]

--- a/libqtile/backend/x11/xcore.py
+++ b/libqtile/backend/x11/xcore.py
@@ -386,7 +386,8 @@ class XCore(base.Core):
     def update_client_list(self, windows) -> None:
         """Set the current clients to the given list of windows"""
         self._root.set_property("_NET_CLIENT_LIST", windows)
-        # TODO: check stack order
+
+    def update_client_order(self, windows) -> None:
         self._root.set_property("_NET_CLIENT_LIST_STACKING", windows)
 
     def update_net_desktops(self, groups, index: int) -> None:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -652,7 +652,7 @@ class Qtile(CommandObject):
                 pass
         self.unmanage(window_id)
 
-    def manage(self, w):
+    def manage(self, w, assume_correct_layering=False):
         try:
             attrs = w.get_attributes()
             internal = w.get_property("QTILE_INTERNAL")
@@ -692,7 +692,10 @@ class Qtile(CommandObject):
                     c.window.net_wm_state_above = self.windows_map[parent].window.net_wm_state_above
                     c.window.net_wm_state_below = self.windows_map[parent].window.net_wm_state_below
                 self.update_client_list()
-                self.change_layer(w.wid, force=True)
+                if assume_correct_layering:
+                    self.update_client_order()
+                else:
+                    self.change_layer(w.wid, force=True)
                 hook.fire("client_managed", c)
             return c
         else:

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1346,10 +1346,8 @@ class Window(_Window):
         self.toggle_minimize()
 
     def cmd_bring_to_front(self):
-        if self.floating:
-            self.qtile.change_layer(self.window.wid)
-        else:
-            self._reconfigure_floating()  # automatically above
+        self.qtile.change_layer(self.window.wid)
+        self.floating = True
 
     def cmd_keep_above(self):
         if self.window.net_wm_state_above:

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -23,7 +23,7 @@ import inspect
 import traceback
 
 import xcffib.xproto
-from xcffib.xproto import EventMask, SetMode, StackMode
+from xcffib.xproto import EventMask, SetMode
 
 from libqtile import hook, utils
 from libqtile.command_object import CommandError, CommandObject
@@ -481,11 +481,11 @@ class _Window(CommandObject):
             width=width,
             height=height,
         )
-        if above:
-            kwarg['stackmode'] = StackMode.Above
 
         self.window.configure(**kwarg)
         self.paint_borders(bordercolor, borderwidth)
+        if above:
+            self.qtile.change_layer(self.window.wid)
 
         if send_notify:
             self.send_configure_notify(x, y, width, height)
@@ -962,7 +962,7 @@ class Window(_Window):
             screen.group.add(self, force=True)
             self.qtile.focus_screen(screen.index)
 
-        self._reconfigure_floating()
+        self._reconfigure_floating(above=False)
 
     def getsize(self):
         return (self.width, self.height)
@@ -970,7 +970,7 @@ class Window(_Window):
     def getposition(self):
         return (self.x, self.y)
 
-    def _reconfigure_floating(self, new_float_state=FLOATING):
+    def _reconfigure_floating(self, new_float_state=FLOATING, above=True):
         if new_float_state == MINIMIZED:
             self.state = IconicState
             self.hide()
@@ -995,7 +995,7 @@ class Window(_Window):
                 width, height,
                 self.borderwidth,
                 self.bordercolor,
-                above=True,
+                above=above,
             )
         if self._float_state != new_float_state:
             self._float_state = new_float_state
@@ -1347,9 +1347,9 @@ class Window(_Window):
 
     def cmd_bring_to_front(self):
         if self.floating:
-            self.window.configure(stackmode=StackMode.Above)
+            self.qtile.change_layer(self.window.wid)
         else:
-            self._reconfigure_floating()  # atomatically above
+            self._reconfigure_floating()  # automatically above
 
     def cmd_match(self, *args, **kwargs):
         return self.match(*args, **kwargs)

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1379,9 +1379,9 @@ class Window(_Window):
         return (window.edges[0] <= x <= window.edges[2] and
                 window.edges[1] <= y <= window.edges[3])
 
-    def cmd_set_position(self, dx, dy):
+    def cmd_set_position(self, x, y):
         if self.floating:
-            self.tweak_float(dx, dy)
+            self.tweak_float(x, y)
             return
         for window in self.group.windows:
             if window == self or window.floating:

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1351,6 +1351,24 @@ class Window(_Window):
         else:
             self._reconfigure_floating()  # automatically above
 
+    def cmd_keep_above(self):
+        if self.window.net_wm_state_above:
+            self.qtile.unpin(self.window.wid)
+        else:
+            self.qtile.pin(self.window.wid)
+
+    def cmd_keep_below(self):
+        if self.window.net_wm_state_below:
+            self.qtile.unpin(self.window.wid)
+        else:
+            self.qtile.pin(self.window.wid, up=False)
+
+    def cmd_raise_client(self):
+        self.qtile.change_layer(self.window.wid)
+
+    def cmd_lower_client(self):
+        self.qtile.change_layer(self.window.wid, up=False)
+
     def cmd_match(self, *args, **kwargs):
         return self.match(*args, **kwargs)
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -870,6 +870,66 @@ def test_focus_stays_on_layout_switch(manager):
     assert manager.c.window.info()['name'] == 'one'
 
 
+@manager_config
+@no_xinerama
+def test_window_stacking_order(manager):
+    def _wnd(name):
+        return manager.c.window[{w['name']: w['id'] for w in manager.c.windows()}[name]]
+
+    def _clients():
+        return [w['name'] for w in manager.c.windows()]
+
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.test_window('four')
+    manager.test_window('five')
+    assert _clients() == ['one', 'two', 'three', 'four', 'five']
+
+    _wnd('one').raise_client()
+    assert _clients() == ['two', 'three', 'four', 'five', 'one']
+    _wnd('four').raise_client()
+    assert _clients() == ['two', 'three', 'five', 'one', 'four']
+    _wnd('one').lower_client()
+    assert _clients() == ['one', 'two', 'three', 'five', 'four']
+    _wnd('two').keep_above()
+    assert _clients() == ['one', 'three', 'five', 'four', 'two']
+    _wnd('five').raise_client()
+    assert _clients() == ['one', 'three', 'four', 'five', 'two']
+    _wnd('three').keep_below()
+    assert _clients() == ['three', 'one', 'four', 'five', 'two']
+    _wnd('four').lower_client()
+    assert _clients() == ['three', 'four', 'one', 'five', 'two']
+    _wnd('four').keep_below()
+    assert _clients() == ['four', 'three', 'one', 'five', 'two']
+    _wnd('one').keep_above()
+    assert _clients() == ['four', 'three', 'five', 'two', 'one']
+    _wnd('five').raise_client()
+    assert _clients() == ['four', 'three', 'five', 'two', 'one']
+    _wnd('five').lower_client()
+    assert _clients() == ['four', 'three', 'five', 'two', 'one']
+    _wnd('two').keep_below()
+    assert _clients() == ['two', 'four', 'three', 'five', 'one']
+    _wnd('four').keep_above()
+    assert _clients() == ['two', 'three', 'five', 'one', 'four']
+    _wnd('four').keep_above()
+    assert _clients() == ['two', 'three', 'five', 'four', 'one']
+    _wnd('five').raise_client()
+    assert _clients() == ['two', 'three', 'four', 'five', 'one']
+    _wnd('one').keep_above()
+    assert _clients() == ['two', 'three', 'four', 'five', 'one']
+    _wnd('one').lower_client()
+    assert _clients() == ['two', 'three', 'one', 'four', 'five']
+    _wnd('two').keep_below()
+    assert _clients() == ['three', 'two', 'one', 'four', 'five']
+    _wnd('three').keep_below()
+    assert _clients() == ['three', 'two', 'one', 'four', 'five']
+    _wnd('two').lower_client()
+    assert _clients() == ['two', 'three', 'one', 'four', 'five']
+    _wnd('one').lower_client()
+    assert _clients() == ['one', 'two', 'three', 'four', 'five']
+
+
 @pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
 def test_xeyes(manager):

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -20,6 +20,7 @@
 
 
 import pytest
+from xcffib.xproto import StackMode
 
 from libqtile.backend.x11 import xcbq
 from libqtile.popup import Popup
@@ -29,13 +30,20 @@ from test.conftest import BareConfig
 @pytest.mark.parametrize("manager", [BareConfig], indirect=True)
 def test_popup_focus(manager):
     manager.test_xeyes()
-    manager.windows_map = {}
 
-    # we have to add .conn so that Popup thinks this is libqtile.qtile
-    manager.conn = xcbq.Connection(manager.display)
+    class FakeQtile:
+        def __init__(self):
+            self.conn = xcbq.Connection(manager.display)
+            self.windows_map = {}
+
+        def change_layer(self, wid):
+            mask, values = xcbq.ConfigureMasks(stackmode=StackMode.Above)
+            self.conn.conn.core.ConfigureWindow(wid, mask, values)
+
+    fake = FakeQtile()
 
     try:
-        popup = Popup(manager)
+        popup = Popup(fake)
         popup.width = manager.c.screen.info()["width"]
         popup.height = manager.c.screen.info()["height"]
         popup.place()
@@ -46,4 +54,4 @@ def test_popup_focus(manager):
         popup.hide()
     finally:
         popup.kill()
-        manager.conn.finalize()
+        fake.conn.finalize()


### PR DESCRIPTION
A completely different approach to #1870, since I wasn't able to iron out the remaining issues with that due to the nature of the approach.

This PR extends the Qtile-object by adding a few functions:
```python
change_layer(wid, up)  # move a client to the top or bottom of the stack
pin(wid, up)  # keep a client above or below all others
unpin(wid)  # undo the changes done by pin
```
The names of the functions (as well as their scope) are open for discussion, of course.

I'm sure this approach isn't perfect either, but it is much simpler and integrates better with X11.

On top of the advantages already mentioned, this should also allow picture-in-picture functionality with fake screens, since the window list is now global instead of group specific. :) 

TODO:
- [x] fix tests (no idea how to do that at the moment)
- [x] add some tests