### PR TITLE
Columns: make margin_on_single accept ints

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,8 @@ Qtile X.X.X, released XXXX-XX-XX:
           AND-semantics, allowing for more complex and specific rules
         - Python 3.9 support
         - switch to Github Actions for CI
+        - Columns layout has new `margin_on_single` option to specify margin
+          size when there is only one window (default -1: use `margin` option).
     !!! warning !!!
         - When (re)starting, Qtile passes its state to the new process in a
           file now, where previously it passed state directly as a string. This

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -118,7 +118,7 @@ class Columns(Layout):
         ("border_width", 2, "Border width."),
         ("border_on_single", False, "Draw a border when there is one only window."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])."),
-        ("margin_on_single", False, "Add margin to the layout for only one window."),
+        ("margin_on_single", -1, "Margin when only one window. `-1` means use `margin`."),
         ("split", True, "New columns presentation mode."),
         ("num_columns", 2, "Preferred number of columns."),
         ("grow_amount", 10, "Amount by which to grow a window/column."),
@@ -225,17 +225,16 @@ class Columns(Layout):
             color = self.border_focus if col.split else self.border_focus_stack
         else:
             color = self.border_normal if col.split else self.border_normal_stack
-        if not self.border_on_single and len(self.columns) == 1 and (len(col) == 1 or not col.split):
-            border = 0
-        else:
-            border = self.border_width
+        border = self.border_width
+        margin_size = self.margin
+        if len(self.columns) == 1 and (len(col) == 1 or not col.split):
+            if not self.border_on_single:
+                border = 0
+            if self.margin_on_single > -1:
+                margin_size = self.margin_on_single
         width = int(
             0.5 + col.width * screen_rect.width * 0.01 / len(self.columns))
         x = screen_rect.x + int(0.5 + pos * screen_rect.width * 0.01 / len(self.columns))
-        if not self.margin_on_single and len(self.columns) == 1 and (len(col) == 1 or not col.split):
-            margin_size = 0
-        else:
-            margin_size = self.margin
         if col.split:
             pos = 0
             for c in col:


### PR DESCRIPTION
This makes the `margin_on_single` Columns option, rather than accepting
a boolean to specify whether it should have margins or use those set my
`margin`, accept an `int` so that different margins can be set on single
windows. `-1` can be used to tell the layout to use that specified by
`margins`, which until the previous commit would be default behaviour,
so this restores that.

This commit also adds the setting to the changelog.