### PR TITLE
Fix generic widget test

### DIFF
--- a/libqtile/widget/import_error.py
+++ b/libqtile/widget/import_error.py
@@ -21,9 +21,14 @@
 from libqtile.widget.base import _TextBox
 
 
+class ImportErrorWidget(_TextBox):
+    def __init__(self, class_name, **config):
+        _TextBox.__init__(self, **config)
+        self.text = "Import Error: %s" % class_name
+
+
 def make_error(module_path, class_name):
-    class ImportErrorWidget(_TextBox):
-        def __init__(self, **config):
-            _TextBox.__init__(self, **config)
-            self.text = "Import Error: %s" % class_name
-    return ImportErrorWidget
+    def import_error_wrapper(**kwargs):
+        return ImportErrorWidget(class_name, **kwargs)
+
+    return import_error_wrapper

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -34,7 +34,8 @@ extras = [
 
 # To skip a test entirely, list the widget class here
 no_test = [
-    widgets.Mirror  # Mirror requires a reflection object
+    widgets.Mirror,  # Mirror requires a reflection object
+    widgets.PulseVolume
 ]
 
 ################################################################################
@@ -82,7 +83,7 @@ def test_widget_init_config(manager_nospawn, widget_class, kwargs):
         assert getattr(widget, k) == v
 
     # Test configuration
-    config = MinimalConf
+    config = MinimalConf()
     config.screens = [
         libqtile.config.Screen(
             top=libqtile.bar.Bar([widget], 10)
@@ -96,7 +97,6 @@ def test_widget_init_config(manager_nospawn, widget_class, kwargs):
     # Check widget is registered by checking names of widgets in bar
     allowed_names = [
         widget.name,
-        "importerrorwidget",  # Allow widgets to be replaced on import error
         "<no name>"  # systray is called "<no name>" as it subclasses _Window
     ]
     assert i["widgets"][0]["name"] in allowed_names


### PR DESCRIPTION
Fixes residual errors in #2224 by moving ImportErrorWidget out of wrapper (I'm not familiar with pickling so very happy to change this if there's a better way to handle the problem).

Removes PulseVolume widget from test for now as it fails with 
```
TypeError: cannot pickle '_cffi_backend.__CDataOwnGC' object
```