### PR TITLE
Make Drawer support multiple backends

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -2,12 +2,17 @@ import typing
 from abc import ABCMeta, abstractmethod
 
 from libqtile import config
+from libqtile.drawer import DrawerBackend
 
 
 class Core(metaclass=ABCMeta):
     @abstractmethod
     def finalize(self):
         """Destructor/Clean up resources"""
+
+    @abstractmethod
+    def get_drawer_backend(self, wid, *args, **kwargs) -> DrawerBackend:
+        pass
 
     @property
     @abstractmethod
@@ -41,3 +46,7 @@ class Core(metaclass=ABCMeta):
     @abstractmethod
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
+
+    @abstractmethod
+    def update_net_desktops(self, groups, index: int) -> None:
+        pass

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -30,6 +30,7 @@ import xcffib.xproto
 from libqtile import config, hook, utils, window
 from libqtile.backend import base
 from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11.drawer import X11DrawerBackend
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -160,6 +161,9 @@ class Core(base.Core):
         ).check()
         self.qtile = None
         self.conn.finalize()
+
+    def get_drawer_backend(self, wid, *args, **kwargs):
+        return X11DrawerBackend(self.conn, wid, *args, **kwargs)
 
     def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
         """Get the screen information for the current connection"""

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -1,0 +1,74 @@
+import cairocffi
+import xcffib.xproto
+
+from libqtile.drawer import DrawerBackend
+
+
+class X11DrawerBackend(DrawerBackend):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._gc = self.connection.conn.generate_id()
+        self.connection.conn.core.CreateGCChecked(
+            self._gc,
+            self.wid,
+            xcffib.xproto.GC.Foreground | xcffib.xproto.GC.Background,
+            [
+                self.connection.default_screen.black_pixel,
+                self.connection.default_screen.white_pixel,
+            ],
+        ).check()
+
+    def finalize(self):
+        self.connection.conn.core.FreeGC(self._gc)
+        self._gc = None
+        super().finalize()
+
+    def create_buffer(self, width, height):
+        pixmap = self.connection.conn.generate_id()
+        self.connection.conn.core.CreatePixmapChecked(
+            self.connection.default_screen.root_depth,
+            pixmap,
+            self.wid,
+            width,
+            height,
+        ).check()
+        return pixmap
+
+    def free_buffer(self, buf):
+        self.connections.conn.core.FreeGC(buf)
+        super().free_buffer(buf)
+
+    def create_surface(self, width, height, drawable=None):
+        return cairocffi.XCBSurface(
+            self.connection.conn,
+            self._pixmap if drawable is None else drawable,
+            self._find_root_visual(),
+            width,
+            height,
+        )
+
+    def _find_root_visual(self):
+        for i in self.connection.default_screen.allowed_depths:
+            for v in i.visuals:
+                if v.visual_id == self.connection.default_screen.root_visual:
+                    return v
+
+    def copy_area(
+        self,
+        source,
+        width,
+        height,
+        destination_offset_x=0,
+        destination_offset_y=0,
+    ):
+        self.connection.conn.core.CopyArea(
+            source,
+            self.wid,
+            self._gc,
+            0,
+            0,
+            destination_offset_x,
+            destination_offset_y,
+            width,
+            height
+        )

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -216,8 +216,9 @@ class Bar(Gap, configurable.Configurable):
             )
 
             self.drawer = drawer.Drawer(
-                self.qtile,
-                self.window.window.wid,
+                self.qtile.core.get_drawer_backend(
+                    self.window.window.wid,
+                ),
                 self.width,
                 self.height
             )

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -718,8 +718,9 @@ class TreeTab(Layout):
     def _create_drawer(self, screen_rect):
         if self._drawer is None:
             self._drawer = drawer.Drawer(
-                self.group.qtile,
-                self._panel.window.wid,
+                self.group.qtile.core.get_drawer_backend(
+                    self._panel.window.wid,
+                ),
                 self.panel_width,
                 screen_rect.height
             )

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -55,7 +55,11 @@ class Popup(configurable.Configurable):
         self.qtile.windows_map[self.win.window.wid] = self.win
         self.win.opacity = self.opacity
         self.drawer = drawer.Drawer(
-            self.qtile, self.win.window.wid, width, height,
+            self.qtile.core.get_drawer_backend(
+                self.win.window.wid,
+            ),
+            width,
+            height,
         )
         self.layout = self.drawer.textlayout(
             text='',

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -195,8 +195,9 @@ class _Widget(CommandObject, configurable.Configurable):
         self.qtile = qtile
         self.bar = bar
         self.drawer = drawer.Drawer(
-            qtile,
-            self.win.wid,
+            qtile.core.get_drawer_backend(
+                self.win.wid,
+            ),
             self.bar.width,
             self.bar.height
         )

--- a/test/stub.py
+++ b/test/stub.py
@@ -1,0 +1,75 @@
+from libqtile.backend.base import Core
+from libqtile.backend.x11 import xcbq
+from libqtile.drawer import DrawerBackend
+
+
+class StubDrawerBackend(DrawerBackend):
+    def create_buffer(self, width, height):
+        pass
+
+    def create_surface(self, width, height, drawable=None):
+        pass
+
+    def copy_area(
+        self,
+        source,
+        width,
+        height,
+        destination_offset_x=0,
+        destination_offset_y=0,
+    ):
+        pass
+
+
+class StubCore(Core):
+    masks = (None, None)
+
+    def __init__(self, display, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.display = display
+
+        # We need to trick the widgets into thinking this is libqtile.qtile so
+        # we add some methods that are called when the widgets are configured
+        # TODO: Make this a stub too? Not sure what to do here before we have
+        # multiple backends
+        self.conn = xcbq.Connection(display)
+
+    def finalize(self):
+        pass
+
+    def get_drawer_backend(self, wid):
+        return StubDrawerBackend(self.conn, wid)
+
+    @property
+    def display_name(self):
+        return ':0.0'
+
+    def get_keys(self):
+        return []
+
+    def get_modifiers(self):
+        return []
+
+    def grab_key(self, key):
+        return (0, 0)
+
+    def ungrab_key(self, key):
+        return (0, 0)
+
+    def ungrab_keys(self):
+        pass
+
+    def grab_button(self, mouse):
+        pass
+
+    def ungrab_buttons(self):
+        return
+
+    def grab_pointer(self):
+        pass
+
+    def ungrab_pointer(self):
+        pass
+
+    def update_net_desktops(self, groups, index: int) -> None:
+        pass

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -21,29 +21,22 @@
 
 import pytest
 
-from libqtile.backend.x11 import xcbq
+from libqtile import hook
 from libqtile.popup import Popup
 from test.conftest import BareConfig
 
 
-@pytest.mark.parametrize("manager", [BareConfig], indirect=True)
-def test_popup_focus(manager):
-    manager.test_xeyes()
-    manager.windows_map = {}
-
-    # we have to add .conn so that Popup thinks this is libqtile.qtile
-    manager.conn = xcbq.Connection(manager.display)
-
-    try:
-        popup = Popup(manager)
-        popup.width = manager.c.screen.info()["width"]
-        popup.height = manager.c.screen.info()["height"]
+class PopupConfig(BareConfig):
+    @hook.subscribe.startup
+    def startup(self, qtile, *args, **kwargs):
+        popup = Popup(qtile)
         popup.place()
         popup.unhide()
-        assert manager.c.group.info()['focus'] == 'xeyes'
-        assert manager.c.group.info()['windows'] == ['xeyes']
-        assert len(manager.c.windows()) == 1
-        popup.hide()
-    finally:
-        popup.kill()
-        manager.conn.finalize()
+
+
+@pytest.mark.parametrize("manager", [PopupConfig], indirect=True)
+def test_popup_focus(manager):
+    manager.test_xeyes()
+    assert manager.c.group.info()['focus'] == 'xeyes'
+    assert manager.c.group.info()['windows'] == ['xeyes']
+    assert len(manager.c.windows()) == 1

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -1,9 +1,10 @@
 import pytest
 
-from libqtile.backend.x11 import xcbq
 from libqtile.bar import Bar
+from libqtile.core.manager import Qtile
 from libqtile.widget import TextBox, WidgetBox
 from test.conftest import BareConfig
+from test.stub import StubCore
 
 
 def no_op(*args, **kwargs):
@@ -17,18 +18,21 @@ class FakeWindow:
     window = _NestedWindow()
 
 
-widget_config = pytest.mark.parametrize("manager", [BareConfig], indirect=True)
+@pytest.fixture(scope='function')
+def qtile_stub(display):
+    qtile = Qtile(
+        StubCore(display),
+        BareConfig(),
+    )
+    qtile.call_soon = no_op
+    qtile.register_widget = no_op
+    try:
+        yield qtile
+    finally:
+        qtile.finalize()
 
 
-@widget_config
-def test_widgetbox_widget(manager):
-    manager.conn = xcbq.Connection(manager.display)
-
-    # We need to trick the widgets into thinking this is libqtile.qtile so
-    # we add some methods that are called when the widgets are configured
-    manager.call_soon = no_op
-    manager.register_widget = no_op
-
+def test_widgetbox_widget(qtile_stub):
     tb_one = TextBox(name="tb_one", text="TB ONE")
     tb_two = TextBox(name="tb_two", text="TB TWO")
 
@@ -45,7 +49,7 @@ def test_widgetbox_widget(manager):
     fakebar.draw = no_op
 
     # Configure the widget box
-    widget_box._configure(manager, fakebar)
+    widget_box._configure(qtile_stub, fakebar)
 
     # Invalid value should be corrected to default
     assert widget_box.close_button_location == "left"


### PR DESCRIPTION
This breaks out all the calls to X from drawer into a backend object
, DrawerCore, that is created by qtile's backend. When we implement a
wayland backend, we can simply make a facsimile DrawerCore. It would
provide, for example, buffers backed by EGL FBOs.