### PR TITLE
Enable column swapping with swap_column_left and swap_column_right methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@ Qtile 0.17.0, released 2021-02-13:
               - validates that qtile can import the config file (e.g. that
                 syntax is correct, ends in a .py extension, etc.)
               - validates Key and Mouse mod/keysym arguments are ok.
+        - Columns layout now enables column swapping by using swap_column_left and swap_column_right
     !!! warning !!!
         - When (re)starting, Qtile passes its state to the new process in a
           file now, where previously it passed state directly as a string. This

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -104,6 +104,8 @@ class Columns(Layout):
         Key([mod, "control"], "k", lazy.layout.grow_up()),
         Key([mod, "control"], "h", lazy.layout.grow_left()),
         Key([mod, "control"], "l", lazy.layout.grow_right()),
+        Key([mod, "shift", "control"], "h", lazy.layout.swap_column_left()),
+        Key([mod, "shift", "control"], "l", lazy.layout.swap_column_right()),
         Key([mod], "Return", lazy.layout.toggle_split()),
         Key([mod], "n", lazy.layout.normalize()),
     """
@@ -479,3 +481,18 @@ class Columns(Layout):
                 col.heights[client] = 100
             col.width = 100
         self.group.layout_all()
+
+    def swap_column(self, src, dst):
+        self.columns[src], self.columns[dst] = self.columns[dst], self.columns[src]
+        self.current = dst
+        self.group.layout_all()
+
+    def cmd_swap_column_left(self):
+        src = self.current
+        dst = src - 1 if src > 0 else len(self.columns) - 1
+        self.swap_column(src, dst)
+
+    def cmd_swap_column_right(self):
+        src = self.current
+        dst = src + 1 if src < len(self.columns) - 1 else 0
+        self.swap_column(src, dst)

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -35,7 +35,7 @@ class ColumnsConfig(Config):
         libqtile.config.Group("d")
     ]
     layouts = [
-        layout.Columns(),
+        layout.Columns(num_columns=3),
     ]
     floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
@@ -55,17 +55,87 @@ def test_columns_window_focus_cycle(manager):
     # setup 3 tiled and two floating clients
     manager.test_window("one")
     manager.test_window("two")
+    manager.test_window("three")
     manager.test_window("float1")
     manager.c.window.toggle_floating()
     manager.test_window("float2")
     manager.c.window.toggle_floating()
-    manager.test_window("three")
+    manager.test_window("four")
 
     # test preconditions, columns adds clients at pos after current, in two stacks
-    assert manager.c.layout.info()['columns'][0]['clients'] == ['one']
-    assert manager.c.layout.info()['columns'][1]['clients'] == ['three', 'two']
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['one']
+    assert columns[1]['clients'] == ['two']
+    assert columns[2]['clients'] == ['four', 'three']
     # last added window has focus
-    assert_focused(manager, "three")
+    assert_focused(manager, "four")
 
     # assert window focus cycle, according to order in layout
-    assert_focus_path(manager, 'two', 'float1', 'float2', 'one', 'three')
+    assert_focus_path(manager, 'three', 'float1', 'float2', 'one', 'two', 'four')
+
+
+@columns_config
+def test_columns_swap_column_left(manager):
+    manager.test_window("1")
+    manager.test_window("2")
+    manager.test_window("3")
+    manager.test_window("4")
+
+    # test preconditions
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['1']
+    assert columns[1]['clients'] == ['2']
+    assert columns[2]['clients'] == ['4', '3']
+    assert_focused(manager, "4")
+
+    # assert columns are swapped left
+    manager.c.layout.swap_column_left()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['1']
+    assert columns[1]['clients'] == ['4', '3']
+    assert columns[2]['clients'] == ['2']
+
+    manager.c.layout.swap_column_left()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['4', '3']
+    assert columns[1]['clients'] == ['1']
+    assert columns[2]['clients'] == ['2']
+
+    manager.c.layout.swap_column_left()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['2']
+    assert columns[1]['clients'] == ['1']
+    assert columns[2]['clients'] == ['4', '3']
+
+
+@columns_config
+def test_columns_swap_column_right(manager):
+    manager.test_window("1")
+    manager.test_window("2")
+    manager.test_window("3")
+    manager.test_window("4")
+
+    # test preconditions
+    assert manager.c.layout.info()['columns'][0]['clients'] == ['1']
+    assert manager.c.layout.info()['columns'][1]['clients'] == ['2']
+    assert manager.c.layout.info()['columns'][2]['clients'] == ['4', '3']
+    assert_focused(manager, "4")
+
+    # assert columns are swapped right
+    manager.c.layout.swap_column_right()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['4', '3']
+    assert columns[1]['clients'] == ['2']
+    assert columns[2]['clients'] == ['1']
+
+    manager.c.layout.swap_column_right()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['2']
+    assert columns[1]['clients'] == ['4', '3']
+    assert columns[2]['clients'] == ['1']
+
+    manager.c.layout.swap_column_right()
+    columns = manager.c.layout.info()['columns']
+    assert columns[0]['clients'] == ['2']
+    assert columns[1]['clients'] == ['1']
+    assert columns[2]['clients'] == ['4', '3']


### PR DESCRIPTION
This PR adds two new methods to the Columns layout: `cmd_swap_column_left` and `cmd_swap_columns_right`. They swap the whole column left/right - cycling when appropriate - and it's useful when you have split windows in a column and want to move them all at once to a new position.

![qtile-column-swapping](https://user-images.githubusercontent.com/446867/107599110-3fbabd00-6bfe-11eb-87cc-a3964a32aacd.gif)

(The missing window at the end of the GIF was just a glitch in Peek)