### PR TITLE
Unify `._items()` behavior

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -21,7 +21,7 @@
 from typing import Union
 
 from libqtile import configurable, drawer, window
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -99,9 +99,10 @@ class Gap(CommandObject):
     def geometry(self):
         return (self.x, self.y, self.width, self.height)
 
-    def _items(self, name):
-        if name == "screen":
-            return (True, None)
+    def _items(self, name: str) -> ItemT:
+        if name == "screen" and self.screen is not None:
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "screen":

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -32,6 +32,8 @@ from typing import Callable, List, Optional, Tuple, Union
 from libqtile.command.graph import SelectorType
 from libqtile.log_utils import logger
 
+ItemT = Optional[Tuple[bool, List[Union[str, int]]]]
+
 
 class SelectError(Exception):
     """Error raised in resolving a command graph object"""
@@ -86,7 +88,7 @@ class CommandObject(metaclass=abc.ABCMeta):
                 raise SelectError("", name, selectors)
         return obj
 
-    def items(self, name: str) -> Tuple[bool, Optional[List[str]]]:
+    def items(self, name: str) -> Tuple[bool, Optional[List[Union[str, int]]]]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -105,7 +107,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         return ret
 
     @abc.abstractmethod
-    def _items(self, name) -> Optional[Tuple[bool, List[str]]]:
+    def _items(self, name) -> ItemT:
         """Generate the items for a given
 
         Same return as `.items()`. Return `None` if name is not a valid item
@@ -153,7 +155,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, Optional[List[str]]]:
+    def cmd_items(self, name) -> Tuple[bool, Optional[List[Union[str, int]]]]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -34,14 +34,17 @@ import contextlib
 import os.path
 import sys
 import warnings
-from typing import Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import xcffib.xproto
 
 from libqtile import configurable, hook, utils, window
 from libqtile.bar import BarType
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.lazy import lazy
+
+if TYPE_CHECKING:
+    from libqtile.group import _Group
 
 
 class Key:
@@ -269,8 +272,8 @@ class Screen(CommandObject):
                  wallpaper: Optional[str] = None, wallpaper_mode: Optional[str] = None,
                  x: Optional[int] = None, y: Optional[int] = None, width: Optional[int] = None,
                  height: Optional[int] = None):
-        self.group = None
-        self.previous_group = None
+        self.group: Optional[_Group] = None
+        self.previous_group: Optional[_Group] = None
 
         self.top = top
         self.bottom = bottom
@@ -390,13 +393,14 @@ class Screen(CommandObject):
             group = self.previous_group
         self.set_group(group)
 
-    def _items(self, name):
-        if name == "layout":
-            return (True, list(range(len(self.group.layouts))))
-        elif name == "window":
-            return (True, [i.window.wid for i in self.group.windows])
+    def _items(self, name: str) -> ItemT:
+        if name == "layout" and self.group is not None:
+            return True, list(range(len(self.group.layouts)))
+        elif name == "window" and self.group is not None:
+            return True, [i.window.wid for i in self.group.windows]
         elif name == "bar":
-            return (False, [x.position for x in self.gaps])
+            return False, [x.position for x in self.gaps]
+        return None
 
     def _select(self, name, sel):
         if name == "layout":

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -32,7 +32,7 @@ import xcffib
 import xcffib.xproto
 
 from libqtile import hook, utils, window
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -325,14 +325,14 @@ class _Group(CommandObject):
                     i.focus(win)
         self.layout_all()
 
-    def _items(self, name):
+    def _items(self, name) -> ItemT:
         if name == "layout":
-            return (True, list(range(len(self.layouts))))
-        if name == "screen":
-            return (True, None)
+            return True, list(range(len(self.layouts)))
+        if name == "screen" and self.screen is not None:
+            return True, []
         if name == "window":
-            return (True, [i.window.wid for i in self.windows])
-        raise RuntimeError("Invalid item: {}".format(name))
+            return self.current_window is not None, [i.window.wid for i in self.windows]
+        return None
 
     def _select(self, name, sel):
         if name == "layout":

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -21,10 +21,10 @@
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Tuple  # noqa: F401
+from typing import Any, List, Tuple
 
 from libqtile import configurable
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
@@ -74,11 +74,12 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         c.group = group
         return c
 
-    def _items(self, name):
-        if name == "screen":
-            return (True, None)
+    def _items(self, name: str) -> ItemT:
+        if name == "screen" and self.group.screen is not None:
+            return True, []
         elif name == "group":
-            return (True, None)
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "screen":

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -34,7 +34,7 @@ import subprocess
 from typing import Any, List, Tuple
 
 from libqtile import bar, configurable, confreader, drawer
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -257,9 +257,10 @@ class _Widget(CommandObject, configurable.Configurable):
             raise CommandError("No such widget: %s" % name)
         return w
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         if name == "bar":
-            return (True, None)
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "bar":

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -26,7 +26,7 @@ import xcffib.xproto
 from xcffib.xproto import EventMask, SetMode, StackMode
 
 from libqtile import hook, utils
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, ItemT
 from libqtile.log_utils import logger
 
 # ICCM Constants
@@ -576,7 +576,7 @@ class _Window(CommandObject):
         hook.fire("client_focus", self)
         return True
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         return None
 
     def _select(self, name, sel):
@@ -1234,13 +1234,14 @@ class Window(_Window):
             logger.info("Unknown window property: %s", name)
         return False
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         if name == "group":
-            return (True, None)
+            return True, []
         elif name == "layout":
-            return (True, list(range(len(self.group.layouts))))
-        elif name == "screen":
-            return (True, None)
+            return True, list(range(len(self.group.layouts)))
+        elif name == "screen" and self.group.screen is not None:
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "group":

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -235,7 +235,7 @@ def test_items_group(manager):
 
     assert group.items("window") == (True, [wid])
     assert group.items("layout") == (True, [0, 1, 2])
-    assert group.items("screen") == (True, None)
+    assert group.items("screen") == (True, [])
 
 
 @server_config
@@ -299,7 +299,7 @@ def test_select_screen(manager):
 
 @server_config
 def test_items_bar(manager):
-    assert manager.c.bar["bottom"].items("screen") == (True, None)
+    assert manager.c.bar["bottom"].items("screen") == (True, [])
 
 
 @server_config
@@ -313,8 +313,8 @@ def test_select_bar(manager):
 
 @server_config
 def test_items_layout(manager):
-    assert manager.c.layout.items("screen") == (True, None)
-    assert manager.c.layout.items("group") == (True, None)
+    assert manager.c.layout.items("screen") == (True, [])
+    assert manager.c.layout.items("group") == (True, [])
 
 
 @server_config
@@ -336,9 +336,9 @@ def test_items_window(manager):
     window = manager.c.window
     window.info()["id"]
 
-    assert window.items("group") == (True, None)
+    assert window.items("group") == (True, [])
     assert window.items("layout") == (True, [0, 1, 2])
-    assert window.items("screen") == (True, None)
+    assert window.items("screen") == (True, [])
 
 
 @server_config
@@ -361,7 +361,7 @@ def test_select_window(manager):
 
 @server_config
 def test_items_widget(manager):
-    assert manager.c.widget["one"].items("bar") == (True, None)
+    assert manager.c.widget["one"].items("bar") == (True, [])
 
 
 @server_config


### PR DESCRIPTION
Set a common return type for the `._items()` method and add the
annotation to the various command objects.  Some of the command objects
had been raising errors or returning `None` rather than an empty list
when there are no specific items to select.

This is built on top of #2340.