### PR TITLE
Enable live loading of config via Qtile.cmd_load_config

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -36,7 +36,7 @@ import xcffib.xinerama
 import xcffib.xproto
 
 import libqtile
-from libqtile import confreader, hook, ipc, utils, window
+from libqtile import hook, ipc, utils, window
 from libqtile.backend.x11 import xcbq
 from libqtile.command import interface
 from libqtile.command.base import CommandError, CommandException, CommandObject
@@ -103,12 +103,9 @@ class Qtile(CommandObject):
         try:
             self.config.load()
             self.config.validate()
-        except Exception as e:
-            logger.exception('Error while reading config file (%s)', e)
-            self.config = confreader.Config()
-            from libqtile.widget import TextBox
-            widgets = self.config.screens[0].bottom.widgets
-            widgets.insert(0, TextBox('Config Err!'))
+        except Exception as error:
+            logger.exception('Error while reading config file (%s)', error)
+            send_notification("Configuration error", str(error.__context__))
 
         self.core.wmname = getattr(self.config, "wmname", "qtile")
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -81,7 +81,7 @@ class Qtile(CommandObject):
         self.widgets_map: Dict[str, _Widget] = {}
         self.groups_map: Dict[str, _Group] = {}
         self.groups: List[_Group] = []
-        self.dgroups: Optional[DGroups] = None
+        self.dgroups = DGroups(self)
 
         self.keys_map: Dict[Tuple[int, int], Union[Key, KeyChord]] = {}
         self.chord_stack: List[KeyChord] = []
@@ -97,9 +97,9 @@ class Qtile(CommandObject):
 
         self.server = IPCCommandServer(self)
         self.config = config
-        self.load_config()
+        self.cmd_load_config()
 
-    def load_config(self):
+    def cmd_load_config(self):
         try:
             self.config.load()
             self.config.validate()
@@ -109,15 +109,13 @@ class Qtile(CommandObject):
 
         self.core.wmname = getattr(self.config, "wmname", "qtile")
 
-        self.dgroups = DGroups(self, self.config.groups, self.config.dgroups_key_binder)
-
-        if self.config.widget_defaults:
-            _Widget.global_defaults = self.config.widget_defaults
-        if self.config.extension_defaults:
-            _Extension.global_defaults = self.config.extension_defaults
+        _Widget.global_defaults = getattr(self.config, "widget_defaults", {})
+        _Extension.global_defaults = getattr(self.config, "extension_defaults", {})
 
         for installed_extension in _Extension.installed_extensions:
             installed_extension._configure(self)
+
+        self.dgroups._configure(config)
 
         for i in self.groups:
             self.groups_map[i.name] = i

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -194,9 +194,8 @@ def send_notification(title, message, urgent=False, timeout=10000, id=None):
     https://developer.gnome.org/notification-spec/
     """
     if not has_dbus:
-        logger.warning(
-            "dbus-next is not installed. Unable to send notifications."
-        )
+        from libqtile.popup import send_popup
+        send_popup(f"<b>{title}</b>\n{message}", timeout=timeout)
         return -1
 
     id = randint(10, 1000) if id is None else id

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -33,6 +33,7 @@ def test_popup_focus(manager):
 
     # we have to add .conn so that Popup thinks this is libqtile.qtile
     manager.conn = xcbq.Connection(manager.display)
+    manager.current_screen = None
 
     try:
         popup = Popup(manager)


### PR DESCRIPTION
This converts Qtile.load_config to Qtile.cmd_load_config to that the
configuration file can be reloaded during runtime. Many things work
right away without much/any adapting, with the exception of the DGroups
which needs a bit of toying with to be happy being reconfigured.

(draft)

This sits atop #2360, as that PR stops `Qtile.load_config` from overwriting and losing the config instance when it fails to load/validate the config. The second commit is the changes I've made so far towards this goal.

I'm posting this a bit early to get some feedback before I delve much deeper. I'm not very familiar with DGroups; I've always run with a fixed number of groups and it's always 'just worked' so I've never had to read into the group code. It seems like they are the only thing left that need some adjusting so that reloading the config will yield a non-surprising result. So, first question, what would you expect to happen if you reload your config under different group conditions (static groups, dynamic but not changed, dynamic but changed)? Should we clear groups completely and start fresh every time the config is loaded? This might be simple, but we may have to then deal with moving windows from old ones to new ones. Then again, we may have to do that anyway. I'm a tad stuck here so open to ideas and suggestions!