### PR TITLE
Add `pytest-timeout` plugin to fail when tests hang

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,9 @@ ban-relative-imports = true
 python_files = test_*.py
 testpaths = test
 addopts = --verbose
+# 10 minutes should be enough for a single test to complete:
+timeout = 600
+timeout_func_only = True
 
 [check-manifest]
 ignore =

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,8 @@ testpaths = test
 addopts = --verbose
 # 10 minutes should be enough for a single test to complete:
 timeout = 600
-timeout_func_only = True
+timeout_func_only = False
+timeout_method = thread
 
 [check-manifest]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,14 @@ setenv = LC_CTYPE = en_US.UTF-8
 passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
 # xcffib has to be installed before cairocffi
+#
+# NOTE: pytest-timeout might trigger a `Timeout` while the coverage trace
+# function is running. This causes a warning about probably incorrect coverage
+# stats. The timeout makes the CI tests fail, so we don't care about coverage.
 deps =
     pytest >= 6.2.1
     pytest-cov >= 2.10.1
+    pytest-timeout >= 1.4.1
     setuptools >= 40.5.0
     xcffib >= 0.8.1
     bowler
@@ -81,6 +86,7 @@ deps =
     bowler
     xcffib >= 0.8.1
     pytest >= 6.2.1
+    pytest-timeout >= 1.4.1
 commands =
     pip install -r requirements.txt
     mypy -p libqtile


### PR DESCRIPTION
Related: #2329 
This pr adds `pytest-timeout` (with a timeout of 30min = 1800s for a test to complete) to the test suite.
Although timings can be obtained with `tox -e <ENVNAME> -- --durations=0`, this only prints them after all tests succeed or fail in a nominal way. If the process is killed (Ctrl-C, GitHub Actions execution time limit exceeded), the acquired duration data will not be printed. Hence it makes sense to print a rough estimation (`%.3f`, in seconds) right after each test ends, resulting in either `PASSED (0.123)` or `FAILED (6.283)` to be printed. In case of a timeout, `TIMEOUT` will be printed instead. This should help identify how long each test takes to execute.