### PR TITLE
Fix for (possibly) unwanted logging behaviour

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1164,14 +1164,18 @@ class Window(_Window):
                     logger.info("Focusing window")
                     self.qtile.current_screen.set_group(self.group)
                     self.group.focus(self)
-                elif focus_behavior == "smart" and self.group.screen:
+                elif focus_behavior == "smart":
+                    if not self.group.screen:
+                        logger.info("Ignoring focus request")
+                        return
                     if self.group.screen == self.qtile.current_screen:
                         logger.info("Focusing window")
                         self.qtile.current_screen.set_group(self.group)
                         self.group.focus(self)
-                    else:
-                        logger.info("Ignoring focus request")
-                elif focus_behavior == "urgent" or (focus_behavior == "smart" and not self.group.screen):
+                    else:  # self.group.screen != self.qtile.current_screen:
+                        logger.info("Setting urgent flag for window")
+                        self.urgent = True
+                elif focus_behavior == "urgent":
                     logger.info("Setting urgent flag for window")
                     self.urgent = True
                 elif focus_behavior == "never":

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1164,10 +1164,13 @@ class Window(_Window):
                     logger.info("Focusing window")
                     self.qtile.current_screen.set_group(self.group)
                     self.group.focus(self)
-                elif focus_behavior == "smart" and self.group.screen and self.group.screen == self.qtile.current_screen:
-                    logger.info("Focusing window")
-                    self.qtile.current_screen.set_group(self.group)
-                    self.group.focus(self)
+                elif focus_behavior == "smart" and self.group.screen:
+                    if self.group.screen == self.qtile.current_screen:
+                        logger.info("Focusing window")
+                        self.qtile.current_screen.set_group(self.group)
+                        self.group.focus(self)
+                    else:
+                        logger.info("Ignoring focus request")
                 elif focus_behavior == "urgent" or (focus_behavior == "smart" and not self.group.screen):
                     logger.info("Setting urgent flag for window")
                     self.urgent = True


### PR DESCRIPTION
Fixes #2242:
The focus request handler has/had a not very readable collection of cases. One case fell through and triggered a warning that shouldn't have been emitted. This pr fixes this fall-through and makes the corresponding section more readable. 