### PR TITLE
Make the Makefile self-documented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,19 @@
-default:
-	@echo "'make check'" for tests
-	@echo "'make check-cov'" for tests with coverage
-	@echo "'make lint'" for source code checks
-	@echo "'make ckpatch'" to check a patch
-	@echo "'make clean'" to clean generated files
-	@echo "'make man'" to generate sphinx documentation
-	@echo "'make run-ffibuild'" to build ffi modules
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[1m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: check
-check:
+check: ## Run the test suite
 	TOXENV=py38 tox
 
 .PHONY: lint
-lint:
+lint: ## Check the source code
 	TOXENV=format,pep8 tox
 
 .PHONY: clean
-clean:
+clean: ## Clean generated files
 	-rm -rf dist qtile.egg-info docs/_build build/ .tox/ .mypy_cache/ .pytest_cache/ .eggs/
 
 # This is a little ugly: we want to be able to have users just run
@@ -25,10 +22,10 @@ clean:
 # 'build_sphinx' target as well, so we commit the man pages, since they are
 # used in the 'install' target.
 .PHONY: man
-man:
+man: ## Generate Sphinx documentation
 	python3 setup.py build_sphinx -b man
 	cp build/sphinx/man/* resources/
 
 .PHONY: run-ffibuild
-run-ffibuild:
+run-ffibuild: ## Build FFI modules
 	./scripts/ffibuild


### PR DESCRIPTION
I found by accident that the default rule of the Makefile was outdated and listing some rules that do not exist anymore, so rather than updating it, I thought we could have it self-documented.

This hack is based on this article (and its comments): https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html