### PR TITLE
Give a common parent parser to the subparsers (and main parser)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Qtile 0.x.x, released xxxx-xx-xx:
-    * !!! Dependency update !!!
+    !!! Config breakage !!!
+        - The `qtile` entry point doesn't run `qtile start` by default anymore
         - New optional dependency for dbus related features: dbus-next.
           Replaces previous reliance on dbus/Glib and allows qtile to use async
           dbus calls within asyncio's eventloop.

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -128,8 +128,12 @@ def check_config(args):
     print("config file can be loaded by qtile")
 
 
-def add_subcommand(subparsers):
-    parser = subparsers.add_parser("check", help="Check a configuration file for errors")
+def add_subcommand(subparsers, parents):
+    parser = subparsers.add_parser(
+        "check",
+        parents=parents,
+        help="Check a configuration file for errors"
+    )
     parser.add_argument(
         "-c", "--config",
         action="store",

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -187,7 +187,7 @@ def cmd_obj(args) -> None:
         sys.exit(1)
 
 
-def add_subcommand(subparsers):
+def add_subcommand(subparsers, parents):
     epilog = textwrap.dedent('''\
     Examples:
      qtile cmd-obj
@@ -196,7 +196,8 @@ def add_subcommand(subparsers):
      qtile cmd-obj -o cmd -f prev_layout -a 3 # prev_layout on group 3
      qtile cmd-obj -o group 3 -f focus_back''')
     description = 'qtile.command functionality exposed to the shell.'
-    parser = subparsers.add_parser("cmd-obj", help=description, epilog=epilog,
+    parser = subparsers.add_parser("cmd-obj", help=description,
+                                   parents=parents, epilog=epilog,
                                    formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--object', '-o', dest='obj_spec', nargs='+',
                         help='Specify path to object (space separated).  '

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -28,7 +28,7 @@ def main():
         description='A full-featured, pure-Python tiling window manager.',
     )
     main_parser.add_argument(
-        '--version',
+        '-v', '--version',
         action='version',
         version=VERSION,
     )

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -13,24 +13,8 @@ except (pkg_resources.DistributionNotFound, ImportError):
 
 
 def main():
-    # backward compat hack: `qtile` with no args (or non-subcommand args)
-    # should default to `qtile start`. it seems impolite for commands to do
-    # nothing when run with no args, so let's warn about this being deprecated.
-    if len(sys.argv) == 1:
-        print("please move to `qtile start` as your qtile invocation, "
-              "instead of just `qtile`; this default will be removed Soon(TM)")
-        sys.argv.insert(1, "start")
-
-    parser = argparse.ArgumentParser(
-        prog='qtile',
-        description='A full-featured, pure-Python tiling window manager.',
-    )
-    parser.add_argument(
-        '--version',
-        action='version',
-        version=VERSION,
-    )
-    parser.add_argument(
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
         '-l', '--log-level',
         default='WARNING',
         dest='log_level',
@@ -39,22 +23,44 @@ def main():
         help='Set qtile log level'
     )
 
-    subparsers = parser.add_subparsers()
-    start.add_subcommand(subparsers)
-    shell.add_subcommand(subparsers)
-    top.add_subcommand(subparsers)
-    run_cmd.add_subcommand(subparsers)
-    cmd_obj.add_subcommand(subparsers)
-    check.add_subcommand(subparsers)
-    migrate.add_subcommand(subparsers)
+    # TODO: remove the parents=[parent_parser], line when we remove the
+    # backward compatibility hack below
+    main_parser = argparse.ArgumentParser(
+        prog='qtile',
+        parents=[parent_parser],
+        description='A full-featured, pure-Python tiling window manager.',
+    )
+    main_parser.add_argument(
+        '--version',
+        action='version',
+        version=VERSION,
+    )
+
+    subparsers = main_parser.add_subparsers()
+    start.add_subcommand(subparsers, [parent_parser])
+    shell.add_subcommand(subparsers, [parent_parser])
+    top.add_subcommand(subparsers, [parent_parser])
+    run_cmd.add_subcommand(subparsers, [parent_parser])
+    cmd_obj.add_subcommand(subparsers, [parent_parser])
+    check.add_subcommand(subparsers, [parent_parser])
+    migrate.add_subcommand(subparsers, [parent_parser])
 
     # `qtile help` should print help
     def print_help(options):
-        parser.print_help()
+        main_parser.print_help()
     help_ = subparsers.add_parser("help", help="Print help information and exit")
     help_.set_defaults(func=print_help)
 
-    options = parser.parse_args()
+    options = main_parser.parse_args()
     log_level = getattr(logging, options.log_level)
     init_log(log_level=log_level, log_color=sys.stdout.isatty())
-    options.func(options)
+
+    # backward compat hack: `qtile` with no args (or non-subcommand args)
+    # should default to `qtile start`. it seems impolite for commands to do
+    # nothing when run with no args, so let's warn about this being deprecated.
+    try:
+        options.func(options)
+    except AttributeError:
+        print("please move to `qtile start` as your qtile invocation, "
+              "instead of just `qtile`; this default will be removed Soon(TM)")
+        start.start(options)

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -23,11 +23,8 @@ def main():
         help='Set qtile log level'
     )
 
-    # TODO: remove the parents=[parent_parser], line when we remove the
-    # backward compatibility hack below
     main_parser = argparse.ArgumentParser(
         prog='qtile',
-        parents=[parent_parser],
         description='A full-featured, pure-Python tiling window manager.',
     )
     main_parser.add_argument(
@@ -52,15 +49,9 @@ def main():
     help_.set_defaults(func=print_help)
 
     options = main_parser.parse_args()
-    log_level = getattr(logging, options.log_level)
-    init_log(log_level=log_level, log_color=sys.stdout.isatty())
-
-    # backward compat hack: `qtile` with no args (or non-subcommand args)
-    # should default to `qtile start`. it seems impolite for commands to do
-    # nothing when run with no args, so let's warn about this being deprecated.
     try:
+        log_level = getattr(logging, options.log_level)
+        init_log(log_level=log_level, log_color=sys.stdout.isatty())
         options.func(options)
     except AttributeError:
-        print("please move to `qtile start` as your qtile invocation, "
-              "instead of just `qtile`; this default will be removed Soon(TM)")
-        start.start(options)
+        main_parser.print_usage()

--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -95,9 +95,11 @@ def do_migrate(args):
         m(args.config).execute(interactive=args.interactive, write=True)
 
 
-def add_subcommand(subparsers):
+def add_subcommand(subparsers, parents):
     parser = subparsers.add_parser(
-        "migrate", help="Migrate a configuration file to the current API"
+        "migrate",
+        parents=parents,
+        help="Migrate a configuration file to the current API"
     )
     parser.add_argument(
         "-c",

--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -57,8 +57,12 @@ def run_cmd(opts) -> None:
     proc.wait()
 
 
-def add_subcommand(subparsers):
-    parser = subparsers.add_parser("run-cmd", help="A wrapper around the command graph")
+def add_subcommand(subparsers, parents):
+    parser = subparsers.add_parser(
+        "run-cmd",
+        parents=parents,
+        help="A wrapper around the command graph"
+    )
     parser.add_argument(
         '-s',
         '--socket',

--- a/libqtile/scripts/shell.py
+++ b/libqtile/scripts/shell.py
@@ -36,8 +36,12 @@ def qshell(args) -> None:
         qsh.loop()
 
 
-def add_subcommand(subparsers):
-    parser = subparsers.add_parser("shell", help="shell-like interface to qtile")
+def add_subcommand(subparsers, parents):
+    parser = subparsers.add_parser(
+        "shell",
+        parents=parents,
+        help="shell-like interface to qtile"
+    )
     parser.add_argument(
         "-s", "--socket",
         action="store", type=str,

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -93,8 +93,12 @@ def start(options):
     logger.info('Exiting...')
 
 
-def add_subcommand(subparsers):
-    parser = subparsers.add_parser("start", help="Start the window manager")
+def add_subcommand(subparsers, parents):
+    parser = subparsers.add_parser(
+        "start",
+        parents=parents,
+        help="Start the window manager"
+    )
     parser.add_argument(
         "-c", "--config",
         action="store",

--- a/libqtile/scripts/top.py
+++ b/libqtile/scripts/top.py
@@ -175,9 +175,10 @@ def top(opts):
         raw_stats(c, limit=lines, force_start=force_start)
 
 
-def add_subcommand(subparsers):
-    parser = subparsers.add_parser("top", help="resource usage information")
-    parser.add_argument('-l', '--lines', type=int, dest="lines", default=10,
+def add_subcommand(subparsers, parents):
+    parser = subparsers.add_parser("top", parents=parents,
+                                   help="resource usage information")
+    parser.add_argument('-L', '--lines', type=int, dest="lines", default=10,
                         help='Number of lines.')
     parser.add_argument('-r', '--raw', dest="raw", action="store_true",
                         default=False, help='Output raw without curses')


### PR DESCRIPTION
By doing so, we can give the --logging flag to any sub-command in a more intuitive way, i.e. after the sub-command and not before it (see the discussion in #2133), while keeping `qtile -l DEBUG` functional (see #2099) as a backward compatibility hack.

This approach has a downside though: `qtile -l DEBUG start` will be a valid command but won't act as expected (the log level will stay the default one, INFO). But this command will get invalid as soon as we remove that backward compatibility hack.

Note: we can probably make `qtile -l DEBUG start` invalid with yet another hack but I thought it was acceptable as-is since the backward compatibility with no sub-command is not meant to stay. Feel free to tell me if you think the opposite.