### PR TITLE
Implement chord_stack

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,11 @@ Qtile 0.x.x, released xxxx-xx-xx:
           reconfiguring qtile's screens in response to randr events. This
           removes the need to restart qtile when adding/removing external
           monitors.
+        - improved key chord / sequence functionality. Leaving a chord with `mode`
+          set brings you to a named mode you activated before, see #2264.
+          A new command, `lazy.ungrab_all_chords`, was introduced to return to the root bindings.
+          The `enter_chord` hook is now always called with a string argument.
+          The third argument to `KeyChord` was renamed from `submaping` to `submapping` (typo fix).
     * bugfixes
         - fix KeyboardLayout widget (xkb-switch is new dependency)
 

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -118,8 +118,33 @@ Chords can also be chained to make even longer sequences.
         ])
     ]
 
-Modes can also be added to chains if required.
+Modes can also be added to chains if required. The following example
+demonstrates the behaviour when using the ``mode`` argument in chains:
 
+::
+
+    from libqtile.config import Key, KeyChord
+
+    keys = [
+        KeyChord([mod], "z", [
+            KeyChord([], "y", [
+                KeyChord([], "x", [
+                    Key([], "c", lazy.spawn("xterm"))
+                ], mode="inner")
+            ])
+        ], mode="outer")
+    ]
+
+After pressing Mod+z y x c, the "inner" mode will remain active. When pressing
+<escape>, the "inner" mode is exited. Since the mode in between does not have
+``mode`` set, it is also left. Arriving at the "outer" mode (which has this
+argument set) stops the "leave" action and "outer" now becomes the active mode.
+
+.. note::
+    If you want to bind a custom key to leave the current mode (e.g. Control +
+    G in addition to ``<escape>``), you can specify ``lazy.ungrab_chord()``
+    as the key action. To leave all modes and return to the root bindings, use
+    ``lazy.ungrab_all_chords()``.
 
 Modifiers
 =========

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -15,11 +15,11 @@ class Core(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def grab_key(self, key: config.Key) -> typing.Tuple[int, int]:
+    def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""
 
     @abstractmethod
-    def ungrab_key(self, key: config.Key) -> typing.Tuple[int, int]:
+    def ungrab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Release the given key event"""
 
     @abstractmethod

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -21,7 +21,15 @@
 
 import asyncio
 import os
-from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import xcffib
 import xcffib.render
@@ -402,7 +410,7 @@ class Core(base.Core):
         self._root.set_property("_NET_DESKTOP_NAMES", "\0".join(i.name for i in groups))
         self._root.set_property("_NET_CURRENT_DESKTOP", index)
 
-    def lookup_key(self, key: config.Key) -> Tuple[int, int]:
+    def lookup_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Find the keysym and the modifier mask for the given key"""
         try:
             keysym = xcbq.get_keysym(key.key)
@@ -412,7 +420,7 @@ class Core(base.Core):
 
         return keysym, modmask
 
-    def grab_key(self, key: config.Key) -> Tuple[int, int]:
+    def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Map the key to receive events on it"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)
@@ -436,7 +444,7 @@ class Core(base.Core):
                 )
         return keysym, modmask & self._valid_mask
 
-    def ungrab_key(self, key: config.Key) -> Tuple[int, int]:
+    def ungrab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Ungrab the key corresponding to the given keysym and modifier mask"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -24,12 +24,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+#
+#
+# required for lazy type annotations
+# can be removed when python 3.7...3.9 support is dropped (see PEP 563)
+from __future__ import annotations
 
 import contextlib
 import os.path
 import sys
 import warnings
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
 import xcffib.xproto
 
@@ -76,12 +81,14 @@ class KeyChord:
     key:
         A key specification, e.g. "a", "Tab", "Return", "space".
     submappings:
-        A list of Key declarations to bind in this chord
+        A list of Key or KeyChord declarations to bind in this chord.
     mode:
-        A string with vim like mode name if it's set chord not end
-        after use one of submapings or Esc key
+        A string with vim like mode name. If it's set, the chord mode will
+        not be left after a keystroke (except for Esc which always leaves the
+        current chord/mode).
     """
-    def __init__(self, modifiers: List[str], key: str, submapings: List[Key], mode: str = ""):
+    def __init__(self, modifiers: List[str], key: str,
+                 submapings: List[Union[Key, KeyChord]], mode: str = ""):
         self.modifiers = modifiers
         self.key = key
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -88,14 +88,14 @@ class KeyChord:
         current chord/mode).
     """
     def __init__(self, modifiers: List[str], key: str,
-                 submapings: List[Union[Key, KeyChord]], mode: str = ""):
+                 submappings: List[Union[Key, KeyChord]], mode: str = ""):
         self.modifiers = modifiers
         self.key = key
 
         def noop(qtile):
             pass
