### PR TITLE
check: copy the entire config dir contents

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -111,11 +111,12 @@ def check_config(args):
     # need to do all the checking in a tempdir because we need to write stuff
     # for stubtest
     with tempfile.TemporaryDirectory() as tempdir:
-        tmp_path = path.join(tempdir, "config.py")
-        shutil.copy(args.configfile, tmp_path)
+        shutil.copytree(path.dirname(args.configfile), tempdir, dirs_exist_ok=True)
+        tmp_path = path.join(tempdir, path.basename(args.configfile))
 
         # are the top level config variables the right type?
-        type_check_config_vars(tempdir, "config")
+        module_name = path.splitext(path.basename(args.configfile))[0]
+        type_check_config_vars(tempdir, module_name)
 
         # are arguments passed to qtile APIs correct?
         type_check_config_args(tmp_path)

--- a/test/test_check.py
+++ b/test/test_check.py
@@ -63,10 +63,11 @@ def test_check_default_config():
 
 
 def check_literal_config(config):
-    with tempfile.NamedTemporaryFile(suffix=".py") as temp:
-        temp.write(textwrap.dedent(config).encode('utf-8'))
-        temp.flush()
-        return run_qtile_check(temp.name)
+    with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.NamedTemporaryFile(dir=tempdir, suffix=".py") as temp:
+            temp.write(textwrap.dedent(config).encode('utf-8'))
+            temp.flush()
+            return run_qtile_check(temp.name)
 
 
 def test_check_bad_syntax():
@@ -102,3 +103,13 @@ def test_extra_vars_are_ok():
     assert check_literal_config("""
         this_is_an_extra_config_var = "yes it is"
     """)
+
+
+def test_extra_files_are_ok():
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_file = os.path.join(tempdir, "config.py")
+        with open(config_file, "w") as config:
+            config.write("from bar import foo\n")
+        with open(os.path.join(tempdir, "bar.py"), "w") as config:
+            config.write("foo = 42")
+        assert run_qtile_check(config_file)


### PR DESCRIPTION
a fair number of people have their configs organized in multiple files;
let's support this in qtile-check by copying the entire tree instead of
just the entrypoint.

Closes #2223

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>