### PR TITLE
core: don't restart on SIGHUP

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -236,7 +236,7 @@ class Qtile(CommandObject):
             async with LoopContext({
                 signal.SIGTERM: self.stop,
                 signal.SIGINT: self.stop,
-                signal.SIGHUP: self.restart,
+                signal.SIGHUP: self.stop,
             }), ipc.Server(
                 self._prepare_socket_path(self.socket_path),
                 self.server.call,


### PR DESCRIPTION
18ff98992692 ("Respond to SIGHUP") adds a restart handler for SIGHUP, but
that doesn't really make sense. SIGHUP means the session has died, so
there's no use in restarting.

This breaks stuff like:

   loginctrl terminate-session $XDG_SESSION_ID

Instead, let's just gracefully stop qtile.

Fixes #2256

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>