### PR TITLE
Fixed xephyr script

### DIFF
--- a/scripts/xephyr
+++ b/scripts/xephyr
@@ -13,7 +13,7 @@ Xephyr +extension RANDR -screen ${SCREEN_SIZE} ${XDISPLAY} -ac &
 XEPHYR_PID=$!
 (
   sleep 1
-  env DISPLAY=${XDISPLAY} QTILE_XEPHYR=1 ${PYTHON} "${HERE}"/../bin/qtile start -l ${LOG_LEVEL} $@ &
+  env DISPLAY=${XDISPLAY} QTILE_XEPHYR=1 ${PYTHON} "${HERE}"/../bin/qtile -l ${LOG_LEVEL} start $@ &
   QTILE_PID=$!
   env DISPLAY=${XDISPLAY} ${APP} &
   wait $QTILE_PID


### PR DESCRIPTION
Update xephyr script to run without `qtile: error: unrecognized arguments: -l INFO` error. Should address https://github.com/qtile/qtile/issues/2130