### PR TITLE
Remove OrderedDict

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -21,7 +21,6 @@
 
 import asyncio
 import os
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Tuple
 
 import xcffib
@@ -163,7 +162,7 @@ class Core(base.Core):
         # important, because it indicates what people have chosen via xrandr
         # --primary or whatever. So we need to alias screens that should be
         # aliased, but preserve order as well. See #383.
-        xywh = OrderedDict()  # type: Dict[Tuple[int, int], Tuple[int, int]]
+        xywh = {}  # type: Dict[Tuple[int, int], Tuple[int, int]]
         for screen in self.conn.pseudoscreens:
             pos = (screen.x, screen.y)
             width, height = xywh.get(pos, (0, 0))

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -37,7 +37,6 @@
 import functools
 import operator
 import typing
-from collections import OrderedDict
 from itertools import chain, islice, repeat
 
 import cairocffi
@@ -72,16 +71,16 @@ def rdict(d):
 rkeysyms = rdict(xkeysyms.keysyms)
 
 # Keyboard modifiers bitmask values from X Protocol
-ModMasks = OrderedDict((
-    ("shift", 1 << 0),
-    ("lock", 1 << 1),
-    ("control", 1 << 2),
-    ("mod1", 1 << 3),
-    ("mod2", 1 << 4),
-    ("mod3", 1 << 5),
-    ("mod4", 1 << 6),
-    ("mod5", 1 << 7),
-))
+ModMasks = {
+    "shift": 1 << 0,
+    "lock": 1 << 1,
+    "control": 1 << 2,
+    "mod1": 1 << 3,
+    "mod2": 1 << 4,
+    "mod3": 1 << 5,
+    "mod4": 1 << 6,
+    "mod5": 1 << 7,
+}
 
 AllButtonsMask = 0b11111 << 8
 ButtonMotionMask = 1 << 13

--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -20,7 +20,7 @@
 
 import io
 import os
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 
 import cairocffi
 import cairocffi.pixbuf
@@ -316,7 +316,7 @@ class Loader:
         self.directories = list(directories)
 
     def __call__(self, *names):
-        d = OrderedDict()
+        d = {}
         seen = set()
         set_names = set()
         for n in names:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -36,7 +36,7 @@ import glob
 import os
 import pickle
 import string
-from collections import OrderedDict, deque
+from collections import deque
 from typing import List, Optional, Tuple
 
 from libqtile import bar, hook, pangocffi, utils, xkeysyms
@@ -746,10 +746,10 @@ class Prompt(base._TextBox):
         return deque(_LastUpdatedOrderedDict.fromkeys(dq))
 
 
-class _LastUpdatedOrderedDict(OrderedDict):
+class _LastUpdatedOrderedDict(dict):
     """Store items in the order the keys were last added."""
 
     def __setitem__(self, key, value):
         if key in self:
             del self[key]
-        OrderedDict.__setitem__(self, key, value)
+        super().__setitem__(key, value)


### PR DESCRIPTION
Since our minimum python is 3.7 and in python 3.7 all dicts are
ordered...remove the cruft.