### PR TITLE
Refactor Qtile LifeCycle

### DIFF
--- a/bin/qtile
+++ b/bin/qtile
@@ -28,7 +28,9 @@ this_dir = os.path.dirname(__file__)
 base_dir = os.path.abspath(os.path.join(this_dir, ".."))
 sys.path.insert(0, base_dir)
 
-from libqtile.scripts.main import main
+# import lifecycle early so no atexit handlers are lost on restart
+import libqtile.core.lifecycle  # noqa: F401, E402
+from libqtile.scripts.main import main  # noqa: E402
 
 if __name__ == '__main__':
     main()

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -183,7 +183,7 @@ class Core(base.Core):
         return self._numlock_mask, self._valid_mask
 
     def setup_listener(
-        self, qtile: "Qtile", eventloop: asyncio.AbstractEventLoop
+        self, qtile: "Qtile"
     ) -> None:
         """Setup a listener for the given qtile instance
 
@@ -195,7 +195,7 @@ class Core(base.Core):
         logger.debug("Adding io watch")
         self.qtile = qtile
         self.fd = self.conn.conn.get_file_descriptor()
-        eventloop.add_reader(self.fd, self._xpoll)
+        asyncio.get_running_loop().add_reader(self.fd, self._xpoll)
 
     def remove_listener(self) -> None:
         """Remove the listener from the given event loop"""
@@ -206,7 +206,7 @@ class Core(base.Core):
     def _remove_listener(self) -> None:
         if self.fd is not None:
             logger.debug("Removing io watch")
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             loop.remove_reader(self.fd)
             self.fd = None
 

--- a/libqtile/core/lifecycle.py
+++ b/libqtile/core/lifecycle.py
@@ -1,0 +1,43 @@
+import atexit
+import enum
+import os
+import sys
+from typing import Optional
+
+from libqtile.log_utils import logger
+
+__all__ = [
+    'lifecycle',
+]
+
+Behavior = enum.Enum('Behavior', 'NONE TERMINATE RESTART')
+
+
+class LifeCycle:
+    # This class exists mostly to move os.execv to the absolute last thing that
+    # the python VM does before termination.
+    # Be very careful about what references this class owns. Any object
+    # referenced here when atexit fires will NOT be finalized properly.
+    def __init__(self) -> None:
+        self.behavior = Behavior.NONE
+        self.state_file: Optional[str] = None
+        atexit.register(self._atexit)
+
+    def _atexit(self) -> None:
+        if self.behavior is Behavior.RESTART:
+            argv = [sys.executable] + sys.argv
+            if '--no-spawn' not in argv:
+                argv.append('--no-spawn')
+            argv = [s for s in argv if not s.startswith('--with-state')]
+            if self.state_file is not None:
+                argv.append('--with-state=' + self.state_file)
+            logger.warning('Restarting Qtile with os.execv(...)')
+            # No other code will execute after the following line does
+            os.execv(sys.executable, argv)
+        elif self.behavior is Behavior.TERMINATE:
+            logger.warning('Qtile will now terminate')
+        elif self.behavior is Behavior.NONE:
+            pass
+
+
+lifecycle = LifeCycle()

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -1,0 +1,95 @@
+import asyncio
+import contextlib
+import signal
+from typing import Awaitable, Optional
+
+from libqtile.log_utils import logger
+
+
+class QtileLoop(contextlib.AbstractAsyncContextManager):
+    def __init__(self, qtile):
+        super().__init__()
+        self.qtile = qtile
+        self._glib_loop: Optional[Awaitable] = None
+
+    async def __aenter__(self) -> 'QtileLoop':
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGINT, self.qtile.stop)
+        loop.add_signal_handler(signal.SIGTERM, self.qtile.stop)
+        loop.set_exception_handler(self._handle_exception)
+
+        with contextlib.suppress(ImportError):
+            self._glib_loop = self._setup_glib_loop()
+
+        if self._glib_loop is None:
+            logger.warning('importing dbus/gobject failed, dbus will not work.')
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        if self._glib_loop is not None:
+            await self._teardown_glib_loop(self._glib_loop)
+            self._glib_loop = None
+
+        await self._cancel_all_tasks()
+
+        loop = asyncio.get_running_loop()
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
+        loop.set_exception_handler(None)
+
+    async def _cancel_all_tasks(self):
+        # we don't want to cancel this task, so filter all_tasks
+        # generator to filter in place
+        pending = (
+            task for task in asyncio.all_tasks()
+            if task is not asyncio.current_task()
+        )
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task()
+
+    def _setup_glib_loop(self):
+        # This is a little strange. python-dbus internally depends on gobject,
+        # so gobject's threads need to be running, and a gobject 'main loop
+        # thread' needs to be spawned, but we try to let it only interact with
+        # us via calls to asyncio's call_soon_threadsafe.
+        # We import dbus here to thrown an ImportError if it isn't
+        # available. Since the only reason we're running this thread is
+        # because of dbus, if dbus isn't around there's no need to run
+        # this thread.
+        import dbus  # noqa
+        from gi.repository import GLib  # type: ignore
+
+        def gobject_thread():
+            ctx = GLib.main_context_default()
+            while not self.qtile.is_stopped():
+                try:
+                    ctx.iteration(True)
+                except Exception:
+                    logger.exception('got exception from gobject')
+
+        return asyncio.get_running_loop().run_in_executor(None, gobject_thread)
+
+    async def _teardown_glib_loop(self, glib_loop):
+        try:
+            from gi.repository import GLib  # type: ignore
+            GLib.idle_add(lambda: None)
+            await glib_loop
+        except ImportError:
+            pass
+
+    def _handle_exception(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        context: dict,
+    ) -> None:
+        # message is always present, but we'd prefer the exception if available
+        if 'exception' in context:
+            exc = context['exception']
+            # CancelledErrors happen when we simply cancel the main task during
+            # a normal restart procedure
+            if not isinstance(exc, asyncio.CancelledError):
+                logger.exception(context['exception'])
+        else:
+            logger.error(f'unhandled error in event loop: {context["msg"]}')

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -119,7 +119,6 @@ class Client:
             Pack and unpack messages as json
         """
         self.fname = fname
-        self.loop = asyncio.get_event_loop()
         self.is_json = is_json
 
     def call(self, data: Any) -> Any:
@@ -131,7 +130,7 @@ class Client:
         If any exception is raised by the server, that will propogate out of
         this call.
         """
-        return self.loop.run_until_complete(self.async_send(msg))
+        return asyncio.run(self.async_send(msg))
 
     async def async_send(self, msg: Any) -> Any:
         """Send the message to the server

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -22,6 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import asyncio
 import os
 import tempfile
 
@@ -336,7 +337,8 @@ def test_incompatible_widget(manager_nospawn):
     # Ensure that adding a widget that doesn't support the orientation of the
     # bar raises ConfigError
     with pytest.raises(libqtile.confreader.ConfigError):
-        manager_nospawn.create_manager(config)
+        m = manager_nospawn.create_manager(config)
+        asyncio.run(m.qtile._configure())
 
 
 def test_basic(manager_nospawn):


### PR DESCRIPTION
This PR refactors the process lifecycle related parts of Qtile to properly manage resource finalization and just generally cleans up the code.

Instead of running os.execv before python's builtin finalization
routines, this uses those same finalization routines to move os.execv to
the last thing done by the interpreter before termination.