### PR TITLE
Add an example of how to restart qtile

### DIFF
--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -181,7 +181,9 @@ def add_subcommand(subparsers, parents):
      qtile cmd-obj -o cmd
      qtile cmd-obj -o cmd -f prev_layout -i
      qtile cmd-obj -o cmd -f prev_layout -a 3 # prev_layout on group 3
-     qtile cmd-obj -o group 3 -f focus_back''')
+     qtile cmd-obj -o group 3 -f focus_back
+     qtile cmd-obj -o cmd -f restart # restart qtile
+     ''')
     description = 'qtile.command functionality exposed to the shell.'
     parser = subparsers.add_parser("cmd-obj", help=description,
                                    parents=parents, epilog=epilog,


### PR DESCRIPTION
Example on how to restart qtile under `qtile cmd-obj --help`.

As commented at https://github.com/qtile/qtile/pull/2364#issuecomment-814323846 .
Agree that `cmd-obj` should be renamed as something else. Unfortunately `run_cmd` is used.