### PR TITLE
fix bar MotionNotify handler

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -335,7 +335,7 @@ class Bar(Gap, configurable.Configurable):
 
     def handle_MotionNotify(self, e):  # noqa: N802
         widget = self.get_widget_in_position(e)
-        if widget and widget is not self.cursor_in:
+        if widget and self.cursor_in and widget is not self.cursor_in:
             self.cursor_in.mouse_leave(
                 e.event_x - self.cursor_in.offsetx,
                 e.event_y - self.cursor_in.offsety,


### PR DESCRIPTION
I have a lot of stack traces like:

021-01-21 18:40:52,441 ERROR libqtile core.py:_xpoll():L295 Got an exception in poll loop
Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/backend/x11/core.py", line 263, in _xpoll
    ret = target(event)
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/bar.py", line 339, in handle_MotionNotify
    self.cursor_in.mouse_leave(
AttributeError: 'NoneType' object has no attribute 'mouse_leave'

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>