### PR TITLE
test_migrate: ensure migrated config file is valid

### DIFF
--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -6,6 +6,7 @@ import tempfile
 import textwrap
 
 from libqtile.scripts.migrate import BACKUP_SUFFIX
+from test.test_check import have_mypy, run_qtile_check
 
 
 def run_qtile_migrate(config):
@@ -46,8 +47,9 @@ def check_migrate(orig, expected):
             f.write(orig.encode('utf-8'))
 
         run_qtile_migrate(config_path)
+        if have_mypy():
+            assert run_qtile_check(config_path)
 
-        config_path = os.path.join(tempdir, "config.py")
         assert expected == read_file(config_path)
         assert orig == read_file(config_path+BACKUP_SUFFIX)
 

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -73,15 +73,15 @@ def test_window_name_change():
 
 def test_libqtile_command_graph():
     orig = textwrap.dedent("""
-        from libqtile.command_graph import CommandObject
+        from libqtile.command_graph import CommandGraphRoot
 
-        o = CommandObject()
+        o = CommandGraphRoot()
     """)
 
     expected = textwrap.dedent("""
-        from libqtile.command.graph import CommandObject
+        from libqtile.command.graph import CommandGraphRoot
 
-        o = CommandObject()
+        o = CommandGraphRoot()
     """)
 
     check_migrate(orig, expected)
@@ -105,14 +105,14 @@ def test_tile_master_windows():
 
 def test_threaded_poll_text():
     orig = textwrap.dedent("""
-        from libqtile.widget import ThreadedPollText
+        from libqtile.widget.base import ThreadedPollText
 
         class MyWidget(ThreadedPollText):
             pass
     """)
 
     expected = textwrap.dedent("""
-        from libqtile.widget import ThreadPoolText
+        from libqtile.widget.base import ThreadPoolText
 
         class MyWidget(ThreadPoolText):
             pass
@@ -126,14 +126,14 @@ def test_pacman():
         from libqtile import bar
         from libqtile.widget import Pacman
 
-        bar.Bar([Pacman()])
+        bar.Bar([Pacman()], 30)
     """)
 
     expected = textwrap.dedent("""
         from libqtile import bar
         from libqtile.widget import CheckUpdates
 
-        bar.Bar([CheckUpdates()])
+        bar.Bar([CheckUpdates()], 30)
     """)
 
     check_migrate(orig, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ commands =
 [testenv:mypy]
 deps =
     mypy
+    bowler
     xcffib >= 0.8.1
     pytest >= 6.2.1
 commands =
@@ -66,7 +67,7 @@ commands =
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install
-    python3 -m pytest -Wall -- test/test_check.py
+    python3 -m pytest -W error -- test/test_check.py test/test_migrate.py
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
The result of qtile migrate should be a valid python file which should
parse and type check correctly. If mypy is present (which it is in CI),
let's check this.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>