### PR TITLE
CHANGELOG: add a note about mouse callbacks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,9 @@ Qtile 0.17.0, released 2021-02-13:
         - show_state attribute from WindowName widget has been removed. Use format attribute instead.
                 show_state = True  -> format = '{state}{name}'
                 show_state = False -> format = '{name}'
+        - mouse_callbacks no longer receives the qtile object as an argument
+          (they receive no arguments); import it via `from libqtile import
+          qtile` instead.
     * features
         - new WidgetBox widget
         - new restart and shutdown hooks


### PR DESCRIPTION
mouse callbacks no longer receive an argument, let's note this.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>