### PR TITLE
TextLayout: add a finalized() wrapper for textlayout

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -58,6 +58,9 @@ class TextLayout:
     def finalize(self):
         self.layout.finalize()
 
+    def finalized(self):
+        self.layout.finalized()
+
     @property
     def text(self):
         return self.layout.get_text()


### PR DESCRIPTION
Not sure how this didn't get caught by the tests...:

2021-02-28 08:43:20,174 ERROR libqtile base.py:on_done():L563 Failed to reschedule.
Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/base.py", line 555, in on_done
    self.update(result)
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/base.py", line 472, in update
    self.draw()
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/base.py", line 430, in draw
    if not self.can_draw():
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/base.py", line 427, in can_draw
    return self.layout is not None and not self.layout.finalized()
AttributeError: 'TextLayout' object has no attribute 'finalized'

Fixes: 4bbe3b1b7dac ("widgets: don't re-draw after finalization")
Signed-off-by: Tycho Andersen <tycho@tycho.pizza>