### PR TITLE
Fix import_error widget

### DIFF
--- a/libqtile/widget/import_error.py
+++ b/libqtile/widget/import_error.py
@@ -22,13 +22,13 @@ from libqtile.widget.base import _TextBox
 
 
 class ImportErrorWidget(_TextBox):
-    def __init__(self, class_name, **config):
+    def __init__(self, class_name, *args, **config):
         _TextBox.__init__(self, **config)
         self.text = "Import Error: %s" % class_name
 
 
 def make_error(module_path, class_name):
-    def import_error_wrapper(**kwargs):
-        return ImportErrorWidget(class_name, **kwargs)
+    def import_error_wrapper(*args, **kwargs):
+        return ImportErrorWidget(class_name, *args, **kwargs)
 
     return import_error_wrapper


### PR DESCRIPTION
ImportError widget crashes if user has configured widget with positional arguments. This can happen if users don't use the relevant keyword but pass the arguments in the correct order.

For example, if a user does not have `xdg` installed and configures `Launchbar` as follows:

``` python
widget.LaunchBar([      
    ("google-chrome", "google-chrome-stable", "Launch Google Chrome"),
    ("firefox", "firefox", "Launch Google Firefox")
    ])
```
`ImportError` will fail as there is a positional argument. However, if the widget had been configured with a keyword argument:

``` python
widget.LaunchBar(progs=[      
    ("google-chrome", "google-chrome-stable", "Launch Google Chrome"),
    ("firefox", "firefox", "Launch Google Firefox")
    ])
```
then there would be no error.

This PR should allow both scenarios to be addressed.