### PR TITLE
[RFC] Fix pylint warnings and enable it as a style guard in the CI config

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -52,7 +52,7 @@ from xcffib.xproto import CW, EventMask, WindowClass
 from libqtile import xkeysyms
 from libqtile.backend.x11.xcursors import Cursors
 from libqtile.log_utils import logger
-from libqtile.utils import hex
+from libqtile.utils import color_hex
 
 keysyms = xkeysyms.keysyms
 
@@ -342,7 +342,7 @@ class Colormap:
             def x8to16(i):
                 return 0xffff * (i & 0xff) // 0xff
 
-            color = hex(color)
+            color = color_hex(color)
             r = x8to16(int(color[-6] + color[-5], 16))
             g = x8to16(int(color[-4] + color[-3], 16))
             b = x8to16(int(color[-2] + color[-1], 16))
@@ -635,7 +635,10 @@ class Window:
             self.wid, mask, values
         )
 
-    def set_property(self, name, value, type=None, format=None):
+    def set_property(self, name, value,
+                     type=None, format=None):  # pylint: disable=redefined-builtin
+        # builtins type and format are redefined. As they are only arguments to a method
+        # which is used regularly, we maintain compatibility here.
         """
         Parameters
         ==========
@@ -685,7 +688,8 @@ class Window:
                 'X error in SetProperty (wid=%r, prop=%r), ignoring',
                 self.wid, name)
 
-    def get_property(self, prop, type=None, unpack=None):
+    def get_property(self, prop, type=None, unpack=None):  # pylint: disable=redefined-builtin
+        # builtin type is redefined. We allow this here to be consistent with self.set_property.
         """Return the contents of a property as a GetPropertyReply
 
         If unpack is specified, a tuple of values is returned.  The type to

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -189,9 +189,10 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         try:
             try:
-                return True, str(eval(code))
+                # The method announces the powers of eval, so we definitely need it:
+                return True, str(eval(code))  # pylint: disable=eval-used
             except SyntaxError:
-                exec(code)
+                exec(code)  # pylint: disable=exec-used
                 return True, None
         except Exception:
             error = traceback.format_exc().strip().split("\n")[-1]

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -683,8 +683,9 @@ class Rule:
     break_on_match :
         Should we stop applying rules if this rule is matched?
     """
-    def __init__(self, match, group=None, float=False, intrusive=False,
-                 break_on_match=True):
+    def __init__(self, match, group=None, float=False,  # pylint: disable=redefined-builtin
+                 intrusive=False, break_on_match=True):
+        # builtin float is redefined. We accept this for compatibility reasons.
         if isinstance(match, Match):
             self.matchlist = [match]
         else:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1023,17 +1023,17 @@ class Qtile(CommandObject):
                 format_string = " ".join("%-{0:d}s".format(max_col_size + 2) for max_col_size in self.max_col_size)
                 return format_string + "\n", len(self.max_col_size)
 
-            def expandlist(self, list, n):
-                if not list:
+            def expandlist(self, row, n):
+                if not row:
                     return ["-" * max_col_size for max_col_size in self.max_col_size]
-                n -= len(list)
+                n -= len(row)
                 if n > 0:
-                    list += [""] * n
-                return list
+                    row += [""] * n
+                return row
 
             def __str__(self):
-                format, n = self.getformat()
-                return "".join([format % tuple(self.expandlist(row, n)) for row in self.rows])
+                fmt, n = self.getformat()
+                return "".join([fmt % tuple(self.expandlist(row, n)) for row in self.rows])
 
         result = FormatTable()
         result.add(["KeySym", "Mod", "Command", "Desc"])

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1474,7 +1474,7 @@ class Qtile(CommandObject):
                     logger.info('No command entered.')
                     return
                 try:
-                    result = eval(u'c.{0:s}'.format(cmd))
+                    result = eval(u'c.{0:s}'.format(cmd))  # pylint: disable=eval-used
                 except (CommandError, CommandException, AttributeError) as err:
                     logger.error(err)
                     result = None

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -41,7 +41,7 @@ class WindowList(Dmenu):
         Dmenu._configure(self, qtile)
 
     def list_windows(self):
-        id = 0
+        idx = 0
         self.item_to_win = {}
 
         if self.all_groups:
@@ -52,9 +52,9 @@ class WindowList(Dmenu):
         for win in windows:
             if win.group and not isinstance(win.group, ScratchPad):
                 item = self.item_format.format(
-                    group=win.group.label or win.group.name, id=id, window=win.name)
+                    group=win.group.label or win.group.name, id=idx, window=win.name)
                 self.item_to_win[item] = win
-                id += 1
+                idx += 1
 
     def run(self):
         self.list_windows()

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -88,19 +88,15 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
 
     def show(self, screen_rect):
         """Called when layout is being shown"""
-        pass
 
     def hide(self):
         """Called when layout is being hidden"""
-        pass
 
     def focus(self, client):
         """Called whenever the focus changes"""
-        pass
 
     def blur(self):
         """Called whenever focus is gone from this layout"""
-        pass
 
     def info(self):
         """Returns a dictionary of layout information"""
@@ -121,7 +117,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         the window to its internal datastructures, without mapping or
         configuring.
         """
