### PR TITLE
migrate: print message and remove backup file if no changes made

### DIFF
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -16,6 +16,7 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+import filecmp
 import os
 import os.path
 import shutil
@@ -98,10 +99,15 @@ def do_migrate(args):
         print("install it and try again")
         sys.exit(1)
 
-    shutil.copyfile(args.config, args.config+BACKUP_SUFFIX)
+    backup = args.config + BACKUP_SUFFIX
+    shutil.copyfile(args.config, backup)
 
     for m in MIGRATIONS:
         m(args.config).execute(interactive=args.interactive, write=True)
+
+    if filecmp.cmp(args.config, backup, shallow=False):
+        print("Config unchanged.")
+        os.remove(backup)
 
 
 def add_subcommand(subparsers, parents):

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -27,12 +27,13 @@ def test_migrate_default_config_noop():
         default_config = os.path.join(os.path.dirname(__file__), '..', 'libqtile', 'resources', 'default_config.py')
         config_path = os.path.join(temp, "config.py")
         shutil.copyfile(default_config, config_path)
+
+        before = hash_file(config_path)
         run_qtile_migrate(config_path)
+        after = hash_file(config_path)
 
-        original = hash_file(config_path)
-        migrated = hash_file(config_path+BACKUP_SUFFIX)
-
-        assert original == migrated
+        assert before == after
+        assert not os.path.exists(config_path + BACKUP_SUFFIX)
 
 
 def read_file(p):


### PR DESCRIPTION
Currently `qtile migrate` makes a backup of the config and prints
nothing if no changes were required. Let's make it clear that there were
no changes by printing out a message saying so, and don't leave the
backup around if it is identical to the main file.