### PR TITLE
Use command client in qsh

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -21,7 +21,7 @@
 from typing import Union
 
 from libqtile import configurable, drawer, window
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -99,9 +99,10 @@ class Gap(CommandObject):
     def geometry(self):
         return (self.x, self.y, self.width, self.height)
 
-    def _items(self, name):
-        if name == "screen":
-            return (True, None)
+    def _items(self, name: str) -> ItemT:
+        if name == "screen" and self.screen is not None:
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "screen":

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -32,6 +32,8 @@ from typing import Callable, List, Optional, Tuple, Union
 from libqtile.command.graph import SelectorType
 from libqtile.log_utils import logger
 
+ItemT = Optional[Tuple[bool, List[Union[str, int]]]]
+
 
 class SelectError(Exception):
     """Error raised in resolving a command graph object"""
@@ -86,7 +88,7 @@ class CommandObject(metaclass=abc.ABCMeta):
                 raise SelectError("", name, selectors)
         return obj
 
-    def items(self, name: str) -> Tuple[bool, Optional[List[str]]]:
+    def items(self, name: str) -> Tuple[bool, Optional[List[Union[str, int]]]]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -105,7 +107,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         return ret
 
     @abc.abstractmethod
-    def _items(self, name) -> Optional[Tuple[bool, List[str]]]:
+    def _items(self, name) -> ItemT:
         """Generate the items for a given
 
         Same return as `.items()`. Return `None` if name is not a valid item
@@ -153,7 +155,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, Optional[List[str]]]:
+    def cmd_items(self, name) -> Tuple[bool, Optional[List[Union[str, int]]]]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -29,7 +29,7 @@ clients to do this interaction.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from libqtile.command.base import SelectError
 from libqtile.command.graph import (
@@ -39,7 +39,11 @@ from libqtile.command.graph import (
     CommandGraphRoot,
     GraphType,
 )
-from libqtile.command.interface import CommandInterface, IPCCommandInterface
+from libqtile.command.interface import (
+    CommandInterface,
+    IPCCommandInterface,
+    SelectorType,
+)
 from libqtile.ipc import Client, find_sockfile
 
 
@@ -124,10 +128,19 @@ class CommandClient:
         return self._current_node.children
 
     @property
+    def selectors(self) -> List[SelectorType]:
+        return self._current_node.selectors
+
+    @property
     def commands(self) -> List[str]:
         """Get the commands available on the current object"""
         command_call = self._current_node.call("commands")
         return self._command.execute(command_call, (), {})
+
+    def items(self, name: str) -> Tuple[bool, List[Union[str, int]]]:
+        """Get the available items"""
+        items_call = self._current_node.call("items")
+        return self._command.execute(items_call, (name,), {})
 
     @property
     def root(self) -> CommandClient:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -34,14 +34,17 @@ import contextlib
 import os.path
 import sys
 import warnings
-from typing import Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import xcffib.xproto
 
 from libqtile import configurable, hook, utils, window
 from libqtile.bar import BarType
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.lazy import lazy
+
+if TYPE_CHECKING:
+    from libqtile.group import _Group
 
 
 class Key:
@@ -269,8 +272,8 @@ class Screen(CommandObject):
                  wallpaper: Optional[str] = None, wallpaper_mode: Optional[str] = None,
                  x: Optional[int] = None, y: Optional[int] = None, width: Optional[int] = None,
                  height: Optional[int] = None):
-        self.group = None
-        self.previous_group = None
+        self.group: Optional[_Group] = None
+        self.previous_group: Optional[_Group] = None
 
         self.top = top
         self.bottom = bottom
@@ -390,13 +393,14 @@ class Screen(CommandObject):
             group = self.previous_group
         self.set_group(group)
 
-    def _items(self, name):
-        if name == "layout":
-            return (True, list(range(len(self.group.layouts))))
-        elif name == "window":
-            return (True, [i.window.wid for i in self.group.windows])
+    def _items(self, name: str) -> ItemT:
+        if name == "layout" and self.group is not None:
+            return True, list(range(len(self.group.layouts)))
+        elif name == "window" and self.group is not None:
+            return True, [i.window.wid for i in self.group.windows]
         elif name == "bar":
-            return (False, [x.position for x in self.gaps])
+            return False, [x.position for x in self.gaps]
+        return None
 
     def _select(self, name, sel):
         if name == "layout":

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -32,7 +32,7 @@ import xcffib
 import xcffib.xproto
 
 from libqtile import hook, utils, window
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -325,14 +325,14 @@ class _Group(CommandObject):
                     i.focus(win)
         self.layout_all()
 
-    def _items(self, name):
+    def _items(self, name) -> ItemT:
         if name == "layout":
-            return (True, list(range(len(self.layouts))))
-        if name == "screen":
-            return (True, None)
+            return True, list(range(len(self.layouts)))
+        if name == "screen" and self.screen is not None:
+            return True, []
         if name == "window":
-            return (True, [i.window.wid for i in self.windows])
-        raise RuntimeError("Invalid item: {}".format(name))
+            return self.current_window is not None, [i.window.wid for i in self.windows]
+        return None
 
     def _select(self, name, sel):
         if name == "layout":

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -21,10 +21,10 @@
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Tuple  # noqa: F401
+from typing import Any, List, Tuple
 
 from libqtile import configurable
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, ItemT
 
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
@@ -74,11 +74,12 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         c.group = group
         return c
 
-    def _items(self, name):
-        if name == "screen":
-            return (True, None)
+    def _items(self, name: str) -> ItemT:
+        if name == "screen" and self.group.screen is not None:
+            return True, []
         elif name == "group":
-            return (True, None)
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "screen":

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -31,7 +31,7 @@ import sys
 import termios
 from typing import Any, List, Optional, Tuple
 
-from libqtile.command import graph
+from libqtile.command.client import CommandClient
 from libqtile.command.interface import (
     CommandError,
     CommandException,
@@ -43,7 +43,7 @@ from libqtile.command.interface import (
 def terminal_width():
     width = None
     try:
-        cr = struct.unpack('hh', fcntl.ioctl(0, termios.TIOCGWINSZ, '1234'))
+        cr = struct.unpack("hh", fcntl.ioctl(0, termios.TIOCGWINSZ, "1234"))
         width = int(cr[1])
     except (IOError, ImportError):
         pass
@@ -52,9 +52,9 @@ def terminal_width():
 
 class QSh:
     """Qtile shell instance"""
+
     def __init__(self, client: CommandInterface, completekey="tab") -> None:
-        self._client = client
-        self._current_node = graph.CommandGraphRoot()  # type: graph.CommandGraphNode
+        self._command_client = CommandClient(client)
         self._completekey = completekey
         self._builtins = [i[3:] for i in dir(self) if i.startswith("do_")]
 
@@ -67,33 +67,30 @@ class QSh:
 
     def _complete(self, buf, arg) -> List[str]:
         if not re.search(r" |\(", buf) or buf.startswith("help "):
-            options = self._builtins + self._commands
+            options = self._builtins + self._command_client.commands
             lst = [i for i in options if i.startswith(arg)]
             return lst
         elif buf.startswith("cd ") or buf.startswith("ls "):
-            last_slash = arg.rfind("/") + 1
-            path, last = arg[:last_slash], arg[last_slash:]
-            node = self._find_path(path)
+            path, sep, last = arg.rpartition("/")
+            node, rest_path = self._find_path(path)
+
             if node is None:
                 return []
-            options = [str(i) for i in self._ls(node)]
-            lst = []
-            if path and not path.endswith("/"):
-                path += "/"
-            for i in options:
-                if i.startswith(last):
-                    lst.append(path + i)
 
-            if len(lst) == 1:
+            children, items = self._ls(node, rest_path)
+            options = children + items
+            completions = [path + sep + i for i in options if i.startswith(last)]
+
+            if len(completions) == 1:
                 # add a slash to continue completing the next part of the path
-                return [lst[0] + "/"]
+                return [completions[0] + "/"]
 
-            return lst
+            return completions
         return []
 
     @property
     def prompt(self) -> str:
-        return "{} > ".format(format_selectors(self._current_node.selectors))
+        return "{} > ".format(format_selectors(self._command_client.selectors))
 
     def columnize(self, lst, update_termwidth=True) -> str:
         if update_termwidth:
@@ -115,83 +112,70 @@ class QSh:
                 ret.append("  ".join(sl))
         return "\n".join(ret)
 
-    @property
-    def _commands(self) -> List[str]:
-        try:
-            commands_cmd = self._current_node.call("commands")
-            return self._client.execute(commands_cmd, (), {})
-        except CommandError:
-            return []
-
-    def _inspect(self, obj: graph.CommandGraphNode) -> Tuple[Optional[List[str]], Optional[List[str]]]:
-        """Returns an (attrs, keys) tuple"""
-        if isinstance(obj, graph.CommandGraphObject) and obj.selector is None:
-            items_call = obj.parent.call("items")
-            allow_root, items = self._client.execute(items_call, (obj.object_type,), {})
-            attrs = obj.children if allow_root else None
-            return attrs, items
+    def _ls(self, client: CommandClient, object_type: Optional[str]) -> Tuple[List[str], List[str]]:
+        if object_type is not None:
+            allow_root, items = client.items(object_type)
+            str_items = [str(i) for i in items]
+            if allow_root:
+                children = client.navigate(object_type, None).children
+            else:
+                children = []
+            return children, str_items
         else:
-            return obj.children, None
+            return client.children, []
 
-    def _ls(self, obj: graph.CommandGraphNode) -> List[str]:
-        attrs, itms = self._inspect(obj)
-        all_items = []  # type: List[str]
-        if attrs:
-            all_items.extend(attrs)
-        if itms:
-            all_items.extend(itms)
-        return all_items
-
-    def _find_path(self, path: str) -> Optional[graph.CommandGraphNode]:
+    def _find_path(self, path: str) -> Tuple[Optional[CommandClient], Optional[str]]:
         """Find an object relative to the current node
 
         Finds and returns the command graph node that is defined relative to
         the current node.
         """
-        root = graph.CommandGraphRoot() if path.startswith("/") else self._current_node
+        root = self._command_client.root if path.startswith("/") else self._command_client
         parts = [i for i in path.split("/") if i]
         return self._find_node(root, *parts)
 
-    def _find_node(self,
-                   src: graph.CommandGraphNode,
-                   *paths: str) -> Optional[graph.CommandGraphNode]:
+    def _find_node(
+        self, src: CommandClient, *paths: str
+    ) -> Tuple[Optional[CommandClient], Optional[str]]:
         """Find an object in the command graph
 
         Return the object in the command graph at the specified path relative
         to the given node.
         """
         if len(paths) == 0:
-            return src
+            return src, None
 
         path, *next_path = paths
 
-        next_node = None
         if path == "..":
-            next_node = src.parent or src
-        else:
-            attrs, items = self._inspect(src)
-            for transformation in [str, int]:
-                try:
-                    transformed_path = transformation(path)
-                except ValueError:
-                    continue
+            return self._find_node(src.parent or src, *next_path)
 
-                if attrs is not None and transformed_path in attrs:
-                    nav_node = src.navigate(transformed_path, None)
-                    next_node = nav_node
-                    break
-                elif items is not None and transformed_path in items:
-                    assert isinstance(src, graph.CommandGraphObject)
-                    nav_node = src.parent.navigate(src.object_type, transformed_path)
-                    next_node = nav_node
-                    break
+        if path not in src.children:
+            return None, None
 
-        if next_node:
-            return self._find_node(next_node, *next_path)
-        else:
-            return None
+        if len(next_path) == 0:
+            return src, path
 
-    def do_cd(self, arg) -> str:
+        item, *maybe_next_path = next_path
+        allow_root, items = src.items(path)
+
+        for transformation in [str, int]:
+            try:
+                transformed_item = transformation(item)
+            except ValueError:
+                continue
+
+            if transformed_item in items:
+                next_node = src.navigate(path, transformed_item)
+                return self._find_node(next_node, *maybe_next_path)
+
+        if not allow_root:
+            return None, None
+
+        next_node = src.navigate(path, None)
+        return self._find_node(next_node, *next_path)
+
+    def do_cd(self, arg: Optional[str]) -> str:
         """Change to another path.
 
         Examples
