### PR TITLE
Fix BatteryIcon reconfigure issue

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -478,6 +478,7 @@ class BatteryIcon(base._Widget):
 
     def _configure(self, qtile, bar) -> None:
         base._Widget._configure(self, qtile, bar)
+        self.image_padding = 0
         self.setup_images()
         self.image_padding = (self.bar.height - self.bar.height / 5) / 2
 


### PR DESCRIPTION
The BatteryIcon widget's icon changes size if the widget is reconfigured (e.g. via `cmd_reconfigure_screens`). This is because
the icon size is adjusted by the value of `image_padding`. This is zero when the widget is initialised but has a larger value when the
widget is reconfigured.