### PR TITLE
layouts: drop explicit names

### DIFF
--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -125,6 +125,8 @@ class QtileClass(SimpleDirectiveMixin, Directive):
         defaults = [
             (k, sphinx_escape(v[0]), sphinx_escape(v[1])) for k, v in sorted(defaults.items())
         ]
+        if len(defaults) == 0:
+            is_configurable = False
 
         context = {
             'module': module,

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -29,16 +29,7 @@ from libqtile.command.base import CommandObject, ItemT
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
     """This class defines the API that should be exposed by all layouts"""
-    @classmethod
-    def _name(cls):
-        return cls.__class__.__name__.lower()
-
-    defaults = [(
-        "name",
-        None,
-        "The name of this layout"
-        " (usually the class' name in lowercase, e.g. 'max')"
-    )]  # type: List[Tuple[str, Any, str]]
+    defaults = []  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, **config):
         # name is a little odd; we can't resolve it until the class is defined

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -148,7 +148,6 @@ class Bsp(Layout):
         Key([mod], "Return", lazy.layout.toggle_split()),
     """
     defaults = [
-        ("name", "bsp", "Name of this layout."),
         ("border_focus", "#881111", "Border colour for the focused window."),
         ("border_normal", "#220000", "Border colour for un-focused windows."),
         ("border_width", 2, "Border width."),

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -111,7 +111,6 @@ class Columns(Layout):
         Key([mod], "n", lazy.layout.normalize()),
     """
     defaults = [
-        ("name", "columns", "Name of this layout."),
         ("border_focus", "#881111", "Border colour for the focused window."),
         ("border_normal", "#220000", "Border colour for un-focused windows."),
         ("border_focus_stack", "#881111",

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -62,7 +62,6 @@ class Floating(Layout):
         ("border_width", 1, "Border width."),
         ("max_border_width", 0, "Border width for maximize."),
         ("fullscreen_border_width", 0, "Border width for fullscreen."),
-        ("name", "floating", "Name of this layout."),
     ]
 
     def __init__(self, float_rules=None, no_reposition_rules=None, **config):

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -40,7 +40,6 @@ class Matrix(_SimpleLayoutBase):
         ("border_focus", "#0000ff", "Border colour for the focused window."),
         ("border_normal", "#000000", "Border colour for un-focused windows."),
         ("border_width", 1, "Border width."),
-        ("name", "matrix", "Name of this layout."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
     ]
 

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -31,12 +31,6 @@ class Max(_SimpleLayoutBase):
     commands to switch to next and previous windows in the stack.
     """
 
-    defaults = [("name", "max", "Name of this layout.")]
-
-    def __init__(self, **config):
-        super().__init__(**config)
-        self.add_defaults(Max.defaults)
-
     def add(self, client):
         return super().add(client, 1)
 

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -210,7 +210,6 @@ class RatioTile(_SimpleLayoutBase):
         ("border_focus", "#0000ff", "Border colour for the focused window."),
         ("border_normal", "#000000", "Border colour for un-focused windows."),
         ("border_width", 1, "Border width."),
-        ("name", "ratiotile", "Name of this layout."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("ratio", GOLDEN_RATIO, "Ratio of the tiles"),
         ("ratio_increment", 0.1, "Amount to increment per ratio increment"),

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -106,7 +106,6 @@ class Slice(Layout):
     defaults = [
         ("width", 256, "Slice width."),
         ("side", "left", "Position of the slice (left, right, top, bottom)."),
-        ("name", "slice", "Name of this layout."),
         ("match", None, "Match-object describing which window(s) to move to the slice."),
         ("fallback", Max(), "Layout to be used for the non-slice area."),
     ]

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -58,7 +58,6 @@ class Stack(Layout):
         ("border_focus", "#0000ff", "Border colour for the focused window."),
         ("border_normal", "#000000", "Border colour for un-focused windows."),
         ("border_width", 1, "Border width."),
-        ("name", "stack", "Name of this layout."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),
         ("fair", False, "Add new windows to the stacks in a round robin way."),

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -48,7 +48,6 @@ class Tile(_SimpleLayoutBase):
         ("border_focus", "#0000ff", "Border colour for the focused window."),
         ("border_normal", "#000000", "Border colour for un-focused windows."),
         ("border_width", 1, "Border width."),
-        ("name", "tile", "Name of this layout."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("ratio", 0.618,
             "Width-percentage of screen size reserved for master windows."),

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -384,7 +384,6 @@ class TreeTab(Layout):
         ("section_left", 4, "Left margin of section label"),
         ("panel_width", 150, "Width of the left panel"),
         ("sections", ['Default'], "Foreground color of inactive tab"),
-        ("name", "treetab", "Name of this layout."),
         ("previous_on_rm", False, "Focus previous window on close instead of first."),
     ]
 

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -88,7 +88,6 @@ class VerticalTile(_SimpleLayoutBase):
         ('border_normal', '#FFFFFF', 'Border color for un-focused windows.'),
         ('border_width', 1, 'Border width.'),
         ('margin', 0, 'Border margin (int or list of ints [N E S W]).'),
-        ('name', 'verticaltile', 'Name of this layout.'),
     ]
 
     ratio = 0.75

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -150,7 +150,6 @@ class MonadTall(_SimpleLayoutBase):
         ("border_width", 2, "Border width."),
         ("single_border_width", None, "Border width for single window"),
         ("single_margin", None, "Margin size for single window"),
-        ("name", "xmonadtall", "Name of this layout."),
         ("margin", 0, "Margin of the layout"),
         ("ratio", .5,
             "The percent of the screen-space the master pane should occupy "

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -38,7 +38,6 @@ class Zoomy(_SimpleLayoutBase):
         ("property_small", "0.1", "Property value to set on zoomed window"),
         ("property_big", "1.0", "Property value to set on normal window"),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
-        ("name", "zoomy", "Name of this layout."),
     ]
 
     def __init__(self, **config):


### PR DESCRIPTION
We have code that names these things in Layout.__init__, and have gotten
these wrong a few times (e.g. 9a947d5181f491979758ee22943127e844129c40 or
the xmonadtall vs. MonadTall discrepancy in this commit).

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>