@@ -202,16 +186,24 @@ class QSh:
             cd ../layout
         """
         if arg is None:
-            self._current_node = graph.CommandGraphRoot()
-            return '/'
-        next_node = self._find_path(arg)
-        if next_node is not None:
-            self._current_node = next_node
-            return format_selectors(self._current_node.selectors) or '/'
-        else:
+            self._command_client = self._command_client.root
+            return "/"
+
+        next_node, rest_path = self._find_path(arg)
+        if next_node is None:
             return "No such path."
 
-    def do_ls(self, arg: str) -> str:
+        if rest_path is None:
+            self._command_client = next_node
+        else:
+            allow_root, _ = next_node.items(rest_path)
+            if not allow_root:
+                return "Item required for {}".format(rest_path)
+            self._command_client = next_node.navigate(rest_path, None)
+
+        return format_selectors(self._command_client.selectors) or "/"
+
+    def do_ls(self, arg: Optional[str]) -> str:
         """List contained items on a node.
 
         Examples
@@ -221,14 +213,24 @@ class QSh:
                 > ls ../layout
         """
         if arg:
-            node = self._find_path(arg)
+            node, rest_path = self._find_path(arg)
             if not node:
                 return "No such path."
+            base_path = arg.rstrip("/") + "/"
         else:
-            node = self._current_node
+            node = self._command_client
+            rest_path = None
+            base_path = ""
 
-        ls = self._ls(node)
-        formatted_ls = ["{}/".format(i) for i in ls]
+        assert node is not None
+
+        objects, items = self._ls(node, rest_path)
+
+        formatted_ls = [
+            "{}{}/".format(base_path, i) for i in objects
+        ] + [
+            "{}[{}]/".format(base_path[:-1], i) for i in items
+        ]
         return self.columnize(formatted_ls)
 
     def do_pwd(self, arg) -> str:
@@ -246,9 +248,9 @@ class QSh:
             bar['top']> pwd
             bar['top']
         """
