### PR TITLE
Implement async hook subscriptions

### DIFF
--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import asyncio
 import logging
 from multiprocessing import Value
 
@@ -64,6 +65,52 @@ def test_hook_calls_subscriber():
     hook.subscribe.group_window_add(test)
     hook.fire("group_window_add", 8)
     assert test.val == 8
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_hook_calls_subscriber_async():
+    val = 0
+
+    async def co(new_val):
+        nonlocal val
+        val = new_val
+
+    hook.subscribe.group_window_add(co)
+    hook.fire("group_window_add", 8)
+
+    assert val == 8
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_hook_calls_subscriber_async_co():
+    val = 0
+
+    async def co(new_val):
+        nonlocal val
+        val = new_val
+
+    hook.subscribe.group_window_add(co(8))
+    hook.fire("group_window_add")
+
+    assert val == 8
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_hook_calls_subscriber_async_in_existing_loop():
+
+    async def t():
+        val = 0
+
+        async def co(new_val):
+            nonlocal val
+            val = new_val
+
+        hook.subscribe.group_window_add(co(8))
+        hook.fire("group_window_add")
+        await asyncio.sleep(0)
+        assert val == 8
+
+    asyncio.run(t())
 
 
 @pytest.mark.usefixtures("hook_fixture")


### PR DESCRIPTION
This allows us to @hook.subscribe to coroutines as well as normal
functions. I've modified the hook.fire routine to handle this as well as
allow for scheduling coroutines on the event loop if one exists in the
current thread while creating, running, and destroying one if it
doesn't. This allows firing hooks from both sync and async contexts.

Async hooks are useful because it removes the headache of writing the
async boilerplate themselves for our users. For instance, in the case
where someone wants to sleep before running some code when a hook fires,
they would merely `await asyncio.sleep(time)` and not block the event
loop, whereas to do so without these changes they would need to add the
boilerplate that is now a part of hook.fire to do so.