### PR TITLE
Fix task is not callable: pytype

### DIFF
--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -47,7 +47,7 @@ class QtileLoop(contextlib.AbstractAsyncContextManager):
         for task in pending:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task()
+                await task
 
     def _setup_glib_loop(self):
         # This is a little strange. python-dbus internally depends on gobject,


### PR DESCRIPTION
Accidentally added () to task out of habit. This works at runtime
because all of the tasks are cancelled and raise a CancelledError
anyways.