-        return format_selectors(self._current_node.selectors) or '/'
+        return format_selectors(self._command_client.selectors) or "/"
 
-    def do_help(self, arg) -> str:
+    def do_help(self, arg: Optional[str]) -> str:
         """Give help on commands and builtins
 
         When invoked without arguments, provides an overview of all commands.
@@ -269,18 +271,19 @@ class QSh:
                 "========",
                 self.columnize(self._builtins),
             ]
-            cmds = self._commands
+            cmds = self._command_client.commands
             if cmds:
-                lst.extend([
-                    "",
-                    "Commands for this object",
-                    "========================",
-                    self.columnize(cmds),
-                ])
+                lst.extend(
+                    [
+                        "",
+                        "Commands for this object",
+                        "========================",
+                        self.columnize(cmds),
+                    ]
+                )
             return "\n".join(lst)
-        elif arg in self._commands:
-            call = self._current_node.call("doc")
-            return self._client.execute(call, (arg,), {})
+        elif arg in self._command_client.commands:
+            return self._command_client.call("doc", arg)
         elif arg in self._builtins:
             c = getattr(self, "do_" + arg)
             ret = inspect.getdoc(c)
@@ -297,7 +300,7 @@ class QSh:
     do_q = do_exit
 
     def process_line(self, line: str) -> Any:
-        builtin_match = re.fullmatch(r"(?P<cmd>\w+)(?:\s+(?P<arg>\S+))?", line)
+        builtin_match = re.fullmatch(r"(?P<cmd>\w+)(?:\s+(?P<arg>\S*))?", line)
         if builtin_match:
             cmd = builtin_match.group("cmd")
             args = builtin_match.group("arg")
@@ -317,15 +320,13 @@ class QSh:
             else:
                 cmd_args = ()
 
-            if not self._client.has_command(self._current_node, cmd):
+            if cmd not in self._command_client.commands:
                 return "Command does not exist: {}".format(cmd)
 
-            cmd_call = self._current_node.call(cmd)
-
             try:
-                return self._client.execute(cmd_call, cmd_args, {})
+                return self._command_client.call(cmd, *cmd_args)
             except CommandException as e:
-                return "Command exception: {}\n".format(e)
+                return "Caught command exception (is the command invoked incorrectly?): {}\n".format(e)
 
         return "Invalid command: {}".format(line)
 
@@ -343,7 +344,10 @@ class QSh:
             if not line:
                 continue
 
-            val = self.process_line(line)
+            try:
+                val = self.process_line(line)
+            except CommandError as e:
+                val = "Caught command error (is the current path still valid?): {}\n".format(e)
             if isinstance(val, str):
                 print(val)
             elif val:

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -34,7 +34,7 @@ import subprocess
 from typing import Any, List, Tuple
 
 from libqtile import bar, configurable, confreader, drawer
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, ItemT
 from libqtile.log_utils import logger
 
 
@@ -257,9 +257,10 @@ class _Widget(CommandObject, configurable.Configurable):
             raise CommandError("No such widget: %s" % name)
         return w
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         if name == "bar":
-            return (True, None)
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "bar":

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -26,7 +26,7 @@ import xcffib.xproto
 from xcffib.xproto import EventMask, SetMode, StackMode
 
 from libqtile import hook, utils
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, ItemT
 from libqtile.log_utils import logger
 
 # ICCM Constants
@@ -576,7 +576,7 @@ class _Window(CommandObject):
         hook.fire("client_focus", self)
         return True
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         return None
 
     def _select(self, name, sel):
@@ -1234,13 +1234,14 @@ class Window(_Window):
             logger.info("Unknown window property: %s", name)
         return False
 
-    def _items(self, name):
+    def _items(self, name: str) -> ItemT:
         if name == "group":
-            return (True, None)
+            return True, []
         elif name == "layout":
-            return (True, list(range(len(self.group.layouts))))
-        elif name == "screen":
-            return (True, None)
+            return True, list(range(len(self.group.layouts)))
+        elif name == "screen" and self.group.screen is not None:
+            return True, []
+        return None
 
     def _select(self, name, sel):
         if name == "group":

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -235,7 +235,7 @@ def test_items_group(manager):
 
     assert group.items("window") == (True, [wid])
     assert group.items("layout") == (True, [0, 1, 2])
-    assert group.items("screen") == (True, None)
+    assert group.items("screen") == (True, [])
 
 
 @server_config
@@ -299,7 +299,7 @@ def test_select_screen(manager):
 
 @server_config
 def test_items_bar(manager):
-    assert manager.c.bar["bottom"].items("screen") == (True, None)
+    assert manager.c.bar["bottom"].items("screen") == (True, [])
 
 
 @server_config
@@ -313,8 +313,8 @@ def test_select_bar(manager):
 
 @server_config
 def test_items_layout(manager):
-    assert manager.c.layout.items("screen") == (True, None)
-    assert manager.c.layout.items("group") == (True, None)
+    assert manager.c.layout.items("screen") == (True, [])
+    assert manager.c.layout.items("group") == (True, [])
 
 
 @server_config
@@ -336,9 +336,9 @@ def test_items_window(manager):
     window = manager.c.window
     window.info()["id"]
 
-    assert window.items("group") == (True, None)
+    assert window.items("group") == (True, [])
     assert window.items("layout") == (True, [0, 1, 2])
-    assert window.items("screen") == (True, None)
+    assert window.items("screen") == (True, [])
 
 
 @server_config
@@ -361,7 +361,7 @@ def test_select_window(manager):
 
 @server_config
 def test_items_widget(manager):
-    assert manager.c.widget["one"].items("bar") == (True, None)
+    assert manager.c.widget["one"].items("bar") == (True, [])
 
 
 @server_config

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -68,12 +68,13 @@ def test_ls(manager):
     client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
+    assert sh.do_ls(None) == "bar/     group/   layout/  screen/  widget/  window/"
     assert sh.do_ls("") == "bar/     group/   layout/  screen/  widget/  window/"
-    assert sh.do_ls("layout") == "group/   window/  screen/  0/     "
+    assert sh.do_ls("layout") == "layout/group/   layout/window/  layout/screen/  layout[0]/    "
 
     assert sh.do_cd("layout") == "layout"
-    assert sh.do_ls("") == "group/   window/  screen/  0/     "
-    assert sh.do_ls("screen") == "layout/  window/  bar/   "
+    assert sh.do_ls(None) == "group/   window/  screen/"
+    assert sh.do_ls("screen") == "screen/layout/  screen/window/  screen/bar/   "
 
 
 @sh_config
@@ -82,10 +83,10 @@ def test_do_cd(manager):
     command = IPCCommandInterface(client)
     sh = QSh(command)
     assert sh.do_cd("layout") == 'layout'
-    assert sh.do_cd("0") == 'layout[0]'
+    assert sh.do_cd("../layout/0") == 'layout[0]'
     assert sh.do_cd("..") == '/'
     assert sh.do_cd("layout") == 'layout'
-    assert sh.do_cd("0/wibble") == 'No such path.'
+    assert sh.do_cd("../layout0/wibble") == 'No such path.'
     assert sh.do_cd(None) == '/'
 
 
@@ -103,7 +104,7 @@ def test_call(manager):
     assert v == "Invalid command: status((("
 
     v = sh.process_line("status(1)")
-    assert v.startswith("Command exception")
+    assert v.startswith("Caught command exception")
 
 
 @sh_config


### PR DESCRIPTION
Rather than handling the graph traversal and running within Qsh, use a
command client.  To enable this, modify some of the logic around finding
items and invoking commands.  This makes the shell seem to break much
less often than it did before.

This is built on top of #2356