### PR TITLE
Change widget configured attribute timing

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -250,6 +250,7 @@ class Bar(Gap, configurable.Configurable):
         configured = True
         try:
             widget._configure(self.qtile, self)
+            widget.configured = True
         except Exception as e:
             logger.error(
                 "{} widget crashed during _configure with "

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -201,7 +201,6 @@ class _Widget(CommandObject, configurable.Configurable):
             self.bar.height
         )
         if not self.configured:
-            self.configured = True
             self.qtile.call_soon(self.timer_setup)
             self.qtile.call_soon(asyncio.create_task, self._config_async())
 


### PR DESCRIPTION
Currently, widgets have their `configured` flag set by the `base._Widget._configure` method. The result of this is that widgets
are shown as configured before any additional `_configure` code is run by the widgets. Moving this to `bar` means widgets are only configured once the whole `_configure` method has completed.

This removed the need for an additional flag (see #2372) as discussed here: https://github.com/qtile/qtile/pull/2372#discussion_r611069633