### PR TITLE
Do more aggressive type checks and apply fixes

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -22,6 +22,8 @@
 The objects in the command graph and command resolution on the objects
 """
 
+from __future__ import annotations
+
 import abc
 import inspect
 import traceback
@@ -58,7 +60,7 @@ class CommandObject(metaclass=abc.ABCMeta):
     (c.f. docstring for `.items()` and `.select()`).
     """
 
-    def select(self, selectors: List[SelectorType]) -> "CommandObject":
+    def select(self, selectors: List[SelectorType]) -> CommandObject:
         """Return a selected object
 
         Recursively finds an object specified by a list of `(name, selector)`
@@ -84,7 +86,7 @@ class CommandObject(metaclass=abc.ABCMeta):
                 raise SelectError("", name, selectors)
         return obj
 
-    def items(self, name: str) -> Tuple[bool, List[str]]:
+    def items(self, name: str) -> Tuple[bool, Optional[List[str]]]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -99,11 +101,11 @@ class CommandObject(metaclass=abc.ABCMeta):
         if ret is None:
             # Not finding information for a particular item class is OK here;
             # we don't expect layouts to have a window, etc.
-            return False, []
+            return False, None
         return ret
 
     @abc.abstractmethod
-    def _items(self, name) -> Tuple[bool, List[str]]:
+    def _items(self, name) -> Optional[Tuple[bool, List[str]]]:
         """Generate the items for a given
 
         Same return as `.items()`. Return `None` if name is not a valid item
@@ -111,7 +113,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def _select(self, name: str, sel: Optional[Union[str, int]]) -> "CommandObject":
+    def _select(self, name: str, sel: Optional[Union[str, int]]) -> CommandObject:
         """Select the given item of the given item class
 
         This method is called with the following guarantees:
@@ -151,7 +153,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, List[str]]:
+    def cmd_items(self, name) -> Tuple[bool, Optional[List[str]]]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -27,6 +27,8 @@ that interacts with qtile objects, it should favor using the command graph
 clients to do this interaction.
 """
 
+from __future__ import annotations
+
 from typing import Any, List, Optional, Union
 
 from libqtile.command.base import SelectError
@@ -64,10 +66,7 @@ class CommandClient:
         if command is None:
             command = IPCCommandInterface(Client(find_sockfile()))
         self._command = command
-        if current_node is None:
-            self._current_node = CommandGraphRoot()  # type: GraphType
-        else:
-            self._current_node = current_node
+        self._current_node = current_node if current_node is not None else CommandGraphRoot()
 
     def __call__(self, *args, **kwargs) -> Any:
         """When the client has navigated to a command, execute it"""
@@ -76,7 +75,7 @@ class CommandClient:
 
         return self._command.execute(self._current_node, args, kwargs)
 
-    def navigate(self, name: str, selector: Optional[str]) -> "CommandClient":
+    def navigate(self, name: str, selector: Optional[str]) -> CommandClient:
         """Resolve the given object in the command graph
 
         Parameters
@@ -104,7 +103,7 @@ class CommandClient:
         next_node = self._current_node.navigate(name, selector)
         return self.__class__(self._command, current_node=next_node)
 
-    def call(self, name: str) -> "CommandClient":
+    def call(self, name: str) -> CommandClient:
         """Resolve the call into the command graph
 
         Parameters
@@ -135,12 +134,12 @@ class CommandClient:
         return self._current_node.children
 
     @property
-    def root(self) -> "CommandClient":
+    def root(self) -> CommandClient:
         """Get the root of the command graph"""
         return self.__class__(self._command)
 
     @property
-    def parent(self) -> "CommandClient":
+    def parent(self) -> CommandClient:
         """Get the parent of the current client"""
         if self._current_node.parent is None:
             raise SelectError("", "", self._current_node.selectors)
@@ -171,10 +170,7 @@ class InteractiveCommandClient:
         if command is None:
             command = IPCCommandInterface(Client(find_sockfile()))
         self._command = command
