### PR TITLE
ThreadedPollText: suppress exception when no loop

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -511,6 +511,12 @@ class ThreadedPollText(InLoopPollText):
                 text = self.poll()
                 if self.qtile is not None:
                     self.qtile.call_soon_threadsafe(self.update, text)
+            except RuntimeError:
+                logger.debug(
+                    'problem polling to update widget %s (ignoring, this is '
+                    'most likely because the event loop has finalize already)',
+                    exc_info=True,
+                )
             except:  # noqa: E722
                 logger.exception("problem polling to update widget %s", self.name)
         # TODO: There are nice asyncio constructs for this sort of thing, I


### PR DESCRIPTION
Reported by ramnes: this exception can happen when the thread attempt to
call qtile.call_soon_threadsafe after the event loop has already been
finalized. This was always happening, but the exception was being lost
before the lifecycle changes.