### PR TITLE
Add `xkb-switch` as optional dependency to KeyboardLayout widget.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Qtile 0.x.x, released xxxx-xx-xx:
           A new command, `lazy.ungrab_all_chords`, was introduced to return to the root bindings.
           The `enter_chord` hook is now always called with a string argument.
           The third argument to `KeyChord` was renamed from `submaping` to `submapping` (typo fix).
+        - Add `xkb-switch` as optional dependency to KeyboardLayout widget for improved functionality.
 
 Qtile 0.17.0, released 2021-02-13:
     !!! Python version breakage !!!

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2014-2015 Sean Vig
 # Copyright (c) 2014 Tycho Andersen
 # Copyright (c) 2019 zordsdavini
+# Copyright (c) 2021 Mateja Maric
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,34 +34,47 @@ kb_variant_regex = re.compile(r'variant:\s+(?P<variant>\w+)')
 
 
 class KeyboardLayout(base.InLoopPollText):
-    """Widget for changing and displaying the current keyboard layout
+    """Widget for changing and displaying the current keyboard layout.
 
-    To use this widget effectively you need to specify keyboard layouts you want to use (using "configured_keyboards")
+    There are two ways of using this widget:
+
+    **1. The First Way** (you need to have xkb-switch installed):
+
+    If you set "use_xkb_switch" to True, this widget will act like most keyboard layout widgets in other WMs and status bars.
+    You simply can simply set your keyboard layout (using "setxkbmap" for example) in your ".xinitrc" or "autostart.sh"
+    and this widget will auto-detect and display your keyboard layout and update on changes.
+
+    **2. The Second Way** (you need to have setxkbmap installed):
+
+    You need to specify keyboard layouts you want to use (using "configured_keyboards")
     and bind function "next_keyboard" to specific keys in order to change layouts.
 
     For example:
 
         Key([mod], "space", lazy.widget["keyboardlayout"].next_keyboard(), desc="Next keyboard layout."),
 
-    It requires setxkbmap to be available in the system.
+    *Note that this way only layouts in "configured_keyboards" will be used.*
+
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("update_interval", 1, "Update time in seconds."),
+        ("update_interval", 0.2, "Update time in seconds."),
+        ("use_xkb_switch", False, "You need xkb-switch installed. If True 'configured_keyboards' and 'option' variables won't be used."),
         ("configured_keyboards", ["us"], "A list of predefined keyboard layouts "
             "represented as strings. For example: "
             "['us', 'us colemak', 'es', 'fr']."),
         ("display_map", {}, "Custom display of layout. Key should be in format "
-            "'layout variant'. For example: "
+         "'layout variant':'display text'. For example: "
             "{'us': 'us ', 'lt sgs': 'sgs', 'ru phonetic': 'ru '}"),
-        ("option", None, "string of setxkbmap option. Ex., 'compose:menu,grp_led:scroll'"),
+        ("option", None, "String of setxkbmap option. Ex., 'compose:menu,grp_led:scroll'"),
     ]
 
     def __init__(self, **config):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(KeyboardLayout.defaults)
 
-        self.keyboard = self.configured_keyboards[0]
+        if not self.use_xkb_switch:
+            self.keyboard = self.configured_keyboards[0]
 
         self.add_callbacks({'Button1': self.next_keyboard})
 
@@ -71,17 +85,21 @@ class KeyboardLayout(base.InLoopPollText):
         If the current keyboard layout is not in the list, it will set as new
         layout the first one in the list.
         """
-
-        current_keyboard = self.keyboard
-        if current_keyboard in self.configured_keyboards:
-            # iterate the list circularly
-            next_keyboard = self.configured_keyboards[
-                (self.configured_keyboards.index(current_keyboard) + 1) %
-                len(self.configured_keyboards)]
+        if self.use_xkb_switch:
+            try:
+                self.call_process(['xkb-switch', '-n'])
+            except CalledProcessError as e:
+                logger.error("Can't set the keyboard layout (%s)", e)
         else:
-            next_keyboard = self.configured_keyboards[0]
-
-        self.keyboard = next_keyboard
+            current_keyboard = self.keyboard
+            if current_keyboard in self.configured_keyboards:
+                # iterate the list circularly
+                next_keyboard = self.configured_keyboards[
+                    (self.configured_keyboards.index(current_keyboard) + 1) %
+                    len(self.configured_keyboards)]
+            else:
+                next_keyboard = self.configured_keyboards[0]
+            self.keyboard = next_keyboard
 
         self.tick()
 
@@ -91,6 +109,10 @@ class KeyboardLayout(base.InLoopPollText):
         return self.keyboard.upper()
 
     def get_keyboard_layout(self, setxkbmap_output):
+        """Used by setxkbmap part of keyboard getter.
+
+        Not called if xkb-switch is used.
+        """
         match_layout = kb_layout_regex.search(setxkbmap_output)
         match_variant = kb_variant_regex.search(setxkbmap_output)
 
@@ -108,19 +130,29 @@ class KeyboardLayout(base.InLoopPollText):
 
         Examples: "us", "us dvorak".  In case of error returns "unknown".
         """
-        try:
-            command = 'setxkbmap -verbose 10 -query'
-            setxkbmap_output = self.call_process(command.split(' '))
-            keyboard = self.get_keyboard_layout(setxkbmap_output)
-            return str(keyboard)
-        except CalledProcessError as e:
-            logger.error('Can not get the keyboard layout: {0}'.format(e))
-        except OSError as e:
-            logger.error('Please, check that xset is available: {0}'.format(e))
+        if self.use_xkb_switch:
+            try:
+                return self.call_process(['xkb-switch', '-p']).replace('(', ' ').replace(')', ' ').rstrip()
+            except CalledProcessError as e:
+                logger.error('Can not get the keyboard layout: {0}'.format(e))
+            except OSError as e:
+                logger.error('Please, check that xkb-switch is available: {0}'.format(e))
+        else:
+            try:
+                command = 'setxkbmap -verbose 10 -query'
+                setxkbmap_output = self.call_process(command.split(' '))
+                keyboard = self.get_keyboard_layout(setxkbmap_output)
+                return str(keyboard)
+            except CalledProcessError as e:
+                logger.error('Can not get the keyboard layout: {0}'.format(e))
+            except OSError as e:
+                logger.error('Please, check that xset is available: {0}'.format(e))
+
         return "unknown"
 
     @keyboard.setter
     def keyboard(self, keyboard):
+        """Not called if xkb-switch is used."""
         command = ['setxkbmap']
         command.extend(keyboard.split(" "))
         if self.option:


### PR DESCRIPTION
I made `use_xkb_switch` option that when enabled should fix #2027 and also makes KeyboardLayout widget easier to use.
When disabled everything should work as it did in previous versions of KeyboardLayout widget, making it backwards compatible.

Changes:

- Use `xkb-switch` in `next_keyboard`, if `use_xkb_switch` is set to True.
- Use `xkb-switch` in `keyboard` getter and sanitize it's output, if `use_xkb_switch` is set to True.
- `keyboard` setter is never used if `use_xkb_switch` is set to True.
- Lower default `update_interval` for better responsiveness.
- Rewrote widget documentation.
- Updated CHANGELOG.