### PR TITLE
Fix runtime warnings in widget tests

### DIFF
--- a/test/widgets/conftest.py
+++ b/test/widgets/conftest.py
@@ -25,3 +25,29 @@ def svg_img_as_pypath():
     )
     audio_volume_muted = py.path.local(audio_volume_muted)
     return audio_volume_muted
+
+
+@pytest.fixture(scope='module')
+def fake_qtile():
+    import asyncio
+
+    def no_op(*args, **kwargs):
+        pass
+
+    class FakeQtile:
+        def __init__(self):
+            self.register_widget = no_op
+
+        # Widgets call call_soon(asyncio.create_task, self._config_async)
+        # at _configure. The coroutine needs to be run in a loop to suppress
+        # warnings
+        def call_soon(self, func, *args):
+            coroutines = [arg for arg in args if asyncio.iscoroutine(arg)]
+            if coroutines:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                for func in coroutines:
+                    loop.run_until_complete(func)
+                loop.close()
+
+    return FakeQtile()

--- a/test/widgets/test_check_updates.py
+++ b/test/widgets/test_check_updates.py
@@ -12,12 +12,6 @@ class FakeWindow:
     window = _NestedWindow()
 
 
-class FakeQtile:
-    def __init__(self):
-        self.call_soon = no_op
-        self.register_widget = no_op
-
-
 wrong_distro = "Barch"
 good_distro = "Arch"
 cmd_0_line = "export toto"   # quick "monkeypatch" simulating 0 output, ie 0 update
@@ -32,55 +26,49 @@ def test_unknown_distro():
     assert text == "N/A"
 
 
-def test_update_available():
+def test_update_available(fake_qtile):
     """ test output with update (check number of updates and color) """
     cu2 = CheckUpdates(distro=good_distro,
                        custom_command=cmd_1_line,
                        colour_have_updates="#123456"
                        )
-    fakeqtile = FakeQtile()
-    cu2.qtile = fakeqtile
     fakebar = Bar([cu2], 24)
     fakebar.window = FakeWindow()
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    cu2._configure(fakeqtile, fakebar)
+    cu2._configure(fake_qtile, fakebar)
     text = cu2.poll()
     assert text == "Updates: 1"
     assert cu2.layout.colour == cu2.colour_have_updates
 
 
-def test_no_update_available_without_no_update_string():
+def test_no_update_available_without_no_update_string(fake_qtile):
     """ test output with no update (without dedicated string nor color) """
     cu3 = CheckUpdates(distro=good_distro, custom_command=cmd_0_line)
-    fakeqtile = FakeQtile()
-    cu3.qtile = fakeqtile
     fakebar = Bar([cu3], 24)
     fakebar.window = FakeWindow()
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    cu3._configure(fakeqtile, fakebar)
+    cu3._configure(fake_qtile, fakebar)
     text = cu3.poll()
     assert text == ""
 
 
-def test_no_update_available_with_no_update_string_and_color_no_updates():
+def test_no_update_available_with_no_update_string_and_color_no_updates(fake_qtile):
     """ test output with no update (with dedicated string and color) """
     cu4 = CheckUpdates(distro=good_distro,
                        custom_command=cmd_0_line,
                        no_update_string=nus,
                        colour_no_updates="#654321"
                        )
-    fakeqtile = FakeQtile()
-    cu4.qtile = fakeqtile
     fakebar = Bar([cu4], 24)
     fakebar.window = FakeWindow()
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    cu4._configure(fakeqtile, fakebar)
+    cu4._configure(fake_qtile, fakebar)
     text = cu4.poll()
     assert text == nus
     assert cu4.layout.colour == cu4.colour_no_updates

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -1,9 +1,5 @@
-import pytest
-
-from libqtile.backend.x11 import xcbq
 from libqtile.bar import Bar
 from libqtile.widget import TextBox, WidgetBox
-from test.conftest import BareConfig
 
 
 def no_op(*args, **kwargs):
@@ -17,17 +13,7 @@ class FakeWindow:
     window = _NestedWindow()
 
 
-widget_config = pytest.mark.parametrize("manager", [BareConfig], indirect=True)
-
-
-@widget_config
-def test_widgetbox_widget(manager):
-    manager.conn = xcbq.Connection(manager.display)
-
-    # We need to trick the widgets into thinking this is libqtile.qtile so
-    # we add some methods that are called when the widgets are configured
-    manager.call_soon = no_op
-    manager.register_widget = no_op
+def test_widgetbox_widget(fake_qtile):
 
     tb_one = TextBox(name="tb_one", text="TB ONE")
     tb_two = TextBox(name="tb_two", text="TB TWO")
@@ -45,7 +31,7 @@ def test_widgetbox_widget(manager):
     fakebar.draw = no_op
 
     # Configure the widget box
-    widget_box._configure(manager, fakebar)
+    widget_box._configure(fake_qtile, fakebar)
 
     # Invalid value should be corrected to default
     assert widget_box.close_button_location == "left"


### PR DESCRIPTION
Creates a fake_qtile fixture for widget tests that safely handles new _config_async coroutine that was introduced in PR #1994.