-        submapings.append(Key([], "Escape", lazy.function(noop)))
-        self.submapings = submapings
+        submappings.append(Key([], "Escape", lazy.function(noop)))
+        self.submappings = submappings
         self.mode = mode
 
     def __repr__(self):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -400,7 +400,7 @@ class Qtile(CommandObject):
             hook.fire("enter_chord", self.chord_stack[-1].mode)
 
         self.ungrab_keys()
-        for key in chord.submapings:
+        for key in chord.submappings:
             self.grab_key(key)
 
     def cmd_ungrab_chord(self) -> None:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -30,7 +30,7 @@ import subprocess
 import tempfile
 import time
 import warnings
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import xcffib
 import xcffib.xinerama
@@ -84,8 +84,8 @@ class Qtile(CommandObject):
         self.groups: List[_Group] = []
         self.dgroups: Optional[DGroups] = None
 
-        self.keys_map: Dict[Tuple[int, int], Key] = {}
-        self.chord_stack = []
+        self.keys_map: Dict[Tuple[int, int], Union[Key, KeyChord]] = {}
+        self.chord_stack: List[KeyChord] = []
         self.numlock_mask, self.valid_mask = self.core.masks
 
         self.current_screen: Optional[Screen] = None
@@ -379,12 +379,12 @@ class Qtile(CommandObject):
         for key in self.keys_map.values():
             self.grab_key(key)
 
-    def grab_key(self, key: Key) -> None:
+    def grab_key(self, key: Union[Key, KeyChord]) -> None:
         """Grab the given key event"""
         keysym, mask_key = self.core.grab_key(key)
         self.keys_map[(keysym, mask_key)] = key
 
-    def ungrab_key(self, key: Key) -> None:
+    def ungrab_key(self, key: Union[Key, KeyChord]) -> None:
         """Ungrab a given key event"""
         keysym, mask_key = self.core.ungrab_key(key)
         self.keys_map.pop((keysym, mask_key))


### PR DESCRIPTION
Fixes: #2241.
I started to hack on #2241.
# Rationale:
+ emacs-like shortcut sequences have been requested: #1208, #470 (opened 2014, closed in 2020. Other projects would've closed this earlier and then forgot about it, so a huge thanks at this point)
+ they are available since #1777 (mid-2020), but probably a niche application. Let's see how this develops.
+ people who wanted this feature (including me) probably gave up and maybe switched to another WM with this functionality, [e.g. this comment](https://github.com/qtile/qtile/issues/1208#issuecomment-455323244). I was really glad when I came across this feature and tried to use it.
+ The functionality this PR provides cannot be achieved with user extensions, as stated in #2241. The hooks are not called in the right places to create a work-around.
+ The pr was developed and tested extensively with [my config](https://github.com/ep12/qtileconf) (especially `xournal_bindings.py`). I was able to do everything I wanted. Before that I filtered the actions by program, see #1661. With the `xournal` chord/mode I don't need all that complicated stuff.
+ Combining normal key bindings with custom modes is really quite ideal: the important stuff can be controlled with one keystroke, special stuff is in a separate mode. 
+ The performance impact of this feature enhancement is ~0.
+ The config breakage impact of this feature is minimal: having `lazy.ungrab_chord()` bound to a key inside two nested `KeyChord`s with `mode` set behaves now differently; a suitable replacement (`lazy.ungrab_all_chords()`) is provided.

# This pr:
+ [x] implements a `chord_stack` onto which the `KeyChord` objects are pushed when a chord mode is entered.
+ [x] when a chord mode is left (`cmd_ungrab_chord`), the next chord that has `mode != ""` is enabled using `grab_chord`
+ [x] if no chord with `mode != ""` can be found, the root key bindings are restored
+ [x] fixes a typo in `libqtile.config.KeyChord`
+ [x] fixes the `KeyChord.__init__(..., submappings, ...)` type annotation such that `qtile check` does not fail anymore when nesting `KeyChord`s
+ [x] fixes all type annotations where `Key` should be replaced with `Union[Key, KeyChord]`
+ [x] adds tests to check if everything is working correctly
+ [x] adds an example + additional text to the documentation
+ [x] removes `current_chord` as it is not required anymore.