### PR TITLE
Implement Drawer modes

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -227,6 +227,7 @@ class Drawer:
     """
     # Default drawing mode
     MODE = DrawingMode.PM_COPY
+    FORCE_MODE = False
 
     def __init__(self, qtile, wid, width, height, mode=None):
         self.qtile = qtile
@@ -234,7 +235,7 @@ class Drawer:
         self._surface = None
         self._pixmap = None
         self._gc = None
-        self.mode = self.MODE if mode is None else mode
+        self.mode = self.MODE if mode is None or self.FORCE_MODE else mode
 
         self.surface = None
         self.ctx = None

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -114,6 +114,7 @@ class _Widget(CommandObject, configurable.Configurable):
     offsety = None
     defaults = [
         ("background", None, "Widget background color"),
+        ("drawing_mode", drawer.DrawingMode.PM_COPY, "Drawing Method"),
         ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
     ]  # type: List[Tuple[str, Any, str]]
 
@@ -197,7 +198,8 @@ class _Widget(CommandObject, configurable.Configurable):
             qtile,
             self.win.wid,
             self.bar.width,
-            self.bar.height
+            self.bar.height,
+            mode=self.drawing_mode,
         )
         if not self.configured:
             self.configured = True

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -38,6 +38,7 @@ from os import statvfs
 import cairocffi
 import psutil
 
+from libqtile import drawer
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -67,8 +68,13 @@ class _Graph(base._Widget):
         ("start_pos", "bottom", "Drawer starting position ('bottom'/'top')"),
     ]
 
-    def __init__(self, width=100, **config):
-        base._Widget.__init__(self, width, **config)
+    def __init__(
+        self,
+        width=100,
+        drawing_mode=drawer.DrawingMode.DIRECT,
+        **config
+    ):
+        base._Widget.__init__(self, width, drawing_mode=drawing_mode, **config)
         self.add_defaults(_Graph.defaults)
         self.values = [0] * self.samples
         self.maxvalue = 0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,7 +37,7 @@ import xcffib.testing
 import xcffib.xproto
 
 import libqtile.config
-from libqtile import command, ipc
+from libqtile import command, drawer, ipc
 from libqtile.backend.x11.core import Core
 from libqtile.confreader import Config
 from libqtile.core.manager import Qtile
@@ -461,6 +461,16 @@ class TestManager:
                 assert screens[scrn]["group"] == g["name"]
         assert len(seen) == len(screens), "Not all screens \
         had an attached group."
+
+
+@pytest.fixture(scope="session", autouse=True)
+def drawer_test_mode():
+    oldmode = drawer.Drawer.MODE
+    drawer.Drawer.MODE = drawer.DrawingMode.TEST
+    drawer.Drawer.FORCE_MODE = True
+    yield
+    drawer.Drawer.MODE = oldmode
+    drawer.Drawer.FORCE_MODE = False
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This allows us to more finely control how widgets draw themselves to the
screen. We can either TEST by not sending anything to X at all, draw
DIRECTly to the window(good for graphs and other animations whose contents
change between every draw() call), or draw the old way with PM_COPY(good
for things that do not change their contents much).

Please let me know if you think an approach that uses different Drawer subclasses would be better...but imo there's so much shared code and such small differences it might be messier.