### PR TITLE
xcbq.Window: remove _add_net_wm_state decorator

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -433,14 +433,6 @@ class NetWmState:
         return
 
 
-def _add_net_wm_state(cls):
-    for name in net_wm_states:
-        lower_name = name.lstrip('_').lower()
-        setattr(cls, lower_name, NetWmState(name))
-    return cls
-
-
-@_add_net_wm_state
 class Window:
     def __init__(self, conn, wid):
         self.conn = conn

--- a/test/backend/x11/test_xcbq.py
+++ b/test/backend/x11/test_xcbq.py
@@ -27,32 +27,6 @@ def test_new_window(xdisplay):
         win.get_geometry()
 
 
-def test_net_wm_states(xdisplay):
-    conn = xcbq.Connection(xdisplay)
-    win = conn.create_window(1, 1, 640, 480)
-    assert isinstance(win, xcbq.Window)
-
-    def attr_name(x):
-        return x.lstrip('_').lower()
-
-    names = [attr_name(x) for x in xcbq.net_wm_states]
-
-    for name in names:
-        val = getattr(win, name)
-        assert val is False
-        setattr(win, name, True)
-        val = getattr(win, name)
-        assert val is True
-
-    for name in names:
-        assert getattr(win, name) is True
-
-    for name in names:
-        setattr(win, name, False)
-        val = getattr(win, name)
-        assert val is False
-
-
 def test_masks():
     cfgmasks = xcbq.ConfigureMasks
     d = {'x': 1, 'y': 2, 'width': 640, 'height': 480}


### PR DESCRIPTION
_add_net_wm_state and the attributes that it provides to xcbq.Window are
not used within libqtile so are no longer necessary.