### PR TITLE
Fix docs

### DIFF
--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -33,6 +33,7 @@ from jinja2 import Template
 from sphinx.util.nodes import nested_parse_with_titles
 
 from libqtile import command_object, configurable, widget
+from libqtile.utils import import_class
 
 qtile_module_template = Template('''
 .. qtile_class:: {{ module }}.{{ class_name }}
@@ -77,16 +78,6 @@ qtile_hooks_template = Template('''
 ''')
 
 
-# Adapted from sphinxcontrib-httpdomain
-def import_object(module_name, expr):
-    mod = __import__(module_name)
-    mod = functools.reduce(getattr, module_name.split('.')[1:], mod)
-    globals = builtins
-    if not isinstance(globals, dict):
-        globals = globals.__dict__
-    return eval(expr, globals, mod.__dict__)
-
-
 class SimpleDirectiveMixin:
     has_content = True
     required_arguments = 1
@@ -114,7 +105,7 @@ class QtileClass(SimpleDirectiveMixin, Directive):
     def make_rst(self):
         module, class_name = self.arguments[0].rsplit('.', 1)
         arguments = self.arguments[1:]
-        obj = import_object(module, class_name)
+        obj = import_class(module, class_name)
         is_configurable = ':no-config:' not in arguments
         is_commandable = ':no-commands:' not in arguments
         arguments = [i for i in arguments if i not in (':no-config:', ':no-commands:')]
@@ -159,7 +150,7 @@ class QtileClass(SimpleDirectiveMixin, Directive):
 class QtileHooks(SimpleDirectiveMixin, Directive):
     def make_rst(self):
         module, class_name = self.arguments[0].rsplit('.', 1)
-        obj = import_object(module, class_name)
+        obj = import_class(module, class_name)
         for method in sorted(obj.hooks):
             rst = qtile_hooks_template.render(method=method)
             for line in rst.splitlines():
@@ -177,11 +168,11 @@ class QtileModule(SimpleDirectiveMixin, Directive):
 
         BaseClass = None
         if ':baseclass:' in self.arguments:
-            BaseClass = import_object(*self.arguments[
+            BaseClass = import_class(*self.arguments[
                 self.arguments.index(':baseclass:') + 1].rsplit('.', 1))
 
         for item in dir(module):
-            obj = import_object(self.arguments[0], item)
+            obj = import_class(self.arguments[0], item)
             if not inspect.isclass(obj) or (BaseClass and
                 not issubclass(obj, BaseClass)):
                 continue

--- a/libqtile/extension/__init__.py
+++ b/libqtile/extension/__init__.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile.utils import make_module_getattr
+from libqtile.utils import lazify_imports
 
 extensions = {
     "CommandSet": "command_set",
@@ -29,5 +29,4 @@ extensions = {
     "WindowList": "window_list"
 }
 
-__all__ = tuple(extensions.keys())
-__getattr__ = make_module_getattr(extensions, __package__)
+__all__, __dir__, __getattr__ = lazify_imports(extensions, __package__)

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -210,19 +210,24 @@ def import_class(module_path, class_name, fallback=None):
         raise
 
 
-def make_module_getattr(registry, package, fallback=None):
+def lazify_imports(registry, package, fallback=None):
     """Leverage PEP 562 to make imports lazy in an __init__.py
 
     The registry must be a dictionary with the items to import as keys and the
     modules they belong to as a value.
     """
+    __all__ = tuple(registry.keys())
+
+    def __dir__():
+        return __all__
+
     def __getattr__(name):
         if name not in registry:
             raise AttributeError
         module_path = "{}.{}".format(package, registry[name])
         return import_class(module_path, name, fallback=fallback)
 
-    return __getattr__
+    return __all__, __dir__, __getattr__
 
 
 def send_notification(title, message, urgent=False, timeout=10000, id=None):

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile.utils import make_module_getattr
+from libqtile.utils import lazify_imports
 from libqtile.widget.import_error import make_error
 
 widgets = {
@@ -91,5 +91,5 @@ widgets = {
     "YahooWeather": "yahoo_weather"
 }
 
-__all__ = tuple(widgets.keys())
-__getattr__ = make_module_getattr(widgets, __package__, fallback=make_error)
+__all__, __dir__, __getattr__ = lazify_imports(widgets, __package__,
+                                               fallback=make_error)


### PR DESCRIPTION
Our documentation calls `dir()` on modules to list the widgets and extensions we have, so following #2048, we must now implement `__dir__` at the module-level to make them available. To make it simpler, I replaced `make_module_getattr` by `lazify_imports`, that creates all the magic stuff that a `__init__.py` needs for vanity imports (and not just the `__getattr__` function).

Fixes #2056.