### PR TITLE
docs: fix simple typo, witdh -> width

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -903,7 +903,7 @@ class MonadWide(MonadTall):
                 self._get_absolute_size_from_relative(
                     sum(self.relative_sizes[:cidx - 1])
                 )
-            # get width from precalculated witdh list
+            # get width from precalculated width list
             width = self._get_absolute_size_from_relative(
                 self.relative_sizes[cidx - 1]
             )


### PR DESCRIPTION
There is a small typo in libqtile/layout/xmonad.py.

Should read `width` rather than `witdh`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md