### PR TITLE
Allow notifications to be deleted

### DIFF
--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -26,6 +26,10 @@
     If dbus is available, this module implements a
     org.freedesktop.Notifications service.
 """
+from collections import OrderedDict
+from enum import Enum
+from threading import RLock, Thread, current_thread, main_thread
+
 from libqtile.log_utils import logger
 
 try:
@@ -36,6 +40,7 @@ try:
     has_dbus = True
 except ImportError:
     has_dbus = False
+
 
 BUS_NAME = 'org.freedesktop.Notifications'
 SERVICE_PATH = '/org/freedesktop/Notifications'
@@ -82,6 +87,20 @@ if has_dbus:
 
 
 class Notification:
+
+    class Urgency(Enum):
+        LOW = 0
+        NORMAL = 1
+        CRITICAL = 2
+
+        def _missing_(self):
+            try:
+                # Default priority is NORMAL
+                priority = self.hints.get('urgency', 1)
+                return Notification.Urgency(int(priority))
+            except (AttributeError, ValueError):
+                return Notification.Urgency.NORMAL
+
     def __init__(self, summary, body='', timeout=-1, hints=None, app_name='',
                  replaces_id=None, app_icon=None, actions=None):
         self.summary = summary
@@ -96,9 +115,16 @@ class Notification:
 
 class NotificationManager:
     def __init__(self):
-        self.notifications = []
-        self.callbacks = []
+        # Use OrderedDict to maintain order
+        self._notifications = OrderedDict()
+        # Use a dict for indexing for quick finding prev/next notification
+        self._notifications_idx = dict()
+        self._current_id = 0
+        self.callbacks_add = []
+        self.callbacks_delete = []
         self._service = None
+        # Use a lock to protect notification concurrency.
+        self._lock = RLock()
 
     @property
     def service(self):
@@ -110,22 +136,174 @@ class NotificationManager:
                 self._service = None
         return self._service
 
+    @property
+    def notifications(self):
+        with self._lock:
+            return list(self._notifications.values())
+
+    def prev(self, notification):
+        # Can pass either notification id or the notification itself
+        if isinstance(notification, int):
+            notif_id = notification
+        elif isinstance(notification, Notification):
+            notif_id = notification.id
+        else:
+            return None
+
+        with self._lock:
+            notif_idx = self._notifications_idx.get(notif_id, None)
+            if notif_idx is not None:
+                prev_id = notif_idx['prev_id']
+                prev_notif = self._notifications.get(prev_id, None)
+                return prev_notif
+
+            # There is a chance that the notification requested might be deleted.
+            # In that case we need to loop the notifications to find the previous.
+            prev_notif = None
+            for notif in self._notifications.values():
+                if notif.id >= notif_id:
+                    break
+                prev_notif = notif
+            return prev_notif
+
+    def next(self, notif):
+        # Can pass either notification id or the notification itself
+        if isinstance(notif, int):
+            notif_id = notif
+        elif isinstance(notif, Notification):
+            notif_id = notif.id
+        else:
+            return None
+
+        with self._lock:
+            notif_idx = self._notifications_idx.get(notif_id, None)
+            if notif_idx is not None:
+                next_id = notif_idx['next_id']
+                next_notif = self._notifications.get(next_id, None)
+                return next_notif
+
+            # There is a chance that the notification requested might be deleted.
+            # In that case we need to loop the notifications to find the next.
+            next_notif = None
+            for notif in self._notifications.values():
+                if notif.id > notif_id:
+                    next_notif = notif
+                    break
+            return next_notif
+
     def register(self, callback, capabilities=None):
         if not self.service:
             logger.warning(
                 'Registering %s without any dbus connection existing',
                 callback.__name__,
             )
-        self.callbacks.append(callback)
+        self.callbacks_add.append(callback)
         if capabilities:
             self._service.register_capabilities(capabilities)
 
+    def register_delete(self, callback):
+        if not self.service:
+            logger.warning(
+                'Registering %s without any dbus connection existing',
+                callback.__name__,
+            )
+        self.callbacks_delete.append(callback)
+
     def add(self, notif):
-        self.notifications.append(notif)
-        notif.id = len(self.notifications)
-        for callback in self.callbacks:
-            callback(notif)
-        return len(self.notifications)
+        with self._lock:
+            # Find the id of the previous notification
+            if self._notifications:
+                prev_id = next(reversed(self._notifications))
+                prev_id = self._notifications[prev_id].id
+            else:
+                prev_id = None
+
+            self._current_id += 1
+            notif.id = self._current_id
+            self._notifications[notif.id] = notif
+            # Assign prev_id to notifications indexing dict
+            self._notifications_idx[notif.id] = dict(
+                prev_id=prev_id,
+                next_id=None
+            )
+
+            # Set next_id of previous notification to this notification's id.
+            if prev_id is not None:
+                self._notifications_idx[prev_id]['next_id'] = notif.id
+
+            notifs_len = len(self._notifications)
+
+        for callback in self.callbacks_add:
+            # Don't let the subscriber crash us
+            try:
+                callback(notif)
+            except Exception as e:
+                logger.error(e)
+
+        return notifs_len
+
+    def delete(self, *notifs):
+        """Delete one or more notifications given the notifications or their
+        ids.
+        """
+        # Should not block the main thread
+        if main_thread() == current_thread():
+            Thread(target=self.delete, args=notifs).start()
+            return
+        notifs_deleted = []
+        with self._lock:
+            for notif in notifs:
+                if isinstance(notif, int):
+                    notif_id = notif
+                elif isinstance(notif, Notification):
+                    notif_id = notif.id
+                else:
+                    continue
+
+                notif = self._notifications.get(notif_id, None)
+                if notif is None:
+                    continue
+                notifs_deleted.append(notif)
+
+                # Get previous and next ids for re-indexing
+                notif_idx = self._notifications_idx[notif_id]
+                prev_id = notif_idx['prev_id']
+                next_id = notif_idx['next_id']
+
+                # Next notification should point to previous of deleted
+                if next_id is not None:
+                    self._notifications_idx[next_id]['prev_id'] = prev_id
+
+                # Previous notification should point to next of deleted
+                if prev_id is not None:
+                    self._notifications_idx[prev_id]['next_id'] = next_id
+
+                del self._notifications_idx[notif_id]
+                del self._notifications[notif_id]
+
+        # Do nothing if nothing was deleted
+        if len(notifs_deleted) == 0:
+            return
+
+        for callback in self.callbacks_delete:
+            # Don't let the subscriber crash us
+            try:
+                callback(*notifs_deleted)
+            except Exception as e:
+                logger.error(e)
+
+    def delete_all(self):
+        with self._lock:
+            notifs_deleted = self._notifications.values()
+            self._notifications = OrderedDict()
+            self._notifications_idx = {}
+
+        for callback in self.callbacks_delete:
+            # Don't let the subscriber crash us
+            try:
+                callback(*notifs_deleted)
+            except Exception as e:
+                logger.error(e)
 
     def show(self, *args, **kwargs):
         notif = Notification(*args, **kwargs)


### PR DESCRIPTION
Hello,

I updated the NotificationManager class to allow Notification deletion. I tried to be consinstent with the current code.
Here is a brief overview of what is changed/added:

- Inner changes:
    - Notifications are held under an OrderedDict for fast retrieval during delete.
    - self.notifications is now a property that returns a list as previously to allow backwards compatibility
    - introduce a dict to allow indexing of previous/next notifications for fast retrieval of prev and next.
    - introduce a lock to provide concurrency when deleting/adding notifications when multiple subscribers are registered.
- Methods:
    - register_delete: Same as register but for delete.
    - delete: Deletes the notifications provided a Notification object or notification ids and calls the delete callbacks.
    - delete_all: Deletes all the notifications and calls the delete callbacks.
    - prev/next: Since now notification index in the list cannot be infered from the notification id (may be deletions), these methods fetch the next/prev based on a Notification object or a notification id.
 
Notification:
- I added an Urgency Enum class inside the Notification class to get the Urgency from a Notification object (e.g Notification.Urgency(notif) == Notification.Urgency.LOW)

Notify widget:
- I updated the Notify widget to comply with Notification deletion with methods similar to update and real_update (delete and real_delete)
- Right click deletes current notification as previously.
- I enabled Left click to delete all notifications.

Existing API does not change, only inner working/logic.

Please let me know if you want any changes on this, if you need extra tests and if yes where is best to declare them.

Cheers.