-        pass
 
     @abstractmethod
     def remove(self, client):
@@ -133,7 +128,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
 
         Returns the "next" window that should gain focus or None.
         """
-        pass
 
     @abstractmethod
     def configure(self, client, screen_rect):
@@ -145,7 +139,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
               `.place()` method.
             - Call either `.hide()` or `.unhide()` on the window.
         """
-        pass
 
     @abstractmethod
     def focus_first(self):
@@ -155,7 +148,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
             - Return the first client in Layout, if any.
             - Not focus the client itself, this is done by caller.
         """
-        pass
 
     @abstractmethod
     def focus_last(self):
@@ -165,7 +157,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
             - Return the last client in Layout, if any.
             - Not focus the client itself, this is done by caller.
         """
-        pass
 
     @abstractmethod
     def focus_next(self, win):
@@ -185,7 +176,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         win:
             The currently focused client.
         """
-        pass
 
     @abstractmethod
     def focus_previous(self, win):
@@ -205,7 +195,6 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         win:
             The currently focused client.
         """
-        pass
 
     @abstractmethod
     def cmd_next(self):

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -154,9 +154,9 @@ class Stack(Layout):
         iterator = iter(self.stacks)
         for i in iterator:
             if client in i:
-                next = i.focus_next(client)
-                if next:
-                    return next
+                n = i.focus_next(client)
+                if n:
+                    return n
                 break
         else:
             return
@@ -169,9 +169,9 @@ class Stack(Layout):
         iterator = iter(reversed(self.stacks))
         for i in iterator:
             if client in i:
-                next = i.focus_previous(client)
-                if next:
-                    return next
+                n = i.focus_previous(client)
+                if n:
+                    return n
                 break
         else:
             return
@@ -327,11 +327,11 @@ class Stack(Layout):
         """
         if not self.current_stack:
             return
-        next = n % len(self.stacks)
+        next_index = n % len(self.stacks)
         win = self.current_stack.cw
         self.current_stack.remove(win)
-        self.stacks[next].add(win)
-        self.stacks[next].focus(win)
+        self.stacks[next_index].add(win)
+        self.stacks[next_index].focus(win)
         self.group.layout_all()
 
     def cmd_info(self):

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -22,8 +22,8 @@
 # Set the locale before any widgets or anything are imported, so any widget
 # whose defaults depend on a reasonable locale sees something reasonable.
 import locale
+import sys
 from os import getenv, makedirs, path
-from sys import exit
 
 import libqtile.backend
 from libqtile import confreader
@@ -89,7 +89,7 @@ def start(options):
         q.loop()
     except Exception:
         logger.exception('Qtile crashed')
-        exit(1)
+        sys.exit(1)
     logger.info('Exiting...')
 
 

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -101,7 +101,7 @@ def rgb(x):
     raise ValueError("Invalid RGB specifier.")
 
 
-def hex(x):
+def color_hex(x):
     r, g, b, _ = rgb(x)
     return '#%02x%02x%02x' % (int(r * 255), int(g * 255), int(b * 255))
 
@@ -184,7 +184,7 @@ def lazify_imports(registry, package, fallback=None):
     return __all__, __dir__, __getattr__
 
 
-def send_notification(title, message, urgent=False, timeout=10000, id=None):
+def send_notification(title, message, urgent=False, timeout=10000, message_id=None):
     """
     Send a notification.
 
@@ -199,7 +199,7 @@ def send_notification(title, message, urgent=False, timeout=10000, id=None):
         )
         return -1
 
-    id = randint(10, 1000) if id is None else id
+    message_id = randint(10, 1000) if message_id is None else message_id
     urgency = 2 if urgent else 1
 
     try:
@@ -207,14 +207,14 @@ def send_notification(title, message, urgent=False, timeout=10000, id=None):
     except RuntimeError:
         logger.warning("Eventloop has not started. Cannot send notification.")
     else:
-        loop.create_task(_notify(title, message, urgency, timeout, id))
+        loop.create_task(_notify(title, message, urgency, timeout, message_id))
 
