### PR TITLE
migrate: add a Pacman -> CheckUpdates migration

### DIFF
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -59,10 +59,19 @@ def threaded_poll_text_rename(config):
     )
 
 
+def pacman_to_checkupdates(config):
+    return (
+        bowler.Query(config)
+        .select_class("Pacman")
+        .rename("CheckUpdates")
+    )
+
+
 MIGRATIONS = [
     client_name_updated,
     tile_master_windows_rename,
     threaded_poll_text_rename,
+    pacman_to_checkupdates,
 ]
 
 

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -119,3 +119,21 @@ def test_threaded_poll_text():
     """)
 
     check_migrate(orig, expected)
+
+
+def test_pacman():
+    orig = textwrap.dedent("""
+        from libqtile import bar
+        from libqtile.widget import Pacman
+
+        bar.Bar([Pacman()])
+    """)
+
+    expected = textwrap.dedent("""
+        from libqtile import bar
+        from libqtile.widget import CheckUpdates
+
+        bar.Bar([CheckUpdates()])
+    """)
+
+    check_migrate(orig, expected)


### PR DESCRIPTION
While the widget parameters to these are different, CheckUpdates is mostly
a superset, so it seems reasonably safe to just do this.

Closes #2244

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>