### PR TITLE
Revert "Make ffibuild optional in tox"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     xcffib >= 0.8.1
 commands =
     python3 setup.py install
-    - {toxinidir}/scripts/ffibuild
+    {toxinidir}/scripts/ffibuild
     python3 -m pytest -Wall --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]


### PR DESCRIPTION
This reverts commit 7489b44d12af55d1a86ce219a0436e404002478c.

Per discussion in #2120, if we allow build failures it may make things
harder to track down in the future. Additionally, for things that don't
themselves have tests (e.g. the pulseaudio widget right now) this serves as
at least a build test of that binding.