### PR TITLE
Allow resizing of Drawer() pt2, electric boogaloo

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -324,6 +324,13 @@ class Drawer:
             self._free_pixmap()
         self._height = height
 
+    def paint_to(self, drawer):
+        # If XCBSurface has been invalidated, we need to draw now to create it
+        if self._surface is None:
+            self.draw()
+        drawer.ctx.set_source_surface(self._surface)
+        drawer.ctx.paint()
+
     def _rounded_rect(self, x, y, width, height, linewidth):
         aspect = 1.0
         corner_radius = height / 10.0

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -626,8 +626,7 @@ class Mirror(_Widget):
             self._length = self.length
             self.bar.draw()
         else:
-            self.drawer.ctx.set_source_surface(self.reflects.drawer.surface)
-            self.drawer.ctx.paint()
+            self.reflects.drawer.paint_to(self.drawer)
             self.drawer.draw(offsetx=self.offset, width=self.width)
 
     def button_press(self, x, y, button):

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -92,7 +92,7 @@ class _Graph(base._Widget):
         return self.bar.height - self.margin_y * 2 - self.border_width * 2
 
     def draw_box(self, x, y, values):
-        step = self.graphwidth / float(self.samples)
+        step = int(self.graphwidth / float(self.samples))
         self.drawer.set_source_rgb(self.graph_color)
         for val in values:
             val = self.val(val)
@@ -100,7 +100,7 @@ class _Graph(base._Widget):
             x += step
 
     def draw_line(self, x, y, values):
-        step = self.graphwidth / float(self.samples - 1)
+        step = int(self.graphwidth / float(self.samples - 1))
         self.drawer.ctx.set_line_join(cairocffi.LINE_JOIN_ROUND)
         self.drawer.set_source_rgb(self.graph_color)
         self.drawer.ctx.set_line_width(self.line_width)
@@ -110,7 +110,7 @@ class _Graph(base._Widget):
         self.drawer.ctx.stroke()
 
     def draw_linefill(self, x, y, values):
-        step = self.graphwidth / float(self.samples - 2)
+        step = int(self.graphwidth / float(self.samples - 2))
         self.drawer.ctx.set_line_join(cairocffi.LINE_JOIN_ROUND)
         self.drawer.set_source_rgb(self.graph_color)
         self.drawer.ctx.set_line_width(self.line_width)


### PR DESCRIPTION
drawer.width is set in Popup when the Popup's width changes.
Unfortunately, the underlying drawing surface on X(pixmap) is not
resized. It doesn't seem like they can be resized after reading the x
proto docs. Cairo to the rescue! Cairo implements a RecordingSurface
that we can use locally while the underlying Drawable may not be
accessible. These changes make the Drawer write to a RecordingSurface
and only copy to the pixmap on Drawer.draw.

This also fixes our random segfaults in CI since the XCBSurface is
created on draw instead of on __init__