-    return id
+    return message_id
 
 
-async def _notify(title, message, urgency, timeout, id):
+async def _notify(title, message, urgency, timeout, message_id):
     notification = ["qtile",  # Application name
-                    id,  # id
+                    message_id,  # id
                     "",  # icon
                     title,  # summary
                     message,  # body

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -189,7 +189,6 @@ class _Widget(CommandObject, configurable.Configurable):
     def timer_setup(self):
         """ This is called exactly once, after the widget has been configured
         and timers are available to be set up. """
-        pass
 
     def _configure(self, qtile, bar):
         self.qtile = qtile
@@ -214,7 +213,6 @@ class _Widget(CommandObject, configurable.Configurable):
             wish to initialise the relevant code (e.g. connections to dbus
             using dbus_next) here.
         """
-        pass
 
     def finalize(self):
         if hasattr(self, 'layout') and self.layout:

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -76,7 +76,6 @@ class _Battery(ABC):
 
             Raises RuntimeError on error.
         """
-        pass
 
 
 def load_battery(**config) -> _Battery:

--- a/libqtile/widget/khal_calendar.py
+++ b/libqtile/widget/khal_calendar.py
@@ -120,7 +120,7 @@ class KhalCalendar(base.ThreadPoolText):
         data = ''.join(filter(lambda x: x in string.printable, data))
         # colorize the event if it is within reminder time
         if (starttime - remtime <= now) and (endtime > now):
-            self.foreground = utils.hex(self.reminder_color)
+            self.foreground = utils.color_hex(self.reminder_color)
         else:
             self.foreground = self.default_foreground
 

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -8,7 +8,9 @@ from collections import defaultdict
 from html import escape
 from socket import error as socket_error
 
-from mpd import CommandError, ConnectionError, MPDClient
+# builtin ConnectionError is redefined. Since it is rarely used, we accept that here.
+from mpd import ConnectionError  # pylint: disable=redefined-builtin
+from mpd import CommandError, MPDClient
 
 from libqtile import utils
 from libqtile.log_utils import logger
@@ -194,7 +196,7 @@ class Mpd2(base.ThreadPoolText):
         self.client.timeout = self.timeout
         self.client.idletimeout = self.idletimeout
         if self.color_progress:
-            self.color_progress = utils.hex(self.color_progress)
+            self.color_progress = utils.color_hex(self.color_progress)
 
         # remap self.keys as mouse_buttons for new button_press functionality.
         # so we don't break existing configurations.

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -78,7 +78,7 @@ class Notify(base._TextBox):
         urgency = notif.hints.get('urgency', 1)
         if urgency != 1:
             self.text = '<span color="%s">%s</span>' % (
-                utils.hex(
+                utils.color_hex(
                     self.foreground_urgent if urgency == 2
                     else self.foreground_low
                 ),

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -487,7 +487,7 @@ class Prompt(base._TextBox):
             self.timeout_add(self.cursorblink, self._blink)
 
     def _highlight_text(self, text) -> str:
-        color = utils.hex(self.cursor_color)
+        color = utils.color_hex(self.cursor_color)
         text = '<span foreground="{0}">{1}</span>'.format(color, text)
         if self.show_cursor:
             text = '<u>{}</u>'.format(text)

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -64,7 +64,6 @@ class AbstractCompleter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def complete(self, txt: str) -> str:
         """Perform the requested completion on the given text"""
-        pass  # pragma: no cover
 
 
 class NullCompleter(AbstractCompleter):


### PR DESCRIPTION
This continues my previous work to get pylint working (#2316).
More specifically, the goal is to deal with all the warnings that pylint throws at us. Once it does not complain anymore, we can finally change `tox.ini` such that tests fail if a change introduces bad code again.
This pr fixes:
+ [x] `redefined-builtin`
+ [x] `unnecessary-pass`
+ [ ] `eval-used` and `exec-used`
+ [ ] `tox.ini`: When this change is made, tests can fail if pylint fails. Until now, the return code of the pylint run is ignored.

Some stats for @ramnes about `redefined-builtin`
| file(\.function)?::line                                | builtin           | lines changed (approx.) | strategy        | reason                                                       |
| ------------------------------------------------------ | ----------------- | ------------- | --------------- | ------------------------------------------------------------ |
| `libqtile.config.Rule.__init__::686`                   | `float`           | -2+3          | disable locally | is just an argument, maintain compatibility.                 |
| `libqtile.scripts.start::25`                           | `exit`            | -2+2          | rename          |                                                              |
| `libqtile.widget.mpd2widget::11`                       | `ConnectionError` | -1+3          | disable locally | `ConnectionError` is rarely used.                            |
| `libqtile.core.manager.cmd_display_kb::1026`           | `list`            | -5+5          | rename          |                                                              |
| `libqtile.core.manager.cmd_display_kb::1035`           | `format`          | -2+2          | rename          |                                                              |
| `libqtile.layout.stack::157`                           | `next`            | -3+3          | rename          |                                                              |
| `libqtile.layout.stack::172`                           | `next`            | -3+3          | rename          |                                                              |
| `libqtile.layout.stack::330`                           | `next`            | -3+3          | rename          |                                                              |
| `libqtile.utils::104`, `libqtile.backend.x11.xcbq::55` | `hex`             | -7+7          | rename          |                                                              |
| `libqtile.utils::187`                                  | `id`              | -4+4          | rename          |                                                              |
| `libqtile.utils::215`                                  | `id`              | -2+2          | rename          |                                                              |
| `libqtile.extension.window_list::44`                   | `id`              | -3+3          | rename          |                                                              |
| `libqtile.backend.x11.xcbq.set_property::638`          | `type`, `format`  | -1+4          | disable locally | are just arguments, maintain compatibility. Also, 20 test lines use this. |
| `libqtile.backend.x11.xcbq.get_property::688`          | `type`            | -1+2          | disable locally | naming consistency with `set_property`                       |

Why _approx._? 'Cause I didn't want to push 14 commits for `redefined-builtin` and might have missed a line here or there.