### PR TITLE
Make ffibuild optional in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     xcffib >= 0.8.1
 commands =
     python3 setup.py install
-    {toxinidir}/scripts/ffibuild
+    - {toxinidir}/scripts/ffibuild
     python3 -m pytest -Wall --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]


### PR DESCRIPTION
On my machine, missing pulse audio makes the tests not run in tox despite pulse not being required. This makes ffibuild run and ignore if it fails