### PR TITLE
Added option to change empty group string for the window name widget

### DIFF
--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -30,10 +30,20 @@ from libqtile.widget import base
 
 class WindowName(base._TextBox):
     """Displays the name of the window that currently has focus"""
+
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ('show_state', True, 'show window status before window name'),
-        ('for_current_screen', False, 'instead of this bars screen use currently active screen')
+        ("show_state", True, "show window status before window name"),
+        (
+            "for_current_screen",
+            False,
+            "instead of this bars screen use currently active screen",
+        ),
+        (
+            "empty_group_string",
+            " ",
+            "string to display when no windows are focused on current group",
+        ),
     ]
 
     def __init__(self, width=bar.STRETCH, **config):
@@ -56,14 +66,17 @@ class WindowName(base._TextBox):
             w = self.qtile.current_screen.group.current_window
         else:
             w = self.bar.screen.group.current_window
-        state = ''
+        state = ""
         if self.show_state and w is not None:
             if w.maximized:
-                state = '[] '
+                state = "[] "
             elif w.minimized:
-                state = '_ '
+                state = "_ "
             elif w.floating:
-                state = 'V '
-        unescaped = "%s%s" % (state, w.name if w and w.name else " ")
+                state = "V "
+        unescaped = "%s%s" % (
+            state,
+            w.name if w and w.name else self.empty_group_string,
+        )
         self.text = pangocffi.markup_escape_text(unescaped)
         self.bar.draw()

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -30,20 +30,11 @@ from libqtile.widget import base
 
 class WindowName(base._TextBox):
     """Displays the name of the window that currently has focus"""
-
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("show_state", True, "show window status before window name"),
-        (
-            "for_current_screen",
-            False,
-            "instead of this bars screen use currently active screen",
-        ),
-        (
-            "empty_group_string",
-            " ",
-            "string to display when no windows are focused on current group",
-        ),
+        ("for_current_screen", False, "instead of this bars screen use currently active screen"),
+        ("empty_group_string", " ", "string to display when no windows are focused on current group"),
     ]
 
     def __init__(self, width=bar.STRETCH, **config):
@@ -66,17 +57,14 @@ class WindowName(base._TextBox):
             w = self.qtile.current_screen.group.current_window
         else:
             w = self.bar.screen.group.current_window
-        state = ""
+        state = ''
         if self.show_state and w is not None:
             if w.maximized:
-                state = "[] "
+                state = '[] '
             elif w.minimized:
-                state = "_ "
+                state = '_ '
             elif w.floating:
                 state = "V "
-        unescaped = "%s%s" % (
-            state,
-            w.name if w and w.name else self.empty_group_string,
-        )
+        unescaped = "%s%s" % (state, w.name if w and w.name else self.empty_group_string)
         self.text = pangocffi.markup_escape_text(unescaped)
         self.bar.draw()

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -32,9 +32,9 @@ class WindowName(base._TextBox):
     """Displays the name of the window that currently has focus"""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("show_state", True, "show window status before window name"),
-        ("for_current_screen", False, "instead of this bars screen use currently active screen"),
-        ("empty_group_string", " ", "string to display when no windows are focused on current group"),
+        ('show_state', True, 'show window status before window name'),
+        ('for_current_screen', False, 'instead of this bars screen use currently active screen'),
+        ('empty_group_string', ' ', 'string to display when no windows are focused on current group'),
     ]
 
     def __init__(self, width=bar.STRETCH, **config):
@@ -64,7 +64,7 @@ class WindowName(base._TextBox):
             elif w.minimized:
                 state = '_ '
             elif w.floating:
-                state = "V "
+                state = 'V '
         unescaped = "%s%s" % (state, w.name if w and w.name else self.empty_group_string)
         self.text = pangocffi.markup_escape_text(unescaped)
         self.bar.draw()


### PR DESCRIPTION
Hello,

In this PR, I've added an option for the window name widget to change the string to display when the desktop/group is empty. Previously, it was simply " ". The default is the same, but specifying empty_group_string in the config.py will allow the user to change it to whatever they wish, e.g. "Desktop".

This is my second ever PR so bear with me if I take some time to fix any needed changes.

As an aside, thanks for creating qtile! It's a great opportunity to learn/play around with python!