### PR TITLE
tests: fix a couple of config instantiations

### DIFF
--- a/libqtile/widget/import_error.py
+++ b/libqtile/widget/import_error.py
@@ -21,9 +21,14 @@
 from libqtile.widget.base import _TextBox
 
 
+class ImportErrorWidget(_TextBox):
+    def __init__(self, class_name, **config):
+        _TextBox.__init__(self, **config)
+        self.text = "Import Error: %s" % class_name
+
+
 def make_error(module_path, class_name):
-    class ImportErrorWidget(_TextBox):
-        def __init__(self, **config):
-            _TextBox.__init__(self, **config)
-            self.text = "Import Error: %s" % class_name
-    return ImportErrorWidget
+    def import_error_wrapper(**kwargs):
+        return ImportErrorWidget(class_name, **kwargs)
+
+    return import_error_wrapper

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -432,7 +432,7 @@ def test_nospacer(manager_nospawn):
 
 
 def test_configure_broken_widgets(manager_nospawn):
-    config = GeomConf
+    config = GeomConf()
 
     widget_list = [
         BrokenWidget(ValueError),

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -82,7 +82,7 @@ def test_widget_init_config(manager_nospawn, widget_class, kwargs):
         assert getattr(widget, k) == v
 
     # Test configuration
-    config = MinimalConf
+    config = MinimalConf()
     config.screens = [
         libqtile.config.Screen(
             top=libqtile.bar.Bar([widget], 10)

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -34,7 +34,8 @@ extras = [
 
 # To skip a test entirely, list the widget class here
 no_test = [
-    widgets.Mirror  # Mirror requires a reflection object
+    widgets.Mirror,  # Mirror requires a reflection object
+    widgets.PulseVolume
 ]
 
 ################################################################################
@@ -96,7 +97,6 @@ def test_widget_init_config(manager_nospawn, widget_class, kwargs):
     # Check widget is registered by checking names of widgets in bar
     allowed_names = [
         widget.name,
-        "importerrorwidget",  # Allow widgets to be replaced on import error
         "<no name>"  # systray is called "<no name>" as it subclasses _Window
     ]
     assert i["widgets"][0]["name"] in allowed_names


### PR DESCRIPTION
622b69428c3b ("Manage Qtile subprocess better") rearranged the way configs
get instantiated, and run_qtile() now automatically instantiates them if
the class object is passed.

However, these two tests were making modifications to the class object,
which were then getting discarded by the instantiation in run_qtile().

We can't just drop this instantiation, because Config.load expects a self
argument:

Traceback (most recent call last):
  File "/home/tycho/packages/qtile/libqtile/core/manager.py", line 104, in load_config
    self.config.load()
TypeError: load() missing 1 required positional argument: 'self'

which means if we're going to make local modifications to config objects, we
need to instantiate them before we do so.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>