### PR TITLE
Retire deprecated Qtile.cmd_get_info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ Qtile X.X.X, released XXXX-XX-XX:
           forseeable future, but will be eventually deprecated. qtile prints a
           warning when run in this configuration.
         - Qtile.cmd_focus_by_click is no longer an available command.
+        - Qtile.cmd_get_info is no longer an available command.
     * features
         - new WidgetBox widget
         - new restart and shutdown hooks

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -917,11 +917,6 @@ class Qtile(CommandObject):
         """
         return {i.name: i.info() for i in self.groups}
 
-    def cmd_get_info(self):
-        """Prints info for all groups"""
-        warnings.warn("The `get_info` command is deprecated, use `groups`", DeprecationWarning)
-        return self.cmd_groups()
-
     def get_mouse_position(self):
         return self.mouse_position
 


### PR DESCRIPTION
This function was deprecated in 2016 so can be removed now.