### PR TITLE
`CommandClient` refactoring of `cmd-obj` command

### DIFF
--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -52,7 +52,7 @@ def get_formated_info(obj: CommandClient, cmd: str, args=True, short=True) -> st
     line, the summary is constructed from doc[1] line.
     """
 
-    doc = obj.call("doc")(cmd).splitlines()
+    doc = obj.call("doc", cmd).splitlines()
 
     tdoc = doc[0]
     doc_args = tdoc[tdoc.find("("):tdoc.find(")") + 1].strip()
@@ -71,7 +71,7 @@ def print_commands(prefix: str, obj: CommandClient) -> None:
     """Print available commands for given object."""
     prefix += " -f "
 
-    cmds = obj.call("commands")()
+    cmds = obj.call("commands")
 
     output = []
     for cmd in cmds:
@@ -128,13 +128,10 @@ def get_object(client: CommandClient, argv: List[str]) -> CommandClient:
 def run_function(client: CommandClient, funcname: str, args: List[str]) -> str:
     "Run command with specified args on given object."
     try:
-        func = client.call(funcname)
+        ret = client.call(funcname, *args)
     except SelectError:
         print("error: Sorry no function ", funcname)
         sys.exit(1)
-
-    try:
-        ret = func(*args)
     except CommandError as e:
         print("error: Command '{}' returned error: {}".format(funcname, str(e)))
         sys.exit(1)

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -177,7 +177,7 @@ def cmd_obj(args) -> None:
         if args.function == "help":
             print_commands("-o " + " ".join(args.obj_spec), obj)
         elif args.info:
-            print(get_formated_info(obj, args.function, args=True, short=False))
+            print(args.function + get_formated_info(obj, args.function, args=True, short=False))
         else:
             ret = run_function(obj, args.function, args.args)
             if ret is not None:

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -31,12 +31,10 @@ import sys
 import textwrap
 from typing import List
 
+from libqtile.command.base import CommandError, CommandException
 from libqtile.command.client import InteractiveCommandClient
-from libqtile.command.interface import (
-    CommandError,
-    CommandException,
-    IPCCommandInterface,
-)
+from libqtile.command.graph import CommandGraphRoot
+from libqtile.command.interface import IPCCommandInterface
 from libqtile.ipc import Client, find_sockfile
 
 
@@ -158,8 +156,8 @@ def run_function(client: InteractiveCommandClient, funcname: str, args: List[str
 
 def print_base_objects() -> None:
     """Prints access objects of Client, use cmd for commands."""
-    actions = ["-o cmd", "-o window", "-o layout", "-o group", "-o bar",
-               "-o screen"]
+    root = CommandGraphRoot()
+    actions = ["-o cmd"] + [f"-o {key}" for key in root.children]
     print("Specify an object on which to execute command")
     print("\n".join(actions))
 


### PR DESCRIPTION
The primary change here is in the 4th commit, which is to change the command client in the `cmd-obj` script to use the `CommandClient` rather than the `InteractiveCommandClient`. This allows the graph navigation to use the named functions `navigate()` and `call()` rather than using `__getattr__`, `__getitem__`, and `__call__`. There are also a couple clean ups in the implementation, for example, all command objects have a `cmd_doc` and `cmd_commands`, so just unconditionally call these commands, rather than checking if they exist.