### PR TITLE
conftest: Qtile -> TestManager

### DIFF
--- a/docs/manual/contributing.rst
+++ b/docs/manual/contributing.rst
@@ -61,9 +61,9 @@ documentation, but there are tutorials online that explain how it is used.
 
 Our tests are written inside the ``test`` folder at the top level of the
 repository. Reading through these, you can get a feel for the approach we take
-to test a given unit. Most of the tests involve an object called ``qtile``
-(note that this is distinct from ``libqtile.qtile``).  This exposes a command
-client at ``qtile.c`` that we use to test a Qtile instance running in a
+to test a given unit. Most of the tests involve an object called ``manager``.
+This is the test manager (defined in test/conftest.py), which exposes a command
+client at ``manager.c`` that we use to test a Qtile instance running in a
 separate thread as if we were using a command client from within a running
 Qtile session.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -259,7 +259,7 @@ class Xephyr:
             pass
 
 
-class Qtile:
+class TestManager:
     """Spawn a Qtile instance
 
     Setup a qtile server instance on the given display, with the given socket
@@ -485,7 +485,7 @@ def xephyr(request, xvfb):
 
 
 @pytest.fixture(scope="function")
-def qtile(request, xephyr):
+def manager(request, xephyr):
     config = getattr(request, "param", BareConfig)
 
     for attr in dir(default_config):
@@ -495,23 +495,23 @@ def qtile(request, xephyr):
     with tempfile.NamedTemporaryFile() as f:
         sockfile = f.name
         try:
-            q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
-            q.start(config)
+            manager = TestManager(sockfile, xephyr.display, request.config.getoption("--debuglog"))
+            manager.start(config)
 
-            yield q
+            yield manager
         finally:
-            q.terminate()
+            manager.terminate()
 
 
 @pytest.fixture(scope="function")
-def qtile_nospawn(request, xephyr):
+def manager_nospawn(request, xephyr):
     with tempfile.NamedTemporaryFile() as f:
         sockfile = f.name
         try:
-            q = Qtile(sockfile, xephyr.display, request.config.getoption("--debuglog"))
-            yield q
+            manager = TestManager(sockfile, xephyr.display, request.config.getoption("--debuglog"))
+            yield manager
         finally:
-            q.terminate()
+            manager.terminate()
 
 
 no_xinerama = pytest.mark.parametrize("xephyr", [{"xinerama": False}], indirect=True)

--- a/test/layouts/test_bsp.py
+++ b/test/layouts/test_bsp.py
@@ -45,26 +45,26 @@ class BspConfig(Config):
 
 
 def bsp_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [BspConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [BspConfig], indirect=True)(x))
 
 # This currently only tests the window focus cycle
 
 
 @bsp_config
-def test_bsp_window_focus_cycle(qtile):
+def test_bsp_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, columns adds clients at pos of current, in two stacks
-    assert qtile.c.layout.info()['clients'] == ['one', 'three', 'two']
+    assert manager.c.layout.info()['clients'] == ['one', 'three', 'two']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'two', 'float1', 'float2', 'one', 'three')
+    assert_focus_path(manager, 'two', 'float1', 'float2', 'one', 'three')

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -45,27 +45,27 @@ class ColumnsConfig(Config):
 
 
 def columns_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [ColumnsConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [ColumnsConfig], indirect=True)(x))
 
 # This currently only tests the window focus cycle
 
 
 @columns_config
-def test_columns_window_focus_cycle(qtile):
+def test_columns_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, columns adds clients at pos after current, in two stacks
-    assert qtile.c.layout.info()['columns'][0]['clients'] == ['one']
-    assert qtile.c.layout.info()['columns'][1]['clients'] == ['three', 'two']
+    assert manager.c.layout.info()['columns'][0]['clients'] == ['one']
+    assert manager.c.layout.info()['columns'][1]['clients'] == ['three', 'two']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'two', 'float1', 'float2', 'one', 'three')
+    assert_focus_path(manager, 'two', 'float1', 'float2', 'one', 'three')

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -116,84 +116,84 @@ class AllLayoutsConfigEvents(AllLayoutsConfig):
         libqtile.hook.subscribe.focus_change(handle_focus_change)
 
 
-each_layout_config = pytest.mark.parametrize("qtile", AllLayoutsConfig.generate(), indirect=True)
-all_layouts_config = pytest.mark.parametrize("qtile", [AllLayouts], indirect=True)
-each_layout_config_events = pytest.mark.parametrize("qtile", AllLayoutsConfigEvents.generate(), indirect=True)
-each_delegate_layout_config = pytest.mark.parametrize("qtile", AllDelegateLayoutsConfig.generate(), indirect=True)
+each_layout_config = pytest.mark.parametrize("manager", AllLayoutsConfig.generate(), indirect=True)
+all_layouts_config = pytest.mark.parametrize("manager", [AllLayouts], indirect=True)
+each_layout_config_events = pytest.mark.parametrize("manager", AllLayoutsConfigEvents.generate(), indirect=True)
+each_delegate_layout_config = pytest.mark.parametrize("manager", AllDelegateLayoutsConfig.generate(), indirect=True)
 
 
 @each_layout_config
-def test_window_types(qtile):
+def test_window_types(manager):
     pytest.importorskip("tkinter")
-    qtile.test_window("one")
+    manager.test_window("one")
 
     # A dialog should take focus and be floating
-    qtile.test_dialog("dialog")
-    qtile.c.window.info()['floating'] is True
-    assert_focused(qtile, "dialog")
+    manager.test_dialog("dialog")
+    manager.c.window.info()['floating'] is True
+    assert_focused(manager, "dialog")
 
     # A notification shouldn't steal focus and should be floating
-    qtile.test_notification("notification")
-    assert qtile.c.group.info()['focus'] != 'notification'
-    qtile.c.group.info_by_name('notification')['floating'] is True
+    manager.test_notification("notification")
+    assert manager.c.group.info()['focus'] != 'notification'
+    manager.c.group.info_by_name('notification')['floating'] is True
 
 
 @each_layout_config
-def test_focus_cycle(qtile):
+def test_focus_cycle(manager):
     pytest.importorskip("tkinter")
 
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_dialog("float1")
-    qtile.test_dialog("float2")
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_dialog("float1")
+    manager.test_dialog("float2")
+    manager.test_window("three")
 
     # Test preconditions (the order of items in 'clients' is managed by each layout)
-    assert set(qtile.c.layout.info()['clients']) == {'one', 'two', 'three'}
-    assert_focused(qtile, "three")
+    assert set(manager.c.layout.info()['clients']) == {'one', 'two', 'three'}
+    assert_focused(manager, "three")
 
     # Assert that the layout cycles the focus on all windows
-    assert_focus_path_unordered(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path_unordered(manager, 'float1', 'float2', 'one', 'two', 'three')
 
 
 @each_layout_config
-def test_focus_back(qtile):
+def test_focus_back(manager):
     # No exception must be raised without windows
-    qtile.c.group.focus_back()
+    manager.c.group.focus_back()
 
     # Nothing must happen with only one window
-    qtile.test_window("one")
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "one")
+    manager.test_window("one")
+    manager.c.group.focus_back()
+    assert_focused(manager, "one")
 
     # 2 windows
-    two = qtile.test_window("two")
-    assert_focused(qtile, "two")
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "one")
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "two")
+    two = manager.test_window("two")
+    assert_focused(manager, "two")
+    manager.c.group.focus_back()
+    assert_focused(manager, "one")
+    manager.c.group.focus_back()
+    assert_focused(manager, "two")
 
     # Float a window
-    three = qtile.test_window("three")
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "two")
-    qtile.c.window.toggle_floating()
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "three")
+    three = manager.test_window("three")
+    manager.c.group.focus_back()
+    assert_focused(manager, "two")
+    manager.c.window.toggle_floating()
+    manager.c.group.focus_back()
+    assert_focused(manager, "three")
 
     # If the previous window is killed, the further previous one must be focused
-    qtile.test_window("four")
-    qtile.kill_window(two)
-    qtile.kill_window(three)
-    assert_focused(qtile, "four")
-    qtile.c.group.focus_back()
-    assert_focused(qtile, "one")
+    manager.test_window("four")
+    manager.kill_window(two)
+    manager.kill_window(three)
+    assert_focused(manager, "four")
+    manager.c.group.focus_back()
+    assert_focused(manager, "one")
 
 
 # TODO: Test more events
 @each_layout_config_events
-def test_focus_change_event(qtile):
+def test_focus_change_event(manager):
     # Test that the correct number of focus_change events are fired e.g. when
     # opening, closing or switching windows.
     # If for example a layout explicitly fired a focus_change event even though
@@ -203,257 +203,257 @@ def test_focus_change_event(qtile):
     # unexpected ways.
 
     # TODO: Why does it start with 2?
-    assert qtile.c.get_test_data()['focus_change'] == 2
+    assert manager.c.get_test_data()['focus_change'] == 2
 
     # Spawning a window must fire only 1 focus_change event
-    one = qtile.test_window("one")
-    assert qtile.c.get_test_data()['focus_change'] == 3
-    two = qtile.test_window("two")
-    assert qtile.c.get_test_data()['focus_change'] == 4
-    three = qtile.test_window("three")
-    assert qtile.c.get_test_data()['focus_change'] == 5
+    one = manager.test_window("one")
+    assert manager.c.get_test_data()['focus_change'] == 3
+    two = manager.test_window("two")
+    assert manager.c.get_test_data()['focus_change'] == 4
+    three = manager.test_window("three")
+    assert manager.c.get_test_data()['focus_change'] == 5
 
     # Switching window must fire only 1 focus_change event
-    assert_focused(qtile, "three")
-    qtile.c.group.focus_by_name("one")
-    assert qtile.c.get_test_data()['focus_change'] == 6
-    assert_focused(qtile, "one")
+    assert_focused(manager, "three")
+    manager.c.group.focus_by_name("one")
+    assert manager.c.get_test_data()['focus_change'] == 6
+    assert_focused(manager, "one")
 
     # Focusing the current window must fire another focus_change event
-    qtile.c.group.focus_by_name("one")
-    assert qtile.c.get_test_data()['focus_change'] == 7
+    manager.c.group.focus_by_name("one")
+    assert manager.c.get_test_data()['focus_change'] == 7
 
     # Toggling a window floating should not fire focus_change events
-    qtile.c.window.toggle_floating()
-    assert qtile.c.get_test_data()['focus_change'] == 7
-    qtile.c.window.toggle_floating()
-    assert qtile.c.get_test_data()['focus_change'] == 7
+    manager.c.window.toggle_floating()
+    assert manager.c.get_test_data()['focus_change'] == 7
+    manager.c.window.toggle_floating()
+    assert manager.c.get_test_data()['focus_change'] == 7
 
     # Removing the focused window must fire only 1 focus_change event
-    assert_focused(qtile, "one")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three", "one"]
-    qtile.kill_window(one)
-    assert qtile.c.get_test_data()['focus_change'] == 8
+    assert_focused(manager, "one")
+    assert manager.c.group.info()['focus_history'] == ["two", "three", "one"]
+    manager.kill_window(one)
+    assert manager.c.get_test_data()['focus_change'] == 8
 
     # The position where 'one' was after it was floated and unfloated
     # above depends on the layout, so we can't predict here what window gets
     # selected after killing it; for this reason, focus 'three' explicitly to
     # continue testing
-    qtile.c.group.focus_by_name("three")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three"]
-    assert qtile.c.get_test_data()['focus_change'] == 9
+    manager.c.group.focus_by_name("three")
+    assert manager.c.group.info()['focus_history'] == ["two", "three"]
+    assert manager.c.get_test_data()['focus_change'] == 9
 
     # Removing a non-focused window must not fire focus_change events
-    qtile.kill_window(two)
-    assert qtile.c.get_test_data()['focus_change'] == 9
-    assert_focused(qtile, "three")
+    manager.kill_window(two)
+    assert manager.c.get_test_data()['focus_change'] == 9
+    assert_focused(manager, "three")
 
     # Removing the last window must still generate 1 focus_change event
-    qtile.kill_window(three)
-    assert qtile.c.layout.info()['clients'] == []
-    assert qtile.c.get_test_data()['focus_change'] == 10
+    manager.kill_window(three)
+    assert manager.c.layout.info()['clients'] == []
+    assert manager.c.get_test_data()['focus_change'] == 10
 
 
 @each_layout_config
-def test_remove(qtile):
-    one = qtile.test_window("one")
-    two = qtile.test_window("two")
-    three = qtile.test_window("three")
-    assert_focused(qtile, "three")
-    assert qtile.c.group.info()['focus_history'] == ["one", "two", "three"]
+def test_remove(manager):
+    one = manager.test_window("one")
+    two = manager.test_window("two")
+    three = manager.test_window("three")
+    assert_focused(manager, "three")
+    assert manager.c.group.info()['focus_history'] == ["one", "two", "three"]
 
     # Removing a focused window must focus another (which one depends on the layout)
-    qtile.kill_window(three)
-    assert qtile.c.window.info()['name'] in qtile.c.layout.info()['clients']
+    manager.kill_window(three)
+    assert manager.c.window.info()['name'] in manager.c.layout.info()['clients']
 
     # To continue testing, explicitly set focus on 'two'
-    qtile.c.group.focus_by_name("two")
-    qtile.test_window("four")
-    assert_focused(qtile, "four")
-    assert qtile.c.group.info()['focus_history'] == ["one", "two", "four"]
+    manager.c.group.focus_by_name("two")
+    manager.test_window("four")
+    assert_focused(manager, "four")
+    assert manager.c.group.info()['focus_history'] == ["one", "two", "four"]
 
     # Removing a non-focused window must not change the current focus
-    qtile.kill_window(two)
-    assert_focused(qtile, "four")
-    assert qtile.c.group.info()['focus_history'] == ["one", "four"]
+    manager.kill_window(two)
+    assert_focused(manager, "four")
+    assert manager.c.group.info()['focus_history'] == ["one", "four"]
 
     # Add more windows and shuffle the focus order
-    five = qtile.test_window("five")
-    qtile.test_window("six")
-    qtile.c.group.focus_by_name("one")
-    seven = qtile.test_window("seven")
-    qtile.c.group.focus_by_name("six")
-    assert_focused(qtile, "six")
-    assert qtile.c.group.info()['focus_history'] == ["four", "five", "one",
-                                                     "seven", "six"]
+    five = manager.test_window("five")
+    manager.test_window("six")
+    manager.c.group.focus_by_name("one")
+    seven = manager.test_window("seven")
+    manager.c.group.focus_by_name("six")
+    assert_focused(manager, "six")
+    assert manager.c.group.info()['focus_history'] == ["four", "five", "one",
+                                                       "seven", "six"]
 
-    qtile.kill_window(five)
-    qtile.kill_window(one)
-    assert_focused(qtile, "six")
-    assert qtile.c.group.info()['focus_history'] == ["four", "seven", "six"]
+    manager.kill_window(five)
+    manager.kill_window(one)
+    assert_focused(manager, "six")
+    assert manager.c.group.info()['focus_history'] == ["four", "seven", "six"]
 
-    qtile.c.group.focus_by_name("seven")
-    qtile.kill_window(seven)
-    assert qtile.c.window.info()['name'] in qtile.c.layout.info()['clients']
+    manager.c.group.focus_by_name("seven")
+    manager.kill_window(seven)
+    assert manager.c.window.info()['name'] in manager.c.layout.info()['clients']
 
 
 @each_layout_config
-def test_remove_floating(qtile):
+def test_remove_floating(manager):
     pytest.importorskip("tkinter")
 
-    one = qtile.test_window("one")
-    qtile.test_window("two")
-    float1 = qtile.test_dialog("float1")
-    assert_focused(qtile, "float1")
-    assert set(qtile.c.layout.info()['clients']) == {"one", "two"}
-    assert qtile.c.group.info()['focus_history'] == ["one", "two", "float1"]
+    one = manager.test_window("one")
+    manager.test_window("two")
+    float1 = manager.test_dialog("float1")
+    assert_focused(manager, "float1")
+    assert set(manager.c.layout.info()['clients']) == {"one", "two"}
+    assert manager.c.group.info()['focus_history'] == ["one", "two", "float1"]
 
     # Removing a focused floating window must focus the one that was focused before
-    qtile.kill_window(float1)
-    assert_focused(qtile, "two")
-    assert qtile.c.group.info()['focus_history'] == ["one", "two"]
+    manager.kill_window(float1)
+    assert_focused(manager, "two")
+    assert manager.c.group.info()['focus_history'] == ["one", "two"]
 
-    float2 = qtile.test_dialog("float2")
-    assert_focused(qtile, "float2")
-    assert qtile.c.group.info()['focus_history'] == ["one", "two", "float2"]
+    float2 = manager.test_dialog("float2")
+    assert_focused(manager, "float2")
+    assert manager.c.group.info()['focus_history'] == ["one", "two", "float2"]
 
     # Removing a non-focused floating window must not change the current focus
-    qtile.c.group.focus_by_name("two")
-    qtile.kill_window(float2)
-    assert_focused(qtile, "two")
-    assert qtile.c.group.info()['focus_history'] == ["one", "two"]
+    manager.c.group.focus_by_name("two")
+    manager.kill_window(float2)
+    assert_focused(manager, "two")
+    assert manager.c.group.info()['focus_history'] == ["one", "two"]
 
     # Add more windows and shuffle the focus order
-    qtile.test_window("three")
-    float3 = qtile.test_dialog("float3")
-    qtile.c.group.focus_by_name("one")
-    float4 = qtile.test_dialog("float4")
-    float5 = qtile.test_dialog("float5")
-    qtile.c.group.focus_by_name("three")
-    qtile.c.group.focus_by_name("float3")
-    assert qtile.c.group.info()['focus_history'] == ["two", "one", "float4",
-                                                     "float5", "three", "float3"]
+    manager.test_window("three")
+    float3 = manager.test_dialog("float3")
+    manager.c.group.focus_by_name("one")
+    float4 = manager.test_dialog("float4")
+    float5 = manager.test_dialog("float5")
+    manager.c.group.focus_by_name("three")
+    manager.c.group.focus_by_name("float3")
+    assert manager.c.group.info()['focus_history'] == ["two", "one", "float4",
+                                                       "float5", "three", "float3"]
 
-    qtile.kill_window(one)
-    assert_focused(qtile, "float3")
-    assert qtile.c.group.info()['focus_history'] == ["two", "float4",
-                                                     "float5", "three", "float3"]
+    manager.kill_window(one)
+    assert_focused(manager, "float3")
+    assert manager.c.group.info()['focus_history'] == ["two", "float4",
+                                                       "float5", "three", "float3"]
 
-    qtile.kill_window(float5)
-    assert_focused(qtile, "float3")
-    assert qtile.c.group.info()['focus_history'] == ["two", "float4", "three", "float3"]
+    manager.kill_window(float5)
+    assert_focused(manager, "float3")
+    assert manager.c.group.info()['focus_history'] == ["two", "float4", "three", "float3"]
 
     # The focus must be given to the previous window even if it's floating
-    qtile.c.group.focus_by_name("float4")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three", "float3", "float4"]
-    qtile.kill_window(float4)
-    assert_focused(qtile, "float3")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three", "float3"]
+    manager.c.group.focus_by_name("float4")
+    assert manager.c.group.info()['focus_history'] == ["two", "three", "float3", "float4"]
+    manager.kill_window(float4)
+    assert_focused(manager, "float3")
+    assert manager.c.group.info()['focus_history'] == ["two", "three", "float3"]
 
-    four = qtile.test_window("four")
-    float6 = qtile.test_dialog("float6")
-    five = qtile.test_window("five")
-    qtile.c.group.focus_by_name("float3")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three", "four",
-                                                     "float6", "five", "float3"]
+    four = manager.test_window("four")
+    float6 = manager.test_dialog("float6")
+    five = manager.test_window("five")
+    manager.c.group.focus_by_name("float3")
+    assert manager.c.group.info()['focus_history'] == ["two", "three", "four",
+                                                       "float6", "five", "float3"]
 
     # Killing several unfocused windows before the current one, and then
     # killing the current window, must focus the remaining most recently
     # focused window
-    qtile.kill_window(five)
-    qtile.kill_window(four)
-    qtile.kill_window(float6)
-    assert qtile.c.group.info()['focus_history'] == ["two", "three", "float3"]
-    qtile.kill_window(float3)
-    assert_focused(qtile, "three")
-    assert qtile.c.group.info()['focus_history'] == ["two", "three"]
+    manager.kill_window(five)
+    manager.kill_window(four)
+    manager.kill_window(float6)
+    assert manager.c.group.info()['focus_history'] == ["two", "three", "float3"]
+    manager.kill_window(float3)
+    assert_focused(manager, "three")
+    assert manager.c.group.info()['focus_history'] == ["two", "three"]
 
 
 @each_layout_config
-def test_desktop_notifications(qtile):
+def test_desktop_notifications(manager):
     pytest.importorskip("tkinter")
 
     # Unlike normal floating windows such as dialogs, notifications don't steal
     # focus when they spawn, so test them separately
 
     # A notification fired in an empty group must not take focus
-    notif1 = qtile.test_notification("notif1")
-    assert qtile.c.group.info()['focus'] is None
-    qtile.kill_window(notif1)
+    notif1 = manager.test_notification("notif1")
+    assert manager.c.group.info()['focus'] is None
+    manager.kill_window(notif1)
 
     # A window is spawned while a notification is displayed
-    notif2 = qtile.test_notification("notif2")
-    one = qtile.test_window("one")
-    assert qtile.c.group.info()['focus_history'] == ["one"]
-    qtile.kill_window(notif2)
+    notif2 = manager.test_notification("notif2")
+    one = manager.test_window("one")
+    assert manager.c.group.info()['focus_history'] == ["one"]
+    manager.kill_window(notif2)
 
     # Another notification is fired, but the focus must not change
-    notif3 = qtile.test_notification("notif3")
-    assert_focused(qtile, 'one')
-    qtile.kill_window(notif3)
+    notif3 = manager.test_notification("notif3")
+    assert_focused(manager, 'one')
+    manager.kill_window(notif3)
 
     # Complicate the scenario with multiple windows and notifications
 
-    dialog1 = qtile.test_dialog("dialog1")
-    qtile.test_window("two")
-    notif4 = qtile.test_notification("notif4")
-    notif5 = qtile.test_notification("notif5")
-    assert qtile.c.group.info()['focus_history'] == ["one", "dialog1", "two"]
+    dialog1 = manager.test_dialog("dialog1")
+    manager.test_window("two")
+    notif4 = manager.test_notification("notif4")
+    notif5 = manager.test_notification("notif5")
+    assert manager.c.group.info()['focus_history'] == ["one", "dialog1", "two"]
 
-    dialog2 = qtile.test_dialog("dialog2")
-    qtile.kill_window(notif5)
-    qtile.test_window("three")
-    qtile.kill_window(one)
-    qtile.c.group.focus_by_name("two")
-    notif6 = qtile.test_notification("notif6")
-    notif7 = qtile.test_notification("notif7")
-    qtile.kill_window(notif4)
-    notif8 = qtile.test_notification("notif8")
-    assert qtile.c.group.info()['focus_history'] == ["dialog1", "dialog2",
-                                                     "three", "two"]
+    dialog2 = manager.test_dialog("dialog2")
+    manager.kill_window(notif5)
+    manager.test_window("three")
+    manager.kill_window(one)
+    manager.c.group.focus_by_name("two")
+    notif6 = manager.test_notification("notif6")
+    notif7 = manager.test_notification("notif7")
+    manager.kill_window(notif4)
+    notif8 = manager.test_notification("notif8")
+    assert manager.c.group.info()['focus_history'] == ["dialog1", "dialog2",
+                                                       "three", "two"]
 
-    qtile.test_dialog("dialog3")
-    qtile.kill_window(dialog1)
-    qtile.kill_window(dialog2)
-    qtile.kill_window(notif6)
-    qtile.c.group.focus_by_name("three")
-    qtile.kill_window(notif7)
-    qtile.kill_window(notif8)
-    assert qtile.c.group.info()['focus_history'] == ["two", "dialog3", "three"]
+    manager.test_dialog("dialog3")
+    manager.kill_window(dialog1)
+    manager.kill_window(dialog2)
+    manager.kill_window(notif6)
+    manager.c.group.focus_by_name("three")
+    manager.kill_window(notif7)
+    manager.kill_window(notif8)
+    assert manager.c.group.info()['focus_history'] == ["two", "dialog3", "three"]
 
 
 @each_delegate_layout_config
-def test_only_uses_delegated_screen_rect(qtile):
-    qtile.test_window("one")
-    qtile.c.group.focus_by_name("one")
-    assert_focused(qtile, "one")
-    assert_dimensions_fit(qtile, 256, 0, 800-256, 600)
+def test_only_uses_delegated_screen_rect(manager):
+    manager.test_window("one")
+    manager.c.group.focus_by_name("one")
+    assert_focused(manager, "one")
+    assert_dimensions_fit(manager, 256, 0, 800-256, 600)
 
 
 @all_layouts_config
-def test_cycle_layouts(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    qtile.test_window("four")
-    qtile.c.group.focus_by_name("three")
-    assert_focused(qtile, "three")
+def test_cycle_layouts(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.test_window("four")
+    manager.c.group.focus_by_name("three")
+    assert_focused(manager, "three")
 
     # Cycling all the layouts must keep the current window focused
-    initial_layout_name = qtile.c.layout.info()['name']
+    initial_layout_name = manager.c.layout.info()['name']
     while True:
-        qtile.c.next_layout()
-        if qtile.c.layout.info()['name'] == initial_layout_name:
+        manager.c.next_layout()
+        if manager.c.layout.info()['name'] == initial_layout_name:
             break
-        # Use qtile.c.layout.info()['name'] in the assertion message, so we
+        # Use manager.c.layout.info()['name'] in the assertion message, so we
         # know which layout is buggy
-        assert qtile.c.window.info()['name'] == "three", qtile.c.layout.info()['name']
+        assert manager.c.window.info()['name'] == "three", manager.c.layout.info()['name']
 
     # Now try backwards
     while True:
-        qtile.c.prev_layout()
-        if qtile.c.layout.info()['name'] == initial_layout_name:
+        manager.c.prev_layout()
+        if manager.c.layout.info()['name'] == initial_layout_name:
             break
-        # Use qtile.c.layout.info()['name'] in the assertion message, so we
+        # Use manager.c.layout.info()['name'] in the assertion message, so we
         # know which layout is buggy
-        assert qtile.c.window.info()['name'] == "three", qtile.c.layout.info()['name']
+        assert manager.c.window.info()['name'] == "three", manager.c.layout.info()['name']

--- a/test/layouts/test_floating.py
+++ b/test/layouts/test_floating.py
@@ -43,33 +43,31 @@ class FloatingConfig(Config):
 
 
 def floating_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [FloatingConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [FloatingConfig], indirect=True)(x))
 
 
 @floating_config
-def test_float_next_prev_window(qtile):
-    self = qtile
-
+def test_float_next_prev_window(manager):
     # spawn three windows
-    self.test_window("one")
-    self.test_window("two")
-    self.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
 
     # focus previous windows
-    assert_focused(self, "three")
-    self.c.group.prev_window()
-    assert_focused(self, "two")
-    self.c.group.prev_window()
-    assert_focused(self, "one")
+    assert_focused(manager, "three")
+    manager.c.group.prev_window()
+    assert_focused(manager, "two")
+    manager.c.group.prev_window()
+    assert_focused(manager, "one")
     # checking that it loops around properly
-    self.c.group.prev_window()
-    assert_focused(self, "three")
+    manager.c.group.prev_window()
+    assert_focused(manager, "three")
 
     # focus next windows
     # checking that it loops around properly
-    self.c.group.next_window()
-    assert_focused(self, "one")
-    self.c.group.next_window()
-    assert_focused(self, "two")
-    self.c.group.next_window()
-    assert_focused(self, "three")
+    manager.c.group.next_window()
+    assert_focused(manager, "one")
+    manager.c.group.next_window()
+    assert_focused(manager, "two")
+    manager.c.group.next_window()
+    assert_focused(manager, "three")

--- a/test/layouts/test_matrix.py
+++ b/test/layouts/test_matrix.py
@@ -52,82 +52,82 @@ class MatrixConfig(Config):
 
 
 def matrix_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MatrixConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MatrixConfig], indirect=True)(x))
 
 
 @matrix_config
-def test_matrix_simple(qtile):
-    qtile.test_window("one")
-    assert qtile.c.layout.info()["rows"] == [["one"]]
-    qtile.test_window("two")
-    assert qtile.c.layout.info()["rows"] == [["one", "two"]]
-    qtile.test_window("three")
-    assert qtile.c.layout.info()["rows"] == [["one", "two"], ["three"]]
+def test_matrix_simple(manager):
+    manager.test_window("one")
+    assert manager.c.layout.info()["rows"] == [["one"]]
+    manager.test_window("two")
+    assert manager.c.layout.info()["rows"] == [["one", "two"]]
+    manager.test_window("three")
+    assert manager.c.layout.info()["rows"] == [["one", "two"], ["three"]]
 
 
 @matrix_config
-def test_matrix_navigation(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    qtile.test_window("four")
-    qtile.test_window("five")
-    qtile.c.layout.right()
-    assert qtile.c.layout.info()["current_window"] == (0, 2)
-    qtile.c.layout.up()
-    assert qtile.c.layout.info()["current_window"] == (0, 1)
-    qtile.c.layout.up()
-    assert qtile.c.layout.info()["current_window"] == (0, 0)
-    qtile.c.layout.up()
-    assert qtile.c.layout.info()["current_window"] == (0, 2)
-    qtile.c.layout.down()
-    assert qtile.c.layout.info()["current_window"] == (0, 0)
-    qtile.c.layout.down()
-    assert qtile.c.layout.info()["current_window"] == (0, 1)
-    qtile.c.layout.right()
-    assert qtile.c.layout.info()["current_window"] == (1, 1)
-    qtile.c.layout.right()
-    assert qtile.c.layout.info()["current_window"] == (0, 1)
+def test_matrix_navigation(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.test_window("four")
+    manager.test_window("five")
+    manager.c.layout.right()
+    assert manager.c.layout.info()["current_window"] == (0, 2)
+    manager.c.layout.up()
+    assert manager.c.layout.info()["current_window"] == (0, 1)
+    manager.c.layout.up()
+    assert manager.c.layout.info()["current_window"] == (0, 0)
+    manager.c.layout.up()
+    assert manager.c.layout.info()["current_window"] == (0, 2)
+    manager.c.layout.down()
+    assert manager.c.layout.info()["current_window"] == (0, 0)
+    manager.c.layout.down()
+    assert manager.c.layout.info()["current_window"] == (0, 1)
+    manager.c.layout.right()
+    assert manager.c.layout.info()["current_window"] == (1, 1)
+    manager.c.layout.right()
+    assert manager.c.layout.info()["current_window"] == (0, 1)
 
 
 @matrix_config
-def test_matrix_add_remove_columns(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    qtile.test_window("four")
-    qtile.test_window("five")
-    qtile.c.layout.add()
-    assert qtile.c.layout.info()["rows"] == [["one", "two", "three"], ["four", "five"]]
-    qtile.c.layout.delete()
-    assert qtile.c.layout.info()["rows"] == [["one", "two"], ["three", "four"], ["five"]]
+def test_matrix_add_remove_columns(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.test_window("four")
+    manager.test_window("five")
+    manager.c.layout.add()
+    assert manager.c.layout.info()["rows"] == [["one", "two", "three"], ["four", "five"]]
+    manager.c.layout.delete()
+    assert manager.c.layout.info()["rows"] == [["one", "two"], ["three", "four"], ["five"]]
 
 
 @matrix_config
-def test_matrix_window_focus_cycle(qtile):
+def test_matrix_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')
 
 
 @matrix_config
-def test_matrix_next_no_clients(qtile):
-    qtile.c.layout.next()
+def test_matrix_next_no_clients(manager):
+    manager.c.layout.next()
 
 
 @matrix_config
-def test_matrix_previous_no_clients(qtile):
-    qtile.c.layout.previous()
+def test_matrix_previous_no_clients(manager):
+    manager.c.layout.previous()

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -52,53 +52,53 @@ class MaxConfig(Config):
 
 
 def max_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MaxConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MaxConfig], indirect=True)(x))
 
 
 @max_config
-def test_max_simple(qtile):
-    qtile.test_window("one")
-    assert qtile.c.layout.info()["clients"] == ["one"]
-    qtile.test_window("two")
-    assert qtile.c.layout.info()["clients"] == ["one", "two"]
+def test_max_simple(manager):
+    manager.test_window("one")
+    assert manager.c.layout.info()["clients"] == ["one"]
+    manager.test_window("two")
+    assert manager.c.layout.info()["clients"] == ["one", "two"]
 
 
 @max_config
-def test_max_updown(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    assert qtile.c.layout.info()["clients"] == ["one", "two", "three"]
-    qtile.c.layout.up()
-    assert qtile.c.groups()["a"]["focus"] == "two"
-    qtile.c.layout.down()
-    assert qtile.c.groups()["a"]["focus"] == "three"
+def test_max_updown(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    manager.c.layout.up()
+    assert manager.c.groups()["a"]["focus"] == "two"
+    manager.c.layout.down()
+    assert manager.c.groups()["a"]["focus"] == "three"
 
 
 @max_config
-def test_max_remove(qtile):
-    qtile.test_window("one")
-    two = qtile.test_window("two")
-    assert qtile.c.layout.info()["clients"] == ["one", "two"]
-    qtile.kill_window(two)
-    assert qtile.c.layout.info()["clients"] == ["one"]
+def test_max_remove(manager):
+    manager.test_window("one")
+    two = manager.test_window("two")
+    assert manager.c.layout.info()["clients"] == ["one", "two"]
+    manager.kill_window(two)
+    assert manager.c.layout.info()["clients"] == ["one"]
 
 
 @max_config
-def test_max_window_focus_cycle(qtile):
+def test_max_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')

--- a/test/layouts/test_ratiotile.py
+++ b/test/layouts/test_ratiotile.py
@@ -56,66 +56,66 @@ class RatioTileConfig(Config):
 
 
 def ratiotile_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [RatioTileConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [RatioTileConfig], indirect=True)(x))
 
 
 @ratiotile_config
-def test_ratiotile_add_windows(qtile):
+def test_ratiotile_add_windows(manager):
     for i in range(12):
-        qtile.test_window(str(i))
+        manager.test_window(str(i))
         if i == 0:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 800, 600)]
         elif i == 1:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 400, 600), (400, 0, 400, 600)]
         elif i == 2:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 266, 600), (266, 0, 266, 600), (532, 0, 268, 600)]
         elif i == 3:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 200, 600), (200, 0, 200, 600), (400, 0, 200, 600),
                 (600, 0, 200, 600)]
         elif i == 4:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 160, 600), (160, 0, 160, 600), (320, 0, 160, 600),
                 (480, 0, 160, 600), (640, 0, 160, 600)]
         elif i == 5:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 133, 600), (133, 0, 133, 600), (266, 0, 133, 600),
                 (399, 0, 133, 600), (532, 0, 133, 600), (665, 0, 135, 600)]
         elif i == 6:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 200, 300), (200, 0, 200, 300), (400, 0, 200, 300),
                 (600, 0, 200, 300), (0, 300, 266, 300),
                 (266, 300, 266, 300), (532, 300, 268, 300)]
         elif i == 7:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 200, 300), (200, 0, 200, 300), (400, 0, 200, 300),
                 (600, 0, 200, 300), (0, 300, 200, 300),
                 (200, 300, 200, 300), (400, 300, 200, 300),
                 (600, 300, 200, 300)]
         elif i == 8:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 160, 300), (160, 0, 160, 300), (320, 0, 160, 300),
                 (480, 0, 160, 300), (640, 0, 160, 300), (0, 300, 200, 300),
                 (200, 300, 200, 300), (400, 300, 200, 300),
                 (600, 300, 200, 300)]
         elif i == 9:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 160, 300), (160, 0, 160, 300), (320, 0, 160, 300),
                 (480, 0, 160, 300), (640, 0, 160, 300), (0, 300, 160, 300),
                 (160, 300, 160, 300), (320, 300, 160, 300),
                 (480, 300, 160, 300), (640, 300, 160, 300)]
         elif i == 10:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 133, 300), (133, 0, 133, 300), (266, 0, 133, 300),
                 (399, 0, 133, 300), (532, 0, 133, 300), (665, 0, 135, 300),
                 (0, 300, 160, 300), (160, 300, 160, 300),
                 (320, 300, 160, 300), (480, 300, 160, 300),
                 (640, 300, 160, 300)]
         elif i == 11:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 133, 300), (133, 0, 133, 300), (266, 0, 133, 300),
                 (399, 0, 133, 300), (532, 0, 133, 300), (665, 0, 135, 300),
                 (0, 300, 133, 300), (133, 300, 133, 300),
@@ -126,40 +126,40 @@ def test_ratiotile_add_windows(qtile):
 
 
 @ratiotile_config
-def test_ratiotile_add_windows_golden_ratio(qtile):
-    qtile.c.next_layout()
+def test_ratiotile_add_windows_golden_ratio(manager):
+    manager.c.next_layout()
     for i in range(12):
-        qtile.test_window(str(i))
+        manager.test_window(str(i))
         if i == 0:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 800, 600)]
         elif i == 4:
             # the rest test col order
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 400, 200), (0, 200, 400, 200), (0, 400, 400, 200),
                 (400, 0, 400, 300), (400, 300, 400, 300)]
         elif i == 5:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 400, 200), (0, 200, 400, 200), (0, 400, 400, 200),
                 (400, 0, 400, 200), (400, 200, 400, 200),
                 (400, 400, 400, 200)]
 
         elif i == 9:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 266, 150), (0, 150, 266, 150), (0, 300, 266, 150),
                 (0, 450, 266, 150), (266, 0, 266, 150),
                 (266, 150, 266, 150), (266, 300, 266, 150),
                 (266, 450, 266, 150), (532, 0, 266, 300),
                 (532, 300, 266, 300)]
         elif i == 10:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 266, 150), (0, 150, 266, 150), (0, 300, 266, 150),
                 (0, 450, 266, 150), (266, 0, 266, 150),
                 (266, 150, 266, 150), (266, 300, 266, 150),
                 (266, 450, 266, 150), (532, 0, 266, 200),
                 (532, 200, 266, 200), (532, 400, 266, 200)]
         elif i == 11:
-            assert qtile.c.layout.info()['layout_info'] == [
+            assert manager.c.layout.info()['layout_info'] == [
                 (0, 0, 266, 150), (0, 150, 266, 150), (0, 300, 266, 150),
                 (0, 450, 266, 150), (266, 0, 266, 150),
                 (266, 150, 266, 150), (266, 300, 266, 150),
@@ -169,47 +169,47 @@ def test_ratiotile_add_windows_golden_ratio(qtile):
 
 
 @ratiotile_config
-def test_ratiotile_basic(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
+def test_ratiotile_basic(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
     sleep(0.1)
-    assert qtile.c.window.info()['width'] == 264
-    assert qtile.c.window.info()['height'] == 598
-    assert qtile.c.window.info()['x'] == 0
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['name'] == 'three'
+    assert manager.c.window.info()['width'] == 264
+    assert manager.c.window.info()['height'] == 598
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['name'] == 'three'
 
-    qtile.c.group.next_window()
-    assert qtile.c.window.info()['width'] == 264
-    assert qtile.c.window.info()['height'] == 598
-    assert qtile.c.window.info()['x'] == 266
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['name'] == 'two'
+    manager.c.group.next_window()
+    assert manager.c.window.info()['width'] == 264
+    assert manager.c.window.info()['height'] == 598
+    assert manager.c.window.info()['x'] == 266
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['name'] == 'two'
 
-    qtile.c.group.next_window()
-    assert qtile.c.window.info()['width'] == 266
-    assert qtile.c.window.info()['height'] == 598
-    assert qtile.c.window.info()['x'] == 532
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['name'] == 'one'
+    manager.c.group.next_window()
+    assert manager.c.window.info()['width'] == 266
+    assert manager.c.window.info()['height'] == 598
+    assert manager.c.window.info()['x'] == 532
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['name'] == 'one'
 
 
 @ratiotile_config
-def test_ratiotile_window_focus_cycle(qtile):
+def test_ratiotile_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, RatioTile adds clients to head
-    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    assert manager.c.layout.info()['clients'] == ['three', 'two', 'one']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'two', 'one', 'float1', 'float2', 'three')
+    assert_focus_path(manager, 'two', 'one', 'float1', 'float2', 'three')

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -63,80 +63,80 @@ class SliceConfig(Config):
 
 
 def slice_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [SliceConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [SliceConfig], indirect=True)(x))
 
 
 @slice_config
-def test_no_slice(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 200, 0, 600, 600)
-    qtile.test_window('two')
-    assert_dimensions(qtile, 200, 0, 600, 600)
+def test_no_slice(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 200, 0, 600, 600)
+    manager.test_window('two')
+    assert_dimensions(manager, 200, 0, 600, 600)
 
 
 @slice_config
-def test_slice_first(qtile):
-    qtile.test_window('slice')
-    assert_dimensions(qtile, 0, 0, 200, 600)
-    qtile.test_window('two')
-    assert_dimensions(qtile, 200, 0, 600, 600)
+def test_slice_first(manager):
+    manager.test_window('slice')
+    assert_dimensions(manager, 0, 0, 200, 600)
+    manager.test_window('two')
+    assert_dimensions(manager, 200, 0, 600, 600)
 
 
 @slice_config
-def test_slice_last(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 200, 0, 600, 600)
-    qtile.test_window('slice')
-    assert_dimensions(qtile, 0, 0, 200, 600)
+def test_slice_last(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 200, 0, 600, 600)
+    manager.test_window('slice')
+    assert_dimensions(manager, 0, 0, 200, 600)
 
 
 @slice_config
-def test_slice_focus(qtile):
-    qtile.test_window('one')
-    assert_focused(qtile, 'one')
-    two = qtile.test_window('two')
-    assert_focused(qtile, 'two')
-    slice = qtile.test_window('slice')
-    assert_focused(qtile, 'slice')
-    assert_focus_path(qtile, 'slice')
-    qtile.test_window('three')
-    assert_focus_path(qtile, 'two', 'one', 'slice', 'three')
-    qtile.kill_window(two)
-    assert_focus_path(qtile, 'one', 'slice', 'three')
-    qtile.kill_window(slice)
-    assert_focus_path(qtile, 'one', 'three')
-    slice = qtile.test_window('slice')
-    assert_focus_path(qtile, 'three', 'one', 'slice')
+def test_slice_focus(manager):
+    manager.test_window('one')
+    assert_focused(manager, 'one')
+    two = manager.test_window('two')
+    assert_focused(manager, 'two')
+    slice = manager.test_window('slice')
+    assert_focused(manager, 'slice')
+    assert_focus_path(manager, 'slice')
+    manager.test_window('three')
+    assert_focus_path(manager, 'two', 'one', 'slice', 'three')
+    manager.kill_window(two)
+    assert_focus_path(manager, 'one', 'slice', 'three')
+    manager.kill_window(slice)
+    assert_focus_path(manager, 'one', 'three')
+    slice = manager.test_window('slice')
+    assert_focus_path(manager, 'three', 'one', 'slice')
 
 
 @slice_config
-def test_all_slices(qtile):
-    qtile.test_window('slice')  # left
-    assert_dimensions(qtile, 0, 0, 200, 600)
-    qtile.c.next_layout()  # right
-    assert_dimensions(qtile, 600, 0, 200, 600)
-    qtile.c.next_layout()  # top
-    assert_dimensions(qtile, 0, 0, 800, 200)
-    qtile.c.next_layout()  # bottom
-    assert_dimensions(qtile, 0, 400, 800, 200)
-    qtile.c.next_layout()  # left again
-    qtile.test_window('one')
-    assert_dimensions(qtile, 200, 0, 600, 600)
-    qtile.c.next_layout()  # right
-    assert_dimensions(qtile, 0, 0, 600, 600)
-    qtile.c.next_layout()  # top
-    assert_dimensions(qtile, 0, 200, 800, 400)
-    qtile.c.next_layout()  # bottom
-    assert_dimensions(qtile, 0, 0, 800, 400)
+def test_all_slices(manager):
+    manager.test_window('slice')  # left
+    assert_dimensions(manager, 0, 0, 200, 600)
+    manager.c.next_layout()  # right
+    assert_dimensions(manager, 600, 0, 200, 600)
+    manager.c.next_layout()  # top
+    assert_dimensions(manager, 0, 0, 800, 200)
+    manager.c.next_layout()  # bottom
+    assert_dimensions(manager, 0, 400, 800, 200)
+    manager.c.next_layout()  # left again
+    manager.test_window('one')
+    assert_dimensions(manager, 200, 0, 600, 600)
+    manager.c.next_layout()  # right
+    assert_dimensions(manager, 0, 0, 600, 600)
+    manager.c.next_layout()  # top
+    assert_dimensions(manager, 0, 200, 800, 400)
+    manager.c.next_layout()  # bottom
+    assert_dimensions(manager, 0, 0, 800, 400)
 
 
 @slice_config
-def test_command_propagation(qtile):
-    qtile.test_window('slice')
-    qtile.test_window('one')
-    qtile.test_window('two')
-    info = qtile.c.layout.info()
+def test_command_propagation(manager):
+    manager.test_window('slice')
+    manager.test_window('one')
+    manager.test_window('two')
+    info = manager.c.layout.info()
     assert info['name'] == 'slice'
-    org_height = qtile.c.window.info()['height']
-    qtile.c.layout.toggle_split()
-    assert qtile.c.window.info()['height'] != org_height
+    org_height = manager.c.window.info()['height']
+    manager.c.layout.toggle_split()
+    assert manager.c.window.info()['height'] != org_height

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -54,12 +54,12 @@ class StackConfig(Config):
 
 
 def stack_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [StackConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [StackConfig], indirect=True)(x))
 
 
-def _stacks(self):
+def _stacks(manager):
     stacks = []
-    for i in self.c.layout.info()["stacks"]:
+    for i in manager.c.layout.info()["stacks"]:
         windows = i["clients"]
         current = i["current"]
         stacks.append(windows[current:] + windows[:current])
@@ -67,186 +67,186 @@ def _stacks(self):
 
 
 @stack_config
-def test_stack_commands(qtile):
-    assert qtile.c.layout.info()["current_stack"] == 0
-    qtile.test_window("one")
-    assert _stacks(qtile) == [["one"], []]
-    assert qtile.c.layout.info()["current_stack"] == 0
-    qtile.test_window("two")
-    assert _stacks(qtile) == [["one"], ["two"]]
-    assert qtile.c.layout.info()["current_stack"] == 1
-    qtile.test_window("three")
-    assert _stacks(qtile) == [["one"], ["three", "two"]]
-    assert qtile.c.layout.info()["current_stack"] == 1
+def test_stack_commands(manager):
+    assert manager.c.layout.info()["current_stack"] == 0
+    manager.test_window("one")
+    assert _stacks(manager) == [["one"], []]
+    assert manager.c.layout.info()["current_stack"] == 0
+    manager.test_window("two")
+    assert _stacks(manager) == [["one"], ["two"]]
+    assert manager.c.layout.info()["current_stack"] == 1
+    manager.test_window("three")
+    assert _stacks(manager) == [["one"], ["three", "two"]]
+    assert manager.c.layout.info()["current_stack"] == 1
 
-    qtile.c.layout.delete()
-    assert _stacks(qtile) == [["one", "three", "two"]]
-    info = qtile.c.groups()["a"]
+    manager.c.layout.delete()
+    assert _stacks(manager) == [["one", "three", "two"]]
+    info = manager.c.groups()["a"]
     assert info["focus"] == "one"
-    qtile.c.layout.delete()
-    assert len(_stacks(qtile)) == 1
+    manager.c.layout.delete()
+    assert len(_stacks(manager)) == 1
 
-    qtile.c.layout.add()
-    assert _stacks(qtile) == [["one", "three", "two"], []]
+    manager.c.layout.add()
+    assert _stacks(manager) == [["one", "three", "two"], []]
 
-    qtile.c.layout.rotate()
-    assert _stacks(qtile) == [[], ["one", "three", "two"]]
-
-
-@stack_config
-def test_stack_cmd_down(qtile):
-    qtile.c.layout.down()
+    manager.c.layout.rotate()
+    assert _stacks(manager) == [[], ["one", "three", "two"]]
 
 
 @stack_config
-def test_stack_addremove(qtile):
-    one = qtile.test_window("one")
-    qtile.c.layout.next()
-    two = qtile.test_window("two")
-    three = qtile.test_window("three")
-    assert _stacks(qtile) == [['one'], ['three', 'two']]
-    assert qtile.c.layout.info()["current_stack"] == 1
-    qtile.kill_window(three)
-    assert qtile.c.layout.info()["current_stack"] == 1
-    qtile.kill_window(two)
-    assert qtile.c.layout.info()["current_stack"] == 0
-    qtile.c.layout.next()
-    two = qtile.test_window("two")
-    qtile.c.layout.next()
-    assert qtile.c.layout.info()["current_stack"] == 0
-    qtile.kill_window(one)
-    assert qtile.c.layout.info()["current_stack"] == 1
+def test_stack_cmd_down(manager):
+    manager.c.layout.down()
 
 
 @stack_config
-def test_stack_rotation(qtile):
-    qtile.c.layout.delete()
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    assert _stacks(qtile) == [["three", "two", "one"]]
-    qtile.c.layout.down()
-    assert _stacks(qtile) == [["two", "one", "three"]]
-    qtile.c.layout.up()
-    assert _stacks(qtile) == [["three", "two", "one"]]
-    qtile.c.layout.down()
-    qtile.c.layout.down()
-    assert _stacks(qtile) == [["one", "three", "two"]]
+def test_stack_addremove(manager):
+    one = manager.test_window("one")
+    manager.c.layout.next()
+    two = manager.test_window("two")
+    three = manager.test_window("three")
+    assert _stacks(manager) == [['one'], ['three', 'two']]
+    assert manager.c.layout.info()["current_stack"] == 1
+    manager.kill_window(three)
+    assert manager.c.layout.info()["current_stack"] == 1
+    manager.kill_window(two)
+    assert manager.c.layout.info()["current_stack"] == 0
+    manager.c.layout.next()
+    two = manager.test_window("two")
+    manager.c.layout.next()
+    assert manager.c.layout.info()["current_stack"] == 0
+    manager.kill_window(one)
+    assert manager.c.layout.info()["current_stack"] == 1
 
 
 @stack_config
-def test_stack_nextprev(qtile):
-    qtile.c.layout.add()
-    one = qtile.test_window("one")
-    two = qtile.test_window("two")
-    three = qtile.test_window("three")
-
-    assert qtile.c.groups()["a"]["focus"] == "three"
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "one"
-
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] == "three"
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] == "two"
-
-    qtile.c.layout.next()
-    qtile.c.layout.next()
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "two"
-
-    qtile.kill_window(three)
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "one"
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] == "two"
-    qtile.c.layout.next()
-    qtile.kill_window(two)
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "one"
-
-    qtile.kill_window(one)
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] is None
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] is None
+def test_stack_rotation(manager):
+    manager.c.layout.delete()
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    assert _stacks(manager) == [["three", "two", "one"]]
+    manager.c.layout.down()
+    assert _stacks(manager) == [["two", "one", "three"]]
+    manager.c.layout.up()
+    assert _stacks(manager) == [["three", "two", "one"]]
+    manager.c.layout.down()
+    manager.c.layout.down()
+    assert _stacks(manager) == [["one", "three", "two"]]
 
 
 @stack_config
-def test_stack_window_removal(qtile):
-    qtile.c.layout.next()
-    qtile.test_window("one")
-    two = qtile.test_window("two")
-    qtile.c.layout.down()
-    qtile.kill_window(two)
+def test_stack_nextprev(manager):
+    manager.c.layout.add()
+    one = manager.test_window("one")
+    two = manager.test_window("two")
+    three = manager.test_window("three")
+
+    assert manager.c.groups()["a"]["focus"] == "three"
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "one"
+
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] == "three"
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] == "two"
+
+    manager.c.layout.next()
+    manager.c.layout.next()
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "two"
+
+    manager.kill_window(three)
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "one"
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] == "two"
+    manager.c.layout.next()
+    manager.kill_window(two)
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "one"
+
+    manager.kill_window(one)
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] is None
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] is None
 
 
 @stack_config
-def test_stack_split(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    stacks = qtile.c.layout.info()["stacks"]
+def test_stack_window_removal(manager):
+    manager.c.layout.next()
+    manager.test_window("one")
+    two = manager.test_window("two")
+    manager.c.layout.down()
+    manager.kill_window(two)
+
+
+@stack_config
+def test_stack_split(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    stacks = manager.c.layout.info()["stacks"]
     assert not stacks[1]["split"]
-    qtile.c.layout.toggle_split()
-    stacks = qtile.c.layout.info()["stacks"]
+    manager.c.layout.toggle_split()
+    stacks = manager.c.layout.info()["stacks"]
     assert stacks[1]["split"]
 
 
 @stack_config
-def test_stack_shuffle(qtile):
-    qtile.c.next_layout()
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
+def test_stack_shuffle(manager):
+    manager.c.next_layout()
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
 
-    stack = qtile.c.layout.info()["stacks"][0]
+    stack = manager.c.layout.info()["stacks"][0]
     assert stack["clients"][stack["current"]] == "three"
     for i in range(5):
-        qtile.c.layout.shuffle_up()
-        stack = qtile.c.layout.info()["stacks"][0]
+        manager.c.layout.shuffle_up()
+        stack = manager.c.layout.info()["stacks"][0]
         assert stack["clients"][stack["current"]] == "three"
     for i in range(5):
-        qtile.c.layout.shuffle_down()
-        stack = qtile.c.layout.info()["stacks"][0]
+        manager.c.layout.shuffle_down()
+        stack = manager.c.layout.info()["stacks"][0]
         assert stack["clients"][stack["current"]] == "three"
 
 
 @stack_config
-def test_stack_client_to(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    assert qtile.c.layout.info()["stacks"][0]["clients"] == ["one"]
-    qtile.c.layout.client_to_previous()
-    assert qtile.c.layout.info()["stacks"][0]["clients"] == ["two", "one"]
-    qtile.c.layout.client_to_previous()
-    assert qtile.c.layout.info()["stacks"][0]["clients"] == ["one"]
-    assert qtile.c.layout.info()["stacks"][1]["clients"] == ["two"]
-    qtile.c.layout.client_to_next()
-    assert qtile.c.layout.info()["stacks"][0]["clients"] == ["two", "one"]
+def test_stack_client_to(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    assert manager.c.layout.info()["stacks"][0]["clients"] == ["one"]
+    manager.c.layout.client_to_previous()
+    assert manager.c.layout.info()["stacks"][0]["clients"] == ["two", "one"]
+    manager.c.layout.client_to_previous()
+    assert manager.c.layout.info()["stacks"][0]["clients"] == ["one"]
+    assert manager.c.layout.info()["stacks"][1]["clients"] == ["two"]
+    manager.c.layout.client_to_next()
+    assert manager.c.layout.info()["stacks"][0]["clients"] == ["two", "one"]
 
 
 @stack_config
-def test_stack_info(qtile):
-    qtile.test_window("one")
-    assert qtile.c.layout.info()["stacks"]
+def test_stack_info(manager):
+    manager.test_window("one")
+    assert manager.c.layout.info()["stacks"]
 
 
 @stack_config
-def test_stack_window_focus_cycle(qtile):
+def test_stack_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, stack adds clients at pos of current
-    assert qtile.c.layout.info()['clients'] == ['three', 'one', 'two']
+    assert manager.c.layout.info()['clients'] == ['three', 'one', 'two']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'one', 'two', 'float1', 'float2', 'three')
+    assert_focus_path(manager, 'one', 'two', 'float1', 'float2', 'three')

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -54,87 +54,87 @@ class TileConfig(Config):
 
 
 def tile_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [TileConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [TileConfig], indirect=True)(x))
 
 
 @tile_config
-def test_tile_updown(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-    assert qtile.c.layout.info()["clients"] == ["three", "two", "one"]
-    qtile.c.layout.shuffle_down()
-    assert qtile.c.layout.info()["clients"] == ["two", "one", "three"]
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()["clients"] == ["three", "two", "one"]
+def test_tile_updown(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    assert manager.c.layout.info()["clients"] == ["three", "two", "one"]
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()["clients"] == ["two", "one", "three"]
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()["clients"] == ["three", "two", "one"]
 
 
 @tile_config
-def test_tile_nextprev(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
+def test_tile_nextprev(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
 
-    assert qtile.c.layout.info()["clients"] == ["three", "two", "one"]
-    assert qtile.c.groups()["a"]["focus"] == "three"
+    assert manager.c.layout.info()["clients"] == ["three", "two", "one"]
+    assert manager.c.groups()["a"]["focus"] == "three"
 
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "two"
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "two"
 
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] == "three"
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] == "three"
 
-    qtile.c.layout.previous()
-    assert qtile.c.groups()["a"]["focus"] == "one"
+    manager.c.layout.previous()
+    assert manager.c.groups()["a"]["focus"] == "one"
 
-    qtile.c.layout.next()
-    qtile.c.layout.next()
-    qtile.c.layout.next()
-    assert qtile.c.groups()["a"]["focus"] == "one"
-
-
-@tile_config
-def test_tile_master_and_slave(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("three")
-
-    assert qtile.c.layout.info()["master"] == ["three"]
-    assert qtile.c.layout.info()["slave"] == ["two", "one"]
-
-    qtile.c.next_layout()
-    assert qtile.c.layout.info()["master"] == ["three", "two"]
-    assert qtile.c.layout.info()["slave"] == ["one"]
+    manager.c.layout.next()
+    manager.c.layout.next()
+    manager.c.layout.next()
+    assert manager.c.groups()["a"]["focus"] == "one"
 
 
 @tile_config
-def test_tile_remove(qtile):
-    one = qtile.test_window("one")
-    qtile.test_window("two")
-    three = qtile.test_window("three")
+def test_tile_master_and_slave(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
 
-    assert qtile.c.layout.info()["master"] == ["three"]
-    qtile.kill_window(one)
-    assert qtile.c.layout.info()["master"] == ["three"]
-    qtile.kill_window(three)
-    assert qtile.c.layout.info()["master"] == ["two"]
+    assert manager.c.layout.info()["master"] == ["three"]
+    assert manager.c.layout.info()["slave"] == ["two", "one"]
+
+    manager.c.next_layout()
+    assert manager.c.layout.info()["master"] == ["three", "two"]
+    assert manager.c.layout.info()["slave"] == ["one"]
 
 
 @tile_config
-def test_tile_window_focus_cycle(qtile):
+def test_tile_remove(manager):
+    one = manager.test_window("one")
+    manager.test_window("two")
+    three = manager.test_window("three")
+
+    assert manager.c.layout.info()["master"] == ["three"]
+    manager.kill_window(one)
+    assert manager.c.layout.info()["master"] == ["three"]
+    manager.kill_window(three)
+    assert manager.c.layout.info()["master"] == ["two"]
+
+
+@tile_config
+def test_tile_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, Tile adds (by default) clients at pos of current
-    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    assert manager.c.layout.info()['clients'] == ['three', 'two', 'one']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'two', 'one', 'float1', 'float2', 'three')
+    assert_focus_path(manager, 'two', 'one', 'float1', 'float2', 'three')

--- a/test/layouts/test_treetab.py
+++ b/test/layouts/test_treetab.py
@@ -46,82 +46,82 @@ class TreeTabConfig(Config):
 
 
 def treetab_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [TreeTabConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [TreeTabConfig], indirect=True)(x))
 
 
 @treetab_config
-def test_window(qtile):
+def test_window(manager):
     pytest.importorskip("tkinter")
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_dialog("float1")
-    qtile.test_dialog("float2")
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_dialog("float1")
+    manager.test_dialog("float2")
+    manager.test_window("three")
 
     # test preconditions, columns adds clients at pos of current, in two stacks
-    assert qtile.c.layout.info()['clients'] == ['one', 'three', 'two']
-    assert qtile.c.layout.info()['sections'] == ['Foo', 'Bar']
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
+    assert manager.c.layout.info()['clients'] == ['one', 'three', 'two']
+    assert manager.c.layout.info()['sections'] == ['Foo', 'Bar']
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
 
     # last added window has focus
-    assert_focused(qtile, "three")
-    qtile.c.layout.up()
-    assert_focused(qtile, "two")
-    qtile.c.layout.down()
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
+    manager.c.layout.up()
+    assert_focused(manager, "two")
+    manager.c.layout.down()
+    assert_focused(manager, "three")
 
     # test command move_up/down
-    qtile.c.layout.move_up()
-    assert qtile.c.layout.info()['clients'] == ['one', 'three', 'two']
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
-    qtile.c.layout.move_down()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
+    manager.c.layout.move_up()
+    assert manager.c.layout.info()['clients'] == ['one', 'three', 'two']
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
+    manager.c.layout.move_down()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Bar': []}
 
     # section_down/up
-    qtile.c.layout.up()  # focus two
-    qtile.c.layout.section_down()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three']], 'Bar': [['two']]}
-    qtile.c.layout.section_up()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
+    manager.c.layout.up()  # focus two
+    manager.c.layout.section_down()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three']], 'Bar': [['two']]}
+    manager.c.layout.section_up()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['three'], ['two']], 'Bar': []}
 
     # del_section
-    qtile.c.layout.up()  # focus three
-    qtile.c.layout.section_down()
-    qtile.c.layout.del_section("Bar")
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
+    manager.c.layout.up()  # focus three
+    manager.c.layout.section_down()
+    manager.c.layout.del_section("Bar")
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
 
     # add_section
-    qtile.c.layout.add_section('Baz')
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Baz': []}
-    qtile.c.layout.del_section('Baz')
+    manager.c.layout.add_section('Baz')
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']], 'Baz': []}
+    manager.c.layout.del_section('Baz')
 
     # move_left/right
-    qtile.c.layout.move_left()  # no effect for top-level children
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
-    qtile.c.layout.move_right()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
-    qtile.c.layout.move_right()  # no effect
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
-    qtile.test_window("four")
-    qtile.c.layout.move_right()
-    qtile.c.layout.up()
-    qtile.test_window("five")
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
+    manager.c.layout.move_left()  # no effect for top-level children
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two'], ['three']]}
+    manager.c.layout.move_right()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
+    manager.c.layout.move_right()  # no effect
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three']]]}
+    manager.test_window("four")
+    manager.c.layout.move_right()
+    manager.c.layout.up()
+    manager.test_window("five")
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
 
     # expand/collapse_branch, and check focus order
-    qtile.c.layout.up()
-    qtile.c.layout.up()  # focus three
-    qtile.c.layout.collapse_branch()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three'], ['five']]]}
-    assert_focus_path(qtile, 'five', 'float1', 'float2', 'one', 'two', 'three')
-    qtile.c.layout.expand_branch()
-    assert qtile.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
-    assert_focus_path(qtile, 'four', 'five', 'float1', 'float2', 'one', 'two', 'three')
+    manager.c.layout.up()
+    manager.c.layout.up()  # focus three
+    manager.c.layout.collapse_branch()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three'], ['five']]]}
+    assert_focus_path(manager, 'five', 'float1', 'float2', 'one', 'two', 'three')
+    manager.c.layout.expand_branch()
+    assert manager.c.layout.info()['client_trees'] == {'Foo': [['one'], ['two', ['three', ['four']], ['five']]]}
+    assert_focus_path(manager, 'four', 'five', 'float1', 'float2', 'one', 'two', 'three')
 
 
 @treetab_config
-def test_sort_windows(qtile):
+def test_sort_windows(manager):
     def sorter(window):
         try:
             if int(window.name) % 2 == 0:
@@ -131,18 +131,18 @@ def test_sort_windows(qtile):
         except ValueError:
             return 'Bar'
 
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("101")
-    qtile.test_window("102")
-    qtile.test_window("103")
-    assert qtile.c.layout.info()['client_trees'] == {
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("101")
+    manager.test_window("102")
+    manager.test_window("103")
+    assert manager.c.layout.info()['client_trees'] == {
         'Foo': [['one'], ['two'], ['101'], ['102'], ['103']],
         'Bar': []
     }
     return  # TODO how to serialize a function object? i.e. `sorter`
-    qtile.c.layout.sort_windows(sorter)
-    assert qtile.c.layout.info()['client_trees'] == {
+    manager.c.layout.sort_windows(sorter)
+    assert manager.c.layout.info()['client_trees'] == {
         'Foo': [],
         'Bar': [['one'], ['two']],
         'Even': [['102']],

--- a/test/layouts/test_verticaltile.py
+++ b/test/layouts/test_verticaltile.py
@@ -56,45 +56,45 @@ class VerticalTileConfig(Config):
 
 
 def verticaltile_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [VerticalTileConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [VerticalTileConfig], indirect=True)(x))
 
 
 @verticaltile_config
-def test_verticaltile_simple(qtile):
-    qtile.test_window("one")
-    assert_dimensions(qtile, 0, 0, 800, 600)
-    qtile.test_window("two")
-    assert_dimensions(qtile, 0, 300, 798, 298)
-    qtile.test_window("three")
-    assert_dimensions(qtile, 0, 400, 798, 198)
+def test_verticaltile_simple(manager):
+    manager.test_window("one")
+    assert_dimensions(manager, 0, 0, 800, 600)
+    manager.test_window("two")
+    assert_dimensions(manager, 0, 300, 798, 298)
+    manager.test_window("three")
+    assert_dimensions(manager, 0, 400, 798, 198)
 
 
 @verticaltile_config
-def test_verticaltile_maximize(qtile):
-    qtile.test_window("one")
-    assert_dimensions(qtile, 0, 0, 800, 600)
-    qtile.test_window("two")
-    assert_dimensions(qtile, 0, 300, 798, 298)
+def test_verticaltile_maximize(manager):
+    manager.test_window("one")
+    assert_dimensions(manager, 0, 0, 800, 600)
+    manager.test_window("two")
+    assert_dimensions(manager, 0, 300, 798, 298)
     # Maximize the bottom layout, taking 75% of space
-    qtile.c.layout.maximize()
-    assert_dimensions(qtile, 0, 150, 798, 448)
+    manager.c.layout.maximize()
+    assert_dimensions(manager, 0, 150, 798, 448)
 
 
 @verticaltile_config
-def test_verticaltile_window_focus_cycle(qtile):
+def test_verticaltile_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -47,7 +47,7 @@ class MonadTallConfig(Config):
 
 
 def monadtall_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MonadTallConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MonadTallConfig], indirect=True)(x))
 
 
 class MonadTallMarginsConfig(Config):
@@ -66,7 +66,7 @@ class MonadTallMarginsConfig(Config):
 
 
 def monadtallmargins_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MonadTallMarginsConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MonadTallMarginsConfig], indirect=True)(x))
 
 
 class MonadWideConfig(Config):
@@ -85,7 +85,7 @@ class MonadWideConfig(Config):
 
 
 def monadwide_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MonadWideConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MonadWideConfig], indirect=True)(x))
 
 
 class MonadWideMarginsConfig(Config):
@@ -104,537 +104,537 @@ class MonadWideMarginsConfig(Config):
 
 
 def monadwidemargins_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [MonadWideMarginsConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [MonadWideMarginsConfig], indirect=True)(x))
 
 
 @monadtall_config
-def test_tall_add_clients(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two']
-    assert_focused(qtile, 'two')
+def test_tall_add_clients(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two']
+    assert_focused(manager, 'two')
 
-    qtile.test_window('three')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two', 'three']
-    assert_focused(qtile, 'three')
+    manager.test_window('three')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two', 'three']
+    assert_focused(manager, 'three')
 
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'two')
+    manager.c.layout.previous()
+    assert_focused(manager, 'two')
 
-    qtile.test_window('four')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two', 'four', 'three']
-    assert_focused(qtile, 'four')
+    manager.test_window('four')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two', 'four', 'three']
+    assert_focused(manager, 'four')
 
 
 @monadwide_config
-def test_wide_add_clients(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two']
-    assert_focused(qtile, 'two')
+def test_wide_add_clients(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two']
+    assert_focused(manager, 'two')
 
-    qtile.test_window('three')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two', 'three']
-    assert_focused(qtile, 'three')
+    manager.test_window('three')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two', 'three']
+    assert_focused(manager, 'three')
 
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'two')
+    manager.c.layout.previous()
+    assert_focused(manager, 'two')
 
-    qtile.test_window('four')
-    assert qtile.c.layout.info()["main"] == 'one'
-    assert qtile.c.layout.info()["secondary"] == ['two', 'four', 'three']
-    assert_focused(qtile, 'four')
+    manager.test_window('four')
+    assert manager.c.layout.info()["main"] == 'one'
+    assert manager.c.layout.info()["secondary"] == ['two', 'four', 'three']
+    assert_focused(manager, 'four')
 
 
 @monadtallmargins_config
-def test_tall_margins(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 4, 4, 788, 588)
+def test_tall_margins(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 4, 4, 788, 588)
 
-    qtile.test_window('two')
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 404, 4, 388, 588)
+    manager.test_window('two')
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 404, 4, 388, 588)
 
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 4, 4, 392, 588)
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 4, 4, 392, 588)
 
 
 @monadwidemargins_config
-def test_wide_margins(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 4, 4, 788, 588)
+def test_wide_margins(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 4, 4, 788, 588)
 
-    qtile.test_window('two')
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 4, 304, 788, 288)
+    manager.test_window('two')
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 4, 304, 788, 288)
 
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 4, 4, 788, 292)
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 4, 4, 788, 292)
 
 
 @monadtall_config
-def test_tall_growmain_solosecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_tall_growmain_solosecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
+    manager.test_window('two')
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
 
-    assert_dimensions(qtile, 0, 0, 396, 596)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 396, 596)
+    manager.c.layout.grow()
     # Grows 5% of 800 = 40 pixels
-    assert_dimensions(qtile, 0, 0, 436, 596)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 396, 596)
+    assert_dimensions(manager, 0, 0, 436, 596)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 396, 596)
 
     # Max width is 75% of 800 = 600 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 0, 596, 596)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 596, 596)
 
     # Min width is 25% of 800 = 200 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 196, 596)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 196, 596)
 
 
 @monadwide_config
-def test_wide_growmain_solosecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_wide_growmain_solosecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
+    manager.test_window('two')
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
 
-    assert_dimensions(qtile, 0, 0, 796, 296)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 796, 296)
+    manager.c.layout.grow()
     # Grows 5% of 800 = 30 pixels
-    assert_dimensions(qtile, 0, 0, 796, 326)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 796, 296)
+    assert_dimensions(manager, 0, 0, 796, 326)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 796, 296)
 
     # Max width is 75% of 600 = 450 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 0, 796, 446)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 796, 446)
 
     # Min width is 25% of 600 = 150 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 796, 146)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 796, 146)
 
 
 @monadtall_config
-def test_tall_growmain_multiplesecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_tall_growmain_multiplesecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.c.layout.previous()
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.c.layout.previous()
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
 
-    assert_dimensions(qtile, 0, 0, 396, 596)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 396, 596)
+    manager.c.layout.grow()
     # Grows 5% of 800 = 40 pixels
-    assert_dimensions(qtile, 0, 0, 436, 596)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 396, 596)
+    assert_dimensions(manager, 0, 0, 436, 596)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 396, 596)
 
     # Max width is 75% of 800 = 600 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 0, 596, 596)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 596, 596)
 
     # Min width is 25% of 800 = 200 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 196, 596)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 196, 596)
 
 
 @monadwide_config
-def test_wide_growmain_multiplesecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_wide_growmain_multiplesecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.c.layout.previous()
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.c.layout.previous()
+    manager.c.layout.previous()
+    assert_focused(manager, 'one')
 
-    assert_dimensions(qtile, 0, 0, 796, 296)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 796, 296)
+    manager.c.layout.grow()
     # Grows 5% of 600 = 30 pixels
-    assert_dimensions(qtile, 0, 0, 796, 326)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 796, 296)
+    assert_dimensions(manager, 0, 0, 796, 326)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 796, 296)
 
     # Max width is 75% of 600 = 450 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 0, 796, 446)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 0, 796, 446)
 
     # Min width is 25% of 600 = 150 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 0, 796, 146)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 0, 796, 146)
 
 
 @monadtall_config
-def test_tall_growsecondary_solosecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_tall_growsecondary_solosecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    assert_focused(qtile, 'two')
+    manager.test_window('two')
+    assert_focused(manager, 'two')
 
-    assert_dimensions(qtile, 400, 0, 396, 596)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 400, 0, 396, 596)
+    manager.c.layout.grow()
     # Grows 5% of 800 = 40 pixels
-    assert_dimensions(qtile, 360, 0, 436, 596)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 400, 0, 396, 596)
+    assert_dimensions(manager, 360, 0, 436, 596)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 400, 0, 396, 596)
 
     # Max width is 75% of 800 = 600 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 200, 0, 596, 596)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 200, 0, 596, 596)
 
     # Min width is 25% of 800 = 200 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 600, 0, 196, 596)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 600, 0, 196, 596)
 
 
 @monadwide_config
-def test_wide_growsecondary_solosecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_wide_growsecondary_solosecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    assert_focused(qtile, 'two')
+    manager.test_window('two')
+    assert_focused(manager, 'two')
 
-    assert_dimensions(qtile, 0, 300, 796, 296)
-    qtile.c.layout.grow()
+    assert_dimensions(manager, 0, 300, 796, 296)
+    manager.c.layout.grow()
     # Grows 5% of 600 = 30 pixels
-    assert_dimensions(qtile, 0, 270, 796, 326)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 300, 796, 296)
+    assert_dimensions(manager, 0, 270, 796, 326)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 300, 796, 296)
 
     # Max width is 75% of 600 = 450 pixels
     for _ in range(10):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 150, 796, 446)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 150, 796, 446)
 
     # Min width is 25% of 600 = 150 pixels
     for _ in range(10):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 450, 796, 146)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 450, 796, 146)
 
 
 @monadtall_config
-def test_tall_growsecondary_multiplesecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_tall_growsecondary_multiplesecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'two')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.c.layout.previous()
+    assert_focused(manager, 'two')
 
-    assert_dimensions(qtile, 400, 0, 396, 296)
+    assert_dimensions(manager, 400, 0, 396, 296)
     # Grow 20 pixels
-    qtile.c.layout.grow()
-    assert_dimensions(qtile, 400, 0, 396, 316)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 400, 0, 396, 296)
+    manager.c.layout.grow()
+    assert_dimensions(manager, 400, 0, 396, 316)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 400, 0, 396, 296)
 
     # Min height of other is 85 pixels, leaving 515
     for _ in range(20):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 400, 0, 396, 511)
+        manager.c.layout.grow()
+    assert_dimensions(manager, 400, 0, 396, 511)
 
-    # Min height of qtile is 85 pixels
+    # Min height of manager is 85 pixels
     for _ in range(40):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 400, 0, 396, 85)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 400, 0, 396, 85)
 
 
 @monadwide_config
-def test_wide_growsecondary_multiplesecondary(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 796, 596)
+def test_wide_growsecondary_multiplesecondary(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 796, 596)
 
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.c.layout.previous()
-    assert_focused(qtile, 'two')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.c.layout.previous()
+    assert_focused(manager, 'two')
 
-    assert_dimensions(qtile, 0, 300, 396, 296)
+    assert_dimensions(manager, 0, 300, 396, 296)
     # Grow 20 pixels
-    qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 300, 416, 296)
-    qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 300, 396, 296)
+    manager.c.layout.grow()
+    assert_dimensions(manager, 0, 300, 416, 296)
+    manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 300, 396, 296)
 
     # Min width of other is 85 pixels, leaving 715
     for _ in range(20):
-        qtile.c.layout.grow()
-    assert_dimensions(qtile, 0, 300, 710, 296)  # TODO why not 711 ?
+        manager.c.layout.grow()
+    assert_dimensions(manager, 0, 300, 710, 296)  # TODO why not 711 ?
 
-    # Min width of qtile is 85 pixels
+    # Min width of manager is 85 pixels
     for _ in range(40):
-        qtile.c.layout.shrink()
-    assert_dimensions(qtile, 0, 300, 85, 296)
+        manager.c.layout.shrink()
+    assert_dimensions(manager, 0, 300, 85, 296)
 
 
 @monadtall_config
-def test_tall_flip(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
+def test_tall_flip(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
 
     # Check all the dimensions
-    qtile.c.layout.next()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 0, 0, 396, 596)
+    manager.c.layout.next()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 0, 0, 396, 596)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 400, 0, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 400, 0, 396, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'three')
-    assert_dimensions(qtile, 400, 300, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'three')
+    assert_dimensions(manager, 400, 300, 396, 296)
 
     # Now flip it and do it again
-    qtile.c.layout.flip()
+    manager.c.layout.flip()
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 400, 0, 396, 596)
+    manager.c.layout.next()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 400, 0, 396, 596)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 0, 0, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 0, 0, 396, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'three')
-    assert_dimensions(qtile, 0, 300, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'three')
+    assert_dimensions(manager, 0, 300, 396, 296)
 
 
 @monadwide_config
-def test_wide_flip(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
+def test_wide_flip(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
 
     # Check all the dimensions
-    qtile.c.layout.next()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 0, 0, 796, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 0, 0, 796, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 0, 300, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 0, 300, 396, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'three')
-    assert_dimensions(qtile, 400, 300, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'three')
+    assert_dimensions(manager, 400, 300, 396, 296)
 
     # Now flip it and do it again
-    qtile.c.layout.flip()
+    manager.c.layout.flip()
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'one')
-    assert_dimensions(qtile, 0, 300, 796, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'one')
+    assert_dimensions(manager, 0, 300, 796, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'two')
-    assert_dimensions(qtile, 0, 0, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'two')
+    assert_dimensions(manager, 0, 0, 396, 296)
 
-    qtile.c.layout.next()
-    assert_focused(qtile, 'three')
-    assert_dimensions(qtile, 400, 0, 396, 296)
+    manager.c.layout.next()
+    assert_focused(manager, 'three')
+    assert_dimensions(manager, 400, 0, 396, 296)
 
 
 @monadtall_config
-def test_tall_shuffle(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.test_window('four')
+def test_tall_shuffle(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.test_window('four')
 
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'four']
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'four']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'four', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'four', 'three']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['four', 'two', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['four', 'two', 'three']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'four'
-    assert qtile.c.layout.info()['secondary'] == ['one', 'two', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'four'
+    assert manager.c.layout.info()['secondary'] == ['one', 'two', 'three']
 
 
 @monadwide_config
-def test_wide_shuffle(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.test_window('four')
+def test_wide_shuffle(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.test_window('four')
 
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'four']
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'four']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'four', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'four', 'three']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['four', 'two', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['four', 'two', 'three']
 
-    qtile.c.layout.shuffle_up()
-    assert qtile.c.layout.info()['main'] == 'four'
-    assert qtile.c.layout.info()['secondary'] == ['one', 'two', 'three']
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()['main'] == 'four'
+    assert manager.c.layout.info()['secondary'] == ['one', 'two', 'three']
 
 
 @monadtall_config
-def test_tall_swap(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.test_window('focused')
+def test_tall_swap(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.test_window('focused')
 
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'focused']
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'focused']
 
     # Swap a secondary left, left aligned
-    qtile.c.layout.swap_left()
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'one']
+    manager.c.layout.swap_left()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'one']
 
     # Swap a main right, left aligned
-    qtile.c.layout.swap_right()
-    assert qtile.c.layout.info()['main'] == 'two'
-    assert qtile.c.layout.info()['secondary'] == ['focused', 'three', 'one']
+    manager.c.layout.swap_right()
+    assert manager.c.layout.info()['main'] == 'two'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'three', 'one']
 
     # flip over
-    qtile.c.layout.flip()
-    qtile.c.layout.shuffle_down()
-    assert qtile.c.layout.info()['main'] == 'two'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'focused', 'one']
+    manager.c.layout.flip()
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()['main'] == 'two'
+    assert manager.c.layout.info()['secondary'] == ['three', 'focused', 'one']
 
     # Swap secondary right, right aligned
-    qtile.c.layout.swap_right()
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'two', 'one']
+    manager.c.layout.swap_right()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
 
     # Swap main left, right aligned
-    qtile.c.layout.swap_left()
-    assert qtile.c.layout.info()['main'] == 'three'
-    assert qtile.c.layout.info()['secondary'] == ['focused', 'two', 'one']
+    manager.c.layout.swap_left()
+    assert manager.c.layout.info()['main'] == 'three'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'two', 'one']
 
     # Do swap main
-    qtile.c.layout.swap_main()
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'two', 'one']
+    manager.c.layout.swap_main()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
 
 
 @monadwide_config
-def test_wide_swap(qtile):
-    qtile.test_window('one')
-    qtile.test_window('two')
-    qtile.test_window('three')
-    qtile.test_window('focused')
+def test_wide_swap(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    manager.test_window('focused')
 
-    assert qtile.c.layout.info()['main'] == 'one'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'focused']
+    assert manager.c.layout.info()['main'] == 'one'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'focused']
 
     # Swap a secondary up
-    qtile.c.layout.swap_right()  # equivalent to swap_down
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['two', 'three', 'one']
+    manager.c.layout.swap_right()  # equivalent to swap_down
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['two', 'three', 'one']
 
     # Swap a main down
-    qtile.c.layout.swap_left()  # equivalent to swap up
-    assert qtile.c.layout.info()['main'] == 'two'
-    assert qtile.c.layout.info()['secondary'] == ['focused', 'three', 'one']
+    manager.c.layout.swap_left()  # equivalent to swap up
+    assert manager.c.layout.info()['main'] == 'two'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'three', 'one']
 
     # flip over
-    qtile.c.layout.flip()
-    qtile.c.layout.shuffle_down()
-    assert qtile.c.layout.info()['main'] == 'two'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'focused', 'one']
+    manager.c.layout.flip()
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()['main'] == 'two'
+    assert manager.c.layout.info()['secondary'] == ['three', 'focused', 'one']
 
     # Swap secondary down
-    qtile.c.layout.swap_left()
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'two', 'one']
+    manager.c.layout.swap_left()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
 
     # Swap main up
-    qtile.c.layout.swap_right()
-    assert qtile.c.layout.info()['main'] == 'three'
-    assert qtile.c.layout.info()['secondary'] == ['focused', 'two', 'one']
+    manager.c.layout.swap_right()
+    assert manager.c.layout.info()['main'] == 'three'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'two', 'one']
 
     # Do swap main
-    qtile.c.layout.swap_main()
-    assert qtile.c.layout.info()['main'] == 'focused'
-    assert qtile.c.layout.info()['secondary'] == ['three', 'two', 'one']
+    manager.c.layout.swap_main()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
 
 
 @monadtall_config
-def test_tall_window_focus_cycle(qtile):
+def test_tall_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # starting from the last tiled client, we first cycle through floating ones,
     # and afterwards through the tiled
-    assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')
 
 
 @monadwide_config
-def test_wide_window_focus_cycle(qtile):
+def test_wide_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions
-    assert qtile.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'float1', 'float2', 'one', 'two', 'three')
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')

--- a/test/layouts/test_zoomy.py
+++ b/test/layouts/test_zoomy.py
@@ -53,36 +53,36 @@ class ZoomyConfig(Config):
 
 
 def zoomy_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [ZoomyConfig], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [ZoomyConfig], indirect=True)(x))
 
 
 @zoomy_config
-def test_zoomy_one(qtile):
-    qtile.test_window('one')
-    assert_dimensions(qtile, 0, 0, 600, 600)
-    qtile.test_window('two')
-    assert_dimensions(qtile, 0, 0, 600, 600)
-    qtile.test_window('three')
-    assert_dimensions(qtile, 0, 0, 600, 600)
-    assert_focus_path(qtile, 'two', 'one', 'three')
+def test_zoomy_one(manager):
+    manager.test_window('one')
+    assert_dimensions(manager, 0, 0, 600, 600)
+    manager.test_window('two')
+    assert_dimensions(manager, 0, 0, 600, 600)
+    manager.test_window('three')
+    assert_dimensions(manager, 0, 0, 600, 600)
+    assert_focus_path(manager, 'two', 'one', 'three')
     # TODO(pc) find a way to check size of inactive windows
 
 
 @zoomy_config
-def test_zoomy_window_focus_cycle(qtile):
+def test_zoomy_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
-    qtile.test_window("one")
-    qtile.test_window("two")
-    qtile.test_window("float1")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("float2")
-    qtile.c.window.toggle_floating()
-    qtile.test_window("three")
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
 
     # test preconditions, Zoomy adds clients at head
-    assert qtile.c.layout.info()['clients'] == ['three', 'two', 'one']
+    assert manager.c.layout.info()['clients'] == ['three', 'two', 'one']
     # last added window has focus
-    assert_focused(qtile, "three")
+    assert_focused(manager, "three")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(qtile, 'two', 'one', 'float1', 'float2', 'three')
+    assert_focus_path(manager, 'two', 'one', 'float1', 'float2', 'three')

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -81,7 +81,7 @@ class GBConfig(libqtile.confreader.Config):
     ]
 
 
-gb_config = pytest.mark.parametrize("qtile", [GBConfig], indirect=True)
+gb_config = pytest.mark.parametrize("manager", [GBConfig], indirect=True)
 
 
 def test_completion():
@@ -126,56 +126,56 @@ def test_completion():
 
 
 @gb_config
-def test_draw(qtile):
-    qtile.test_window("one")
-    b = qtile.c.bar["bottom"].info()
+def test_draw(manager):
+    manager.test_window("one")
+    b = manager.c.bar["bottom"].info()
     assert b["widgets"][0]["name"] == "groupbox"
 
 
 @gb_config
-def test_prompt(qtile):
-    assert qtile.c.widget["prompt"].info()["width"] == 0
-    qtile.c.spawncmd(":")
-    qtile.c.widget["prompt"].fake_keypress("a")
-    qtile.c.widget["prompt"].fake_keypress("Tab")
+def test_prompt(manager):
+    assert manager.c.widget["prompt"].info()["width"] == 0
+    manager.c.spawncmd(":")
+    manager.c.widget["prompt"].fake_keypress("a")
+    manager.c.widget["prompt"].fake_keypress("Tab")
 
-    qtile.c.spawncmd(":")
-    qtile.c.widget["prompt"].fake_keypress("slash")
-    qtile.c.widget["prompt"].fake_keypress("Tab")
-
-
-@gb_config
-def test_event(qtile):
-    qtile.c.group["bb"].toscreen()
+    manager.c.spawncmd(":")
+    manager.c.widget["prompt"].fake_keypress("slash")
+    manager.c.widget["prompt"].fake_keypress("Tab")
 
 
 @gb_config
-def test_textbox(qtile):
-    assert "text" in qtile.c.list_widgets()
+def test_event(manager):
+    manager.c.group["bb"].toscreen()
+
+
+@gb_config
+def test_textbox(manager):
+    assert "text" in manager.c.list_widgets()
     s = "some text"
-    qtile.c.widget["text"].update(s)
-    assert qtile.c.widget["text"].get() == s
+    manager.c.widget["text"].update(s)
+    assert manager.c.widget["text"].get() == s
     s = "Aye, much longer string than the initial one"
-    qtile.c.widget["text"].update(s)
-    assert qtile.c.widget["text"].get() == s
-    qtile.c.group["Pppy"].toscreen()
-    qtile.c.widget["text"].set_font(fontsize=12)
+    manager.c.widget["text"].update(s)
+    assert manager.c.widget["text"].get() == s
+    manager.c.group["Pppy"].toscreen()
+    manager.c.widget["text"].set_font(fontsize=12)
 
 
 @gb_config
-def test_textbox_errors(qtile):
-    qtile.c.widget["text"].update(None)
-    qtile.c.widget["text"].update("".join(chr(i) for i in range(255)))
-    qtile.c.widget["text"].update("V\xE2r\xE2na\xE7\xEE")
-    qtile.c.widget["text"].update("\ua000")
+def test_textbox_errors(manager):
+    manager.c.widget["text"].update(None)
+    manager.c.widget["text"].update("".join(chr(i) for i in range(255)))
+    manager.c.widget["text"].update("V\xE2r\xE2na\xE7\xEE")
+    manager.c.widget["text"].update("\ua000")
 
 
 @gb_config
-def test_groupbox_button_press(qtile):
-    qtile.c.group["ccc"].toscreen()
-    assert qtile.c.groups()["a"]["screen"] is None
-    qtile.c.bar["bottom"].fake_button_press(0, "bottom", 10, 10, 1)
-    assert qtile.c.groups()["a"]["screen"] == 0
+def test_groupbox_button_press(manager):
+    manager.c.group["ccc"].toscreen()
+    assert manager.c.groups()["a"]["screen"] is None
+    manager.c.bar["bottom"].fake_button_press(0, "bottom", 10, 10, 1)
+    assert manager.c.groups()["a"]["screen"] == 0
 
 
 class GeomConf(libqtile.confreader.Config):
@@ -200,7 +200,7 @@ class GeomConf(libqtile.confreader.Config):
     ]
 
 
-geom_config = pytest.mark.parametrize("qtile", [GeomConf], indirect=True)
+geom_config = pytest.mark.parametrize("manager", [GeomConf], indirect=True)
 
 
 class DBarH(libqtile.bar.Bar):
@@ -221,27 +221,27 @@ class DWidget:
 
 
 @geom_config
-def test_geometry(qtile):
-    qtile.test_xeyes()
-    g = qtile.c.screens()[0]["gaps"]
+def test_geometry(manager):
+    manager.test_xeyes()
+    g = manager.c.screens()[0]["gaps"]
     assert g["top"] == (0, 0, 800, 10)
     assert g["bottom"] == (0, 590, 800, 10)
     assert g["left"] == (0, 10, 10, 580)
     assert g["right"] == (790, 10, 10, 580)
-    assert len(qtile.c.windows()) == 1
-    geom = qtile.c.windows()[0]
+    assert len(manager.c.windows()) == 1
+    geom = manager.c.windows()[0]
     assert geom["x"] == 10
     assert geom["y"] == 10
     assert geom["width"] == 778
     assert geom["height"] == 578
-    internal = qtile.c.internal_windows()
+    internal = manager.c.internal_windows()
     assert len(internal) == 4
-    wid = qtile.c.bar["bottom"].info()["window"]
-    assert qtile.c.window[wid].inspect()
+    wid = manager.c.bar["bottom"].info()["window"]
+    assert manager.c.window[wid].inspect()
 
 
 @geom_config
-def test_resize(qtile):
+def test_resize(manager):
     def wd(dwidget_list):
         return [i.length for i in dwidget_list]
 
@@ -330,16 +330,16 @@ class IncompatibleWidgetConf(libqtile.confreader.Config):
     ]
 
 
-def test_incompatible_widget(qtile_nospawn):
+def test_incompatible_widget(manager_nospawn):
     config = IncompatibleWidgetConf
 
     # Ensure that adding a widget that doesn't support the orientation of the
     # bar raises ConfigError
     with pytest.raises(libqtile.confreader.ConfigError):
-        qtile_nospawn.create_manager(config)
+        manager_nospawn.create_manager(config)
 
 
-def test_basic(qtile_nospawn):
+def test_basic(manager_nospawn):
     config = GeomConf
     config.screens = [
         libqtile.config.Screen(
@@ -358,9 +358,9 @@ def test_basic(qtile_nospawn):
         )
     ]
 
-    qtile_nospawn.start(config)
+    manager_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = manager_nospawn.c.bar["bottom"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][1]["offset"] == 10
     assert i["widgets"][1]["width"] == 252
@@ -374,7 +374,7 @@ def test_basic(qtile_nospawn):
     libqtile.hook.clear()
 
 
-def test_singlespacer(qtile_nospawn):
+def test_singlespacer(manager_nospawn):
     config = GeomConf
     config.screens = [
         libqtile.config.Screen(
@@ -387,15 +387,15 @@ def test_singlespacer(qtile_nospawn):
         )
     ]
 
-    qtile_nospawn.start(config)
+    manager_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = manager_nospawn.c.bar["bottom"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][0]["width"] == 800
     libqtile.hook.clear()
 
 
-def test_nospacer(qtile_nospawn):
+def test_nospacer(manager_nospawn):
     config = GeomConf
     config.screens = [
         libqtile.config.Screen(
@@ -409,9 +409,9 @@ def test_nospacer(qtile_nospawn):
         )
     ]
 
-    qtile_nospawn.start(config)
+    manager_nospawn.start(config)
 
-    i = qtile_nospawn.c.bar["bottom"].info()
+    i = manager_nospawn.c.bar["bottom"].info()
     assert i["widgets"][0]["offset"] == 0
     assert i["widgets"][1]["offset"] == 10
     libqtile.hook.clear()

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -68,18 +68,18 @@ class CallConfig(Config):
     auto_fullscreen = True
 
 
-call_config = pytest.mark.parametrize("qtile", [CallConfig], indirect=True)
+call_config = pytest.mark.parametrize("manager", [CallConfig], indirect=True)
 
 
 @call_config
-def test_layout_filter(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
-    assert qtile.c.groups()["a"]["focus"] == "two"
-    qtile.c.simulate_keypress(["control"], "j")
-    assert qtile.c.groups()["a"]["focus"] == "one"
-    qtile.c.simulate_keypress(["control"], "k")
-    assert qtile.c.groups()["a"]["focus"] == "two"
+def test_layout_filter(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    assert manager.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "j")
+    assert manager.c.groups()["a"]["focus"] == "one"
+    manager.c.simulate_keypress(["control"], "k")
+    assert manager.c.groups()["a"]["focus"] == "two"
 
 
 class TestCommands(CommandObject):
@@ -157,81 +157,81 @@ class ServerConfig(Config):
     ]
 
 
-server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
+server_config = pytest.mark.parametrize("manager", [ServerConfig], indirect=True)
 
 
 @server_config
-def test_cmd_commands(qtile):
-    assert qtile.c.commands()
-    assert qtile.c.layout.commands()
-    assert qtile.c.screen.bar["bottom"].commands()
+def test_cmd_commands(manager):
+    assert manager.c.commands()
+    assert manager.c.layout.commands()
+    assert manager.c.screen.bar["bottom"].commands()
 
 
 @server_config
-def test_call_unknown(qtile):
+def test_call_unknown(manager):
     with pytest.raises(libqtile.command_client.SelectError, match="Not valid child or command"):
-        qtile.c.nonexistent
+        manager.c.nonexistent
 
-    qtile.c.layout
+    manager.c.layout
     with pytest.raises(libqtile.command_client.SelectError, match="Not valid child or command"):
-        qtile.c.layout.nonexistent
+        manager.c.layout.nonexistent
 
 
 @server_config
-def test_items_qtile(qtile):
-    v = qtile.c.items("group")
+def test_items_qtile(manager):
+    v = manager.c.items("group")
     assert v[0]
     assert sorted(v[1]) == ["a", "b", "c"]
 
-    assert qtile.c.items("layout") == (True, [0, 1, 2])
+    assert manager.c.items("layout") == (True, [0, 1, 2])
 
-    v = qtile.c.items("widget")
+    v = manager.c.items("widget")
     assert not v[0]
     assert sorted(v[1]) == ['one', 'two']
 
-    assert qtile.c.items("bar") == (False, ["bottom"])
-    t, lst = qtile.c.items("window")
+    assert manager.c.items("bar") == (False, ["bottom"])
+    t, lst = manager.c.items("window")
     assert t
     assert len(lst) == 2
-    assert qtile.c.window[lst[0]]
-    assert qtile.c.items("screen") == (True, [0, 1])
+    assert manager.c.window[lst[0]]
+    assert manager.c.items("screen") == (True, [0, 1])
 
 
 @server_config
-def test_select_qtile(qtile):
-    assert qtile.c.layout.info()["group"] == "a"
-    assert len(qtile.c.layout.info()["stacks"]) == 1
-    assert len(qtile.c.layout[2].info()["stacks"]) == 3
+def test_select_qtile(manager):
+    assert manager.c.layout.info()["group"] == "a"
+    assert len(manager.c.layout.info()["stacks"]) == 1
+    assert len(manager.c.layout[2].info()["stacks"]) == 3
     with pytest.raises(libqtile.command_client.SelectError, match="Item not available in object"):
-        qtile.c.layout[99]
+        manager.c.layout[99]
 
-    assert qtile.c.group.info()["name"] == "a"
-    assert qtile.c.group["c"].info()["name"] == "c"
+    assert manager.c.group.info()["name"] == "a"
+    assert manager.c.group["c"].info()["name"] == "c"
     with pytest.raises(libqtile.command_client.SelectError, match="Item not available in object"):
-        qtile.c.group["nonexistent"]
+        manager.c.group["nonexistent"]
 
-    assert qtile.c.widget["one"].info()["name"] == "one"
+    assert manager.c.widget["one"].info()["name"] == "one"
     with pytest.raises(CommandError, match="No object widget"):
-        qtile.c.widget.info()
+        manager.c.widget.info()
 
-    assert qtile.c.bar["bottom"].info()["position"] == "bottom"
+    assert manager.c.bar["bottom"].info()["position"] == "bottom"
 
-    qtile.test_window("one")
-    wid = qtile.c.window.info()["id"]
-    assert qtile.c.window[wid].info()["id"] == wid
+    manager.test_window("one")
+    wid = manager.c.window.info()["id"]
+    assert manager.c.window[wid].info()["id"] == wid
 
-    assert qtile.c.screen.info()["index"] == 0
-    assert qtile.c.screen[1].info()["index"] == 1
+    assert manager.c.screen.info()["index"] == 0
+    assert manager.c.screen[1].info()["index"] == 1
     with pytest.raises(libqtile.command_client.SelectError, match="Item not available in object"):
-        qtile.c.screen[22]
+        manager.c.screen[22]
 
 
 @server_config
-def test_items_group(qtile):
-    group = qtile.c.group
+def test_items_group(manager):
+    group = manager.c.group
 
-    qtile.test_window("test")
-    wid = qtile.c.window.info()["id"]
+    manager.test_window("test")
+    wid = manager.c.window.info()["id"]
 
     assert group.items("window") == (True, [wid])
     assert group.items("layout") == (True, [0, 1, 2])
@@ -239,17 +239,17 @@ def test_items_group(qtile):
 
 
 @server_config
-def test_select_group(qtile):
-    group = qtile.c.group
+def test_select_group(manager):
+    group = manager.c.group
 
     assert group.layout.info()["group"] == "a"
     assert len(group.layout.info()["stacks"]) == 1
     assert len(group.layout[2].info()["stacks"]) == 3
 
     with pytest.raises(CommandError):
-        qtile.c.group.window.info()
-    qtile.test_window("test")
-    wid = qtile.c.window.info()["id"]
+        manager.c.group.window.info()
+    manager.test_window("test")
+    wid = manager.c.window.info()["id"]
 
     assert group.window.info()["id"] == wid
     assert group.window[wid].info()["id"] == wid
@@ -263,29 +263,29 @@ def test_select_group(qtile):
 
 
 @server_config
-def test_items_screen(qtile):
-    s = qtile.c.screen
+def test_items_screen(manager):
+    s = manager.c.screen
     assert s.items("layout") == (True, [0, 1, 2])
 
-    qtile.test_window("test")
-    wid = qtile.c.window.info()["id"]
+    manager.test_window("test")
+    wid = manager.c.window.info()["id"]
     assert s.items("window") == (True, [wid])
 
     assert s.items("bar") == (False, ["bottom"])
 
 
 @server_config
-def test_select_screen(qtile):
-    screen = qtile.c.screen
+def test_select_screen(manager):
+    screen = manager.c.screen
     assert screen.layout.info()["group"] == "a"
     assert len(screen.layout.info()["stacks"]) == 1
     assert len(screen.layout[2].info()["stacks"]) == 3
 
     with pytest.raises(CommandError):
-        qtile.c.window.info()
+        manager.c.window.info()
 
-    qtile.test_window("test")
-    wid = qtile.c.window.info()["id"]
+    manager.test_window("test")
+    wid = manager.c.window.info()["id"]
     assert screen.window.info()["id"] == wid
     assert screen.window[wid].info()["id"] == wid
 
@@ -298,28 +298,28 @@ def test_select_screen(qtile):
 
 
 @server_config
-def test_items_bar(qtile):
-    assert qtile.c.bar["bottom"].items("screen") == (True, None)
+def test_items_bar(manager):
+    assert manager.c.bar["bottom"].items("screen") == (True, None)
 
 
 @server_config
-def test_select_bar(qtile):
-    assert qtile.c.screen[1].bar["bottom"].screen.info()["index"] == 1
-    b = qtile.c.bar
+def test_select_bar(manager):
+    assert manager.c.screen[1].bar["bottom"].screen.info()["index"] == 1
+    b = manager.c.bar
     assert b["bottom"].screen.info()["index"] == 0
     with pytest.raises(CommandError):
         b.screen.info()
 
 
 @server_config
-def test_items_layout(qtile):
-    assert qtile.c.layout.items("screen") == (True, None)
-    assert qtile.c.layout.items("group") == (True, None)
+def test_items_layout(manager):
+    assert manager.c.layout.items("screen") == (True, None)
+    assert manager.c.layout.items("group") == (True, None)
 
 
 @server_config
-def test_select_layout(qtile):
-    layout = qtile.c.layout
+def test_select_layout(manager):
+    layout = manager.c.layout
 
     assert layout.screen.info()["index"] == 0
     with pytest.raises(libqtile.command_client.SelectError, match="Item not available in object"):
@@ -331,9 +331,9 @@ def test_select_layout(qtile):
 
 
 @server_config
-def test_items_window(qtile):
-    qtile.test_window("test")
-    window = qtile.c.window
+def test_items_window(manager):
+    manager.test_window("test")
+    window = manager.c.window
     window.info()["id"]
 
     assert window.items("group") == (True, None)
@@ -342,9 +342,9 @@ def test_items_window(qtile):
 
 
 @server_config
-def test_select_window(qtile):
-    qtile.test_window("test")
-    window = qtile.c.window
+def test_select_window(manager):
+    manager.test_window("test")
+    window = manager.c.window
     window.info()["id"]
 
     assert window.group.info()["name"] == "a"
@@ -360,13 +360,13 @@ def test_select_window(qtile):
 
 
 @server_config
-def test_items_widget(qtile):
-    assert qtile.c.widget["one"].items("bar") == (True, None)
+def test_items_widget(manager):
+    assert manager.c.widget["one"].items("bar") == (True, None)
 
 
 @server_config
-def test_select_widget(qtile):
-    widget = qtile.c.widget["one"]
+def test_select_widget(manager):
+    widget = manager.c.widget["one"]
     assert widget.bar.info()["position"] == "bottom"
     with pytest.raises(libqtile.command_client.SelectError, match="Item not available in object"):
         widget.bar["bottom"]

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -93,7 +93,7 @@ class FakeScreenConfig(Config):
                     widget.Sep(),
                     widget.Systray(),
                     widget.Sep(),
-                    widget.Clock(format='%H:%M:%S %d.%m.%Y',
+                    widget.Clock(format='%H:%M:%S %d.%manager.%Y',
                                  fontsize=FONTSIZE, padding=6),
                 ],
                 24,
@@ -152,280 +152,280 @@ xephyr_config = {
     "width": 900,
     "height": 980
 }
-fakescreen_config = pytest.mark.parametrize("xephyr, qtile", [(xephyr_config, FakeScreenConfig)], indirect=True)
+fakescreen_config = pytest.mark.parametrize("xephyr, manager", [(xephyr_config, FakeScreenConfig)], indirect=True)
 
 
 @fakescreen_config
-def test_basic(qtile):
-    qtile.test_window("zero")
-    assert qtile.c.layout.info()["clients"] == ["zero"]
-    assert qtile.c.screen.info() == {
+def test_basic(manager):
+    manager.test_window("zero")
+    assert manager.c.layout.info()["clients"] == ["zero"]
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 0, 'index': 0, 'width': 600, 'height': 480}
-    qtile.c.to_screen(1)
-    qtile.test_window("one")
-    assert qtile.c.layout.info()["clients"] == ["one"]
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(1)
+    manager.test_window("one")
+    assert manager.c.layout.info()["clients"] == ["one"]
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 600, 'index': 1, 'width': 300, 'height': 580}
-    qtile.c.to_screen(2)
-    qtile.test_xeyes()
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(2)
+    manager.test_xeyes()
+    assert manager.c.screen.info() == {
         'y': 480, 'x': 0, 'index': 2, 'width': 500, 'height': 400}
-    qtile.c.to_screen(3)
-    qtile.test_xclock()
-    assert qtile.c.screen.info() == {'y': 580, 'x': 500, 'index': 3, 'width': 400, 'height': 400}
+    manager.c.to_screen(3)
+    manager.test_xclock()
+    assert manager.c.screen.info() == {'y': 580, 'x': 500, 'index': 3, 'width': 400, 'height': 400}
 
 
 @fakescreen_config
-def test_gaps(qtile):
-    g = qtile.c.screens()[0]["gaps"]
+def test_gaps(manager):
+    g = manager.c.screens()[0]["gaps"]
     assert g["bottom"] == (0, 456, 600, 24)
     assert g["left"] == (0, 0, 16, 456)
     assert g["right"] == (580, 0, 20, 456)
-    g = qtile.c.screens()[1]["gaps"]
+    g = manager.c.screens()[1]["gaps"]
     assert g["top"] == (600, 0, 300, 30)
     assert g["bottom"] == (600, 556, 300, 24)
     assert g["left"] == (600, 30, 12, 526)
-    g = qtile.c.screens()[2]["gaps"]
+    g = manager.c.screens()[2]["gaps"]
     assert g["top"] == (0, 480, 500, 30)
     assert g["bottom"] == (0, 864, 500, 16)
     assert g["right"] == (460, 510, 40, 354)
-    g = qtile.c.screens()[3]["gaps"]
+    g = manager.c.screens()[3]["gaps"]
     assert g["top"] == (500, 580, 400, 30)
     assert g["left"] == (500, 610, 20, 370)
     assert g["right"] == (876, 610, 24, 370)
 
 
 @fakescreen_config
-def test_maximize_with_move_to_screen(qtile):
+def test_maximize_with_move_to_screen(manager):
     """Ensure that maximize respects bars"""
-    qtile.test_xclock()
-    qtile.c.window.toggle_maximize()
-    assert qtile.c.window.info()['width'] == 564
-    assert qtile.c.window.info()['height'] == 456
-    assert qtile.c.window.info()['x'] == 16
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['group'] == 'a'
+    manager.test_xclock()
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()['width'] == 564
+    assert manager.c.window.info()['height'] == 456
+    assert manager.c.window.info()['x'] == 16
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['group'] == 'a'
 
     # go to second screen
-    qtile.c.to_screen(1)
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(1)
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 600, 'index': 1, 'width': 300, 'height': 580}
-    assert qtile.c.group.info()['name'] == 'b'
-    qtile.c.group['a'].toscreen()
+    assert manager.c.group.info()['name'] == 'b'
+    manager.c.group['a'].toscreen()
 
-    assert qtile.c.window.info()['width'] == 288
-    assert qtile.c.window.info()['height'] == 526
-    assert qtile.c.window.info()['x'] == 612
-    assert qtile.c.window.info()['y'] == 30
-    assert qtile.c.window.info()['group'] == 'a'
+    assert manager.c.window.info()['width'] == 288
+    assert manager.c.window.info()['height'] == 526
+    assert manager.c.window.info()['x'] == 612
+    assert manager.c.window.info()['y'] == 30
+    assert manager.c.window.info()['group'] == 'a'
 
 
 @fakescreen_config
-def test_float_first_on_second_screen(qtile):
-    qtile.c.to_screen(1)
-    assert qtile.c.screen.info() == {
+def test_float_first_on_second_screen(manager):
+    manager.c.to_screen(1)
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 600, 'index': 1, 'width': 300, 'height': 580}
 
-    qtile.test_xclock()
+    manager.test_xclock()
     # I don't know where y=30, x=12 comes from...
-    assert qtile.c.window.info()['float_info'] == {
+    assert manager.c.window.info()['float_info'] == {
         'y': 30, 'x': 12, 'width': 164, 'height': 164
     }
 
-    qtile.c.window.toggle_floating()
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
 
-    assert qtile.c.window.info()['x'] == 612
-    assert qtile.c.window.info()['y'] == 30
-    assert qtile.c.window.info()['group'] == 'b'
-    assert qtile.c.window.info()['float_info'] == {
+    assert manager.c.window.info()['x'] == 612
+    assert manager.c.window.info()['y'] == 30
+    assert manager.c.window.info()['group'] == 'b'
+    assert manager.c.window.info()['float_info'] == {
         'y': 30, 'x': 12, 'width': 164, 'height': 164
     }
 
 
 @fakescreen_config
-def test_float_change_screens(qtile):
+def test_float_change_screens(manager):
     # add some eyes, and float clock
-    qtile.test_xeyes()
-    qtile.test_xclock()
-    qtile.c.window.toggle_floating()
-    assert set(qtile.c.group.info()['windows']) == set(('xeyes', 'xclock'))
-    assert qtile.c.group.info()['floating_info']['clients'] == ['xclock']
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+    manager.test_xeyes()
+    manager.test_xclock()
+    manager.c.window.toggle_floating()
+    assert set(manager.c.group.info()['windows']) == set(('xeyes', 'xclock'))
+    assert manager.c.group.info()['floating_info']['clients'] == ['xclock']
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
     # 16 is given by the left gap width
-    assert qtile.c.window.info()['x'] == 16
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['group'] == 'a'
+    assert manager.c.window.info()['x'] == 16
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['group'] == 'a'
 
     # put on group b
-    assert qtile.c.screen.info() == {
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 0, 'index': 0, 'width': 600, 'height': 480}
-    assert qtile.c.group.info()['name'] == 'a'
-    qtile.c.to_screen(1)
-    assert qtile.c.group.info()['name'] == 'b'
-    assert qtile.c.screen.info() == {
+    assert manager.c.group.info()['name'] == 'a'
+    manager.c.to_screen(1)
+    assert manager.c.group.info()['name'] == 'b'
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 600, 'index': 1, 'width': 300, 'height': 580}
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group.info()['name'] == 'a'
-    assert set(qtile.c.group.info()['windows']) == set(('xeyes', 'xclock'))
-    assert qtile.c.window.info()['name'] == 'xclock'
+    manager.c.group['a'].toscreen()
+    assert manager.c.group.info()['name'] == 'a'
+    assert set(manager.c.group.info()['windows']) == set(('xeyes', 'xclock'))
+    assert manager.c.window.info()['name'] == 'xclock'
     # width/height unchanged
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
     # x is shifted by 600, y is shifted by 0
-    assert qtile.c.window.info()['x'] == 616
-    assert qtile.c.window.info()['y'] == 0
-    assert qtile.c.window.info()['group'] == 'a'
-    assert qtile.c.group.info()['floating_info']['clients'] == ['xclock']
+    assert manager.c.window.info()['x'] == 616
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['group'] == 'a'
+    assert manager.c.group.info()['floating_info']['clients'] == ['xclock']
 
     # move to screen 3
-    qtile.c.to_screen(2)
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(2)
+    assert manager.c.screen.info() == {
         'y': 480, 'x': 0, 'index': 2, 'width': 500, 'height': 400}
-    assert qtile.c.group.info()['name'] == 'c'
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group.info()['name'] == 'a'
-    assert set(qtile.c.group.info()['windows']) == set(('xeyes', 'xclock'))
-    assert qtile.c.window.info()['name'] == 'xclock'
+    assert manager.c.group.info()['name'] == 'c'
+    manager.c.group['a'].toscreen()
+    assert manager.c.group.info()['name'] == 'a'
+    assert set(manager.c.group.info()['windows']) == set(('xeyes', 'xclock'))
+    assert manager.c.window.info()['name'] == 'xclock'
     # width/height unchanged
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
     # x is shifted by 0, y is shifted by 480
-    assert qtile.c.window.info()['x'] == 16
-    assert qtile.c.window.info()['y'] == 480
+    assert manager.c.window.info()['x'] == 16
+    assert manager.c.window.info()['y'] == 480
 
     # now screen 4 for fun
-    qtile.c.to_screen(3)
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(3)
+    assert manager.c.screen.info() == {
         'y': 580, 'x': 500, 'index': 3, 'width': 400, 'height': 400}
-    assert qtile.c.group.info()['name'] == 'd'
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group.info()['name'] == 'a'
-    assert set(qtile.c.group.info()['windows']) == set(('xeyes', 'xclock'))
-    assert qtile.c.window.info()['name'] == 'xclock'
+    assert manager.c.group.info()['name'] == 'd'
+    manager.c.group['a'].toscreen()
+    assert manager.c.group.info()['name'] == 'a'
+    assert set(manager.c.group.info()['windows']) == set(('xeyes', 'xclock'))
+    assert manager.c.window.info()['name'] == 'xclock'
     # width/height unchanged
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
     # x is shifted by 500, y is shifted by 580
-    assert qtile.c.window.info()['x'] == 516
-    assert qtile.c.window.info()['y'] == 580
+    assert manager.c.window.info()['x'] == 516
+    assert manager.c.window.info()['y'] == 580
 
     # and back to one
-    qtile.c.to_screen(0)
-    assert qtile.c.screen.info() == {
+    manager.c.to_screen(0)
+    assert manager.c.screen.info() == {
         'y': 0, 'x': 0, 'index': 0, 'width': 600, 'height': 480}
-    assert qtile.c.group.info()['name'] == 'b'
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group.info()['name'] == 'a'
-    assert set(qtile.c.group.info()['windows']) == set(('xeyes', 'xclock'))
-    assert qtile.c.window.info()['name'] == 'xclock'
+    assert manager.c.group.info()['name'] == 'b'
+    manager.c.group['a'].toscreen()
+    assert manager.c.group.info()['name'] == 'a'
+    assert set(manager.c.group.info()['windows']) == set(('xeyes', 'xclock'))
+    assert manager.c.window.info()['name'] == 'xclock'
     # back to the original location
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == 16
-    assert qtile.c.window.info()['y'] == 0
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 16
+    assert manager.c.window.info()['y'] == 0
 
 
 @fakescreen_config
-def test_float_outside_edges(qtile):
-    qtile.test_xclock()
-    qtile.c.window.toggle_floating()
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
+def test_float_outside_edges(manager):
+    manager.test_xclock()
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
     # 16 is given by the left gap width
-    assert qtile.c.window.info()['x'] == 16
-    assert qtile.c.window.info()['y'] == 0
+    assert manager.c.window.info()['x'] == 16
+    assert manager.c.window.info()['y'] == 0
     # empty because window is floating
-    assert qtile.c.layout.info() == {
+    assert manager.c.layout.info() == {
         'clients': [], 'current': 0, 'group': 'a', 'name': 'max'}
 
     # move left, but some still on screen 0
-    qtile.c.window.move_floating(-30, 20)
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == -14
-    assert qtile.c.window.info()['y'] == 20
-    assert qtile.c.window.info()['group'] == 'a'
+    manager.c.window.move_floating(-30, 20)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == -14
+    assert manager.c.window.info()['y'] == 20
+    assert manager.c.window.info()['group'] == 'a'
 
     # move up, but some still on screen 0
-    qtile.c.window.set_position_floating(-10, -20)
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == -10
-    assert qtile.c.window.info()['y'] == -20
-    assert qtile.c.window.info()['group'] == 'a'
+    manager.c.window.set_position_floating(-10, -20)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == -10
+    assert manager.c.window.info()['y'] == -20
+    assert manager.c.window.info()['group'] == 'a'
 
     # move above a
-    qtile.c.window.set_position_floating(50, -20)
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == 50
-    assert qtile.c.window.info()['y'] == -20
-    assert qtile.c.window.info()['group'] == 'a'
+    manager.c.window.set_position_floating(50, -20)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 50
+    assert manager.c.window.info()['y'] == -20
+    assert manager.c.window.info()['group'] == 'a'
 
     # move down so still left, but next to screen c
-    qtile.c.window.set_position_floating(-10, 520)
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == -10
-    assert qtile.c.window.info()['y'] == 520
-    assert qtile.c.window.info()['group'] == 'c'
+    manager.c.window.set_position_floating(-10, 520)
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == -10
+    assert manager.c.window.info()['y'] == 520
+    assert manager.c.window.info()['group'] == 'c'
 
     # move above b
-    qtile.c.window.set_position_floating(700, -10)
-    assert qtile.c.window.info()['width'] == 164
-    assert qtile.c.window.info()['height'] == 164
-    assert qtile.c.window.info()['x'] == 700
-    assert qtile.c.window.info()['y'] == -10
-    assert qtile.c.window.info()['group'] == 'b'
+    manager.c.window.set_position_floating(700, -10)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 700
+    assert manager.c.window.info()['y'] == -10
+    assert manager.c.window.info()['group'] == 'b'
 
 
 @fakescreen_config
-def test_hammer_tile(qtile):
+def test_hammer_tile(manager):
     # change to tile layout
-    qtile.c.next_layout()
-    qtile.c.next_layout()
+    manager.c.next_layout()
+    manager.c.next_layout()
     for i in range(7):
-        qtile.test_xclock()
+        manager.test_xclock()
     for i in range(30):
 
-        qtile.c.to_screen((i + 1) % 4)
-        qtile.c.group['a'].toscreen()
-    assert qtile.c.group['a'].info()['windows'] == [
+        manager.c.to_screen((i + 1) % 4)
+        manager.c.group['a'].toscreen()
+    assert manager.c.group['a'].info()['windows'] == [
         'xclock', 'xclock', 'xclock', 'xclock',
         'xclock', 'xclock', 'xclock']
 
 
 @fakescreen_config
-def test_hammer_ratio_tile(qtile):
+def test_hammer_ratio_tile(manager):
     # change to ratio tile layout
-    qtile.c.next_layout()
+    manager.c.next_layout()
     for i in range(7):
-        qtile.test_xclock()
+        manager.test_xclock()
     for i in range(30):
-        qtile.c.to_screen((i + 1) % 4)
-        qtile.c.group['a'].toscreen()
-    assert qtile.c.group['a'].info()['windows'] == [
+        manager.c.to_screen((i + 1) % 4)
+        manager.c.group['a'].toscreen()
+    assert manager.c.group['a'].info()['windows'] == [
         'xclock', 'xclock', 'xclock', 'xclock',
         'xclock', 'xclock', 'xclock']
 
 
 @fakescreen_config
-def test_ratio_to_fourth_screen(qtile):
+def test_ratio_to_fourth_screen(manager):
     # change to ratio tile layout
-    qtile.c.next_layout()
+    manager.c.next_layout()
     for i in range(7):
-        qtile.test_xclock()
-    qtile.c.to_screen(1)
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group['a'].info()['windows'] == [
+        manager.test_xclock()
+    manager.c.to_screen(1)
+    manager.c.group['a'].toscreen()
+    assert manager.c.group['a'].info()['windows'] == [
         'xclock', 'xclock', 'xclock', 'xclock',
         'xclock', 'xclock', 'xclock']
 
     # now move to 4th, fails...
-    qtile.c.to_screen(3)
-    qtile.c.group['a'].toscreen()
-    assert qtile.c.group['a'].info()['windows'] == [
+    manager.c.to_screen(3)
+    manager.c.group['a'].toscreen()
+    assert manager.c.group['a'].info()['windows'] == [
         'xclock', 'xclock', 'xclock', 'xclock',
         'xclock', 'xclock', 'xclock']

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -26,10 +26,9 @@ from multiprocessing import Value
 
 import pytest
 
-import libqtile.core
-import libqtile.hook
 import libqtile.log_utils
 import libqtile.utils
+from libqtile import hook
 from libqtile.resources import default_config
 from test.conftest import BareConfig
 
@@ -47,96 +46,91 @@ class Call:
 
 @pytest.fixture
 def hook_fixture():
-    class Dummy:
-        pass
-
-    dummy = Dummy()
     libqtile.log_utils.init_log(logging.CRITICAL, log_path=None, log_color=False)
-    libqtile.init(dummy)
 
     yield
 
-    libqtile.hook.clear()
+    hook.clear()
 
 
 def test_cannot_fire_unknown_event():
     with pytest.raises(libqtile.utils.QtileError):
-        libqtile.hook.fire("unknown")
+        hook.fire("unknown")
 
 
 @pytest.mark.usefixtures("hook_fixture")
 def test_hook_calls_subscriber():
     test = Call(0)
-    libqtile.core.manager.hook.subscribe.group_window_add(test)
-    libqtile.core.manager.hook.fire("group_window_add", 8)
+    hook.subscribe.group_window_add(test)
+    hook.fire("group_window_add", 8)
     assert test.val == 8
 
 
 @pytest.mark.usefixtures("hook_fixture")
 def test_subscribers_can_be_added_removed():
     test = Call(0)
-    libqtile.core.manager.hook.subscribe.group_window_add(test)
-    assert libqtile.core.manager.hook.subscriptions
-    libqtile.core.manager.hook.clear()
-    assert not libqtile.core.manager.hook.subscriptions
+    hook.subscribe.group_window_add(test)
+    assert hook.subscriptions
+    hook.clear()
+    assert not hook.subscriptions
 
 
 @pytest.mark.usefixtures("hook_fixture")
 def test_can_unsubscribe_from_hook():
     test = Call(0)
 
-    libqtile.core.manager.hook.subscribe.group_window_add(test)
-    libqtile.core.manager.hook.fire("group_window_add", 3)
+    hook.subscribe.group_window_add(test)
+    hook.fire("group_window_add", 3)
     assert test.val == 3
 
-    libqtile.core.manager.hook.unsubscribe.group_window_add(test)
-    libqtile.core.manager.hook.fire("group_window_add", 4)
+    hook.unsubscribe.group_window_add(test)
+    hook.fire("group_window_add", 4)
     assert test.val == 3
 
 
-def test_can_subscribe_to_startup_hooks(qtile_nospawn):
+def test_can_subscribe_to_startup_hooks(manager_nospawn):
     config = BareConfig
     for attr in dir(default_config):
         if not hasattr(config, attr):
             setattr(config, attr, getattr(default_config, attr))
-    self = qtile_nospawn
+    manager = manager_nospawn
 
-    self.startup_once_calls = Value('i', 0)
-    self.startup_calls = Value('i', 0)
-    self.startup_complete_calls = Value('i', 0)
+    manager.startup_once_calls = Value('i', 0)
+    manager.startup_calls = Value('i', 0)
+    manager.startup_complete_calls = Value('i', 0)
 
     def inc_startup_once_calls():
-        self.startup_once_calls.value += 1
+        manager.startup_once_calls.value += 1
 
     def inc_startup_calls():
-        self.startup_calls.value += 1
+        manager.startup_calls.value += 1
 
     def inc_startup_complete_calls():
-        self.startup_complete_calls.value += 1
+        manager.startup_complete_calls.value += 1
 
-    libqtile.core.manager.hook.subscribe.startup_once(inc_startup_once_calls)
-    libqtile.core.manager.hook.subscribe.startup(inc_startup_calls)
-    libqtile.core.manager.hook.subscribe.startup_complete(inc_startup_complete_calls)
+    hook.subscribe.startup_once(inc_startup_once_calls)
+    hook.subscribe.startup(inc_startup_calls)
+    hook.subscribe.startup_complete(inc_startup_complete_calls)
 
-    self.start(config)
-    self.start_qtile = True
-    assert self.startup_once_calls.value == 1
-    assert self.startup_calls.value == 1
-    assert self.startup_complete_calls.value == 1
+    manager.start(config)
+    manager.start_qtile = True
+    assert manager.startup_once_calls.value == 1
+    assert manager.startup_calls.value == 1
+    assert manager.startup_complete_calls.value == 1
     # TODO Restart and check that startup_once doesn't fire again
 
 
 @pytest.mark.usefixtures('hook_fixture')
-def test_can_update_by_selection_change(qtile):
+def test_can_update_by_selection_change(manager):
     test = Call(0)
-    libqtile.core.manager.hook.subscribe.selection_change(test)
-    libqtile.core.manager.hook.fire('selection_change', 'hello')
+    hook.subscribe.selection_change(test)
+    hook.fire('selection_change', 'hello')
     assert test.val == 'hello'
 
 
 @pytest.mark.usefixtures('hook_fixture')
-def test_can_call_by_selection_notify(qtile):
+def test_can_call_by_selection_notify(manager):
     test = Call(0)
-    libqtile.core.manager.hook.subscribe.selection_notify(test)
-    libqtile.core.manager.hook.fire('selection_notify', 'hello')
+    hook.subscribe.selection_notify(test)
+    hook.fire('selection_notify', 'hello')
     assert test.val == 'hello'

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -34,7 +34,6 @@ import xcffib.xproto
 import libqtile.bar
 import libqtile.config
 import libqtile.confreader
-import libqtile.core.manager
 import libqtile.hook
 import libqtile.layout
 import libqtile.widget
@@ -87,111 +86,102 @@ class ManagerConfig(Config):
     follow_mouse_focus = True
 
 
-manager_config = pytest.mark.parametrize("qtile", [ManagerConfig], indirect=True)
+manager_config = pytest.mark.parametrize("manager", [ManagerConfig], indirect=True)
 
 
 @manager_config
-def test_screen_dim(qtile):
-    # self.c.restart()
+def test_screen_dim(manager):
+    manager.test_xclock()
+    assert manager.c.screen.info()["index"] == 0
+    assert manager.c.screen.info()["x"] == 0
+    assert manager.c.screen.info()["width"] == 800
+    assert manager.c.group.info()["name"] == 'a'
+    assert manager.c.group.info()["focus"] == 'xclock'
 
-    qtile.test_xclock()
-    assert qtile.c.screen.info()["index"] == 0
-    assert qtile.c.screen.info()["x"] == 0
-    assert qtile.c.screen.info()["width"] == 800
-    assert qtile.c.group.info()["name"] == 'a'
-    assert qtile.c.group.info()["focus"] == 'xclock'
+    manager.c.to_screen(1)
+    manager.test_xeyes()
+    assert manager.c.screen.info()["index"] == 1
+    assert manager.c.screen.info()["x"] == 800
+    assert manager.c.screen.info()["width"] == 640
+    assert manager.c.group.info()["name"] == 'b'
+    assert manager.c.group.info()["focus"] == 'xeyes'
 
-    qtile.c.to_screen(1)
-    qtile.test_xeyes()
-    assert qtile.c.screen.info()["index"] == 1
-    assert qtile.c.screen.info()["x"] == 800
-    assert qtile.c.screen.info()["width"] == 640
-    assert qtile.c.group.info()["name"] == 'b'
-    assert qtile.c.group.info()["focus"] == 'xeyes'
-
-    qtile.c.to_screen(0)
-    assert qtile.c.screen.info()["index"] == 0
-    assert qtile.c.screen.info()["x"] == 0
-    assert qtile.c.screen.info()["width"] == 800
-    assert qtile.c.group.info()["name"] == 'a'
-    assert qtile.c.group.info()["focus"] == 'xclock'
+    manager.c.to_screen(0)
+    assert manager.c.screen.info()["index"] == 0
+    assert manager.c.screen.info()["x"] == 0
+    assert manager.c.screen.info()["width"] == 800
+    assert manager.c.group.info()["name"] == 'a'
+    assert manager.c.group.info()["focus"] == 'xclock'
 
 
 @pytest.mark.parametrize("xephyr", [{"xoffset": 0}], indirect=True)
 @manager_config
-def test_clone_dim(qtile):
-    self = qtile
+def test_clone_dim(manager):
+    manager.test_xclock()
+    assert manager.c.screen.info()["index"] == 0
+    assert manager.c.screen.info()["x"] == 0
+    assert manager.c.screen.info()["width"] == 800
+    assert manager.c.group.info()["name"] == 'a'
+    assert manager.c.group.info()["focus"] == 'xclock'
 
-    self.test_xclock()
-    assert self.c.screen.info()["index"] == 0
-    assert self.c.screen.info()["x"] == 0
-    assert self.c.screen.info()["width"] == 800
-    assert self.c.group.info()["name"] == 'a'
-    assert self.c.group.info()["focus"] == 'xclock'
-
-    assert len(self.c.screens()) == 1
+    assert len(manager.c.screens()) == 1
 
 
 @manager_config
-def test_to_screen(qtile):
-    self = qtile
+def test_to_screen(manager):
+    assert manager.c.screen.info()["index"] == 0
+    manager.c.to_screen(1)
+    assert manager.c.screen.info()["index"] == 1
+    manager.test_window("one")
+    manager.c.to_screen(0)
+    manager.test_window("two")
 
-    assert self.c.screen.info()["index"] == 0
-    self.c.to_screen(1)
-    assert self.c.screen.info()["index"] == 1
-    self.test_window("one")
-    self.c.to_screen(0)
-    self.test_window("two")
-
-    ga = self.c.groups()["a"]
+    ga = manager.c.groups()["a"]
     assert ga["windows"] == ["two"]
 
-    gb = self.c.groups()["b"]
+    gb = manager.c.groups()["b"]
     assert gb["windows"] == ["one"]
 
-    assert self.c.window.info()["name"] == "two"
-    self.c.next_screen()
-    assert self.c.window.info()["name"] == "one"
-    self.c.next_screen()
-    assert self.c.window.info()["name"] == "two"
-    self.c.prev_screen()
-    assert self.c.window.info()["name"] == "one"
+    assert manager.c.window.info()["name"] == "two"
+    manager.c.next_screen()
+    assert manager.c.window.info()["name"] == "one"
+    manager.c.next_screen()
+    assert manager.c.window.info()["name"] == "two"
+    manager.c.prev_screen()
+    assert manager.c.window.info()["name"] == "one"
 
 
 @manager_config
-def test_togroup(qtile):
-    self = qtile
-
-    self.test_window("one")
+def test_togroup(manager):
+    manager.test_window("one")
     with pytest.raises(CommandError):
-        self.c.window.togroup("nonexistent")
-    assert self.c.groups()["a"]["focus"] == "one"
+        manager.c.window.togroup("nonexistent")
+    assert manager.c.groups()["a"]["focus"] == "one"
 
-    self.c.window.togroup("a")
-    assert self.c.groups()["a"]["focus"] == "one"
+    manager.c.window.togroup("a")
+    assert manager.c.groups()["a"]["focus"] == "one"
 
-    self.c.window.togroup("b", switch_group=True)
-    assert self.c.groups()["b"]["focus"] == "one"
-    assert self.c.groups()["a"]["focus"] is None
-    assert self.c.group.info()["name"] == "b"
+    manager.c.window.togroup("b", switch_group=True)
+    assert manager.c.groups()["b"]["focus"] == "one"
+    assert manager.c.groups()["a"]["focus"] is None
+    assert manager.c.group.info()["name"] == "b"
 
-    self.c.window.togroup("a")
-    assert self.c.groups()["a"]["focus"] == "one"
-    assert self.c.group.info()["name"] == "b"
+    manager.c.window.togroup("a")
+    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.group.info()["name"] == "b"
 
-    self.c.to_screen(1)
-    self.c.window.togroup("c")
-    assert self.c.groups()["c"]["focus"] == "one"
+    manager.c.to_screen(1)
+    manager.c.window.togroup("c")
+    assert manager.c.groups()["c"]["focus"] == "one"
 
 
 @manager_config
-def test_resize(qtile):
-    self = qtile
-    self.c.screen[0].resize(x=10, y=10, w=100, h=100)
+def test_resize(manager):
+    manager.c.screen[0].resize(x=10, y=10, w=100, h=100)
 
     @Retry(ignore_exceptions=(AssertionError), fail_msg="Screen didn't resize")
     def run():
-        d = self.c.screen[0].info()
+        d = manager.c.screen[0].info()
         assert d['width'] == 100
         assert d['height'] == 100
         return d
@@ -200,30 +190,28 @@ def test_resize(qtile):
 
 
 @no_xinerama
-def test_minimal(qtile):
-    assert qtile.c.status() == "OK"
+def test_minimal(manager):
+    assert manager.c.status() == "OK"
 
 
 @manager_config
 @no_xinerama
-def test_events(qtile):
-    assert qtile.c.status() == "OK"
+def test_events(manager):
+    assert manager.c.status() == "OK"
 
 
 # FIXME: failing test disabled. For some reason we don't seem
 # to have a keymap in Xnest or Xephyr 99% of the time.
 @manager_config
 @no_xinerama
-def test_keypress(qtile):
-    self = qtile
-
-    self.test_window("one")
-    self.test_window("two")
+def test_keypress(manager):
+    manager.test_window("one")
+    manager.test_window("two")
     with pytest.raises(CommandError):
-        self.c.simulate_keypress(["unknown"], "j")
-    assert self.c.groups()["a"]["focus"] == "two"
-    self.c.simulate_keypress(["control"], "j")
-    assert self.c.groups()["a"]["focus"] == "one"
+        manager.c.simulate_keypress(["unknown"], "j")
+    assert manager.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "j")
+    assert manager.c.groups()["a"]["focus"] == "one"
 
 
 class _ChordsConfig(Config):
@@ -267,85 +255,81 @@ class _ChordsConfig(Config):
     auto_fullscreen = True
 
 
-chords_config = pytest.mark.parametrize("qtile", [_ChordsConfig], indirect=True)
+chords_config = pytest.mark.parametrize("manager", [_ChordsConfig], indirect=True)
 
 
 @chords_config
 @no_xinerama
-def test_immediate_chord(qtile):
-    self = qtile
-
-    self.test_window("three")
-    self.test_window("two")
-    self.test_window("one")
-    assert self.c.groups()["a"]["focus"] == "one"
+def test_immediate_chord(manager):
+    manager.test_window("three")
+    manager.test_window("two")
+    manager.test_window("one")
+    assert manager.c.groups()["a"]["focus"] == "one"
     # use normal bind to shift focus up
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # enter into key chord and "k" bindin no longer working
-    self.c.simulate_keypress(["control"], "a")
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "a")
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # leave chord using "Escape", "k" bind work again
-    self.c.simulate_keypress([], "Escape")
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "three"
+    manager.c.simulate_keypress([], "Escape")
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "three"
     # enter key chord and use it's "j" binding to shift focus down
-    self.c.simulate_keypress(["control"], "a")
-    self.c.simulate_keypress([], "j")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "a")
+    manager.c.simulate_keypress([], "j")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # in immediate chord we leave it after use any
     # bind from it, "j" bind no longer working
-    self.c.simulate_keypress([], "j")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress([], "j")
+    assert manager.c.groups()["a"]["focus"] == "two"
 
 
 @chords_config
 @no_xinerama
-def test_mode_chord(qtile):
-    self = qtile
-
-    self.test_window("three")
-    self.test_window("two")
-    self.test_window("one")
-    assert self.c.groups()["a"]["focus"] == "one"
+def test_mode_chord(manager):
+    manager.test_window("three")
+    manager.test_window("two")
+    manager.test_window("one")
+    assert manager.c.groups()["a"]["focus"] == "one"
     # use normal bind to shift focus up
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # enter into key chord and "k" bindin no longer working
-    self.c.simulate_keypress(["control"], "b")
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "b")
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # leave chord using "Escape", "k" bind work again
-    self.c.simulate_keypress([], "Escape")
-    self.c.simulate_keypress([], "k")
-    assert self.c.groups()["a"]["focus"] == "three"
+    manager.c.simulate_keypress([], "Escape")
+    manager.c.simulate_keypress([], "k")
+    assert manager.c.groups()["a"]["focus"] == "three"
     # enter key chord and use it's "j" binding to shift focus down
-    self.c.simulate_keypress(["control"], "b")
-    self.c.simulate_keypress([], "j")
-    assert self.c.groups()["a"]["focus"] == "two"
+    manager.c.simulate_keypress(["control"], "b")
+    manager.c.simulate_keypress([], "j")
+    assert manager.c.groups()["a"]["focus"] == "two"
     # in mode chord we __not__ leave it after use any
     # bind from it, "j" bind still working
-    self.c.simulate_keypress([], "j")
-    assert self.c.groups()["a"]["focus"] == "one"
+    manager.c.simulate_keypress([], "j")
+    assert manager.c.groups()["a"]["focus"] == "one"
     # only way to exit mode chord is by hit "Escape"
-    self.c.simulate_keypress([], "Escape")
-    self.c.simulate_keypress([], "j")
-    assert self.c.groups()["a"]["focus"] == "one"
+    manager.c.simulate_keypress([], "Escape")
+    manager.c.simulate_keypress([], "j")
+    assert manager.c.groups()["a"]["focus"] == "one"
 
 
 @manager_config
 @no_xinerama
-def test_spawn(qtile):
+def test_spawn(manager):
     # Spawn something with a pid greater than init's
-    assert int(qtile.c.spawn("true")) > 1
+    assert int(manager.c.spawn("true")) > 1
 
 
 @manager_config
 @no_xinerama
-def test_spawn_list(qtile):
+def test_spawn_list(manager):
     # Spawn something with a pid greater than init's
-    assert int(qtile.c.spawn(["echo", "true"])) > 1
+    assert int(manager.c.spawn(["echo", "true"])) > 1
 
 
 @Retry(ignore_exceptions=(AssertionError,), fail_msg='Window did not die!')
@@ -357,46 +341,42 @@ def assert_window_died(client, window_info):
 
 @manager_config
 @no_xinerama
-def test_kill_window(qtile):
-    qtile.test_window("one")
-    window_info = qtile.c.window.info()
-    qtile.c.window[window_info["id"]].kill()
-    assert_window_died(qtile.c, window_info)
+def test_kill_window(manager):
+    manager.test_window("one")
+    window_info = manager.c.window.info()
+    manager.c.window[window_info["id"]].kill()
+    assert_window_died(manager.c, window_info)
 
 
 @manager_config
 @no_xinerama
-def test_kill_other(qtile):
-    self = qtile
+def test_kill_other(manager):
+    manager.c.group.setlayout("tile")
+    one = manager.test_window("one")
+    assert manager.c.window.info()["width"] == 798
+    window_one_info = manager.c.window.info()
+    assert manager.c.window.info()["height"] == 578
+    two = manager.test_window("two")
+    assert manager.c.window.info()["name"] == "two"
+    assert manager.c.window.info()["width"] == 398
+    assert manager.c.window.info()["height"] == 578
+    assert len(manager.c.windows()) == 2
 
-    self.c.group.setlayout("tile")
-    one = self.test_window("one")
-    assert self.c.window.info()["width"] == 798
-    window_one_info = self.c.window.info()
-    assert self.c.window.info()["height"] == 578
-    two = self.test_window("two")
-    assert self.c.window.info()["name"] == "two"
-    assert self.c.window.info()["width"] == 398
-    assert self.c.window.info()["height"] == 578
-    assert len(self.c.windows()) == 2
+    manager.kill_window(one)
+    assert_window_died(manager.c, window_one_info)
 
-    self.kill_window(one)
-    assert_window_died(self.c, window_one_info)
-
-    assert self.c.window.info()["name"] == "two"
-    assert self.c.window.info()["width"] == 798
-    assert self.c.window.info()["height"] == 578
-    self.kill_window(two)
+    assert manager.c.window.info()["name"] == "two"
+    assert manager.c.window.info()["width"] == 798
+    assert manager.c.window.info()["height"] == 578
+    manager.kill_window(two)
 
 
 @manager_config
 @no_xinerama
-def test_kill_via_message(qtile):
-    self = qtile
-
-    self.test_window("one")
-    window_info = self.c.window.info()
-    conn = xcbq.Connection(self.display)
+def test_kill_via_message(manager):
+    manager.test_window("one")
+    window_info = manager.c.window.info()
+    conn = xcbq.Connection(manager.display)
     data = xcffib.xproto.ClientMessageData.synthetic([0, 0, 0, 0, 0], "IIIII")
     ev = xcffib.xproto.ClientMessageEvent.synthetic(
         32, window_info["id"], conn.atoms['_NET_CLOSE_WINDOW'], data
@@ -404,642 +384,589 @@ def test_kill_via_message(qtile):
     conn.default_screen.root.send_event(ev, mask=xcffib.xproto.EventMask.SubstructureRedirect)
     conn.xsync()
     conn.finalize()
-    assert_window_died(self.c, window_info)
+    assert_window_died(manager.c, window_info)
 
 
 @manager_config
 @no_xinerama
-def test_regression_groupswitch(qtile):
-    self = qtile
-
-    self.c.group["c"].toscreen()
-    self.c.group["d"].toscreen()
-    assert self.c.groups()["c"]["screen"] is None
+def test_regression_groupswitch(manager):
+    manager.c.group["c"].toscreen()
+    manager.c.group["d"].toscreen()
+    assert manager.c.groups()["c"]["screen"] is None
 
 
 @manager_config
 @no_xinerama
-def test_next_layout(qtile):
-    self = qtile
-
-    self.test_window("one")
-    self.test_window("two")
-    assert len(self.c.layout.info()["stacks"]) == 1
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.c.next_layout()
-    self.c.next_layout()
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 1
+def test_next_layout(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    assert len(manager.c.layout.info()["stacks"]) == 1
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.c.next_layout()
+    manager.c.next_layout()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 1
 
 
 @manager_config
 @no_xinerama
-def test_setlayout(qtile):
-    self = qtile
-
-    assert not self.c.layout.info()["name"] == "max"
-    self.c.group.setlayout("max")
-    assert self.c.layout.info()["name"] == "max"
+def test_setlayout(manager):
+    assert not manager.c.layout.info()["name"] == "max"
+    manager.c.group.setlayout("max")
+    assert manager.c.layout.info()["name"] == "max"
 
 
 @manager_config
 @no_xinerama
-def test_to_layout_index(qtile):
-    self = qtile
-
-    self.c.to_layout_index(-1)
-    assert self.c.layout.info()["name"] == "max"
-    self.c.to_layout_index(-4)
-    assert self.c.layout.info()["name"] == "stack"
+def test_to_layout_index(manager):
+    manager.c.to_layout_index(-1)
+    assert manager.c.layout.info()["name"] == "max"
+    manager.c.to_layout_index(-4)
+    assert manager.c.layout.info()["name"] == "stack"
     with pytest.raises(SelectError):
-        self.c.to_layout.index(-5)
-    self.c.to_layout_index(-2)
-    assert self.c.layout.info()["name"] == "tile"
+        manager.c.to_layout.index(-5)
+    manager.c.to_layout_index(-2)
+    assert manager.c.layout.info()["name"] == "tile"
 
 
 @manager_config
 @no_xinerama
-def test_adddelgroup(qtile):
-    self = qtile
+def test_adddelgroup(manager):
+    manager.test_window("one")
+    manager.c.addgroup("dummygroup")
+    manager.c.addgroup("testgroup")
+    assert "testgroup" in manager.c.groups().keys()
 
-    self.test_window("one")
-    self.c.addgroup("dummygroup")
-    self.c.addgroup("testgroup")
-    assert "testgroup" in self.c.groups().keys()
-
-    self.c.window.togroup("testgroup")
-    self.c.delgroup("testgroup")
-    assert "testgroup" not in self.c.groups().keys()
+    manager.c.window.togroup("testgroup")
+    manager.c.delgroup("testgroup")
+    assert "testgroup" not in manager.c.groups().keys()
     # Assert that the test window is still a member of some group.
-    assert sum(len(i["windows"]) for i in self.c.groups().values())
+    assert sum(len(i["windows"]) for i in manager.c.groups().values())
 
-    for i in list(self.c.groups().keys())[:-1]:
-        self.c.delgroup(i)
+    for i in list(manager.c.groups().keys())[:-1]:
+        manager.c.delgroup(i)
     with pytest.raises(CommandException):
-        self.c.delgroup(list(self.c.groups().keys())[0])
+        manager.c.delgroup(list(manager.c.groups().keys())[0])
 
     # Assert that setting layout via cmd_addgroup works
-    self.c.addgroup("testgroup2", layout='max')
-    assert self.c.groups()["testgroup2"]['layout'] == 'max'
+    manager.c.addgroup("testgroup2", layout='max')
+    assert manager.c.groups()["testgroup2"]['layout'] == 'max'
 
 
 @manager_config
 @no_xinerama
-def test_delgroup(qtile):
-    self = qtile
-
-    self.test_window("one")
+def test_delgroup(manager):
+    manager.test_window("one")
     for i in ['a', 'd', 'c']:
-        self.c.delgroup(i)
+        manager.c.delgroup(i)
     with pytest.raises(CommandException):
-        self.c.delgroup('b')
+        manager.c.delgroup('b')
 
 
 @manager_config
 @no_xinerama
-def test_nextprevgroup(qtile):
-    self = qtile
-
-    start = self.c.group.info()["name"]
-    ret = self.c.screen.next_group()
-    assert self.c.group.info()["name"] != start
-    assert self.c.group.info()["name"] == ret
-    ret = self.c.screen.prev_group()
-    assert self.c.group.info()["name"] == start
+def test_nextprevgroup(manager):
+    start = manager.c.group.info()["name"]
+    ret = manager.c.screen.next_group()
+    assert manager.c.group.info()["name"] != start
+    assert manager.c.group.info()["name"] == ret
+    ret = manager.c.screen.prev_group()
+    assert manager.c.group.info()["name"] == start
 
 
 @manager_config
 @no_xinerama
-def test_toggle_group(qtile):
-    self = qtile
-
-    self.c.group["a"].toscreen()
-    self.c.group["b"].toscreen()
-    self.c.screen.toggle_group("c")
-    assert self.c.group.info()["name"] == "c"
-    self.c.screen.toggle_group("c")
-    assert self.c.group.info()["name"] == "b"
-    self.c.screen.toggle_group()
-    assert self.c.group.info()["name"] == "c"
+def test_toggle_group(manager):
+    manager.c.group["a"].toscreen()
+    manager.c.group["b"].toscreen()
+    manager.c.screen.toggle_group("c")
+    assert manager.c.group.info()["name"] == "c"
+    manager.c.screen.toggle_group("c")
+    assert manager.c.group.info()["name"] == "b"
+    manager.c.screen.toggle_group()
+    assert manager.c.group.info()["name"] == "c"
 
 
 @manager_config
 @no_xinerama
-def test_inspect_xeyes(qtile):
-    self = qtile
-
-    self.test_xeyes()
-    assert self.c.window.inspect()
+def test_inspect_xeyes(manager):
+    manager.test_xeyes()
+    assert manager.c.window.inspect()
 
 
 @manager_config
 @no_xinerama
-def test_inspect_xclock(qtile):
-    self = qtile
-
-    self.test_xclock()
-    assert self.c.window.inspect()["wm_class"]
+def test_inspect_xclock(manager):
+    manager.test_xclock()
+    assert manager.c.window.inspect()["wm_class"]
 
 
 @manager_config
 @no_xinerama
-def test_static(qtile):
-    self = qtile
-
-    self.test_xeyes()
-    self.test_window("one")
-    self.c.window[self.c.window.info()["id"]].static(0, 0, 0, 100, 100)
+def test_static(manager):
+    manager.test_xeyes()
+    manager.test_window("one")
+    manager.c.window[manager.c.window.info()["id"]].static(0, 0, 0, 100, 100)
 
 
 @manager_config
 @no_xinerama
-def test_match(qtile):
-    self = qtile
-
-    self.test_xeyes()
-    assert self.c.window.info()['name'] == 'xeyes'
-    assert not self.c.window.info()['name'] == 'nonexistent'
+def test_match(manager):
+    manager.test_xeyes()
+    assert manager.c.window.info()['name'] == 'xeyes'
+    assert not manager.c.window.info()['name'] == 'nonexistent'
 
 
 @manager_config
 @no_xinerama
-def test_default_float(qtile):
-    self = qtile
-
+def test_default_float(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xclock()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xclock()
 
-    assert self.c.group.info()['focus'] == 'xclock'
-    assert self.c.window.info()['width'] == 164
-    assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 318
-    assert self.c.window.info()['y'] == 208
-    assert self.c.window.info()['floating'] is True
+    assert manager.c.group.info()['focus'] == 'xclock'
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 318
+    assert manager.c.window.info()['y'] == 208
+    assert manager.c.window.info()['floating'] is True
 
-    self.c.window.move_floating(10, 20)
-    assert self.c.window.info()['width'] == 164
-    assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 328
-    assert self.c.window.info()['y'] == 228
-    assert self.c.window.info()['floating'] is True
+    manager.c.window.move_floating(10, 20)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 328
+    assert manager.c.window.info()['y'] == 228
+    assert manager.c.window.info()['floating'] is True
 
-    self.c.window.set_position_floating(10, 20)
-    assert self.c.window.info()['width'] == 164
-    assert self.c.window.info()['height'] == 164
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
-    assert self.c.window.info()['floating'] is True
+    manager.c.window.set_position_floating(10, 20)
+    assert manager.c.window.info()['width'] == 164
+    assert manager.c.window.info()['height'] == 164
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
+    assert manager.c.window.info()['floating'] is True
 
 
 @manager_config
 @no_xinerama
-def test_last_float_size(qtile):
+def test_last_float_size(manager):
     """
     When you re-float something it would be preferable to have it use the previous float size
     """
-    self = qtile
-
-    self.test_xeyes()
-    assert self.c.window.info()['name'] == 'xeyes'
-    assert self.c.window.info()['width'] == 798
-    assert self.c.window.info()['height'] == 578
+    manager.test_xeyes()
+    assert manager.c.window.info()['name'] == 'xeyes'
+    assert manager.c.window.info()['width'] == 798
+    assert manager.c.window.info()['height'] == 578
     # float and it moves
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['width'] == 150
-    assert self.c.window.info()['height'] == 100
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 150
+    assert manager.c.window.info()['height'] == 100
     # resize
-    self.c.window.set_size_floating(50, 90)
-    assert self.c.window.info()['width'] == 50
-    assert self.c.window.info()['height'] == 90
+    manager.c.window.set_size_floating(50, 90)
+    assert manager.c.window.info()['width'] == 50
+    assert manager.c.window.info()['height'] == 90
     # back to not floating
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['width'] == 798
-    assert self.c.window.info()['height'] == 578
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 798
+    assert manager.c.window.info()['height'] == 578
     # float again, should use last float size
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['width'] == 50
-    assert self.c.window.info()['height'] == 90
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 50
+    assert manager.c.window.info()['height'] == 90
 
     # make sure it works through min and max
-    self.c.window.toggle_maximize()
-    self.c.window.toggle_minimize()
-    self.c.window.toggle_minimize()
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['width'] == 50
-    assert self.c.window.info()['height'] == 90
+    manager.c.window.toggle_maximize()
+    manager.c.window.toggle_minimize()
+    manager.c.window.toggle_minimize()
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['width'] == 50
+    assert manager.c.window.info()['height'] == 90
 
 
 @manager_config
 @no_xinerama
-def test_float_max_min_combo(qtile):
-    self = qtile
-
+def test_float_max_min_combo(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xcalc()
-    self.test_xeyes()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xcalc()
+    manager.test_xeyes()
 
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
-    assert self.c.window.info()['floating'] is False
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
+    assert manager.c.window.info()['floating'] is False
 
-    self.c.window.toggle_maximize()
-    assert self.c.window.info()['floating'] is True
-    assert self.c.window.info()['maximized'] is True
-    assert self.c.window.info()['width'] == 800
-    assert self.c.window.info()['height'] == 580
-    assert self.c.window.info()['x'] == 0
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()['floating'] is True
+    assert manager.c.window.info()['maximized'] is True
+    assert manager.c.window.info()['width'] == 800
+    assert manager.c.window.info()['height'] == 580
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_minimize()
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['floating'] is True
-    assert self.c.window.info()['minimized'] is True
-    assert self.c.window.info()['width'] == 800
-    assert self.c.window.info()['height'] == 580
-    assert self.c.window.info()['x'] == 0
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_minimize()
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['floating'] is True
+    assert manager.c.window.info()['minimized'] is True
+    assert manager.c.window.info()['width'] == 800
+    assert manager.c.window.info()['height'] == 580
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_floating()
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['floating'] is False
-    assert self.c.window.info()['minimized'] is False
-    assert self.c.window.info()['maximized'] is False
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_floating()
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['floating'] is False
+    assert manager.c.window.info()['minimized'] is False
+    assert manager.c.window.info()['maximized'] is False
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
 
 @manager_config
 @no_xinerama
-def test_toggle_fullscreen(qtile):
-    self = qtile
-
+def test_toggle_fullscreen(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xcalc()
-    self.test_xeyes()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xcalc()
+    manager.test_xeyes()
 
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['float_info'] == {
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['float_info'] == {
         'y': 0, 'x': 400, 'width': 150, 'height': 100}
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_fullscreen()
-    assert self.c.window.info()['floating'] is True
-    assert self.c.window.info()['maximized'] is False
-    assert self.c.window.info()['fullscreen'] is True
-    assert self.c.window.info()['width'] == 800
-    assert self.c.window.info()['height'] == 600
-    assert self.c.window.info()['x'] == 0
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.window.info()['floating'] is True
+    assert manager.c.window.info()['maximized'] is False
+    assert manager.c.window.info()['fullscreen'] is True
+    assert manager.c.window.info()['width'] == 800
+    assert manager.c.window.info()['height'] == 600
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_fullscreen()
-    assert self.c.window.info()['floating'] is False
-    assert self.c.window.info()['maximized'] is False
-    assert self.c.window.info()['fullscreen'] is False
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.window.info()['floating'] is False
+    assert manager.c.window.info()['maximized'] is False
+    assert manager.c.window.info()['fullscreen'] is False
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
 
 @manager_config
 @no_xinerama
-def test_toggle_max(qtile):
-    self = qtile
-
+def test_toggle_max(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xcalc()
-    self.test_xeyes()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xcalc()
+    manager.test_xeyes()
 
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['float_info'] == {
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['float_info'] == {
         'y': 0, 'x': 400, 'width': 150, 'height': 100}
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_maximize()
-    assert self.c.window.info()['floating'] is True
-    assert self.c.window.info()['maximized'] is True
-    assert self.c.window.info()['width'] == 800
-    assert self.c.window.info()['height'] == 580
-    assert self.c.window.info()['x'] == 0
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()['floating'] is True
+    assert manager.c.window.info()['maximized'] is True
+    assert manager.c.window.info()['width'] == 800
+    assert manager.c.window.info()['height'] == 580
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_maximize()
-    assert self.c.window.info()['floating'] is False
-    assert self.c.window.info()['maximized'] is False
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()['floating'] is False
+    assert manager.c.window.info()['maximized'] is False
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
 
 @manager_config
 @no_xinerama
-def test_toggle_min(qtile):
-    self = qtile
-
+def test_toggle_min(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xcalc()
-    self.test_xeyes()
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xcalc()
+    manager.test_xeyes()
 
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['float_info'] == {
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['float_info'] == {
         'y': 0, 'x': 400, 'width': 150, 'height': 100}
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_minimize()
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['floating'] is True
-    assert self.c.window.info()['minimized'] is True
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_minimize()
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['floating'] is True
+    assert manager.c.window.info()['minimized'] is True
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
-    self.c.window.toggle_minimize()
-    assert self.c.group.info()['focus'] == 'xeyes'
-    assert self.c.window.info()['floating'] is False
-    assert self.c.window.info()['minimized'] is False
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['x'] == 400
-    assert self.c.window.info()['y'] == 0
+    manager.c.window.toggle_minimize()
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.window.info()['floating'] is False
+    assert manager.c.window.info()['minimized'] is False
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 400
+    assert manager.c.window.info()['y'] == 0
 
 
 @manager_config
 @no_xinerama
-def test_toggle_floating(qtile):
-    self = qtile
-
-    self.test_xeyes()
-    assert self.c.window.info()['floating'] is False
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['floating'] is True
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['floating'] is False
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['floating'] is True
+def test_toggle_floating(manager):
+    manager.test_xeyes()
+    assert manager.c.window.info()['floating'] is False
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['floating'] is True
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['floating'] is False
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['floating'] is True
 
     # change layout (should still be floating)
-    self.c.next_layout()
-    assert self.c.window.info()['floating'] is True
+    manager.c.next_layout()
+    assert manager.c.window.info()['floating'] is True
 
 
 @manager_config
 @no_xinerama
-def test_floating_focus(qtile):
-    self = qtile
-
+def test_floating_focus(manager):
     # change to 2 col stack
-    self.c.next_layout()
-    assert len(self.c.layout.info()["stacks"]) == 2
-    self.test_xcalc()
-    self.test_xeyes()
-    # self.test_window("one")
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    self.c.window.toggle_floating()
-    self.c.window.move_floating(10, 20)
-    assert self.c.window.info()['name'] == 'xeyes'
-    assert self.c.group.info()['focus'] == 'xeyes'
+    manager.c.next_layout()
+    assert len(manager.c.layout.info()["stacks"]) == 2
+    manager.test_xcalc()
+    manager.test_xeyes()
+    # manager.test_window("one")
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    manager.c.window.toggle_floating()
+    manager.c.window.move_floating(10, 20)
+    assert manager.c.window.info()['name'] == 'xeyes'
+    assert manager.c.group.info()['focus'] == 'xeyes'
     # check what stack thinks is focus
-    assert [x['current'] for x in self.c.layout.info()['stacks']] == [0, 0]
+    assert [x['current'] for x in manager.c.layout.info()['stacks']] == [0, 0]
 
     # change focus to xcalc
-    self.c.group.next_window()
-    assert self.c.window.info()['width'] == 398
-    assert self.c.window.info()['height'] == 578
-    assert self.c.window.info()['name'] != 'xeyes'
-    assert self.c.group.info()['focus'] != 'xeyes'
+    manager.c.group.next_window()
+    assert manager.c.window.info()['width'] == 398
+    assert manager.c.window.info()['height'] == 578
+    assert manager.c.window.info()['name'] != 'xeyes'
+    assert manager.c.group.info()['focus'] != 'xeyes'
     # check what stack thinks is focus
     # check what stack thinks is focus
-    assert [x['current'] for x in self.c.layout.info()['stacks']] == [0, 0]
+    assert [x['current'] for x in manager.c.layout.info()['stacks']] == [0, 0]
 
     # focus back to xeyes
-    self.c.group.next_window()
-    assert self.c.window.info()['name'] == 'xeyes'
+    manager.c.group.next_window()
+    assert manager.c.window.info()['name'] == 'xeyes'
     # check what stack thinks is focus
-    assert [x['current'] for x in self.c.layout.info()['stacks']] == [0, 0]
+    assert [x['current'] for x in manager.c.layout.info()['stacks']] == [0, 0]
 
     # now focusing via layout is borked (won't go to float)
-    self.c.layout.up()
-    assert self.c.window.info()['name'] != 'xeyes'
-    self.c.layout.up()
-    assert self.c.window.info()['name'] != 'xeyes'
+    manager.c.layout.up()
+    assert manager.c.window.info()['name'] != 'xeyes'
+    manager.c.layout.up()
+    assert manager.c.window.info()['name'] != 'xeyes'
     # check what stack thinks is focus
-    assert [x['current'] for x in self.c.layout.info()['stacks']] == [0, 0]
+    assert [x['current'] for x in manager.c.layout.info()['stacks']] == [0, 0]
 
     # focus back to xeyes
-    self.c.group.next_window()
-    assert self.c.window.info()['name'] == 'xeyes'
+    manager.c.group.next_window()
+    assert manager.c.window.info()['name'] == 'xeyes'
     # check what stack thinks is focus
-    assert [x['current'] for x in self.c.layout.info()['stacks']] == [0, 0]
+    assert [x['current'] for x in manager.c.layout.info()['stacks']] == [0, 0]
 
 
 @manager_config
 @no_xinerama
-def test_move_floating(qtile):
-    self = qtile
+def test_move_floating(manager):
+    manager.test_xeyes()
+    # manager.test_window("one")
+    assert manager.c.window.info()['width'] == 798
+    assert manager.c.window.info()['height'] == 578
 
-    self.test_xeyes()
-    # self.test_window("one")
-    assert self.c.window.info()['width'] == 798
-    assert self.c.window.info()['height'] == 578
+    assert manager.c.window.info()['x'] == 0
+    assert manager.c.window.info()['y'] == 0
+    manager.c.window.toggle_floating()
+    assert manager.c.window.info()['floating'] is True
 
-    assert self.c.window.info()['x'] == 0
-    assert self.c.window.info()['y'] == 0
-    self.c.window.toggle_floating()
-    assert self.c.window.info()['floating'] is True
+    manager.c.window.move_floating(10, 20)
+    assert manager.c.window.info()['width'] == 150
+    assert manager.c.window.info()['height'] == 100
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
 
-    self.c.window.move_floating(10, 20)
-    assert self.c.window.info()['width'] == 150
-    assert self.c.window.info()['height'] == 100
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
+    manager.c.window.set_size_floating(50, 90)
+    assert manager.c.window.info()['width'] == 50
+    assert manager.c.window.info()['height'] == 90
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
 
-    self.c.window.set_size_floating(50, 90)
-    assert self.c.window.info()['width'] == 50
-    assert self.c.window.info()['height'] == 90
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
+    manager.c.window.resize_floating(10, 20)
+    assert manager.c.window.info()['width'] == 60
+    assert manager.c.window.info()['height'] == 110
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
 
-    self.c.window.resize_floating(10, 20)
-    assert self.c.window.info()['width'] == 60
-    assert self.c.window.info()['height'] == 110
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
-
-    self.c.window.set_size_floating(10, 20)
-    assert self.c.window.info()['width'] == 10
-    assert self.c.window.info()['height'] == 20
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
+    manager.c.window.set_size_floating(10, 20)
+    assert manager.c.window.info()['width'] == 10
+    assert manager.c.window.info()['height'] == 20
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
 
     # change layout (x, y should be same)
-    self.c.next_layout()
-    assert self.c.window.info()['width'] == 10
-    assert self.c.window.info()['height'] == 20
-    assert self.c.window.info()['x'] == 10
-    assert self.c.window.info()['y'] == 20
+    manager.c.next_layout()
+    assert manager.c.window.info()['width'] == 10
+    assert manager.c.window.info()['height'] == 20
+    assert manager.c.window.info()['x'] == 10
+    assert manager.c.window.info()['y'] == 20
 
 
 @manager_config
 @no_xinerama
-def test_screens(qtile):
-    self = qtile
-
-    assert len(self.c.screens())
+def test_screens(manager):
+    assert len(manager.c.screens())
 
 
 @manager_config
 @no_xinerama
-def test_focus_stays_on_layout_switch(qtile):
-    qtile.test_window("one")
-    qtile.test_window("two")
+def test_focus_stays_on_layout_switch(manager):
+    manager.test_window("one")
+    manager.test_window("two")
 
     # switch to a double stack layout
-    qtile.c.next_layout()
+    manager.c.next_layout()
 
     # focus on a different window than the default
-    qtile.c.layout.next()
+    manager.c.layout.next()
 
     # toggle the layout
-    qtile.c.next_layout()
-    qtile.c.prev_layout()
+    manager.c.next_layout()
+    manager.c.prev_layout()
 
-    assert qtile.c.window.info()['name'] == 'one'
+    assert manager.c.window.info()['name'] == 'one'
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_xeyes(qtile):
-    qtile.test_xeyes()
+def test_xeyes(manager):
+    manager.test_xeyes()
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_xcalc(qtile):
-    qtile.test_xcalc()
+def test_xcalc(manager):
+    manager.test_xcalc()
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_xcalc_kill_window(qtile):
-    self = qtile
-
-    self.test_xcalc()
-    window_info = self.c.window.info()
-    self.c.window.kill()
-    assert_window_died(self.c, window_info)
+def test_xcalc_kill_window(manager):
+    manager.test_xcalc()
+    window_info = manager.c.window.info()
+    manager.c.window.kill()
+    assert_window_died(manager.c, window_info)
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_map_request(qtile):
-    self = qtile
-
-    self.test_window("one")
-    info = self.c.groups()["a"]
+def test_map_request(manager):
+    manager.test_window("one")
+    info = manager.c.groups()["a"]
     assert "one" in info["windows"]
     assert info["focus"] == "one"
 
-    self.test_window("two")
-    info = self.c.groups()["a"]
+    manager.test_window("two")
+    info = manager.c.groups()["a"]
     assert "two" in info["windows"]
     assert info["focus"] == "two"
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_unmap(qtile):
-    self = qtile
-
-    one = self.test_window("one")
-    two = self.test_window("two")
-    three = self.test_window("three")
-    info = self.c.groups()["a"]
+def test_unmap(manager):
+    one = manager.test_window("one")
+    two = manager.test_window("two")
+    three = manager.test_window("three")
+    info = manager.c.groups()["a"]
     assert info["focus"] == "three"
 
-    assert len(self.c.windows()) == 3
-    self.kill_window(three)
+    assert len(manager.c.windows()) == 3
+    manager.kill_window(three)
 
-    assert len(self.c.windows()) == 2
-    info = self.c.groups()["a"]
+    assert len(manager.c.windows()) == 2
+    info = manager.c.groups()["a"]
     assert info["focus"] == "two"
 
-    self.kill_window(two)
-    assert len(self.c.windows()) == 1
-    info = self.c.groups()["a"]
+    manager.kill_window(two)
+    assert len(manager.c.windows()) == 1
+    info = manager.c.groups()["a"]
     assert info["focus"] == "one"
 
-    self.kill_window(one)
-    assert len(self.c.windows()) == 0
-    info = self.c.groups()["a"]
+    manager.kill_window(one)
+    assert len(manager.c.windows()) == 0
+    info = manager.c.groups()["a"]
     assert info["focus"] is None
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_setgroup(qtile):
-    self = qtile
-
-    self.test_window("one")
-    self.c.group["b"].toscreen()
-    self.groupconsistency()
-    if len(self.c.screens()) == 1:
-        assert self.c.groups()["a"]["screen"] is None
+def test_setgroup(manager):
+    manager.test_window("one")
+    manager.c.group["b"].toscreen()
+    manager.groupconsistency()
+    if len(manager.c.screens()) == 1:
+        assert manager.c.groups()["a"]["screen"] is None
     else:
-        assert self.c.groups()["a"]["screen"] == 1
-    assert self.c.groups()["b"]["screen"] == 0
+        assert manager.c.groups()["a"]["screen"] == 1
+    assert manager.c.groups()["b"]["screen"] == 0
 
-    self.c.group["c"].toscreen()
-    self.groupconsistency()
-    assert self.c.groups()["c"]["screen"] == 0
+    manager.c.group["c"].toscreen()
+    manager.groupconsistency()
+    assert manager.c.groups()["c"]["screen"] == 0
 
     # Setting the current group once again switches back to the previous group
-    self.c.group["c"].toscreen()
-    self.groupconsistency()
-    assert self.c.group.info()["name"] == "b"
+    manager.c.group["c"].toscreen()
+    manager.groupconsistency()
+    assert manager.c.group.info()["name"] == "b"
 
 
-@pytest.mark.parametrize("qtile", [BareConfig, ManagerConfig], indirect=True)
+@pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 @pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
-def test_unmap_noscreen(qtile):
-    self = qtile
-    self.test_window("one")
-    pid = self.test_window("two")
-    assert len(self.c.windows()) == 2
-    self.c.group["c"].toscreen()
-    self.groupconsistency()
-    self.c.status()
-    assert len(self.c.windows()) == 2
-    self.kill_window(pid)
-    assert len(self.c.windows()) == 1
-    assert self.c.groups()["a"]["focus"] == "one"
+def test_unmap_noscreen(manager):
+    manager.test_window("one")
+    pid = manager.test_window("two")
+    assert len(manager.c.windows()) == 2
+    manager.c.group["c"].toscreen()
+    manager.groupconsistency()
+    manager.c.status()
+    assert len(manager.c.windows()) == 2
+    manager.kill_window(pid)
+    assert len(manager.c.windows()) == 1
+    assert manager.c.groups()["a"]["focus"] == "one"
 
 
 class TScreen(libqtile.config.Screen):
@@ -1119,15 +1046,13 @@ class ClientNewStaticConfig(_Config):
         libqtile.hook.subscribe.client_new(client_new)
 
 
-clientnew_config = pytest.mark.parametrize("qtile", [ClientNewStaticConfig], indirect=True)
+clientnew_config = pytest.mark.parametrize("manager", [ClientNewStaticConfig], indirect=True)
 
 
 @clientnew_config
-def test_clientnew_config(qtile):
-    self = qtile
-
-    a = self.test_window("one")
-    self.kill_window(a)
+def test_clientnew_config(manager):
+    a = manager.test_window("one")
+    manager.kill_window(a)
 
 
 class ToGroupConfig(_Config):
@@ -1138,49 +1063,49 @@ class ToGroupConfig(_Config):
         libqtile.hook.subscribe.client_new(client_new)
 
 
-togroup_config = pytest.mark.parametrize("qtile", [ToGroupConfig], indirect=True)
+togroup_config = pytest.mark.parametrize("manager", [ToGroupConfig], indirect=True)
 
 
 @togroup_config
-def test_togroup_config(qtile):
-    qtile.c.group["d"].toscreen()
-    qtile.c.group["a"].toscreen()
-    a = qtile.test_window("one")
-    assert len(qtile.c.group["d"].info()["windows"]) == 1
-    qtile.kill_window(a)
+def test_togroup_config(manager):
+    manager.c.group["d"].toscreen()
+    manager.c.group["a"].toscreen()
+    a = manager.test_window("one")
+    assert len(manager.c.group["d"].info()["windows"]) == 1
+    manager.kill_window(a)
 
 
 @manager_config
-def test_color_pixel(qtile):
-    (success, e) = qtile.c.eval("self.conn.color_pixel(\"ffffff\")")
+def test_color_pixel(manager):
+    (success, e) = manager.c.eval("self.conn.color_pixel(\"ffffff\")")
     assert success, e
 
 
 @manager_config
-def test_change_loglevel(qtile):
-    assert qtile.c.loglevel() == logging.INFO
-    assert qtile.c.loglevelname() == 'INFO'
-    qtile.c.debug()
-    assert qtile.c.loglevel() == logging.DEBUG
-    assert qtile.c.loglevelname() == 'DEBUG'
-    qtile.c.info()
-    assert qtile.c.loglevel() == logging.INFO
-    assert qtile.c.loglevelname() == 'INFO'
-    qtile.c.warning()
-    assert qtile.c.loglevel() == logging.WARNING
-    assert qtile.c.loglevelname() == 'WARNING'
-    qtile.c.error()
-    assert qtile.c.loglevel() == logging.ERROR
-    assert qtile.c.loglevelname() == 'ERROR'
-    qtile.c.critical()
-    assert qtile.c.loglevel() == logging.CRITICAL
-    assert qtile.c.loglevelname() == 'CRITICAL'
+def test_change_loglevel(manager):
+    assert manager.c.loglevel() == logging.INFO
+    assert manager.c.loglevelname() == 'INFO'
+    manager.c.debug()
+    assert manager.c.loglevel() == logging.DEBUG
+    assert manager.c.loglevelname() == 'DEBUG'
+    manager.c.info()
+    assert manager.c.loglevel() == logging.INFO
+    assert manager.c.loglevelname() == 'INFO'
+    manager.c.warning()
+    assert manager.c.loglevel() == logging.WARNING
+    assert manager.c.loglevelname() == 'WARNING'
+    manager.c.error()
+    assert manager.c.loglevel() == logging.ERROR
+    assert manager.c.loglevelname() == 'ERROR'
+    manager.c.critical()
+    assert manager.c.loglevel() == logging.CRITICAL
+    assert manager.c.loglevelname() == 'CRITICAL'
 
 
 @manager_config
-def test_user_position(qtile):
+def test_user_position(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def user_position_window():
         nonlocal w
@@ -1194,12 +1119,12 @@ def test_user_position(qtile):
         w.map()
         conn.conn.flush()
     try:
-        qtile.create_window(user_position_window)
-        assert qtile.c.window.info()['floating'] is True
-        assert qtile.c.window.info()['x'] == 5
-        assert qtile.c.window.info()['y'] == 5
-        assert qtile.c.window.info()['width'] == 10
-        assert qtile.c.window.info()['height'] == 10
+        manager.create_window(user_position_window)
+        assert manager.c.window.info()['floating'] is True
+        assert manager.c.window.info()['x'] == 5
+        assert manager.c.window.info()['y'] == 5
+        assert manager.c.window.info()['width'] == 10
+        assert manager.c.window.info()['height'] == 10
     finally:
         w.kill_client()
         conn.finalize()
@@ -1223,9 +1148,9 @@ def wait_for_focus_events(conn):
 
 
 @manager_config
-def test_only_one_focus(qtile):
+def test_only_one_focus(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def both_wm_take_focus_and_input_hint():
         nonlocal w
@@ -1254,8 +1179,8 @@ def test_only_one_focus(qtile):
         w.map()
         conn.conn.flush()
     try:
-        qtile.create_window(both_wm_take_focus_and_input_hint)
-        assert qtile.c.window.info()['floating'] is True
+        manager.create_window(both_wm_take_focus_and_input_hint)
+        assert manager.c.window.info()['floating'] is True
         got_take_focus, got_focus_in = wait_for_focus_events(conn)
         assert not got_take_focus
         assert got_focus_in
@@ -1265,9 +1190,9 @@ def test_only_one_focus(qtile):
 
 
 @manager_config
-def test_only_wm_protocols_focus(qtile):
+def test_only_wm_protocols_focus(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def only_wm_protocols_focus():
         nonlocal w
@@ -1295,8 +1220,8 @@ def test_only_wm_protocols_focus(qtile):
         w.map()
         conn.conn.flush()
     try:
-        qtile.create_window(only_wm_protocols_focus)
-        assert qtile.c.window.info()['floating'] is True
+        manager.create_window(only_wm_protocols_focus)
+        assert manager.c.window.info()['floating'] is True
         got_take_focus, got_focus_in = wait_for_focus_events(conn)
         assert got_take_focus
         assert not got_focus_in
@@ -1306,9 +1231,9 @@ def test_only_wm_protocols_focus(qtile):
 
 
 @manager_config
-def test_only_input_hint_focus(qtile):
+def test_only_input_hint_focus(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def only_input_hint():
         nonlocal w
@@ -1326,8 +1251,8 @@ def test_only_input_hint_focus(qtile):
         w.map()
         conn.conn.flush()
     try:
-        qtile.create_window(only_input_hint)
-        assert qtile.c.window.info()['floating'] is True
+        manager.create_window(only_input_hint)
+        assert manager.c.window.info()['floating'] is True
         got_take_focus, got_focus_in = wait_for_focus_events(conn)
         assert not got_take_focus
         assert got_focus_in
@@ -1337,9 +1262,9 @@ def test_only_input_hint_focus(qtile):
 
 
 @manager_config
-def test_no_focus(qtile):
+def test_no_focus(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def no_focus():
         nonlocal w
@@ -1354,8 +1279,8 @@ def test_no_focus(qtile):
         w.map()
         conn.conn.flush()
     try:
-        qtile.create_window(no_focus)
-        assert qtile.c.window.info()['floating'] is True
+        manager.create_window(no_focus)
+        assert manager.c.window.info()['floating'] is True
         got_take_focus, got_focus_in = wait_for_focus_events(conn)
         assert not got_take_focus
         assert not got_focus_in
@@ -1365,9 +1290,9 @@ def test_no_focus(qtile):
 
 
 @manager_config
-def test_hints_setting_unsetting(qtile):
+def test_hints_setting_unsetting(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def no_input_hint():
         nonlocal w
@@ -1376,11 +1301,11 @@ def test_hints_setting_unsetting(qtile):
         conn.conn.flush()
 
     try:
-        qtile.create_window(no_input_hint)
+        manager.create_window(no_input_hint)
         # We default the input hint to true since some non-trivial number of
         # windows don't set it, and most of them want focus. The spec allows
         # WMs to assume "convenient" values.
-        assert qtile.c.window.hints()['input']
+        assert manager.c.window.hints()['input']
 
         # now try to "update" it, but don't really set an update (i.e. the
         # InputHint bit is 0, so the WM should not derive a new hint from the
@@ -1390,21 +1315,21 @@ def test_hints_setting_unsetting(qtile):
         conn.flush()
 
         # should still have the hint
-        assert qtile.c.window.hints()['input']
+        assert manager.c.window.hints()['input']
 
         # now do an update: turn it off
         hints[0] = xcbq.HintsFlags["InputHint"]
         hints[1] = 0
         w.set_property("WM_HINTS", hints, type="WM_HINTS", format=32)
         conn.flush()
-        assert not qtile.c.window.hints()['input']
+        assert not manager.c.window.hints()['input']
 
         # turn it back on
         hints[0] = xcbq.HintsFlags["InputHint"]
         hints[1] = 1
         w.set_property("WM_HINTS", hints, type="WM_HINTS", format=32)
         conn.flush()
-        assert qtile.c.window.hints()['input']
+        assert manager.c.window.hints()['input']
 
     finally:
         w.kill_client()
@@ -1412,9 +1337,9 @@ def test_hints_setting_unsetting(qtile):
 
 
 @manager_config
-def test_strut_handling(qtile):
+def test_strut_handling(manager):
     w = None
-    conn = xcbq.Connection(qtile.display)
+    conn = xcbq.Connection(manager.display)
 
     def has_struts():
         nonlocal w
@@ -1424,27 +1349,27 @@ def test_strut_handling(qtile):
         conn.conn.flush()
 
     def test_initial_state():
-        assert qtile.c.window.info()['width'] == 798
-        assert qtile.c.window.info()['height'] == 578
-        assert qtile.c.window.info()['x'] == 0
-        assert qtile.c.window.info()['y'] == 0
-        bar_id = qtile.c.bar["bottom"].info()["window"]
-        bar = qtile.c.window[bar_id].info()
+        assert manager.c.window.info()['width'] == 798
+        assert manager.c.window.info()['height'] == 578
+        assert manager.c.window.info()['x'] == 0
+        assert manager.c.window.info()['y'] == 0
+        bar_id = manager.c.bar["bottom"].info()["window"]
+        bar = manager.c.window[bar_id].info()
         assert bar["height"] == 20
         assert bar["y"] == 580
 
-    qtile.test_xcalc()
+    manager.test_xcalc()
     test_initial_state()
 
     try:
-        qtile.create_window(has_struts)
-        qtile.c.window.static(0, None, None, None, None)
-        assert qtile.c.window.info()['width'] == 798
-        assert qtile.c.window.info()['height'] == 568
-        assert qtile.c.window.info()['x'] == 0
-        assert qtile.c.window.info()['y'] == 0
-        bar_id = qtile.c.bar["bottom"].info()["window"]
-        bar = qtile.c.window[bar_id].info()
+        manager.create_window(has_struts)
+        manager.c.window.static(0, None, None, None, None)
+        assert manager.c.window.info()['width'] == 798
+        assert manager.c.window.info()['height'] == 568
+        assert manager.c.window.info()['x'] == 0
+        assert manager.c.window.info()['y'] == 0
+        bar_id = manager.c.bar["bottom"].info()["window"]
+        bar = manager.c.window[bar_id].info()
         assert bar["height"] == 20
         assert bar["y"] == 570
 

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -26,24 +26,24 @@ from libqtile.popup import Popup
 from test.conftest import BareConfig
 
 
-@pytest.mark.parametrize("qtile", [BareConfig], indirect=True)
-def test_popup_focus(qtile):
-    qtile.test_xeyes()
-    qtile.windows_map = {}
+@pytest.mark.parametrize("manager", [BareConfig], indirect=True)
+def test_popup_focus(manager):
+    manager.test_xeyes()
+    manager.windows_map = {}
 
     # we have to add .conn so that Popup thinks this is libqtile.qtile
-    qtile.conn = xcbq.Connection(qtile.display)
+    manager.conn = xcbq.Connection(manager.display)
 
     try:
-        popup = Popup(qtile)
-        popup.width = qtile.c.screen.info()["width"]
-        popup.height = qtile.c.screen.info()["height"]
+        popup = Popup(manager)
+        popup.width = manager.c.screen.info()["width"]
+        popup.height = manager.c.screen.info()["height"]
         popup.place()
         popup.unhide()
-        assert qtile.c.group.info()['focus'] == 'xeyes'
-        assert qtile.c.group.info()['windows'] == ['xeyes']
-        assert len(qtile.c.windows()) == 1
+        assert manager.c.group.info()['focus'] == 'xeyes'
+        assert manager.c.group.info()['windows'] == ['xeyes']
+        assert len(manager.c.windows()) == 1
         popup.hide()
     finally:
         popup.kill()
-        qtile.conn.finalize()
+        manager.conn.finalize()

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -65,7 +65,7 @@ class ServerConfig(Config):
     ]
 
 
-server_config = pytest.mark.parametrize("qtile", [ServerConfig], indirect=True)
+server_config = pytest.mark.parametrize("manager", [ServerConfig], indirect=True)
 
 
 def run_qtile_cmd(args):
@@ -78,33 +78,33 @@ def run_qtile_cmd(args):
 
 
 @server_config
-def test_qtile_cmd(qtile):
+def test_qtile_cmd(manager):
 
-    qtile.test_window("foo")
-    wid = qtile.c.window.info()["id"]
+    manager.test_window("foo")
+    wid = manager.c.window.info()["id"]
 
     for obj in ["window", "group", "screen"]:
-        assert run_qtile_cmd('-s {} -o {} -f info'.format(qtile.sockfile, obj))
+        assert run_qtile_cmd('-s {} -o {} -f info'.format(manager.sockfile, obj))
 
-    layout = run_qtile_cmd('-s {} -o layout -f info'.format(qtile.sockfile))
+    layout = run_qtile_cmd('-s {} -o layout -f info'.format(manager.sockfile))
     assert layout['name'] == 'stack'
     assert layout['group'] == 'a'
 
-    window = run_qtile_cmd('-s {} -o window {} -f info'.format(qtile.sockfile, wid))
+    window = run_qtile_cmd('-s {} -o window {} -f info'.format(manager.sockfile, wid))
     assert window['id'] == wid
     assert window['name'] == 'foo'
     assert window['group'] == 'a'
 
-    group = run_qtile_cmd('-s {} -o group {} -f info'.format(qtile.sockfile, 'a'))
+    group = run_qtile_cmd('-s {} -o group {} -f info'.format(manager.sockfile, 'a'))
     assert group['name'] == 'a'
     assert group['screen'] == 0
     assert group['layouts'] == ['stack', 'stack', 'stack']
     assert group['focus'] == 'foo'
 
-    assert run_qtile_cmd('-s {} -o screen {} -f info'.format(qtile.sockfile, 0)) == \
+    assert run_qtile_cmd('-s {} -o screen {} -f info'.format(manager.sockfile, 0)) == \
         {'height': 600, 'index': 0, 'width': 800, 'x': 0, 'y': 0}
 
-    bar = run_qtile_cmd('-s {} -o bar {} -f info'.format(qtile.sockfile, 'bottom'))
+    bar = run_qtile_cmd('-s {} -o bar {} -f info'.format(manager.sockfile, 'bottom'))
     assert bar['height'] == 20
     assert bar['width'] == 800
     assert bar['size'] == 20

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -49,193 +49,193 @@ class ScratchPadBaseConfic(Config):
 
 # scratchpad_config = lambda x:
 def scratchpad_config(x):
-    return no_xinerama(pytest.mark.parametrize("qtile", [ScratchPadBaseConfic], indirect=True)(x))
+    return no_xinerama(pytest.mark.parametrize("manager", [ScratchPadBaseConfic], indirect=True)(x))
 
 
 @Retry(ignore_exceptions=(KeyError,))
-def is_spawned(qtile, name):
-    qtile.c.group["SCRATCHPAD"].dropdown_info(name)['window']
+def is_spawned(manager, name):
+    manager.c.group["SCRATCHPAD"].dropdown_info(name)['window']
     return True
 
 
 @Retry(ignore_exceptions=(ValueError,))
-def is_killed(qtile, name):
-    if 'window' not in qtile.c.group["SCRATCHPAD"].dropdown_info(name):
+def is_killed(manager, name):
+    if 'window' not in manager.c.group["SCRATCHPAD"].dropdown_info(name):
         return True
     raise ValueError('not yet killed')
 
 
 @scratchpad_config
-def test_toggling(qtile):
+def test_toggling(manager):
     # adjust command for current display
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % qtile.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % manager.display)
 
-    qtile.test_window("one")
-    assert qtile.c.group["a"].info()['windows'] == ['one']
+    manager.test_window("one")
+    assert manager.c.group["a"].info()['windows'] == ['one']
 
     # First toggling: wait for window
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    is_spawned(qtile, 'dd-a')
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    is_spawned(manager, 'dd-a')
 
     # assert window in current group "a"
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'one']
-    assert_focused(qtile, 'dd-a')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'one']
+    assert_focused(manager, 'dd-a')
 
     # toggle again --> "hide" xterm in scratchpad group
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    assert qtile.c.group["a"].info()['windows'] == ['one']
-    assert_focused(qtile, 'one')
-    assert qtile.c.group["SCRATCHPAD"].info()['windows'] == ['dd-a']
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    assert manager.c.group["a"].info()['windows'] == ['one']
+    assert_focused(manager, 'one')
+    assert manager.c.group["SCRATCHPAD"].info()['windows'] == ['dd-a']
 
     # toggle again --> show again
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'one']
-    assert_focused(qtile, 'dd-a')
-    assert qtile.c.group["SCRATCHPAD"].info()['windows'] == []
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'one']
+    assert_focused(manager, 'dd-a')
+    assert manager.c.group["SCRATCHPAD"].info()['windows'] == []
 
 
 @scratchpad_config
-def test_focus_cycle(qtile):
+def test_focus_cycle(manager):
     # adjust command for current display
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % qtile.display)
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-b', command='xterm -T dd-b -display %s sh' % qtile.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % manager.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-b', command='xterm -T dd-b -display %s sh' % manager.display)
 
-    qtile.test_window("one")
+    manager.test_window("one")
     # spawn dd-a by toggling
-    assert_focused(qtile, 'one')
+    assert_focused(manager, 'one')
 
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    is_spawned(qtile, 'dd-a')
-    assert_focused(qtile, 'dd-a')
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    is_spawned(manager, 'dd-a')
+    assert_focused(manager, 'dd-a')
 
-    qtile.test_window("two")
-    assert_focused(qtile, 'two')
+    manager.test_window("two")
+    assert_focused(manager, 'two')
 
     # spawn dd-b by toggling
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-b')
-    is_spawned(qtile, 'dd-b')
-    assert_focused(qtile, 'dd-b')
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-b')
+    is_spawned(manager, 'dd-b')
+    assert_focused(manager, 'dd-b')
 
     # check all windows
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'dd-b', 'one', 'two']
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'dd-b', 'one', 'two']
 
-    assert_focus_path(qtile, 'one', 'two', 'dd-a', 'dd-b')
+    assert_focus_path(manager, 'one', 'two', 'dd-a', 'dd-b')
 
 
 @scratchpad_config
-def test_focus_lost_hide(qtile):
+def test_focus_lost_hide(manager):
     # adjust command for current display
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-c', command='xterm -T dd-c -display %s sh' % qtile.display)
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-d', command='xterm -T dd-d -display %s sh' % qtile.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-c', command='xterm -T dd-c -display %s sh' % manager.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-d', command='xterm -T dd-d -display %s sh' % manager.display)
 
-    qtile.test_window("one")
-    assert_focused(qtile, 'one')
+    manager.test_window("one")
+    assert_focused(manager, 'one')
 
     # spawn dd-c by toggling
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-c')
-    is_spawned(qtile, 'dd-c')
-    assert_focused(qtile, 'dd-c')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-c', 'one']
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-c')
+    is_spawned(manager, 'dd-c')
+    assert_focused(manager, 'dd-c')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-c', 'one']
 
     # New Window with Focus --> hide current DropDown
-    qtile.test_window("two")
-    assert_focused(qtile, 'two')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
+    manager.test_window("two")
+    assert_focused(manager, 'two')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
 
     # spawn dd-b by toggling
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-d')
-    is_spawned(qtile, 'dd-d')
-    assert_focused(qtile, 'dd-d')
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-d')
+    is_spawned(manager, 'dd-d')
+    assert_focused(manager, 'dd-d')
 
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-d', 'one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-d', 'one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
 
     # focus next, is the first tiled window --> "hide" dd-d
-    qtile.c.group.next_window()
-    assert_focused(qtile, 'one')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c', 'dd-d']
+    manager.c.group.next_window()
+    assert_focused(manager, 'one')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c', 'dd-d']
 
     # Bring dd-c to front
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-c')
-    assert_focused(qtile, 'dd-c')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-c', 'one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-d']
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-c')
+    assert_focused(manager, 'dd-c')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-c', 'one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-d']
 
     # Bring dd-d to front --> "hide dd-c
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-d')
-    assert_focused(qtile, 'dd-d')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-d', 'one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-d')
+    assert_focused(manager, 'dd-d')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-d', 'one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c']
 
     # change current group to "b" hids DropDowns
-    qtile.c.group['b'].toscreen()
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['one', 'two']
-    assert sorted(qtile.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c', 'dd-d']
+    manager.c.group['b'].toscreen()
+    assert sorted(manager.c.group["a"].info()['windows']) == ['one', 'two']
+    assert sorted(manager.c.group["SCRATCHPAD"].info()['windows']) == ['dd-c', 'dd-d']
 
 
 @scratchpad_config
-def test_kill(qtile):
+def test_kill(manager):
     # adjust command for current display
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % qtile.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % manager.display)
 
-    qtile.test_window("one")
-    assert_focused(qtile, 'one')
+    manager.test_window("one")
+    assert_focused(manager, 'one')
 
     # dd-a has no window associated yet
-    assert 'window' not in qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')
+    assert 'window' not in manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')
 
     # First toggling: wait for window
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    is_spawned(qtile, 'dd-a')
-    assert_focused(qtile, 'dd-a')
-    assert qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')['window']['name'] == 'dd-a'
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    is_spawned(manager, 'dd-a')
+    assert_focused(manager, 'dd-a')
+    assert manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')['window']['name'] == 'dd-a'
 
     # kill current window "dd-a"
-    qtile.c.window.kill()
-    is_killed(qtile, 'dd-a')
-    assert_focused(qtile, 'one')
-    assert 'window' not in qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')
+    manager.c.window.kill()
+    is_killed(manager, 'dd-a')
+    assert_focused(manager, 'one')
+    assert 'window' not in manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')
 
 
 @scratchpad_config
-def test_floating_toggle(qtile):
+def test_floating_toggle(manager):
     # adjust command for current display
-    qtile.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % qtile.display)
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure('dd-a', command='xterm -T dd-a -display %s sh' % manager.display)
 
-    qtile.test_window("one")
-    assert_focused(qtile, 'one')
+    manager.test_window("one")
+    assert_focused(manager, 'one')
 
     # dd-a has no window associated yet
-    assert 'window' not in qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')
+    assert 'window' not in manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')
     # First toggling: wait for window
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    is_spawned(qtile, 'dd-a')
-    assert_focused(qtile, 'dd-a')
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    is_spawned(manager, 'dd-a')
+    assert_focused(manager, 'dd-a')
 
-    assert 'window' in qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'one']
+    assert 'window' in manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'one']
 
-    qtile.c.window.toggle_floating()
+    manager.c.window.toggle_floating()
     # dd-a has no window associated any more, but is still in group
-    assert 'window' not in qtile.c.group["SCRATCHPAD"].dropdown_info('dd-a')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'one']
+    assert 'window' not in manager.c.group["SCRATCHPAD"].dropdown_info('dd-a')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'one']
 
-    qtile.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
-    is_spawned(qtile, 'dd-a')
-    assert sorted(qtile.c.group["a"].info()['windows']) == ['dd-a', 'dd-a', 'one']
+    manager.c.group["SCRATCHPAD"].dropdown_toggle('dd-a')
+    is_spawned(manager, 'dd-a')
+    assert sorted(manager.c.group["a"].info()['windows']) == ['dd-a', 'dd-a', 'one']
 
 
 @scratchpad_config
-def test_stepping_between_groups_should_skip_scratchpads(qtile):
+def test_stepping_between_groups_should_skip_scratchpads(manager):
     # we are on a group
-    qtile.c.screen.next_group()
+    manager.c.screen.next_group()
     # we are on b group
-    qtile.c.screen.next_group()
+    manager.c.screen.next_group()
     # we should be on a group
-    assert qtile.c.group.info()["name"] == "a"
+    assert manager.c.group.info()["name"] == "a"
 
-    qtile.c.screen.prev_group()
+    manager.c.screen.prev_group()
     # we should be on b group
-    assert qtile.c.group.info()["name"] == "b"
+    assert manager.c.group.info()["name"] == "b"

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -45,12 +45,12 @@ class ShConfig(Config):
     ]
 
 
-sh_config = pytest.mark.parametrize("qtile", [ShConfig], indirect=True)
+sh_config = pytest.mark.parametrize("manager", [ShConfig], indirect=True)
 
 
 @sh_config
-def test_columnize(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_columnize(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.columnize(["one", "two"]) == "one  two"
@@ -64,8 +64,8 @@ def test_columnize(qtile):
 
 
 @sh_config
-def test_ls(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_ls(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.do_ls("") == "bar/     group/   layout/  screen/  widget/  window/"
@@ -77,8 +77,8 @@ def test_ls(qtile):
 
 
 @sh_config
-def test_do_cd(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_do_cd(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.do_cd("layout") == 'layout'
@@ -89,8 +89,8 @@ def test_do_cd(qtile):
 
 
 @sh_config
-def test_call(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_call(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.process_line("status()") == "OK"
@@ -106,8 +106,8 @@ def test_call(qtile):
 
 
 @sh_config
-def test_complete(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_complete(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh._complete("c", "c") == [
@@ -124,8 +124,8 @@ def test_complete(qtile):
 
 
 @sh_config
-def test_help(qtile):
-    client = ipc.Client(qtile.sockfile)
+def test_help(manager):
+    client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.do_help("nonexistent").startswith("No such command")

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -43,8 +43,8 @@ def test_text_battery_charging(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
@@ -59,8 +59,8 @@ def test_text_battery_discharging(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
@@ -75,15 +75,15 @@ def test_text_battery_full(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
     assert text == "Full"
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery(show_short_text=False)
 
     text = batt.poll()
@@ -98,15 +98,15 @@ def test_text_battery_empty(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
     assert text == "Empty"
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery(show_short_text=False)
 
     text = batt.poll()
@@ -119,8 +119,8 @@ def test_text_battery_empty(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
@@ -135,8 +135,8 @@ def test_text_battery_unknown(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery()
 
     text = batt.poll()
@@ -151,15 +151,15 @@ def test_text_battery_hidden(monkeypatch):
         time=1729,
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery(hide_threshold=0.6)
 
     text = batt.poll()
     assert text != ""
 
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery(hide_threshold=0.4)
 
     text = batt.poll()
@@ -167,8 +167,8 @@ def test_text_battery_hidden(monkeypatch):
 
 
 def test_text_battery_error(monkeypatch):
-    with monkeypatch.context() as m:
-        m.setattr(battery, "load_battery", DummyErrorBattery)
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", DummyErrorBattery)
         batt = Battery()
 
     text = batt.poll()

--- a/test/widgets/test_misc.py
+++ b/test/widgets/test_misc.py
@@ -45,16 +45,16 @@ class WidgetTestConf(BareConfig):
     screens = [Screen(bottom=Bar([ColorChanger(name="colorchanger")], 20))]
 
 
-widget_conf = pytest.mark.parametrize("qtile", [WidgetTestConf], indirect=True)
+widget_conf = pytest.mark.parametrize("manager", [WidgetTestConf], indirect=True)
 
 
 @widget_conf
-def test_textbox_color_change(qtile):
-    qtile.c.widget["colorchanger"].update('f')
-    assert qtile.c.widget["colorchanger"].info()["foreground"] == "0000ff"
+def test_textbox_color_change(manager):
+    manager.c.widget["colorchanger"].update('f')
+    assert manager.c.widget["colorchanger"].info()["foreground"] == "0000ff"
 
-    qtile.c.widget["colorchanger"].update('f')
-    assert qtile.c.widget["colorchanger"].info()["foreground"] == "ff0000"
+    manager.c.widget["colorchanger"].update('f')
+    assert manager.c.widget["colorchanger"].info()["foreground"] == "ff0000"
 
 
 def test_thermalsensor_regex_compatibility():

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -17,17 +17,17 @@ class FakeWindow:
     window = _NestedWindow()
 
 
-widget_config = pytest.mark.parametrize("qtile", [BareConfig], indirect=True)
+widget_config = pytest.mark.parametrize("manager", [BareConfig], indirect=True)
 
 
 @widget_config
-def test_widgetbox_widget(qtile):
-    qtile.conn = xcbq.Connection(qtile.display)
+def test_widgetbox_widget(manager):
+    manager.conn = xcbq.Connection(manager.display)
 
     # We need to trick the widgets into thinking this is libqtile.qtile so
     # we add some methods that are called when the widgets are configured
-    qtile.call_soon = no_op
-    qtile.register_widget = no_op
+    manager.call_soon = no_op
+    manager.register_widget = no_op
 
     tb_one = TextBox(name="tb_one", text="TB ONE")
     tb_two = TextBox(name="tb_two", text="TB TWO")
@@ -45,7 +45,7 @@ def test_widgetbox_widget(qtile):
     fakebar.draw = no_op
 
     # Configure the widget box
-    widget_box._configure(qtile, fakebar)
+    widget_box._configure(manager, fakebar)
 
     # Invalid value should be corrected to default
     assert widget_box.close_button_location == "left"

--- a/test/x11/test_xcore.py
+++ b/test/x11/test_xcore.py
@@ -1,15 +1,15 @@
 from libqtile.backend.x11 import xcore
 
 
-def test_keys(qtile_nospawn):
-    xc = xcore.XCore(qtile_nospawn.display)
+def test_keys(manager_nospawn):
+    xc = xcore.XCore(manager_nospawn.display)
     assert "a" in xc.get_keys()
     assert "shift" in xc.get_modifiers()
 
 
-def test_no_two_qtiles(qtile):
+def test_no_two_qtiles(manager):
     try:
-        xcore.XCore(qtile.display)
+        xcore.XCore(manager.display)
     except xcore.ExistingWMException:
         pass
     else:


### PR DESCRIPTION
The Qtile class in test/conftest.py and the fixture 'qtile' that yields
it to tests share a name with the Qtile class in libqtile and the
'qtile' name that its instance takes. This has lead to confusion as they
do not represent the same thing, and are used in different ways. To make
the distinction more clear, this commit simply renames the testing
Qtile class to TestManager, and renames the fixture to 'm', so that
the manager passed to tests is referenced by the variable 'm'.