### PR TITLE
Add dependencies for static analysis/docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
             - run: |
                 sudo apt update
-                sudo apt install graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors
+                sudo apt install libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors
                 pip install tox tox-gh-actions
               name: install dependencies
             - name: run tests


### PR DESCRIPTION
Because of the missing system libraries we were skipping static analysis for
dbus/gi related things, as well as not generating the relevant
documentation in CI.