### PR TITLE
Add natural resizing mechanism to resize from any window corner

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ Qtile X.X.X, released XXXX-XX-XX:
           Running `qtile` without arguments will continue to work for the
           forseeable future, but will be eventually deprecated. qtile prints a
           warning when run in this configuration.
+        - lazy.window.get_size() will return (x, y, width, height) rather than just (width, height)
         - Qtile.cmd_focus_by_click is no longer an available command.
     * features
         - new WidgetBox widget
@@ -46,6 +47,8 @@ Qtile X.X.X, released XXXX-XX-XX:
         - switch to Github Actions for CI
         - Columns layout has new `margin_on_single` option to specify margin
           size when there is only one window (default -1: use `margin` option).
+        - Resizing with the default Drag configuration will resize from windows
+          from the corner closest to the corner.
     !!! warning !!!
         - When (re)starting, Qtile passes its state to the new process in a
           file now, where previously it passed state directly as a string. This


### PR DESCRIPTION
This lets users resize a window from any corner (that closest to the
cursor when the drag starts), holding the opposite corner in place.

The default approach using `lazy.window.set_size_floating()` and
`start=lazy.window.get_size()` cannot be modified to perform this
without modifying the core drag mechanism, as the initial drag x-y
position (stored during the start= function) is required to determine
the direction of resizing (i.e. a rightward drag from the left side
shrinks in x). Going down the route of modifying the core drag mechanism
would likely lead to config breakages.

Instead, this introduces two similar methods to be used as:

Drag(..., ..., lazy.window.drag_resize_floating(), start=lazy.window.start_resize())