### PR TITLE
Do not try to focus upon _NET_WM_USER_TIME property change event

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1230,10 +1230,6 @@ class Window(_Window):
             # are set when the property is emitted
             # self.update_state()
             self.update_state()
-        elif name == "_NET_WM_USER_TIME":
-            if not self.qtile.config.follow_mouse_focus and \
-                    self.group.current_window != self:
-                self.group.focus(self, False)
         else:
             logger.info("Unknown window property: %s", name)
         return False


### PR DESCRIPTION
When this property is changed on a window and `follow_mouse_focus` is
False, that window is focussed by Qtile. However, this behaviour is not
described in the specification and causes unexpected side effects.
Fixes #2172