### PR TITLE
Calling config main functions can now be fully deprecated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ Qtile 0.x.x, released xxxx-xx-xx:
           dbus calls within asyncio's eventloop.
         - widget.BatteryIcon no longer has a fallback text mode; use
           widget.Battery instead
+    !!! deprecation warning !!!
+        - 'main' config functions, deprecated in 0.16.1, will no longer be executed.
     * features
         - added measure_mem and measure_swap attributes to memory widget to allow user to choose measurement units.
         - memory widget can now be displayed with decimal values

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -29,7 +29,6 @@ import signal
 import subprocess
 import tempfile
 import time
-import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import xcffib
@@ -112,9 +111,6 @@ class Qtile(CommandObject):
             widgets.insert(0, TextBox('Config Err!'))
 
         self.core.wmname = getattr(self.config, "wmname", "qtile")
-        if self.config.main:
-            warnings.warn("Defining a main function is deprecated, use libqtile.qtile", DeprecationWarning)
-            self.config.main(self)
 
         self.dgroups = DGroups(self, self.config.groups, self.config.dgroups_key_binder)
 

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -20,6 +20,7 @@
 
 import pytest
 
+import libqtile
 import libqtile.config
 import libqtile.hook
 from libqtile import layout
@@ -103,17 +104,19 @@ class AllLayoutsConfigEvents(AllLayoutsConfig):
     """
     Extends AllLayoutsConfig to test events.
     """
-    def main(self, c):
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
         # TODO: Test more events
 
-        c.test_data = {
-            'focus_change': 0,
-        }
+        @libqtile.hook.subscribe.startup
+        def _():
+            libqtile.qtile.test_data = {
+                'focus_change': 0,
+            }
 
-        def handle_focus_change():
-            c.test_data['focus_change'] += 1
-
-        libqtile.hook.subscribe.focus_change(handle_focus_change)
+        @libqtile.hook.subscribe.focus_change
+        def _():
+            libqtile.qtile.test_data['focus_change'] += 1
 
 
 each_layout_config = pytest.mark.parametrize("manager", AllLayoutsConfig.generate(), indirect=True)
@@ -199,38 +202,37 @@ def test_focus_change_event(manager):
     # In short, this test prevents layouts from influencing each other in
     # unexpected ways.
 
-    # TODO: Why does it start with 2?
-    assert manager.c.get_test_data()['focus_change'] == 2
+    assert manager.c.get_test_data()['focus_change'] == 0
 
     # Spawning a window must fire only 1 focus_change event
     one = manager.test_window("one")
-    assert manager.c.get_test_data()['focus_change'] == 3
+    assert manager.c.get_test_data()['focus_change'] == 1
     two = manager.test_window("two")
-    assert manager.c.get_test_data()['focus_change'] == 4
+    assert manager.c.get_test_data()['focus_change'] == 2
     three = manager.test_window("three")
-    assert manager.c.get_test_data()['focus_change'] == 5
+    assert manager.c.get_test_data()['focus_change'] == 3
 
     # Switching window must fire only 1 focus_change event
     assert_focused(manager, "three")
     manager.c.group.focus_by_name("one")
-    assert manager.c.get_test_data()['focus_change'] == 6
+    assert manager.c.get_test_data()['focus_change'] == 4
     assert_focused(manager, "one")
 
     # Focusing the current window must fire another focus_change event
     manager.c.group.focus_by_name("one")
-    assert manager.c.get_test_data()['focus_change'] == 7
+    assert manager.c.get_test_data()['focus_change'] == 5
 
     # Toggling a window floating should not fire focus_change events
     manager.c.window.toggle_floating()
-    assert manager.c.get_test_data()['focus_change'] == 7
+    assert manager.c.get_test_data()['focus_change'] == 5
     manager.c.window.toggle_floating()
-    assert manager.c.get_test_data()['focus_change'] == 7
+    assert manager.c.get_test_data()['focus_change'] == 5
 
     # Removing the focused window must fire only 1 focus_change event
     assert_focused(manager, "one")
     assert manager.c.group.info()['focus_history'] == ["two", "three", "one"]
     manager.kill_window(one)
-    assert manager.c.get_test_data()['focus_change'] == 8
+    assert manager.c.get_test_data()['focus_change'] == 6
 
     # The position where 'one' was after it was floated and unfloated
     # above depends on the layout, so we can't predict here what window gets
@@ -238,17 +240,17 @@ def test_focus_change_event(manager):
     # continue testing
     manager.c.group.focus_by_name("three")
     assert manager.c.group.info()['focus_history'] == ["two", "three"]
-    assert manager.c.get_test_data()['focus_change'] == 9
+    assert manager.c.get_test_data()['focus_change'] == 7
 
     # Removing a non-focused window must not fire focus_change events
     manager.kill_window(two)
-    assert manager.c.get_test_data()['focus_change'] == 9
+    assert manager.c.get_test_data()['focus_change'] == 7
     assert_focused(manager, "three")
 
     # Removing the last window must still generate 1 focus_change event
     manager.kill_window(three)
     assert manager.c.layout.info()['clients'] == []
-    assert manager.c.get_test_data()['focus_change'] == 10
+    assert manager.c.get_test_data()['focus_change'] == 8
 
 
 @each_layout_config

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1169,43 +1169,6 @@ class _Config(Config):
     auto_fullscreen = True
 
 
-class ClientNewStaticConfig(_Config):
-    @staticmethod
-    def main(c):
-        def client_new(c):
-            c.cmd_static(0)
-        libqtile.hook.subscribe.client_new(client_new)
-
-
-clientnew_config = pytest.mark.parametrize("manager", [ClientNewStaticConfig], indirect=True)
-
-
-@clientnew_config
-def test_clientnew_config(manager):
-    a = manager.test_window("one")
-    manager.kill_window(a)
-
-
-class ToGroupConfig(_Config):
-    @staticmethod
-    def main(c):
-        def client_new(c):
-            c.togroup("d")
-        libqtile.hook.subscribe.client_new(client_new)
-
-
-togroup_config = pytest.mark.parametrize("manager", [ToGroupConfig], indirect=True)
-
-
-@togroup_config
-def test_togroup_config(manager):
-    manager.c.group["d"].toscreen()
-    manager.c.group["a"].toscreen()
-    a = manager.test_window("one")
-    assert len(manager.c.group["d"].info()["windows"]) == 1
-    manager.kill_window(a)
-
-
 @manager_config
 def test_color_pixel(manager):
     (success, e) = manager.c.eval("self.conn.color_pixel(\"ffffff\")")


### PR DESCRIPTION
Defining a 'main' function was deprecated in version 0.16.1. This change
finishes off its deprecation so it is no longer executed.

A couple of tests that used a main function were removed rather than
replaced because the functionality that they test is already tested
elsewhere.