### PR TITLE
Don't close the IPC connection on restarts

### DIFF
--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -195,11 +195,6 @@ class Server:
         except IPCError:
             logger.warn("Invalid data received, closing connection")
         else:
-            if req[1] == "restart":
-                # if we are going to restart, close the connection first, as we won't be back
-                logger.debug("Closing connection on restart")
-                writer.write_eof()
-
             rep = self.handler(req)
 
             result = _IPC.pack(rep, is_json=is_json)


### PR DESCRIPTION
We have a session manager that keeps our socket alive across restarts, so let's keep the connection alive from the client side as well.

Fixes #1355.