### PR TITLE
pytest-runner is deprecated, remove.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,14 @@ passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
-    pytest-runner
+    pytest >= 6.2.1
+    pytest-cov >= 2.10.1
     setuptools >= 40.5.0
     xcffib >= 0.8.1
 commands =
-    python3 setup.py pytest --addopts "-Wall --cov libqtile --cov-report term-missing {posargs}"
+    python3 setup.py install
+    {toxinidir}/scripts/ffibuild
+    python3 -m pytest -Wall --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
pytest-runner depends on deprecated features in setuptools per
https://pypi.org/project/pytest-runner/. This removes it without any
other effects.