### PR TITLE
Finalize core

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -5,6 +5,10 @@ from libqtile import config
 
 
 class Core(metaclass=ABCMeta):
+    @abstractmethod
+    def finalize(self):
+        """Destructor/Clean up resources"""
+
     @property
     @abstractmethod
     def display_name(self) -> str:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -280,6 +280,8 @@ class Qtile(CommandObject):
                         bar.finalize()
         except:  # noqa: E722
             logger.exception('exception during finalize')
+        finally:
+            self.core.finalize()
 
     def _process_fake_screens(self):
         """

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -281,6 +281,7 @@ class Qtile(CommandObject):
         except:  # noqa: E722
             logger.exception('exception during finalize')
         finally:
+            hook.clear()
             self.core.finalize()
 
     def _process_fake_screens(self):

--- a/test/backend/test_backend.py
+++ b/test/backend/test_backend.py
@@ -5,9 +5,9 @@ from libqtile.utils import QtileError
 
 
 def test_get_core_x11(manager_nospawn):
-    get_core('x11', manager_nospawn.display)
+    get_core('x11', manager_nospawn.display).finalize()
 
 
 def test_get_core_bad(manager_nospawn):
     with pytest.raises(QtileError):
-        get_core("NonBackend")
+        get_core("NonBackend").finalize()

--- a/test/backend/x11/test_xcore.py
+++ b/test/backend/x11/test_xcore.py
@@ -3,14 +3,17 @@ from libqtile.backend.x11 import core
 
 def test_keys(manager_nospawn):
     xc = core.Core(manager_nospawn.display)
-    assert "a" in xc.get_keys()
-    assert "shift" in xc.get_modifiers()
+    try:
+        assert "a" in xc.get_keys()
+        assert "shift" in xc.get_modifiers()
+    finally:
+        xc.finalize()
 
 
 def test_no_two_qtiles(manager):
     try:
-        core.Core(manager.display)
+        core.Core(manager.display).finalize()
     except core.ExistingWMException:
         pass
     else:
-        raise Exception("excpected an error on multiple qtiles connecting")
+        raise Exception("expected an error on multiple qtiles connecting")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -229,13 +229,14 @@ class Xephyr:
         if can_connect_x11(self.display, ok=lambda: self.proc.poll() is None):
             return
 
-        # we wern't able to get a display up
+        # we weren't able to get a display up
         if self.proc.poll() is None:
-            raise AssertionError("Unable to conncet to running Xephyr")
+            raise AssertionError("Unable to connect to running Xephyr")
         else:
-            raise AssertionError("Unable to start Xephyr, quit with return code {:d}".format(
-                self.proc.returncode
-            ))
+            raise AssertionError(
+                "Unable to start Xephyr, quit with return code "
+                f"{self.proc.returncode}"
+            )
 
     def stop_xephyr(self):
         """Stop the Xephyr instance"""
@@ -473,7 +474,7 @@ def xvfb():
         yield
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def xephyr(request, xvfb):
     kwargs = getattr(request, "param", {})
 

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -331,13 +331,12 @@ class IncompatibleWidgetConf(libqtile.confreader.Config):
 
 
 def test_incompatible_widget(manager_nospawn):
-    config = IncompatibleWidgetConf
-
     # Ensure that adding a widget that doesn't support the orientation of the
     # bar raises ConfigError
+    m = manager_nospawn.create_manager(IncompatibleWidgetConf)
     with pytest.raises(libqtile.confreader.ConfigError):
-        m = manager_nospawn.create_manager(config)
         m._configure()
+    m.core.finalize()
 
 
 def test_basic(manager_nospawn):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -32,19 +32,22 @@ tests_dir = os.path.dirname(os.path.realpath(__file__))
 
 def test_validate():
     xc = Core()
-    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
-    f.load()
-    f.keys[0].key = "nonexistent"
-    with pytest.raises(confreader.ConfigError):
-        f.validate()
+    try:
+        f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
+        f.load()
+        f.keys[0].key = "nonexistent"
+        with pytest.raises(confreader.ConfigError):
+            f.validate()
 
-    f.keys[0].key = "x"
-    f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
-    f.load()
-    f.keys[0].modifiers = ["nonexistent"]
-    with pytest.raises(confreader.ConfigError):
-        f.validate()
-    f.keys[0].modifiers = ["shift"]
+        f.keys[0].key = "x"
+        f = confreader.Config(os.path.join(tests_dir, "configs", "basic.py"), xc)
+        f.load()
+        f.keys[0].modifiers = ["nonexistent"]
+        with pytest.raises(confreader.ConfigError):
+            f.validate()
+        f.keys[0].modifiers = ["shift"]
+    finally:
+        xc.finalize()
 
 
 def test_syntaxerr():


### PR DESCRIPTION
Broke these out from https://github.com/qtile/qtile/pull/2107. This improves our finalization process by cleaning up things like window properties and hooks on shutdown. It allowed me to make xephyr a session level fixture, which seems to fix the spurious xephyr xcb connection issues that occur sometimes.