### PR TITLE
Fix Systray reconfigure bug

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -250,6 +250,7 @@ class Bar(Gap, configurable.Configurable):
         configured = True
         try:
             widget._configure(self.qtile, self)
+            widget.configured = True
         except Exception as e:
             logger.error(
                 "{} widget crashed during _configure with "

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -201,7 +201,6 @@ class _Widget(CommandObject, configurable.Configurable):
             self.bar.height
         )
         if not self.configured:
-            self.configured = True
             self.qtile.call_soon(self.timer_setup)
             self.qtile.call_soon(asyncio.create_task, self._config_async())
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -118,6 +118,10 @@ class Systray(window._Window, base._Widget):
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
+
+        if self.configured:
+            return
+
         win = qtile.conn.create_window(-1, -1, 1, 1)
         window._Window.__init__(self, xcbq.Window(qtile.conn, win.wid), qtile)
         qtile.windows_map[win.wid] = self


### PR DESCRIPTION
Systray widget icons are displayed in incorrect location if widget is reconfigured (e.g. via `cmd_reconfigure_screens`). This
PR addresses that by only allowing the X selection configuration to occur once.

Fixes #2363
Fixes #2313

I don't have a multi-monitor setup so I can't check if any other issues arise on a `reconfigure_screens` call. Will need someone to test.

This sits on top of #2373.