### PR TITLE
Fix issue #2173

### DIFF
--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -39,8 +39,8 @@ class KeyboardLayout(base.InLoopPollText):
     and bind function "next_keyboard" to specific keys in order to change layouts.
 
     For example:
-        Key([mod], "space", lazy.widget["keyboardlayout"].next_keyboard(), desc="Next keyboard layout."),
 
+        Key([mod], "space", lazy.widget["keyboardlayout"].next_keyboard(), desc="Next keyboard layout."),
 
     It requires setxkbmap to be available in the system.
     """

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -60,6 +60,8 @@ class KeyboardLayout(base.InLoopPollText):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(KeyboardLayout.defaults)
 
+        self.keyboard = self.configured_keyboards[0]
+
         self.add_callbacks({'Button1': self.next_keyboard})
 
     def next_keyboard(self):


### PR DESCRIPTION
Fixes: #2173 
When I was looking through the code I realized that setxkbmap options
and even keyboard layouts themselves are not set until the first run of `next_keyboard` function which calls keyboard setter.

I solved this by simply setting the keyboard to the first one from the list of predefined `configured_keyboards`, after the initialization of widget.

I also added one newline in widget documentation in hope to format code example as code block.