### PR TITLE
qtile: exit 1 on invalid command

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -55,3 +55,7 @@ def main():
         options.func(options)
     except AttributeError:
         main_parser.print_usage()
+        print("")
+        print("Did you mean:")
+        print(" ".join(sys.argv + ['start']))
+        sys.exit(1)


### PR DESCRIPTION
With the latest refactorings, just running `qtile` would exit(0), even
though this usage is now an error. Let's make it exit(1) so it's more
obvious that people need to do something else. Failures now look like:

~/packages/qtile exit-1-on-invalid-command qtile
usage: qtile [-h] [-v] {start,shell,top,run-cmd,cmd-obj,check,migrate,help} ...

Did you mean:
/home/tycho/.local/bin/qtile start
~/packages/qtile exit-1-on-invalid-command 1 qtile foo
usage: qtile [-h] [-v] {start,shell,top,run-cmd,cmd-obj,check,migrate,help} ...
qtile: error: invalid choice: 'foo' (choose from 'start', 'shell', 'top', 'run-cmd', 'cmd-obj', 'check', 'migrate', 'help')

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>