-        if current_node is None:
-            self._current_node = CommandGraphRoot()  # type: GraphType
-        else:
-            self._current_node = current_node
+        self._current_node = current_node if current_node is not None else CommandGraphRoot()
 
     def __call__(self, *args, **kwargs) -> Any:
         """When the client has navigated to a command, execute it"""
@@ -183,7 +179,7 @@ class InteractiveCommandClient:
 
         return self._command.execute(self._current_node, args, kwargs)
 
-    def __getattr__(self, name: str) -> "InteractiveCommandClient":
+    def __getattr__(self, name: str) -> InteractiveCommandClient:
         """Get the child element of the currently selected object
 
         Resolve the element specified by the given name, either the child
@@ -216,7 +212,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.navigate(name, None)
         return self.__class__(self._command, current_node=next_node)
 
-    def __getitem__(self, name: Union[str, int]) -> "InteractiveCommandClient":
+    def __getitem__(self, name: Union[str, int]) -> InteractiveCommandClient:
         """Get the selected element of the currently selected object
 
         From the current command graph object, select the instance with the

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -23,6 +23,8 @@ The objects defining the nodes in the command graph and the navigation of the
 abstract command graph
 """
 
+from __future__ import annotations
+
 import abc
 from typing import Dict, List, Optional, Tuple, Type, Union
 
@@ -49,7 +51,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def parent(self) -> Optional["CommandGraphNode"]:
+    def parent(self) -> Optional[CommandGraphNode]:
         """The parent of the current node"""
 
     @property
@@ -57,13 +59,13 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
     def children(self) -> List[str]:
         """The child objects that are contained within this object"""
 
-    def navigate(self, name: str, selector: Optional[Union[str, int]]) -> "CommandGraphNode":
+    def navigate(self, name: str, selector: Optional[Union[str, int]]) -> CommandGraphNode:
         """Navigate from the current node to the specified child"""
         if name in self.children:
             return _COMMAND_GRAPH_MAP[name](selector, self)
         raise KeyError("Given node is not an object: {}".format(name))
 
-    def call(self, name: str) -> "CommandGraphCall":
+    def call(self, name: str) -> CommandGraphCall:
         """Execute the given call on the selected object"""
         return CommandGraphCall(name, self)
 
@@ -199,11 +201,11 @@ class _WindowGraphNode(CommandGraphObject):
     children = ["group", "screen", "layout"]
 
 
-_COMMAND_GRAPH_MAP = {
+_COMMAND_GRAPH_MAP: Dict[str, Type[CommandGraphObject]] = {
     "bar": _BarGraphNode,
     "group": _GroupGraphNode,
     "layout": _LayoutGraphNode,
     "widget": _WidgetGraphNode,
     "window": _WindowGraphNode,
     "screen": _ScreenGraphNode,
-}  # type: Dict[str, Type[CommandGraphObject]]
+}

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -149,8 +149,9 @@ class QtileCommandInterface(CommandInterface):
         """
         obj = self._command_object.select(call.selectors)
 
-        cmd = obj.command(call.name)
-        if not cmd:
+        try:
+            cmd = obj.command(call.name)
+        except SelectError:
             return "No such command."
 
         logger.debug("Command: %s(%s, %s)", call.name, args, kwargs)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -74,8 +74,8 @@ class Qtile(CommandObject):
         self._state = state
         self.socket_path = socket_path
 
-        self._drag: Optional[Drag] = None
-        self.mouse_map: Dict[int, List[Click]] = {}
+        self._drag: Optional[Tuple] = None
+        self.mouse_map: Dict[int, List[Union[Click, Drag]]] = {}
         self.mouse_position = (0, 0)
 
         self.windows_map: Dict[int, window._Window] = {}

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -46,7 +46,7 @@ class LazyCall:
         self._args = args
         self._kwargs = kwargs
 
-        self._layouts = set()  # type: Set[str]
+        self._layouts: Set[str] = set()
         self._when_floating = True
 
     @property

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -28,8 +28,8 @@ from typing import Any
 try:
     from dbus_next.aio import MessageBus  # type: ignore
     from dbus_next.service import ServiceInterface  # type: ignore
