### PR TITLE
Feature: z-layering of windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,8 @@ Qtile 0.18.1, released 2021-09-16:
           a further time removes the flag
         - added `cmd_move_above` and `cmd_move_below` to Windows so they can be
           shifted along z
+        - added `only_focused` setting to Max-layout, allowing to draw multiple
+          clients on top of each other when set to False
 
 Qtile 0.18.0, released 2021-07-04:
     !!! Config breakage !!!

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,11 @@ Qtile 0.18.1, released 2021-09-16:
     * features
         - All layouts will accept a list of colors for border_* options with which
           they will draw multiple borders on the appropriate windows.
+        - added `cmd_keep_above` and `cmd_keep_below` to Windows so they can be
+          kept above/below other windows permanently; calling the functions
+          a further time removes the flag
+        - added `cmd_move_above` and `cmd_move_below` to Windows so they can be
+          shifted along z
 
 Qtile 0.18.0, released 2021-07-04:
     !!! Config breakage !!!

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -99,6 +99,9 @@ class Core(CommandObject, metaclass=ABCMeta):
     def update_client_list(self, windows_map: Dict[int, WindowType]) -> None:
         """Update the list of windows being managed"""
 
+    def update_client_stack(self) -> None:
+        """Update the list of windows currently stacked by Z axis"""
+
     @contextlib.contextmanager
     def masked(self):
         """A context manager to suppress window events while operating on many windows."""

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -96,7 +96,7 @@ class Core(CommandObject, metaclass=ABCMeta):
     def warp_pointer(self, x: int, y: int) -> None:
         """Warp the pointer to the given coordinates relative."""
 
-    def update_client_list(self, windows_map: Dict[int, WindowType]) -> None:
+    def update_client_list(self) -> None:
         """Update the list of windows being managed"""
 
     def update_client_stack(self) -> None:

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -218,6 +218,18 @@ class _Window(CommandObject, metaclass=ABCMeta):
         """Return a dictionary of info."""
         return self.info()
 
+    def cmd_keep_above(self) -> None:
+        """Keep this window above all others"""
+
+    def cmd_keep_below(self) -> None:
+        """Keep this window below all others"""
+
+    def cmd_move_above(self) -> None:
+        """Move this window above the next window along the z axis"""
+
+    def cmd_move_below(self) -> None:
+        """Move this window below the previous window along the z axis"""
+
 
 class Window(_Window, metaclass=ABCMeta):
     """

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -415,7 +415,7 @@ class Core(base.Core):
         """The name of the connected display"""
         return self._display_name
 
-    def update_client_list(self, windows_map: Dict[int, base.WindowType]) -> None:
+    def update_client_list(self) -> None:
         """Updates the client list
 
         This is needed for third party tasklists and drag and drop of tabs in
@@ -423,7 +423,7 @@ class Core(base.Core):
         """
         # Regular top-level managed windows, i.e. excluding Static, Internal and Systray Icons
         wids = [
-            wid for wid, c in windows_map.items() if isinstance(c, window.Window)
+            wid for wid, c in self.qtile.windows_map.items() if isinstance(c, window.Window)
         ]
         self._root.set_property("_NET_CLIENT_LIST", wids)
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -233,7 +233,7 @@ class Core(base.Core):
             return
 
         # Qtile just started - scan for clients
-        children = self._root.query_tree()
+        children = [window.XWindow(self.conn, i) for i in self._root.query_tree()]
         for item in children:
             try:
                 attrs = item.get_attributes()
@@ -416,7 +416,7 @@ class Core(base.Core):
         return self._display_name
 
     def update_client_list(self, windows_map: Dict[int, base.WindowType]) -> None:
-        """Updates the client stack list
+        """Updates the client list
 
         This is needed for third party tasklists and drag and drop of tabs in
         chrome
@@ -426,7 +426,14 @@ class Core(base.Core):
             wid for wid, c in windows_map.items() if isinstance(c, window.Window)
         ]
         self._root.set_property("_NET_CLIENT_LIST", wids)
-        # TODO: check stack order
+
+    def update_client_stack(self) -> None:
+        """Set the current stacking order of clients to the given list of windows"""
+        stack = self._root.query_tree()
+        wids = [
+            wid for wid, c in self.qtile.windows_map.items()
+            if isinstance(c, window.Window) and c.group and wid in stack
+        ]
         self._root.set_property("_NET_CLIENT_LIST_STACKING", wids)
 
     def update_desktops(self, groups, index: int) -> None:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -233,7 +233,7 @@ class Core(base.Core):
             return
 
         # Qtile just started - scan for clients
-        _, _, children = self._root.query_tree()
+        children = self._root.query_tree()
         for item in children:
             try:
                 attrs = item.get_attributes()

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -420,13 +420,7 @@ class XWindow:
 
     def query_tree(self):
         q = self.conn.conn.core.QueryTree(self.wid).reply()
-        root = None
-        parent = None
-        if q.root:
-            root = XWindow(self.conn, q.root)
-        if q.parent:
-            parent = XWindow(self.conn, q.parent)
-        return root, parent, [XWindow(self.conn, i) for i in q.children]
+        return [XWindow(self.conn, i) for i in q.children]
 
     def paint_borders(self, depth, colors, borderwidth, width, height):
         """

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -935,7 +935,7 @@ class _Window:
 
         layering = self.window.get_layering_information()
         stack = list(self.window.query_tree())
