### PR TITLE
Smarter floating

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -570,8 +570,8 @@ class Match:
         matches against the _NET_WM_PID atom (only int allowed for this
         rule)
     func:
-        matches against the given function, which receives the client as only
-        argument
+        delegate the match to the given function, which receives the tested
+        client as argument and must return True if it matches, False otherwise
     """
     def __init__(self, title=None, wm_class=None, role=None, wm_type=None,
                  wm_instance_class=None, net_wm_pid=None,

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -53,6 +53,7 @@ class Floating(Layout):
         Match(wm_class='notification'),
         Match(wm_class='splash'),
         Match(wm_class='toolbar'),
+        Match(func=lambda c: c.has_fixed_size())
     ]
 
     defaults = [

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -227,6 +227,17 @@ class _Window(CommandObject):
     def has_focus(self):
         return self == self.qtile.current_window
 
+    def has_fixed_size(self):
+        try:
+            if ('PMinSize' in self.hints['flags'] and
+                    'PMaxSize' in self.hints['flags'] and
+                    0 < self.hints["min_width"] == self.hints["max_width"] and
+                    0 < self.hints["min_height"] == self.hints["max_height"]):
+                return True
+        except KeyError:
+            pass
+        return False
+
     def has_user_set_position(self):
         try:
             if 'USPosition' in self.hints['flags'] or 'PPosition' in self.hints['flags']:


### PR DESCRIPTION
[As noted by @pmkap in #1518](https://github.com/qtile/qtile/issues/1518#issuecomment-619381672), i3 floating defaults are quite good and the main difference with ours is a check of the size hints to see if the window has a fixed size. This is a great way to match windows that are complete desktop applications but still meant to float, like gnome-screenshot, so let's do it too. :)