### PR TITLE
Fix unhandled exception in wallpaper widget

### DIFF
--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -73,17 +73,17 @@ class Wallpaper(base._TextBox):
             logger.exception("I/O error(%s): %s", e.errno, e.strerror)
 
     def set_wallpaper(self):
-        if self.random_selection:
-            self.index = random.randint(0, len(self.images) - 1)
-        else:
-            self.index += 1
-            self.index %= len(self.images)
         if len(self.images) == 0:
             if self.wallpaper is None:
                 self.text = "empty"
                 return
             else:
                 self.images.append(self.wallpaper)
+        if self.random_selection:
+            self.index = random.randint(0, len(self.images) - 1)
+        else:
+            self.index += 1
+            self.index %= len(self.images)
         cur_image = self.images[self.index]
         if self.label is None:
             self.text = os.path.basename(cur_image)


### PR DESCRIPTION
The lines:
```
        else:
            self.index += 1
            self.index %= len(self.images)
```
could result in a `ZeroDivisionError` if `self.images` is empty.

This commit makes the test to see if `self.images` is empty occur before this.

This could be responsible for the failing test in #2224 (unconfirmed) but would also be covered by #2236.