### PR TITLE
Try to fix CI

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -958,13 +958,13 @@ class Painter:
             root_pixmap = root_pixmap[0]
         else:
             root_pixmap = self.conn.generate_id()
-            self.conn.core.CreatePixmap(
+            self.conn.core.CreatePixmapChecked(
                 self.default_screen.root_depth,
                 root_pixmap,
                 self.default_screen.root.wid,
                 self.default_screen.width_in_pixels,
                 self.default_screen.height_in_pixels,
-            )
+            ).check()
 
         for depth in self.default_screen.allowed_depths:
             for visual in depth.visuals:

--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -217,14 +217,14 @@ class Drawer:
         self.pixmap = self.qtile.conn.conn.generate_id()
         self.gc = self.qtile.conn.conn.generate_id()
 
-        self.qtile.conn.conn.core.CreatePixmap(
+        self.qtile.conn.conn.core.CreatePixmapChecked(
             self.qtile.conn.default_screen.root_depth,
             self.pixmap,
             self.wid,
             self.width,
             self.height
-        )
-        self.qtile.conn.conn.core.CreateGC(
+        ).check()
+        self.qtile.conn.conn.core.CreateGCChecked(
             self.gc,
             self.wid,
             xcffib.xproto.GC.Foreground | xcffib.xproto.GC.Background,
@@ -232,7 +232,7 @@ class Drawer:
                 self.qtile.conn.default_screen.black_pixel,
                 self.qtile.conn.default_screen.white_pixel
             ]
-        )
+        ).check()
         self.surface = cairocffi.XCBSurface(
             qtile.conn.conn,
             self.pixmap,


### PR DESCRIPTION
This fixes our spurious CI failures directly. During our tests, we
sometimes attempt to draw before external resources are ready. This only
creates the external resources when they are actually used.