-        if self.wid not in stack of len(stack) < 2:
+        if self.wid not in stack or len(stack) < 2:
             if kwargs:
                 self.window.configure(**kwargs)
             return
@@ -1870,6 +1870,41 @@ class Window(_Window, base.Window):
     def cmd_bring_to_front(self):
         self.change_layer()
         self.floating = True
+
+    def cmd_keep_above(self):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.window.conn.atoms["_NET_WM_STATE_BELOW"]
+        if atom in reply:
+            reply.remove(atom)
+        atom = self.window.conn.atoms["_NET_WM_STATE_ABOVE"]
+        if atom in reply:
+            reply.remove(atom)
+        else:
+            reply.append(atom)
+        self.window.set_property('_NET_WM_STATE', reply)
+        self.change_layer()
+
+    def cmd_keep_below(self):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.window.conn.atoms["_NET_WM_STATE_ABOVE"]
+        if atom in reply:
+            reply.remove(atom)
+        atom = self.window.conn.atoms["_NET_WM_STATE_BELOW"]
+        if atom in reply:
+            reply.remove(atom)
+        else:
+            reply.append(atom)
+        self.window.set_property('_NET_WM_STATE', reply)
+        self.change_layer(up=False)
+
+    def cmd_move_above(self):
+        self.change_layer()
+
+    def cmd_move_below(self):
+        self.change_layer(up=False)
+
+    def cmd_match(self, *args, **kwargs):
+        return self.match(*args, **kwargs)
 
     def _is_in_window(self, x, y, window):
         return (window.edges[0] <= x <= window.edges[2] and

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1456,6 +1456,49 @@ class Window(_Window, base.Window):
     def toggle_minimize(self):
         self.minimized = not self.minimized
 
+    @property
+    def kept_above(self):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_ABOVE']
+        return atom in reply
+
+    @kept_above.setter
+    def kept_above(self, value):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_ABOVE']
+        if value and atom not in reply:
+            reply.append(atom)
+        elif not value and atom in reply:
+            reply.remove(atom)
+        else:
+            return
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_BELOW']
+        if atom in reply:
+            reply.remove(atom)
+        self.window.set_property('_NET_WM_STATE', reply)
+        self.change_layer()
+
+    @property
+    def kept_below(self):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_BELOW']
+        return atom in reply
+
+    @kept_below.setter
+    def kept_below(self, value):
+        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_BELOW']
+        if value and atom not in reply:
+            reply.append(atom)
+        elif not value and atom in reply:
+            reply.remove(atom)
+        else:
+            return
+        atom = self.qtile.core.conn.atoms['_NET_WM_STATE_ABOVE']
+        if atom in reply:
+            reply.remove(atom)
+        self.window.set_property('_NET_WM_STATE', reply)
+
     def cmd_static(
         self,
         screen: Optional[int] = None,
@@ -1872,30 +1915,10 @@ class Window(_Window, base.Window):
         self.floating = True
 
     def cmd_keep_above(self):
-        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
-        atom = self.window.conn.atoms["_NET_WM_STATE_BELOW"]
-        if atom in reply:
-            reply.remove(atom)
-        atom = self.window.conn.atoms["_NET_WM_STATE_ABOVE"]
-        if atom in reply:
-            reply.remove(atom)
-        else:
-            reply.append(atom)
-        self.window.set_property('_NET_WM_STATE', reply)
-        self.change_layer()
+        self.kept_above = not self.kept_above
 
     def cmd_keep_below(self):
-        reply = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
-        atom = self.window.conn.atoms["_NET_WM_STATE_ABOVE"]
-        if atom in reply:
-            reply.remove(atom)
-        atom = self.window.conn.atoms["_NET_WM_STATE_BELOW"]
-        if atom in reply:
-            reply.remove(atom)
-        else:
-            reply.append(atom)
-        self.window.set_property('_NET_WM_STATE', reply)
-        self.change_layer(up=False)
+        self.kept_below = not self.kept_below
 
     def cmd_move_above(self):
         self.change_layer()

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -441,41 +441,6 @@ class XFixes:
                                                   self.selection_mask)
 
 
-class NetWmState:
-    """NetWmState is a descriptor for _NET_WM_STATE_* properties"""
-    def __init__(self, prop_name):
-        self.prop_name = prop_name
-
-    def __get__(self, xcbq_win, cls):
-        try:
-            atom = self.atom
-        except AttributeError:
-            atom = xcbq_win.conn.atoms[self.prop_name]
-            self.atom = atom
-        reply = xcbq_win.get_property('_NET_WM_STATE', 'ATOM', unpack=int)
-        if atom in reply:
-            return True
-        return False
-
-    def __set__(self, xcbq_win, value):
-        try:
-            atom = self.atom
-        except AttributeError:
-            atom = xcbq_win.conn.atoms[self.prop_name]
-            self.atom = atom
-
-        value = bool(value)
-        reply = list(xcbq_win.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
-        is_set = atom in reply
-        if is_set and not value:
-            reply.remove(atom)
-            xcbq_win.set_property('_NET_WM_STATE', reply)
-        elif value and not is_set:
-            reply.append(atom)
-            xcbq_win.set_property('_NET_WM_STATE', reply)
-        return
-
-
 class Connection:
     _extmap = {
         "xinerama": Xinerama,

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -610,7 +610,7 @@ class Qtile(CommandObject):
             # Window may have been bound to a group in the hook.
             if not win.group and self.current_screen.group:
                 self.current_screen.group.add(win, focus=win.can_steal_focus)
-        self.core.update_client_list(self.windows_map)
+        self.core.update_client_list()
         self.core.update_client_stack()
         win.change_layer()
         hook.fire("client_managed", win)
@@ -626,7 +626,7 @@ class Qtile(CommandObject):
                 if c.group:
                     c.group.remove(c)
             del self.windows_map[wid]
-            self.core.update_client_list(self.windows_map)
+            self.core.update_client_list()
             self.core.update_client_stack()
 
     def find_screen(self, x: int, y: int) -> Optional[Screen]:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -611,6 +611,8 @@ class Qtile(CommandObject):
             if not win.group and self.current_screen.group:
                 self.current_screen.group.add(win, focus=win.can_steal_focus)
         self.core.update_client_list(self.windows_map)
+        self.core.update_client_stack()
+        win.change_layer()
         hook.fire("client_managed", win)
 
     def unmanage(self, wid: int) -> None:
@@ -625,6 +627,7 @@ class Qtile(CommandObject):
                     c.group.remove(c)
             del self.windows_map[wid]
             self.core.update_client_list(self.windows_map)
+            self.core.update_client_stack()
 
     def find_screen(self, x: int, y: int) -> Optional[Screen]:
         """Find a screen based on the x and y offset"""

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -30,21 +30,37 @@ class Max(_SimpleLayoutBase):
     small screens. Conceptually, the windows are managed as a stack, with
     commands to switch to next and previous windows in the stack.
     """
+    defaults = [
+        ("only_focused", True, "Only draw the focused window"),
+    ]
+
+    def __init__(self, **config):
+        _SimpleLayoutBase.__init__(self, **config)
+        self.add_defaults(Max.defaults)
 
     def add(self, client):
         return super().add(client, 1)
 
     def configure(self, client, screen_rect):
-        if self.clients and client is self.clients.current_client:
+        if not self.only_focused or (
+            self.clients and client is self.clients.current_client
+        ):
             client.place(
                 screen_rect.x,
                 screen_rect.y,
                 screen_rect.width,
                 screen_rect.height,
                 0,
-                None
+                None,
             )
             client.unhide()
+            if (
+                not self.only_focused
+                and self.clients
+                and client is self.clients.current_client
+                and len(self.clients) > 1
+            ):
+                client.cmd_move_above()
         else:
             client.hide()
 

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -29,6 +29,7 @@ import pytest
 
 import libqtile.config
 from libqtile import layout
+from libqtile.backend.x11 import xcbq
 from libqtile.confreader import Config
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
@@ -53,12 +54,54 @@ class MaxConfig(Config):
 max_config = pytest.mark.parametrize("manager", [MaxConfig], indirect=True)
 
 
+class MaxLayeredConfig(Config):
+    auto_fullscreen = True
+    groups = [
+        libqtile.config.Group('a'),
+        libqtile.config.Group('b'),
+        libqtile.config.Group('c'),
+        libqtile.config.Group('d')
+    ]
+    layouts = [
+        layout.Max(only_focused=False)
+    ]
+    floating_layout = libqtile.layout.floating.Floating()
+    keys = []
+    mouse = []
+    screens = []
+
+
+maxlayered_config = pytest.mark.parametrize('manager', [MaxLayeredConfig], indirect=True)
+
+
+def assert_z_stack(manager, windows):
+    if manager.backend.name != "x11":
+        # TODO: Test wayland backend when proper Z-axis is implemented there
+        return
+    stack = manager.backend.get_all_windows()
+    wins = [(w['name'], stack.index(w['id'])) for w in manager.c.windows()]
+    wins.sort(key=lambda x: x[1])
+    assert [x[0] for x in wins] == windows
+
+
 @max_config
 def test_max_simple(manager):
     manager.test_window("one")
     assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ['one'])
     manager.test_window("two")
     assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ['one', 'two'])
+
+
+@maxlayered_config
+def test_max_layered(manager):
+    manager.test_window("one")
+    assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ['one'])
+    manager.test_window('two')
+    assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ['one', 'two'])
 
 
 @max_config
@@ -67,19 +110,45 @@ def test_max_updown(manager):
     manager.test_window("two")
     manager.test_window("three")
     assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    assert_z_stack(manager, ['one', 'two', 'three'])
     manager.c.layout.up()
     assert manager.c.groups()["a"]["focus"] == "two"
+    assert_z_stack(manager, ['one', 'two', 'three'])
     manager.c.layout.down()
     assert manager.c.groups()["a"]["focus"] == "three"
+    assert_z_stack(manager, ['one', 'two', 'three'])
 
 
-@max_config
+@maxlayered_config
+def test_layered_max_updown(manager):
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('three')
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert_z_stack(manager, ['one', 'two', 'three'])
+    manager.c.layout.up()
+    assert manager.c.groups()['a']['focus'] == 'two'
+    assert_z_stack(manager, ['one', 'three', 'two'])
+    manager.c.layout.up()
+    assert manager.c.groups()['a']['focus'] == 'one'
+    assert_z_stack(manager, ['three', 'two', 'one'])
+    manager.c.layout.down()
+    assert manager.c.groups()['a']['focus'] == 'two'
+    assert_z_stack(manager, ['three', 'one', 'two'])
+    manager.c.layout.down()
+    assert manager.c.groups()['a']['focus'] == 'three'
+    assert_z_stack(manager, ['one', 'two', 'three'])
+
+
+@pytest.mark.parametrize("manager", [MaxConfig, MaxLayeredConfig], indirect=True)
 def test_max_remove(manager):
     manager.test_window("one")
     two = manager.test_window("two")
     assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ['one', 'two'])
     manager.kill_window(two)
     assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ['one'])
 
 
 @max_config
@@ -95,6 +164,28 @@ def test_max_window_focus_cycle(manager):
 
     # test preconditions
     assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert_z_stack(manager, ['one', 'two', 'float1', 'float2', 'three'])
+    # last added window has focus
+    assert_focused(manager, 'three')
+
+    # assert window focus cycle, according to order in layout
+    assert_focus_path(manager, 'float1', 'float2', 'one', 'two', 'three')
+
+
+@maxlayered_config
+def test_layered_max_window_focus_cycle(manager):
+    # setup 3 tiled and two floating clients
+    manager.test_window('one')
+    manager.test_window('two')
+    manager.test_window('float1')
+    manager.c.window.toggle_floating()
+    manager.test_window('float2')
+    manager.c.window.toggle_floating()
+    manager.test_window('three')
+
+    # test preconditions
+    assert manager.c.layout.info()['clients'] == ['one', 'two', 'three']
+    assert_z_stack(manager, ['one', 'float1', 'float2', 'two', 'three'])
     # last added window has focus
     assert_focused(manager, "three")
 


### PR DESCRIPTION
After a great example by @senthilbaboo (#2144), I reworked the (second) attempt at layering code (#2029) to make better use of X-functionality. This is the first implementation I finished and tested, so there will be some rough edges and room for improvement. I also have yet to see how the tests fare.

The `core.manager.change_layer()`-method is at the heart of this PR; things seems to work as well as the previous implementation so far (even a little better, since #676 seems to be fixed by this), but so far I don't really like the spaghettis in that method, especially considering that there are more X-flags we should be taking care of.

- [x] convert `_Window.cmd_keep_above()` and `_Window.cmd_keep_below()` to properties (keep the methods for easy access, though)