### PR TITLE
Add custom_command output line count modification argument to CheckUpdate widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,9 @@ Qtile 0.x.x, released xxxx-xx-xx:
           A new command, `lazy.ungrab_all_chords`, was introduced to return to the root bindings.
           The `enter_chord` hook is now always called with a string argument.
           The third argument to `KeyChord` was renamed from `submaping` to `submapping` (typo fix).
+        - added new argument for CheckUpdates widget: `custom_command_modify` which allows user to modify the
+          the line count of the output of `custom_command` with a lambda function (i.e. `lambda x: x-3`).
+          Argument defaults to `lambda x: x` and is overridden by `distro` argument's internal lambda.
 
 Qtile 0.17.0, released 2021-02-13:
     !!! Python version breakage !!!

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -31,6 +31,7 @@ class CheckUpdates(base.ThreadPoolText):
     defaults = [
         ("distro", "Arch", "Name of your distribution"),
         ("custom_command", None, "Custom shell command for checking updates (counts the lines of the output)"),
+        ("custom_command_modify", (lambda x: x), "Lambda function to modify line count from custom_command"),
         ("update_interval", 60, "Update interval in seconds."),
         ('execute', None, 'Command to execute on click'),
         ("display_format", "Updates: {updates}", "Display format if updates available"),
@@ -56,15 +57,20 @@ class CheckUpdates(base.ThreadPoolText):
                          "Mandriva": ("urpmq --auto-select", 0)
                          }
 
-        # Check if distro name is valid.
-        try:
-            self.cmd = self.cmd_dict[self.distro][0].split()
-            self.subtr = self.cmd_dict[self.distro][1]
-        except KeyError:
-            distros = sorted(self.cmd_dict.keys())
-            logger.error(self.distro + ' is not a valid distro name. ' +
-                         'Use one of the list: ' + str(distros) + '.')
-            self.cmd = None
+        if self.custom_command:
+            # Use custom_command
+            self.cmd = self.custom_command
+
+        else:
+            # Check if distro name is valid.
+            try:
+                self.cmd = self.cmd_dict[self.distro][0]
+                self.custom_command_modify = (lambda x: x - self.cmd_dict[self.distro][1])
+            except KeyError:
+                distros = sorted(self.cmd_dict.keys())
+                logger.error(self.distro + ' is not a valid distro name. ' +
+                             'Use one of the list: ' + str(distros) + '.')
+                self.cmd = None
 
         if self.execute:
             self.add_callbacks({'Button1': self.do_execute})
@@ -72,14 +78,10 @@ class CheckUpdates(base.ThreadPoolText):
     def _check_updates(self):
         # type: () -> str
         try:
-            if self.custom_command is None:
-                updates = self.call_process(self.cmd)
-            else:
-                updates = self.call_process(self.custom_command, shell=True)
-                self.subtr = 0
+            updates = self.call_process(self.cmd, shell=True)
         except CalledProcessError:
             updates = ""
-        num_updates = len(updates.splitlines()) - self.subtr
+        num_updates = self.custom_command_modify(len(updates.splitlines()))
 
         if num_updates == 0:
             self.layout.colour = self.colour_no_updates


### PR DESCRIPTION
Changes the custom_command argument input from string to tuple or list ("string", int)
mimicking the format of the distro argument allowing for line stripping of package manager update commands.
For example: `custom_command = "pacman -Qu"` (while still acceptable for backwards compatibility)
can now be written as `custom_command = ("pacman -Qu", 0)` where 0 can be any integer of lines to be removed.

checking of whether to use distro or custom_command and setting of internal values was also moved to \_init\_ so that the custom command doesn't have to be reparsed every time it is called by poll().

instigating issue: #2311 

Edit: `custom_command` reverted to string format and new `custom_command_modify` argument added that allows user to input lambda function for greater flexibility. Note new argument is overridden by `distro` argument