### PR TITLE
Fix #2282 : displaying bar with margin properly after hide/show toggle.

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -164,6 +164,7 @@ class Bar(Gap, configurable.Configurable):
         self.saved_focus = None
         self.cursor_in = None
         self.window = None
+        self.size_calculated = 0
 
         self.queued_draws = 0
 
@@ -433,9 +434,10 @@ class Bar(Gap, configurable.Configurable):
     def show(self, is_show=True):
         if is_show != self.is_show():
             if is_show:
-                self.size = self.initial_size
+                self.size = self.size_calculated
                 self.window.unhide()
             else:
+                self.size_calculated = self.size
                 self.size = 0
                 self.window.hide()
             self.screen.group.layout_all()

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -460,3 +460,39 @@ def test_configure_broken_widgets(manager_nospawn):
     for index, widget in enumerate(widget_list):
         if isinstance(widget, BrokenWidget):
             assert i["widgets"][index]["name"] == "configerrorwidget"
+
+
+def test_bar_hide_show_with_margin(manager_nospawn):
+    """ Check :
+            - the height of a horizontal bar with its margins,
+            - the ordinate of a unique window.
+        after 3 successive actions :
+            - creation
+            - hidding the bar
+            - unhidding the bar
+    """
+    config = GeomConf
+
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [],
+                12,
+                margin=[5, 5, 5, 5]
+            )
+        )
+    ]
+
+    manager_nospawn.start(config)
+    manager_nospawn.test_window("w")
+
+    assert manager_nospawn.c.bar["top"].info().get("size") == 22
+    assert manager_nospawn.c.windows()[0]["y"] == 22
+
+    manager_nospawn.c.hide_show_bar("top")
+    assert manager_nospawn.c.bar["top"].info().get("size") == 0
+    assert manager_nospawn.c.windows()[0]["y"] == 0
+
+    manager_nospawn.c.hide_show_bar("top")
+    assert manager_nospawn.c.bar["top"].info().get("size") == 22
+    assert manager_nospawn.c.windows()[0]["y"] == 22


### PR DESCRIPTION
Modification of libqtile/bar.py to save and restore the calculated size of a bar during toggle.

Modification of test/test_bar.py by adding 1 test to check the size of a bar :
- before hidding,
- after hidding,
- and after unhidding.