### PR TITLE
executable: make --log-level a "global" argument

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -1,6 +1,8 @@
 import argparse
+import logging
 import sys
 
+from libqtile.log_utils import init_log
 from libqtile.scripts import cmd_obj, run_cmd, shell, start, top
 
 try:
@@ -28,6 +30,14 @@ def main():
         action='version',
         version=VERSION,
     )
+    parser.add_argument(
+        '-l', '--log-level',
+        default='WARNING',
+        dest='log_level',
+        type=str.upper,
+        choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
+        help='Set qtile log level'
+    )
 
     subparsers = parser.add_subparsers()
     start.add_subcommand(subparsers)
@@ -43,4 +53,6 @@ def main():
     help_.set_defaults(func=print_help)
 
     options = parser.parse_args()
+    log_level = getattr(logging, options.log_level)
+    init_log(log_level=log_level, log_color=sys.stdout.isatty())
     options.func(options)

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -22,13 +22,12 @@
 # Set the locale before any widgets or anything are imported, so any widget
 # whose defaults depend on a reasonable locale sees something reasonable.
 import locale
-import logging
 from os import getenv, makedirs, path
-from sys import exit, stdout
+from sys import exit
 
 import libqtile.backend
 from libqtile import confreader
-from libqtile.log_utils import init_log, logger
+from libqtile.log_utils import logger
 
 
 def rename_process():
@@ -48,8 +47,6 @@ def rename_process():
 
 
 def make_qtile(options):
-    log_level = getattr(logging, options.log_level)
-    init_log(log_level=log_level, log_color=stdout.isatty())
     kore = libqtile.backend.get_core(options.backend)
 
     if not path.isfile(options.configfile):
@@ -119,13 +116,6 @@ def add_subcommand(subparsers):
         default=False,
         dest="no_spawn",
         help='Avoid spawning apps. (Used for restart)'
-    )
-    parser.add_argument(
-        '-l', '--log-level',
-        default='WARNING',
-        dest='log_level',
-        choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'),
-        help='Set qtile log level'
     )
     parser.add_argument(
         '--with-state',


### PR DESCRIPTION
All commands use our logging framework, so it seems reasonable to want to
set the log level for all of them with the same code. Let's just move the
bits from `qtile start` into the main function.

This patch also allows case insensitive log levels, so we can do
--log-level=debug too.

Closes #2099

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>