### PR TITLE
Add new groups when too few for number of screens

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -112,9 +112,7 @@ class Qtile(CommandObject):
             warnings.warn("Defining a main function is deprecated, use libqtile.qtile", DeprecationWarning)
             self.config.main(self)
 
-        if self.config.groups:
-            self.dgroups = DGroups(self, self.config.groups,
-                                   self.config.dgroups_key_binder)
+        self.dgroups = DGroups(self, self.config.groups, self.config.dgroups_key_binder)
 
         if self.config.widget_defaults:
             _Widget.global_defaults = self.config.widget_defaults
@@ -288,9 +286,15 @@ class Qtile(CommandObject):
             if not self.current_screen:
                 self.current_screen = scr
 
-            scr._configure(
-                self, i, x, y, w, h, self.groups[i],
-            )
+            if len(self.groups) < i + 1:
+                name = f"autogen_{i + 1}"
+                self.add_group(name)
+                grp = self.groups[i]
+                logger.warning(f"Too few groups in config. Added group: {name}")
+            else:
+                grp = self.groups[i]
+
+            scr._configure(self, i, x, y, w, h, grp)
             self.screens.append(scr)
 
     def paint_screen(self, screen, image_path, mode=None):

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -215,6 +215,17 @@ def test_keypress(manager):
     assert manager.c.groups()["a"]["focus"] == "one"
 
 
+class TooFewGroupsConfig(ManagerConfig):
+    groups = []
+
+
+@pytest.mark.parametrize("manager", [TooFewGroupsConfig], indirect=True)
+@pytest.mark.parametrize("xephyr", [{"xinerama": True}, {"xinerama": False}], indirect=True)
+def test_too_few_groups(manager):
+    assert manager.c.groups()
+    assert len(manager.c.groups()) == len(manager.c.screens())
+
+
 class _ChordsConfig(Config):
     groups = [
         libqtile.config.Group("a")


### PR DESCRIPTION
This makes Qtile create more groups when setting up if there are fewer
groups than there are screens. Fixes #475.