### PR TITLE
Add migration for config main function

### DIFF
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -68,11 +68,33 @@ def pacman_to_checkupdates(config):
     )
 
 
+def hook_main_function(config):
+    def modify_main(node, capture, filename):
+        main = capture.get("function_def")
+        if main.prev_sibling:
+            for leaf in main.prev_sibling.leaves():
+                if "startup" == leaf.value:
+                    return
+        args = capture.get("function_arguments")
+        if args:
+            args[0].remove()
+            main.prefix += "from libqtile import hook, qtile\n"
+            main.prefix += "@hook.subscribe.startup\n"
+
+    return (
+        bowler.Query(config)
+        .select_function("main")
+        .is_def()
+        .modify(modify_main)
+    )
+
+
 MIGRATIONS = [
     client_name_updated,
     tile_master_windows_rename,
     threaded_poll_text_rename,
     pacman_to_checkupdates,
+    hook_main_function,
 ]
 
 

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 import textwrap
 
+import pytest
+
 from libqtile.scripts.migrate import BACKUP_SUFFIX
 from test.test_check import have_mypy, run_qtile_check
 
@@ -140,3 +142,28 @@ def test_pacman():
     """)
 
     check_migrate(orig, expected)
+
+
+def test_main():
+    orig = textwrap.dedent("""
+        def main(qtile):
+            qtile.do_something()
+    """)
+
+    expected = textwrap.dedent("""
+        from libqtile import hook, qtile
+        @hook.subscribe.startup
+        def main():
+            qtile.do_something()
+    """)
+
+    check_migrate(orig, expected)
+
+    noop = textwrap.dedent("""
+        from libqtile.hook import subscribe
+        @subscribe.startup
+        def main():
+            pass
+    """)
+    with pytest.raises(FileNotFoundError):
+        check_migrate(noop, noop)


### PR DESCRIPTION
As discussed in #2310, this adds a `qtile migrate` migration that will
add the `@hook.subscribe.startup` decoration to `def main` in a config
file.