### PR TITLE
Strut compliance to ewmh specifications

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -201,7 +201,6 @@ SUPPORTED_ATOMS = [
     '_NET_WM_DESKTOP',
     '_NET_WM_WINDOW_TYPE',
     '_NET_WM_STATE',
-    '_NET_WM_STRUT',
     '_NET_WM_STRUT_PARTIAL',
     '_NET_WM_PID',
 ]

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -527,25 +527,24 @@ class Qtile(CommandObject):
     def current_window(self):
         return self.current_screen.group.current_window
 
-    def add_strut(self, strut):
+    def reserve_space(self, reserved_space, screen):
         from libqtile.bar import Bar, Gap
 
         for i, pos in enumerate(["left", "right", "top", "bottom"]):
-            if strut[i]:
-                bar = getattr(self.current_screen, pos)
+            if reserved_space[i]:
+                bar = getattr(screen, pos)
                 if isinstance(bar, Bar):
-                    bar.adjust_for_strut(strut[i])
+                    bar.adjust_for_strut(reserved_space[i])
                 elif isinstance(bar, Gap):
-                    bar.size += strut[i]
+                    bar.size += reserved_space[i]
                     if bar.size <= 0:
-                        setattr(self.current_screen, pos, None)
+                        setattr(screen, pos, None)
                 else:
-                    setattr(self.current_screen, pos, Gap(strut[i]))
+                    setattr(screen, pos, Gap(reserved_space[i]))
+        screen.resize()
 
-        self.current_screen.resize()
-
-    def remove_strut(self, strut):
-        self.add_strut([-i for i in strut])
+    def free_reserved_space(self, reserved_space, screen):
+        self.reserve_space([-i for i in reserved_space], screen)
 
     def map_window(self, window: xcbq.Window) -> None:
         c = self.manage(window)
@@ -589,7 +588,7 @@ class Qtile(CommandObject):
                 except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
                     return
 
-                if w.get_wm_type() == "dock" or c.strut:
+                if w.get_wm_type() == "dock" or c.reserved_space:
                     c.cmd_static(self.current_screen.index)
                     return
 
@@ -613,8 +612,8 @@ class Qtile(CommandObject):
         c = self.windows_map.get(win)
         if c:
             hook.fire("client_killed", c)
-            if c.strut:
-                self.remove_strut(c.strut)
+            if isinstance(c, window.Static):
+                self.free_reserved_space(c.reserved_space, c.screen)
             if getattr(c, "group", None):
                 c.group.remove(c)
             del self.windows_map[win]

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1469,17 +1469,33 @@ def test_hints_setting_unsetting(manager):
 
 @manager_config
 def test_strut_handling(manager):
-    w = None
+    w = []
     conn = xcbq.Connection(manager.display)
 
     def has_struts():
         nonlocal w
-        w = conn.create_window(0, 0, 10, 10)
-        w.set_property("_NET_WM_STRUT", [0, 0, 0, 10])
-        w.map()
+        w.append(conn.create_window(0, 0, 10, 10))
+        w[-1].set_property("_NET_WM_STRUT_PARTIAL", [0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 800])
+        w[-1].map()
+        conn.conn.flush()
+
+    def with_gaps_left():
+        nonlocal w
+        w.append(conn.create_window(800, 0, 10, 10))
+        w[-1].set_property("_NET_WM_STRUT_PARTIAL", [820, 0, 0, 0, 0, 480, 0, 0, 0, 0, 0, 0])
+        w[-1].map()
+        conn.conn.flush()
+
+    def with_gaps_bottom():
+        nonlocal w
+        w.append(conn.create_window(800, 0, 10, 10))
+        w[-1].set_property("_NET_WM_STRUT_PARTIAL", [0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 800, 1440])
+        w[-1].map()
         conn.conn.flush()
 
     def test_initial_state():
+        while manager.c.screen.info()["index"] != 0:
+            manager.c.next_screen()
         assert manager.c.window.info()['width'] == 798
         assert manager.c.window.info()['height'] == 578
         assert manager.c.window.info()['x'] == 0
@@ -1488,13 +1504,22 @@ def test_strut_handling(manager):
         bar = manager.c.window[bar_id].info()
         assert bar["height"] == 20
         assert bar["y"] == 580
+        manager.c.next_screen()
+        assert manager.c.window.info()['width'] == 638
+        assert manager.c.window.info()['height'] == 478
+        assert manager.c.window.info()['x'] == 800
+        assert manager.c.window.info()['y'] == 0
 
+    manager.test_xcalc()
+    manager.c.next_screen()
     manager.test_xcalc()
     test_initial_state()
 
     try:
+        while manager.c.screen.info()["index"] != 0:
+            manager.c.next_screen()
         manager.create_window(has_struts)
-        manager.c.window.static(0, None, None, None, None)
+        manager.c.window.static(None, None, None, None, None)
         assert manager.c.window.info()['width'] == 798
         assert manager.c.window.info()['height'] == 568
         assert manager.c.window.info()['x'] == 0
@@ -1504,8 +1529,18 @@ def test_strut_handling(manager):
         assert bar["height"] == 20
         assert bar["y"] == 570
 
+        manager.c.next_screen()
+        manager.create_window(with_gaps_bottom)
+        manager.c.window.static(None, None, None, None, None)
+        manager.create_window(with_gaps_left)
+        manager.c.window.static(None, None, None, None, None)
+        assert manager.c.window.info()['width'] == 618
+        assert manager.c.window.info()['height'] == 468
+        assert manager.c.window.info()['x'] == 820
+        assert manager.c.window.info()['y'] == 0
     finally:
-        w.kill_client()
+        for window in w:
+            window.kill_client()
         conn.finalize()
 
     test_initial_state()


### PR DESCRIPTION
According to [this part](https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45841379520816) of the ewmh specification the strut values are meant to be used as absolute coordinates and not relative to any borders of physical screens. Fixes #1947 