-    from dbus_next.service import method  # type: ignore
-    from dbus_next.service import signal  # type: ignore
+    from dbus_next.service import method
+    from dbus_next.service import signal
     has_dbus = True
 except ImportError:
     has_dbus = False

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -28,8 +28,7 @@ from typing import Any
 try:
     from dbus_next.aio import MessageBus  # type: ignore
     from dbus_next.service import ServiceInterface  # type: ignore
-    from dbus_next.service import method
-    from dbus_next.service import signal
+    from dbus_next.service import method, signal
     has_dbus = True
 except ImportError:
     has_dbus = False

--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -43,13 +43,11 @@ def run_cmd(opts) -> None:
     rule_args = {"float": opts.float, "intrusive": opts.intrusive,
                  "group": opts.group, "break_on_match": not opts.dont_break}
 
-    cmd = root.navigate("add_rule", None)
-    assert isinstance(cmd, graph.CommandGraphCall)
+    cmd = root.call("add_rule")
     _, rule_id = client.send((root.selectors, cmd.name, (match_args, rule_args), {}))
 
-    def remove_rule():
-        cmd = root.navigate("remove_rule", None)
-        assert isinstance(cmd, graph.CommandGraphCall)
+    def remove_rule() -> None:
+        cmd = root.call("remove_rule")
         client.send((root.selectors, cmd.name, (rule_id,), {}))
 
     atexit.register(remove_rule)

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -79,7 +79,7 @@ def make_qtile(options):
 
 def start(options):
     try:
-        locale.setlocale(locale.LC_ALL, locale.getdefaultlocale())  # type: ignore
+        locale.setlocale(locale.LC_ALL, locale.getdefaultlocale())
     except locale.Error:
         pass
 

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -23,12 +23,13 @@
 
 import fcntl
 import inspect
+import pprint
 import re
 import readline
 import struct
 import sys
 import termios
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from libqtile.command import graph
 from libqtile.command.interface import (
@@ -295,7 +296,7 @@ class QSh:
     do_quit = do_exit
     do_q = do_exit
 
-    def process_line(self, line: str) -> str:
+    def process_line(self, line: str) -> Any:
         builtin_match = re.fullmatch(r"(?P<cmd>\w+)(?:\s+(?P<arg>\S+))?", line)
         if builtin_match:
             cmd = builtin_match.group("cmd")
@@ -343,4 +344,7 @@ class QSh:
                 continue
 
             val = self.process_line(line)
-            print(val)
+            if isinstance(val, str):
+                print(val)
+            elif val:
+                pprint.pprint(val)

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -23,7 +23,6 @@
 
 import fcntl
 import inspect
-import pprint
 import re
 import readline
 import struct
@@ -344,7 +343,4 @@ class QSh:
                 continue
 
             val = self.process_line(line)
-            if isinstance(val, str):
-                print(val)
-            elif val:
-                pprint.pprint(val)
+            print(val)

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -30,7 +30,7 @@
 from os import path
 
 from libqtile import bar, pangocffi, utils
-from libqtile.notify import notifier  # type: ignore
+from libqtile.notify import notifier
 from libqtile.widget import base
 
 

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from libqtile.widget._pulse_audio import (
-    ffi,
-    lib,
-)
+from libqtile.widget._pulse_audio import ffi, lib
 from libqtile.widget.volume import Volume
 
 log = logging.getLogger(__name__)

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from libqtile.widget._pulse_audio import (  # type: ignore # otherwise mypy complains
+from libqtile.widget._pulse_audio import (
     ffi,
     lib,
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,6 +108,9 @@ include_trailing_comma = true
 [mypy]
 mypy_path = stubs
 python_version = 3.7
+warn_unused_configs = True
+warn_unused_ignores = True
+warn_unreachable = True
 [mypy-_cffi_backend]
 ignore_missing_imports = True
 [mypy-cairocffi._generated.ffi]


### PR DESCRIPTION
Setup the mypy testing to be a bit more aggressive in testing types,
including checking for unreachable code and non-sensical type
assertions.  Make changes based on this analysis to make the code pass
the type checks, including both getting rid of some of this dead code
and fixing the type annotations.  This also changes over to using the
__future__ annotations functionality to not have to handle the
not-yet-defined types as strings.