### PR TITLE
Add CI checks for code and documentation "style"

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,6 +141,7 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
+        not-callable,  # TEMP: has false-positives currently. Re-enable later.
         protected-access,  # we need this a lot, so it will stay here!
         # all messages disabled above were suggested by
         # `pylint --generate-rcfile`

--- a/.pylintrc
+++ b/.pylintrc
@@ -143,6 +143,7 @@ disable=print-statement,
         comprehension-escape,
         not-callable,  # TEMP: has false-positives currently. Re-enable later.
         protected-access,  # we need this a lot, so it will stay here!
+        c-extension-no-member,  # this is probably staying here, too.
         # all messages disabled above were suggested by
         # `pylint --generate-rcfile`
         # maybe some of them can be re-enabled later, but only after we have
@@ -162,7 +163,6 @@ disable=print-statement,
         broad-except,
         bare-except,
         assignment-from-no-return,
-        c-extension-no-member,
         redefined-outer-name,
         unused-argument,
         unused-variable,
@@ -183,6 +183,9 @@ disable=print-statement,
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
 # enable=c-extension-no-member
+# Time to play Whac-A-Mole:
+enable=consider-using-sys-exit,
+       useless-super-delegation,
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,19 +1,640 @@
 [MASTER]
 
-# files that cause recursion depth exceeded errors
-ignore=graph.py,manager.py
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
 
-# also ignore cffi generated modules
-ignore-patterns=_ffi.*.py
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
 
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=^_.*$  # e. g. _ffi_*.py
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
 jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+## TODO: Check the format of docstrings (for sphinx compat):
