### PR TITLE
Add a new command to label the current group on the flight

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1420,6 +1420,25 @@ class Qtile(CommandObject):
 
         mb.start_input(prompt, f, "group", strict_completer=True)
 
+    def cmd_labelgroup(self, prompt="label", widget="prompt"):
+        """Launch prompt widget to label the current group
+
+        Parameters
+        ==========
+        prompt :
+            Text with which to prompt user (default: "label")
+        widget :
+            Name of the prompt widget (default: "prompt")
+        """
+        def f(name):
+            self.current_group.cmd_set_label(name or None)
+
+        try:
+            mb = self.widgets_map[widget]
+            mb.start_input(prompt, f, allow_empty_input=True)
+        except KeyError:
+            logger.error("No widget named '{0:s}' present.".format(widget))
+
     def cmd_spawncmd(self, prompt="spawn", widget="prompt",
                      command="%s", complete="cmd", shell=True):
         """Spawn a command using a prompt widget, with tab-completion.

--- a/libqtile/core/state.py
+++ b/libqtile/core/state.py
@@ -60,6 +60,7 @@ class QtileState:
         for (group, layout, label) in self.groups:
             try:
                 qtile.groups_map[group].layout = layout
+                qtile.groups_map[group].label = label
             except KeyError:
                 qtile.add_group(group, layout, label=label)
 

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -425,8 +425,8 @@ class Prompt(base._TextBox):
 
         hook.subscribe.client_focus(f)
 
-    def start_input(self, prompt, callback,
-                    complete=None, strict_completer=False) -> None:
+    def start_input(self, prompt, callback, complete=None,
+                    strict_completer=False, allow_empty_input=False) -> None:
         """Run the prompt
 
         Displays a prompt and starts to take one line of keyboard input from
@@ -450,6 +450,8 @@ class Prompt(base._TextBox):
         strict_completer :
             When True the return value wil be the exact completer result where
             available.
+        allow_empty_input :
+            When True, an empty value will still call the callback function
         """
 
         if self.cursor and self.cursorblink and not self.active:
@@ -464,6 +466,7 @@ class Prompt(base._TextBox):
         self.callback = callback
         self.completer = self.completers[complete](self.qtile)
         self.strict_completer = strict_completer
+        self.allow_empty_input = allow_empty_input
         self._update()
         self.bar.widget_grab_keyboard(self)
         if self.record_history:
@@ -571,7 +574,7 @@ class Prompt(base._TextBox):
             self.user_input = self.actual_value or self.user_input
             del self.actual_value
         self._history_to_input()
-        if self.user_input:
+        if self.user_input or self.allow_empty_input:
             # If history record is activated, also save command in history
             if self.record_history:
                 # ensure no dups in history

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -86,6 +86,7 @@ class ManagerConfig(Config):
     screens = [libqtile.config.Screen(
         bottom=libqtile.bar.Bar(
             [
+                libqtile.widget.Prompt(),
                 libqtile.widget.GroupBox(),
             ],
             20
@@ -1204,6 +1205,21 @@ def test_togroup_config(manager):
     a = manager.test_window("one")
     assert len(manager.c.group["d"].info()["windows"]) == 1
     manager.kill_window(a)
+
+
+@manager_config
+def test_labelgroup(manager):
+    manager.c.group["a"].toscreen()
+    assert manager.c.group["a"].info()["label"] == "a"
+
+    manager.c.labelgroup()
+    manager.c.widget["prompt"].fake_keypress("b")
+    manager.c.widget["prompt"].fake_keypress("Return")
+    assert manager.c.group["a"].info()["label"] == "b"
+
+    manager.c.labelgroup()
+    manager.c.widget["prompt"].fake_keypress("Return")
+    assert manager.c.group["a"].info()["label"] == "a"
 
 
 @manager_config


### PR DESCRIPTION
Entering an empty value will restore the original name of the group.