### PR TITLE
CHANGELOG: add a note about ThreadedPollText removal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,8 @@ Qtile X.X.X, released XXXX-XX-XX:
         - Qtile.cmd_get_info is no longer an available command.
         - libqtile.command_* has been deprecated, it has been moved to
           libqtile.command.*
+        - libqtile.widget.base.ThreadedPollText has been removed; out of tree
+          widgets can use ThreadPoolText in the same package instead.
     * features
         - new WidgetBox widget
         - new restart and shutdown hooks


### PR DESCRIPTION
34a3b2193498 ("Remove ThreadedPollText") broke my out of tree widgets, and
I'm probably not the only one who has them. Let's add a note about this in
the CHANGELOG.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>