### PR TITLE
Fix references to `tick` in ThreadLoopPool widgets

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -113,4 +113,4 @@ class CheckUpdates(base.ThreadPoolText):
             self.timeout_add(1, self._refresh_count)
 
         else:
-            self.tick()
+            self.timer_setup()

--- a/libqtile/widget/memory.py
+++ b/libqtile/widget/memory.py
@@ -57,10 +57,6 @@ class Memory(base.ThreadPoolText):
         super().__init__("", **config)
         self.add_defaults(Memory.defaults)
 
-    def tick(self):
-        self.update(self.poll())
-        return self.update_interval
-
     def poll(self):
         mem = psutil.virtual_memory()
         swap = psutil.swap_memory()


### PR DESCRIPTION
ThreadLoopPool does not have a tick method.

CheckUpdates widget called `tick` to update text after installing
updates so this functionality is currently broken.

Memory widget has redundant tick method which can be removed.