### PR TITLE
xcursors: drop a "warning" to "info"

### DIFF
--- a/libqtile/backend/x11/xcursors.py
+++ b/libqtile/backend/x11/xcursors.py
@@ -109,7 +109,7 @@ class Cursors(dict):
         try:
             xcursor = ffi.dlopen('libxcb-cursor.so.0')
         except OSError:
-            logger.warning("xcb-cursor not found, fallback to font pointer")
+            logger.info("xcb-cursor not found, fallback to font pointer")
             return False
 
         conn = self.conn.conn


### PR DESCRIPTION
This is not really "warning" material -- only people who are using custom
cursors even care about this, which is not may people based on
qtile-examples. Let's make the log 'info'.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>