### PR TITLE
Only respect WM_SIZE_HINTS limits if the proper flags are set

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -986,10 +986,16 @@ class Window(_Window):
         if new_float_state == MINIMIZED:
             self.hide()
         else:
-            width = max(self.width, self.hints.get('min_width', 0))
-            width = min(width, self.hints.get('max_width', 0)) or width
-            height = max(self.height, self.hints.get('min_height', 0))
-            height = min(height, self.hints.get('max_height', 0)) or height
+            width = self.width
+            height = self.height
+
+            flags = self.hints.get("flags", {})
+            if "PMinSize" in flags:
+                width = max(self.width, self.hints.get('min_width', 0))
+                height = max(self.height, self.hints.get('min_height', 0))
+            if "PMaxSize" in flags:
+                width = min(width, self.hints.get('max_width', 0)) or width
+                height = min(height, self.hints.get('max_height', 0)) or height
 
             if self.hints['base_width'] and self.hints['width_inc']:
                 width_adjustment = (width - self.hints['base_width']) % self.hints['width_inc']

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -59,6 +59,7 @@ def test_min_size_hint(manager):
 
         # set the size hints
         hints = [0] * 18
+        hints[0] = xcbq.NormalHintsFlags["PMinSize"]
         hints[5] = hints[6] = 100
         w.set_property("WM_NORMAL_HINTS", hints, type="WM_SIZE_HINTS", format=32)
         w.map()
@@ -84,7 +85,78 @@ def test_min_size_hint(manager):
 
 
 @bare_config
+def test_min_size_hint_no_flag(manager):
+    w = None
+    conn = xcbq.Connection(manager.display)
+
+    def size_hints():
+        nonlocal w
+        w = conn.create_window(0, 0, 100, 100)
+
+        # set the size hints
+        hints = [0] * 18
+        hints[5] = hints[6] = 100
+        w.set_property("WM_NORMAL_HINTS", hints, type="WM_SIZE_HINTS", format=32)
+        w.map()
+        conn.conn.flush()
+
+    try:
+        manager.create_window(size_hints)
+        manager.c.window.enable_floating()
+        print(w.get_wm_normal_hints())
+        assert manager.c.window.info()['width'] == 100
+        assert manager.c.window.info()['height'] == 100
+
+        manager.c.window.set_size_floating(50, 50)
+        assert manager.c.window.info()['width'] == 50
+        assert manager.c.window.info()['height'] == 50
+
+        manager.c.window.set_size_floating(200, 200)
+        assert manager.c.window.info()['width'] == 200
+        assert manager.c.window.info()['height'] == 200
+    finally:
+        w.kill_client()
+        conn.finalize()
+
+
+@bare_config
 def test_max_size_hint(manager):
+    w = None
+    conn = xcbq.Connection(manager.display)
+
+    def size_hints():
+        nonlocal w
+        w = conn.create_window(0, 0, 100, 100)
+
+        # set the size hints
+        hints = [0] * 18
+        hints[0] = xcbq.NormalHintsFlags["PMaxSize"]
+        hints[7] = hints[8] = 100
+        w.set_property("WM_NORMAL_HINTS", hints, type="WM_SIZE_HINTS", format=32)
+        w.map()
+        conn.conn.flush()
+
+    try:
+        manager.create_window(size_hints)
+        manager.c.window.enable_floating()
+        print(w.get_wm_normal_hints())
+        assert manager.c.window.info()['width'] == 100
+        assert manager.c.window.info()['height'] == 100
+
+        manager.c.window.set_size_floating(50, 50)
+        assert manager.c.window.info()['width'] == 50
+        assert manager.c.window.info()['height'] == 50
+
+        manager.c.window.set_size_floating(200, 200)
+        assert manager.c.window.info()['width'] == 100
+        assert manager.c.window.info()['height'] == 100
+    finally:
+        w.kill_client()
+        conn.finalize()
+
+
+@bare_config
+def test_max_size_hint_no_flag(manager):
     w = None
     conn = xcbq.Connection(manager.display)
 
@@ -111,8 +183,8 @@ def test_max_size_hint(manager):
         assert manager.c.window.info()['height'] == 50
 
         manager.c.window.set_size_floating(200, 200)
-        assert manager.c.window.info()['width'] == 100
-        assert manager.c.window.info()['height'] == 100
+        assert manager.c.window.info()['width'] == 200
+        assert manager.c.window.info()['height'] == 200
     finally:
         w.kill_client()
         conn.finalize()
@@ -129,6 +201,7 @@ def test_both_size_hints(manager):
 
         # set the size hints
         hints = [0] * 18
+        hints[0] = xcbq.NormalHintsFlags["PMinSize"] | xcbq.NormalHintsFlags["PMaxSize"]
         hints[5] = hints[6] = hints[7] = hints[8] = 100
         w.set_property("WM_NORMAL_HINTS", hints, type="WM_SIZE_HINTS", format=32)
         w.map()


### PR DESCRIPTION
Some applications (e.g. emacsclient) set a minimum or maximum size but do not set the corresponding flag. In such a situation, respecting the flags and only considering limits that do have a flag seems to be the expected behavior.