+# load-plugins=pylint.extensions.docparams
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        protected-access,  # we need this a lot, so it will stay here!
+        # all messages disabled above were suggested by
+        # `pylint --generate-rcfile`
+        # maybe some of them can be re-enabled later, but only after we have
+        # fought the following demons:
+        # TODO: re-enable those options (remove the lines) one by one
+        arguments-differ,
+        unused-wildcard-import,
+        useless-super-delegation,
+        # useless-else-on-loop,
+        super-init-not-called,
+        no-name-in-module,
+        no-member,
+        raise-missing-from,
+        logging-not-lazy,
+        logging-format-interpolation,
+        logging-fstring-interpolation,
+        broad-except,
+        bare-except,
+        assignment-from-no-return,
+        c-extension-no-member,
+        redefined-outer-name,
+        unused-argument,
+        unused-variable,
+        attribute-defined-outside-init,
+        access-member-before-definition,
+        abstract-method,
+        global-statement,
+        pointless-statement,
+        import-error,  # probably a dependency that is not installed locally;
+        # we should deal with that locally (e.g. disable this warning when
+        # importing modules that are optional dependencies)
+        wildcard-import,
+        R,  # no refactoring messages until the important bits are dealt with
+        C,  # no convention messages -----------------||---------------------
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+# enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+# warnings (especially TODO, HACK, XXX, ...) do not count:
+evaluation=10.0 - ((float(5 * error + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=2000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: de_AT (hunspell), de_BE
+# (hunspell), de_CH (hunspell), de_DE (hunspell), de_LI (hunspell), de_LU
+# (hunspell), en (aspell), en_AG (hunspell), en_AU (aspell), en_BS (hunspell),
+# en_BW (hunspell), en_BZ (hunspell), en_CA (aspell), en_DK (hunspell), en_GB
+# (hunspell), en_GH (hunspell), en_HK (hunspell), en_IE (hunspell), en_IN
+# (hunspell), en_JM (hunspell), en_NA (hunspell), en_NG (hunspell), en_NZ
+# (hunspell), en_SG (hunspell), en_TT (hunspell), en_US (hunspell), en_ZA
+# (hunspell), en_ZW (hunspell), he (hspell).
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO,
+      HACK,
+      TMP,
+      TEMP
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
 
 [BASIC]
 
-max-line-length = 120
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
 
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
 good-names=i,
            j,
            k,
            x,
            y,
+           z,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method. [5]
+max-args=10
+
+# Maximum number of attributes for a class (see R0902). [7]
+max-attributes=10
+
+# Maximum number of boolean expressions in an if statement (see R0916). [5]
+max-bool-expr=5
+
+# Maximum number of branch for function / method body. [12]
+max-branches=20
+
+# Maximum number of locals for function / method body. [15]
+max-locals=15
+
+# Maximum number of parents for a class (see R0901). [7]
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904). [20]
+max-public-methods=40
+
+# Maximum number of return / yield for function / method body. [6]
+max-returns=6
+
+# Maximum number of statements in function / method body. [50]
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903). [2]
+min-public-methods=1
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,11 @@ to our [issue tracker](https://github.com/qtile/qtile/issues) on GitHub.
 Pull requests are not considered complete until they include all of the
 following:
 
-1. Code: Should conform PEP8 and should pass `make lint`.
-2. Unit tests: Should pass CI
-3. Documentation: Should get updated if it needed
+1. Code: conforms to PEP8 and passes `make lint`.
+2. Unit tests: CI tests pass. Adding new tests to verify that your code works is recommended.
+   See [our website](http://docs.qtile.org/en/latest/manual/contributing.html#running-tests-locally)
+   on how to run the tests locally.
+3. Documentation: Should get updated if it needed.
 
 **Feel free to add your contribution (no matter how small) to the appropriate
 place in the CHANGELOG as well!**

--- a/docs/manual/contributing.rst
+++ b/docs/manual/contributing.rst
@@ -74,3 +74,37 @@ Qtile session.
 For any Qtile-specific question on testing, feel free to ask on our `issue
 tracker <https://github.com/qtile/qtile/issues>`_ or on IRC (#qtile on
 irc.oftc.net).
+
+Running tests locally
+---------------------
+
+This section gives an overview about ``tox`` so that you don't have to search
+`its documentation <https://tox.readthedocs.io/en/latest/>`_ just to get
+started.
+Checks are grouped in so-called ``environments``. Some of them are configured to
+check that the code works (the usual unit test, e.g. ``py39``, ``pypy3``),
+others make sure that your code conforms to the style guide (``pep8``,
+``codestyle``, ``mypy``). A third kind of test verifies that the documentation
+and packaging processes work (``docs``, ``docstyle``, ``packaging``).
+
+The following examples show how to run tests locally:
+   * To run the functional tests, use ``tox -e py39`` (or a different
+     environment). You can specify to only run a specific test file or even a
+     specific test within that file with the following commands:
+
+     .. code-block:: bash
+
+        tox -e py39 # Run all tests with python 3.9 as the interpreter
+        tox -e py39 -- -x test/widgets/test_widgetbox.py  # run a single file
+        tox -e py39 -- -x test/widgets/test_widgetbox.py::test_widgetbox_widget
+
+   * To run style and building checks, use ``tox -e docs,packaging,pep8,...``.
+     You can use ``-p auto`` to run the environments in parallel.
+
+     .. important::
+
+        The CI is configured to run all the environments. Hence it can be time-
+        consuming to make all the tests pass. As stated above, pull requests
+        that don't pass the tests are considered incomplete. Don't forget that
+        this does not only include the functionality, but the style, typing
+        annotations (if necessary) and documentation as well!

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -400,7 +400,7 @@ class Bar(Gap, configurable.Configurable):
 
     def draw(self):
         if not self.widgets:
-            return
+            return  # calling self._actual_draw in this case would cause a NameError.
         if self.queued_draws == 0:
             self.qtile.call_soon(self._actual_draw)
         self.queued_draws += 1
@@ -410,7 +410,8 @@ class Bar(Gap, configurable.Configurable):
         self._resize(self.length, self.widgets)
         for i in self.widgets:
             i.draw()
-        end = i.offset + i.length
+        end = i.offset + i.length  # pylint: disable=undefined-loop-variable
+        # we verified that self.widgets is not empty in self.draw(), see above.
         if end < self.length:
             if self.horizontal:
                 self.drawer.draw(offsetx=end, width=self.length - end)

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -109,7 +109,7 @@ class DGroups:
             self.rules.remove(rule)
             del self.rules_map[rule_id]
         else:
-            logger.warn('Rule "%s" not found', rule_id)
+            logger.warning('Rule "%s" not found', rule_id)
 
     def add_dgroup(self, group, start=False):
         self.groups_map[group.name] = group

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -192,7 +192,7 @@ class Server:
 
             req, is_json = _IPC.unpack(data)
         except IPCError:
-            logger.warn("Invalid data received, closing connection")
+            logger.warning("Invalid data received, closing connection")
         else:
             rep = self.handler(req)
 

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -16,6 +16,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from libqtile.layout.base import Layout, _ClientList
+from libqtile.log_utils import logger
 
 
 class _Column(_ClientList):
@@ -179,6 +180,9 @@ class Columns(Layout):
         return c
 
     def remove_column(self, col):
+        if len(self.columns) == 1:
+            logger.warning("Trying to remove all columns.")
+            return
         idx = self.columns.index(col)
         del self.columns[idx]
         if idx <= self.current:
@@ -281,7 +285,8 @@ class Columns(Layout):
     def focus_next(self, win):
         """Returns the next client after 'win' in layout,
            or None if there is no such client"""
-        # First: try to get next window in column of win
+        # First: try to get next window in column of win (self.columns is non-empty)
+        # pylint: disable=undefined-loop-variable
         for idx, col in enumerate(self.columns):
             if win in col:
                 nxt = col.focus_next(win)
@@ -296,7 +301,8 @@ class Columns(Layout):
     def focus_previous(self, win):
         """Returns the client previous to 'win' in layout.
            or None if there is no such client"""
-        # First: try to focus previous client in column
+        # First: try to focus previous client in column (self.columns is non-empty)
+        # pylint: disable=undefined-loop-variable
         for idx, col in enumerate(self.columns):
             if win in col:
                 prev = col.focus_previous(win)

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -68,6 +68,9 @@ class Stack(Layout):
     def __init__(self, **config):
         Layout.__init__(self, **config)
         self.add_defaults(Stack.defaults)
+        if self.num_stacks <= 0:
+            # Catch stupid mistakes early and generate a useful message
+            raise ValueError('num_stacks must be at least 1')
         self.stacks = [_WinStack(autosplit=self.autosplit)
                        for i in range(self.num_stacks)]
 
@@ -99,10 +102,9 @@ class Stack(Layout):
         for i in lst[offset + 1:]:
             if i:
                 return i
-        else:
-            for i in lst[:offset]:
-                if i:
-                    return i
+        for i in lst[:offset]:
+            if i:
+                return i
 
     def delete_current_stack(self):
         if len(self.stacks) > 1:
@@ -206,6 +208,8 @@ class Stack(Layout):
                 return n.cw
 
     def configure(self, client, screen_rect):
+        # pylint: disable=undefined-loop-variable
+        # We made sure that self.stacks is not empty, so s is defined.
         for i, s in enumerate(self.stacks):
             if client in s:
                 break

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import group, hook, window
+from typing import Dict, List
+
+from libqtile import config, group, hook, window
 
 
 class WindowVisibilityToggler:
@@ -204,12 +206,12 @@ class ScratchPad(group._Group):
     The ScratchPad, by default, has no label and thus is not shown in
     GroupBox widget.
     """
-    def __init__(self, name='scratchpad', dropdowns=[], label=''):
+    def __init__(self, name='scratchpad', dropdowns: List[config.DropDown] = None, label=''):
         group._Group.__init__(self, name, label=label)
-        self._dropdownconfig = {dd.name: dd for dd in dropdowns}
-        self.dropdowns = {}
-        self._spawned = {}
-        self._to_hide = []
+        self._dropdownconfig = {dd.name: dd for dd in dropdowns} if dropdowns is not None else {}
+        self.dropdowns: Dict[str, DropDownToggler] = {}
+        self._spawned: Dict[int, str] = {}
+        self._to_hide: List[str] = []
 
     def _check_unsubscribe(self):
         if not self.dropdowns:

--- a/libqtile/scripts/top.py
+++ b/libqtile/scripts/top.py
@@ -31,10 +31,9 @@ import time
 from libqtile import ipc
 from libqtile.command import client, interface
 
-""" These imports are here because they are not supported in pypy
-having them at the top of the file causes problems when running any
-of the other scripts.
-"""
+# These imports are here because they are not supported in pypy.
+# having them at the top of the file causes problems when running any
+# of the other scripts.
 try:
     import tracemalloc
     from tracemalloc import Snapshot

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -82,7 +82,7 @@ def default_cmd(): return None
 
 
 format_fns = {
-    'all': lambda s: escape(s)
+    'all': escape,
 }
 
 

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -724,11 +724,11 @@ class Prompt(base._TextBox):
         try:
             obj = self.qtile.select([(object_name, selector)])
         except SelectError:
-            logger.warn("cannot select a object")
+            logger.warning("cannot select a object")
             return
         cmd = obj.command(cmd_name)
         if not cmd:
-            logger.warn("command not found")
+            logger.warning("command not found")
             return
 
         def f(args):

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from libqtile.widget._pulse_audio import ffi, lib
+from libqtile.widget._pulse_audio import (  # type: ignore # otherwise mypy complains
+    ffi,
+    lib,
+)
 from libqtile.widget.volume import Volume
 
 log = logging.getLogger(__name__)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -93,13 +93,14 @@ class WidgetBox(base._Widget):
         ),
     ]
 
-    def __init__(self, widgets=list(), **config):
+    def __init__(self, widgets: list = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
         self.box_is_open = False
-        self._widgets = widgets
+        self._widgets = widgets if widgets is not None else []
         self.add_callbacks({"Button1": self.cmd_toggle})
 
+        self.close_button_location: str
         if self.close_button_location not in ["left", "right"]:
             val = self.close_button_location
             msg = "Invalid value for 'close_button_location': {}".format(val)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ envlist =
     py39,
     docs,
     pep8,
+    codestyle,
+    docstyle,
     mypy,
     packaging
 
@@ -56,6 +58,23 @@ deps =
 commands =
     flake8 {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test
 
+[testenv:codestyle]
+deps =
+    pylint >= 2.7
+    pycodestyle >= 2.7
+skip_install = true
+commands =
+    - pylint {toxinidir}/libqtile {posargs}
+    pycodestyle --max-line-length=120 --exclude="_*.py" {toxinidir}/libqtile
+
+[testenv:docstyle]
+deps =
+    pydocstyle >= 5.0
+skip_install = true
+commands =
+    - pydocstyle --match "(?!(test)?_).*\.py" libqtile/
+
+
 [testenv:mypy]
 deps =
     mypy
@@ -83,4 +102,4 @@ python =
     pypy-3.7: pypy3
     3.7: py37
     3.8: py38
-    3.9: py39, packaging, format, pep8, mypy, docs, vulture
+    3.9: py39, packaging, format, pep8, codestyle, docstyle, mypy, docs, vulture


### PR DESCRIPTION
See #2314.

This pr adds two new test environments `codestyle` and `docstyle` to the `tox` configuration.  
Check your code locally with `tox -e codestyle,docstyle` if you like.

The `codestyle` environment runs `pylint` and `pycodestyle`. The current HEAD already satisfies `pycodestyle` and hence the test will fail if `pycodestyle` does.
The most important bit is `pylint`: It will help us to find not only real _style_ issues, but also basic programming mistakes (mutable default arguments, ...). Right now it complains about A LOT of things although I have initially disabled dozens of warnings to help find critical insuffiencies.

The goal is to either fix the problems to disable the messages or, if absolutely necessary, disable the warnings on a local basis. By that I mean: for single lines, functions or modules.  
The more localised, the better: Let's give an example here: We don't want to disable the warning regarding the use of `eval` or `exec` for a module, probably not even for a function, but instead for a single line where we need to make sure that it is safe to use.

We can disable messages locally with a comment `# pylint: disable=exec-used,some-other-warning,...`.  
Depending on where that comment is placed, it disables a warning for a line, function or module.  
It should be made clear why a message is disabled. If it isn't obvious, better write a few comment lines explaining the choice.

Currently, only the main code is checked with the tools mentioned above.  
Later on we might also want to check the tests which can easily be done, of course. Until then there remains a lot to do.

The `docstyle` environment runs `pydocstyle` to check if we did our homework and documented out functions well enough.  Currently, it is ignored but can be used to find undocumented places in the code or to check if your documentation is verbose enough.

+ [x] add CI configuration
+ [x] deal with `dangerous-default-value`, `undefined-loop-variable`, `deprecated-method`, `useless-else-on-loop` and `pointless-string-statement`
+ [x] enable `consider-using-sys-exit`, `useless-super-delegation`
+ [x] add a note to `CONTRIBUTING.md` and `docs/manual/contributing.rst`
+ [x] deal with `redefined-builtin`: Not done, but postponed for another pr.