### PR TITLE
Add wayland backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,35 @@ jobs:
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python-version }}
-            - run: |
+            - name: Install dependencies
+              run: |
                 sudo apt update
-                sudo apt install libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors
+                sudo apt install libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 \
+                  graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors libwlroots-dev git ninja-build
                 pip install tox tox-gh-actions
-              name: install dependencies
+                # we want wlroots' dependencies only, so remove the packages (these are outdated in ubuntu's repos)
+                sudo dpkg -r --force-depends wlroots libwayland-dev
+            - name: Build wayland
+              env:
+                WAYLAND: 1.19.0
+              run: |
+                wget --no-check-certificate https://wayland.freedesktop.org/releases/wayland-$WAYLAND.tar.xz
+                tar -xJf wayland-$WAYLAND.tar.xz
+                cd wayland-$WAYLAND
+                ./configure --disable-documentation
+                make
+                sudo make install
+            - name: Build wlroots
+              env:
+                WLROOTS: 0.13.0
+              run: |
+                wget --no-check-certificate https://github.com/swaywm/wlroots/archive/$WLROOTS.tar.gz
+                tar -xzf $WLROOTS.tar.gz
+                sudo pip install meson
+                cd wlroots-$WLROOTS
+                meson build
+                ninja -C build
+                sudo ninja -C build install
             - name: run tests
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]

--- a/docs/manual/ref/commands.rst
+++ b/docs/manual/ref/commands.rst
@@ -23,4 +23,4 @@ those given here.
 .. qtile_class:: libqtile.config.Screen
    :noindex:
 
-.. qtile_class:: libqtile.window.Window
+.. qtile_class:: libqtile.backend.x11.window.Window

--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -3,6 +3,7 @@ import importlib
 from libqtile.utils import QtileError
 
 CORES = [
+    'wayland',
     'x11',
 ]
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -116,6 +116,20 @@ class Window(metaclass=ABCMeta):
         """Is it OK for this window to steal focus?"""
         return True
 
+    @property
+    def floating(self) -> bool:
+        """Whether this window should be floating."""
+        return False
+
+    @property
+    def wants_to_fullscreen(self):
+        """Does this window want to be fullscreen?"""
+        return False
+
+    def match(self, match: config.Match) -> bool:
+        """Match window against given attributes."""
+        return False
+
 
 class Internal(Window, metaclass=ABCMeta):
     pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -5,6 +5,8 @@ import enum
 import typing
 from abc import ABCMeta, abstractmethod
 
+from libqtile.command.base import CommandObject, ItemT
+
 if typing.TYPE_CHECKING:
     from typing import Dict, List, Tuple, Union
 
@@ -102,7 +104,7 @@ class FloatStates(enum.Enum):
     MINIMIZED = 6
 
 
-class Window(metaclass=ABCMeta):
+class Window(CommandObject, metaclass=ABCMeta):
     def __init__(self):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
@@ -162,6 +164,16 @@ class Window(metaclass=ABCMeta):
     def place(self, x, y, width, height, borderwidth, bordercolor,
               above=False, margin=None):
         """Place the window in the given position."""
+
+    def _items(self, name: str) -> ItemT:
+        return None
+
+    def _select(self, name, sel):
+        return None
+
+    @abstractmethod
+    def cmd_focus(self, warp: typing.Optional[bool] = None) -> None:
+        """Focuses the window."""
 
 
 class Internal(Window, metaclass=ABCMeta):

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -91,6 +91,14 @@ class Window(metaclass=ABCMeta):
     def wid(self) -> int:
         """The unique window ID"""
 
+    @abstractmethod
+    def hide(self) -> None:
+        """Hide the window"""
+
+    @abstractmethod
+    def unhide(self) -> None:
+        """Unhide the window"""
+
 
 class Internal(metaclass=ABCMeta):
     pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -23,6 +23,10 @@ class Core(metaclass=ABCMeta):
         """Setup a listener for the given qtile instance"""
 
     @abstractmethod
+    def update_desktops(self, groups, index: int) -> None:
+        """Set the current desktops of the window manager"""
+
+    @abstractmethod
     def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -194,6 +194,9 @@ class Window(_Window, metaclass=ABCMeta):
         """What window is this window a transient windor for?"""
         return None
 
+    def paint_borders(self, color, width) -> None:
+        """Paint the window borders with the given color and width"""
+
     @abstractmethod
     def cmd_focus(self, warp: Optional[bool] = None) -> None:
         """Focuses the window."""

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -5,7 +5,7 @@ import typing
 from abc import ABCMeta, abstractmethod
 
 if typing.TYPE_CHECKING:
-    from typing import List, Tuple, Union
+    from typing import Dict, List, Tuple, Union
 
     from libqtile import config
     from libqtile.core.manager import Qtile
@@ -70,6 +70,9 @@ class Core(metaclass=ABCMeta):
 
     def warp_pointer(self, x: int, y: int) -> None:
         """Warp the pointer to the given coordinates relative."""
+
+    def update_client_list(self, windows_map: Dict[int, WindowType]) -> None:
+        """Update the list of windows being managed"""
 
 
 @enum.unique

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -136,6 +136,19 @@ class Window(metaclass=ABCMeta):
         """Match window against given attributes."""
         return False
 
+    @abstractmethod
+    def focus(self, warp: bool):
+        """Focus this window and optional warp the pointer to it."""
+
+    @property
+    def has_focus(self):
+        return self == self.qtile.current_window
+
+    @abstractmethod
+    def place(self, x, y, width, height, borderwidth, bordercolor,
+              above=False, margin=None):
+        """Place the window in the given position."""
+
 
 class Internal(Window, metaclass=ABCMeta):
     pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -67,6 +67,10 @@ class Core(metaclass=ABCMeta):
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
 
+    @abstractmethod
+    def focus_by_click(self, event: typing.Any) -> None:
+        """Focus a window by clicking on it."""
+
     def scan(self) -> None:
         """Scan for clients if required."""
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -117,6 +117,10 @@ class Window(metaclass=ABCMeta):
     def unhide(self) -> None:
         """Unhide the window"""
 
+    @abstractmethod
+    def kill(self) -> None:
+        """Kill the window"""
+
     @property
     def can_steal_focus(self):
         """Is it OK for this window to steal focus?"""

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -27,6 +27,10 @@ class Core(metaclass=ABCMeta):
         """Set the current desktops of the window manager"""
 
     @abstractmethod
+    def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
+        """Get the screen information"""
+
+    @abstractmethod
     def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -80,7 +80,10 @@ class FloatStates(enum.Enum):
 
 
 class Window(metaclass=ABCMeta):
-    pass
+    @property
+    @abstractmethod
+    def wid(self) -> int:
+        """The unique window ID"""
 
 
 class Internal(metaclass=ABCMeta):

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -85,6 +85,9 @@ class Core(metaclass=ABCMeta):
         """A context manager to suppress window events while operating on many windows."""
         yield
 
+    def flush(self) -> None:
+        """If needed, flush the backend's event queue."""
+
     def graceful_shutdown(self):
         """Try to close windows gracefully before exiting"""
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import enum
 import typing
 from abc import ABCMeta, abstractmethod
@@ -74,6 +75,11 @@ class Core(metaclass=ABCMeta):
 
     def update_client_list(self, windows_map: Dict[int, WindowType]) -> None:
         """Update the list of windows being managed"""
+
+    @contextlib.contextmanager
+    def masked(self):
+        """A context manager to suppress window events while operating on many windows."""
+        yield
 
 
 @enum.unique

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -63,3 +63,6 @@ class Core(metaclass=ABCMeta):
     @abstractmethod
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
+
+    def scan(self) -> None:
+        """Scan for clients if required."""

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -81,6 +81,9 @@ class Core(metaclass=ABCMeta):
         """A context manager to suppress window events while operating on many windows."""
         yield
 
+    def graceful_shutdown(self):
+        """Try to close windows gracefully before exiting"""
+
 
 @enum.unique
 class FloatStates(enum.Enum):

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from libqtile.command.base import CommandObject, ItemT
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Tuple, Union
+    from typing import Dict, List, Optional, Tuple, Union
 
     from libqtile import config
     from libqtile.core.manager import Qtile
@@ -133,6 +133,9 @@ class Window(CommandObject, metaclass=ABCMeta):
     def kill(self) -> None:
         """Kill the window"""
 
+    def get_wm_class(self) -> Optional[str]:
+        """Return the class of the window"""
+
     @property
     def can_steal_focus(self):
         """Is it OK for this window to steal focus?"""
@@ -160,6 +163,14 @@ class Window(CommandObject, metaclass=ABCMeta):
     def has_focus(self):
         return self == self.qtile.current_window
 
+    def has_user_set_position(self) -> bool:
+        """Whether this window has user-defined geometry"""
+        return False
+
+    def is_transient_for(self) -> Optional["WindowType"]:
+        """What window is this window a transient windor for?"""
+        return None
+
     @abstractmethod
     def place(self, x, y, width, height, borderwidth, bordercolor,
               above=False, margin=None):
@@ -172,7 +183,7 @@ class Window(CommandObject, metaclass=ABCMeta):
         return None
 
     @abstractmethod
-    def cmd_focus(self, warp: typing.Optional[bool] = None) -> None:
+    def cmd_focus(self, warp: Optional[bool] = None) -> None:
         """Focuses the window."""
 
     @abstractmethod

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -15,6 +15,14 @@ class Core(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def setup_listener(self, qtile: "Qtile") -> None:
+        """Setup a listener for the given qtile instance"""
+
+    @abstractmethod
+    def remove_listener(self) -> None:
+        """Setup a listener for the given qtile instance"""
+
+    @abstractmethod
     def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -49,7 +49,7 @@ class Core(metaclass=ABCMeta):
         """Release the grabbed key events"""
 
     @abstractmethod
-    def grab_button(self, mouse: config.Mouse) -> None:
+    def grab_button(self, mouse: config.Mouse) -> int:
         """Configure the backend to grab the mouse event"""
 
     @abstractmethod

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -263,6 +263,30 @@ class Window(_Window, metaclass=ABCMeta):
     def cmd_bring_to_front(self) -> None:
         """Bring the window to the front"""
 
+    def cmd_opacity(self, opacity):
+        """Set the window's opacity"""
+        if opacity < .1:
+            self.opacity = .1
+        elif opacity > 1:
+            self.opacity = 1
+        else:
+            self.opacity = opacity
+
+    def cmd_down_opacity(self):
+        """Decrease the window's opacity"""
+        if self.opacity > .2:
+            # don't go completely clear
+            self.opacity -= .1
+        else:
+            self.opacity = .1
+
+    def cmd_up_opacity(self):
+        """Increase the window's opacity"""
+        if self.opacity < .9:
+            self.opacity += .1
+        else:
+            self.opacity = 1
+
 
 class Internal(_Window, metaclass=ABCMeta):
     pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -92,3 +92,6 @@ class Internal(metaclass=ABCMeta):
 
 class Static(metaclass=ABCMeta):
     pass
+
+
+WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -104,7 +104,7 @@ class FloatStates(enum.Enum):
     MINIMIZED = 6
 
 
-class Window(CommandObject, metaclass=ABCMeta):
+class _Window(CommandObject, metaclass=ABCMeta):
     def __init__(self):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
@@ -113,13 +113,13 @@ class Window(CommandObject, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def wid(self) -> int:
-        """The unique window ID"""
+    def group(self) -> _Group:
+        """The group to which this window belongs."""
 
     @property
     @abstractmethod
-    def group(self) -> _Group:
-        """The group to which this window belongs."""
+    def wid(self) -> int:
+        """The unique window ID"""
 
     @abstractmethod
     def hide(self) -> None:
@@ -141,6 +141,19 @@ class Window(CommandObject, metaclass=ABCMeta):
         """Is it OK for this window to steal focus?"""
         return True
 
+    @abstractmethod
+    def place(self, x, y, width, height, borderwidth, bordercolor,
+              above=False, margin=None):
+        """Place the window in the given position."""
+
+    def _items(self, name: str) -> ItemT:
+        return None
+
+    def _select(self, name, sel):
+        return None
+
+
+class Window(_Window, metaclass=ABCMeta):
     @property
     def floating(self) -> bool:
         """Whether this window is floating."""
@@ -179,17 +192,6 @@ class Window(CommandObject, metaclass=ABCMeta):
 
     def is_transient_for(self) -> Optional["WindowType"]:
         """What window is this window a transient windor for?"""
-        return None
-
-    @abstractmethod
-    def place(self, x, y, width, height, borderwidth, bordercolor,
-              above=False, margin=None):
-        """Place the window in the given position."""
-
-    def _items(self, name: str) -> ItemT:
-        return None
-
-    def _select(self, name, sel):
         return None
 
     @abstractmethod
@@ -262,11 +264,11 @@ class Window(CommandObject, metaclass=ABCMeta):
         """Bring the window to the front"""
 
 
-class Internal(Window, metaclass=ABCMeta):
+class Internal(_Window, metaclass=ABCMeta):
     pass
 
 
-class Static(Window, metaclass=ABCMeta):
+class Static(_Window, metaclass=ABCMeta):
     pass
 
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -9,6 +9,7 @@ if typing.TYPE_CHECKING:
 
     from libqtile import config
     from libqtile.core.manager import Qtile
+    from libqtile.group import _Group
 
 
 class Core(metaclass=ABCMeta):
@@ -86,10 +87,21 @@ class FloatStates(enum.Enum):
 
 
 class Window(metaclass=ABCMeta):
+    def __init__(self):
+        self.borderwidth: int = 0
+        self.name: str = "<no name>"
+        self.reserved_space: List = None
+        self.defunct: bool = False
+
     @property
     @abstractmethod
     def wid(self) -> int:
         """The unique window ID"""
+
+    @property
+    @abstractmethod
+    def group(self) -> _Group:
+        """The group to which this window belongs."""
 
     @abstractmethod
     def hide(self) -> None:
@@ -99,12 +111,17 @@ class Window(metaclass=ABCMeta):
     def unhide(self) -> None:
         """Unhide the window"""
 
+    @property
+    def can_steal_focus(self):
+        """Is it OK for this window to steal focus?"""
+        return True
 
-class Internal(metaclass=ABCMeta):
+
+class Internal(Window, metaclass=ABCMeta):
     pass
 
 
-class Static(metaclass=ABCMeta):
+class Static(Window, metaclass=ABCMeta):
     pass
 
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
 import typing
 from abc import ABCMeta, abstractmethod
 
-from libqtile import config
+if typing.TYPE_CHECKING:
+    from typing import List, Tuple, Union
+
+    from libqtile import config
+    from libqtile.core.manager import Qtile
 
 
 class Core(metaclass=ABCMeta):
@@ -15,7 +21,7 @@ class Core(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def setup_listener(self, qtile: "Qtile") -> None:
+    def setup_listener(self, qtile: Qtile) -> None:
         """Setup a listener for the given qtile instance"""
 
     @abstractmethod
@@ -31,11 +37,11 @@ class Core(metaclass=ABCMeta):
         """Get the screen information"""
 
     @abstractmethod
-    def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
+    def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Configure the backend to grab the key event"""
 
     @abstractmethod
-    def ungrab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
+    def ungrab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Release the given key event"""
 
     @abstractmethod

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import typing
 from abc import ABCMeta, abstractmethod
 
@@ -66,3 +67,25 @@ class Core(metaclass=ABCMeta):
 
     def scan(self) -> None:
         """Scan for clients if required."""
+
+
+@enum.unique
+class FloatStates(enum.Enum):
+    NOT_FLOATING = 1
+    FLOATING = 2
+    MAXIMIZED = 3
+    FULLSCREEN = 4
+    TOP = 5
+    MINIMIZED = 6
+
+
+class Window(metaclass=ABCMeta):
+    pass
+
+
+class Internal(metaclass=ABCMeta):
+    pass
+
+
+class Static(metaclass=ABCMeta):
+    pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -68,6 +68,9 @@ class Core(metaclass=ABCMeta):
     def scan(self) -> None:
         """Scan for clients if required."""
 
+    def warp_pointer(self, x: int, y: int) -> None:
+        """Warp the pointer to the given coordinates relative."""
+
 
 @enum.unique
 class FloatStates(enum.Enum):

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -175,6 +175,10 @@ class Window(CommandObject, metaclass=ABCMeta):
     def cmd_focus(self, warp: typing.Optional[bool] = None) -> None:
         """Focuses the window."""
 
+    @abstractmethod
+    def cmd_info(self) -> Dict:
+        """Return a dictionary of info."""
+
 
 class Internal(Window, metaclass=ABCMeta):
     pass

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -143,11 +143,21 @@ class Window(CommandObject, metaclass=ABCMeta):
 
     @property
     def floating(self) -> bool:
-        """Whether this window should be floating."""
+        """Whether this window is floating."""
         return False
 
     @property
-    def wants_to_fullscreen(self):
+    def maximized(self) -> bool:
+        """Whether this window is maximized."""
+        return False
+
+    @property
+    def fullscreen(self) -> bool:
+        """Whether this window is fullscreened."""
+        return False
+
+    @property
+    def wants_to_fullscreen(self) -> bool:
         """Does this window want to be fullscreen?"""
         return False
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -200,6 +200,67 @@ class Window(CommandObject, metaclass=ABCMeta):
     def cmd_info(self) -> Dict:
         """Return a dictionary of info."""
 
+    @abstractmethod
+    def cmd_get_position(self) -> Tuple[int, int]:
+        """Get the (x, y) of the window"""
+
+    @abstractmethod
+    def cmd_get_size(self) -> Tuple[int, int]:
+        """Get the (width, height) of the window"""
+
+    @abstractmethod
+    def cmd_move_floating(self, dx: int, dy: int) -> None:
+        """Move window by dx and dy"""
+
+    @abstractmethod
+    def cmd_resize_floating(self, dw: int, dh: int) -> None:
+        """Add dw and dh to size of window"""
+
+    @abstractmethod
+    def cmd_set_position_floating(self, x: int, y: int) -> None:
+        """Move window to x and y"""
+
+    @abstractmethod
+    def cmd_set_size_floating(self, w: int, h: int) -> None:
+        """Set window dimensions to w and h"""
+
+    @abstractmethod
+    def cmd_place(self, x, y, width, height, borderwidth, bordercolor,
+                  above=False, margin=None) -> None:
+        """Place the window with the given position and geometry."""
+
+    @abstractmethod
+    def cmd_toggle_floating(self) -> None:
+        """Toggle the floating state of the window."""
+
+    @abstractmethod
+    def cmd_enable_floating(self) -> None:
+        """Float the window."""
+
+    @abstractmethod
+    def cmd_disable_floating(self) -> None:
+        """Tile the window."""
+
+    @abstractmethod
+    def cmd_toggle_maximize(self) -> None:
+        """Toggle the fullscreen state of the window."""
+
+    @abstractmethod
+    def cmd_toggle_fullscreen(self) -> None:
+        """Toggle the fullscreen state of the window."""
+
+    @abstractmethod
+    def cmd_enable_fullscreen(self) -> None:
+        """Fullscreen the window"""
+
+    @abstractmethod
+    def cmd_disable_fullscreen(self) -> None:
+        """Un-fullscreen the window"""
+
+    @abstractmethod
+    def cmd_bring_to_front(self) -> None:
+        """Bring the window to the front"""
+
 
 class Internal(Window, metaclass=ABCMeta):
     pass

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -48,6 +48,9 @@ class Core(base.Core):
     def __init__(self):
         """Setup the Wayland core backend"""
         self.qtile = None
+        self.desktops = 1
+        self.current_desktop = 0
+
         self.display = Display()
         self.event_loop = self.display.get_event_loop()
         self.backend = Backend(self.display)
@@ -216,6 +219,19 @@ class Core(base.Core):
     def _poll(self) -> None:
         self.display.flush_clients()
         self.event_loop.dispatch(-1)
+
+    def update_desktops(self, groups, index: int) -> None:
+        """Set the current desktops of the window manager
+
+        The list of desktops is given by the list of groups, with the current
+        desktop given by the index
+        """
+        new_count = len(groups)
+        while new_count > self.desktops:
+            self.desktops += 1
+        while new_count < self.desktops:
+            self.desktops -= 1
+        self.current_desktop = index
 
     def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -197,7 +197,7 @@ class Core(base.Core):
             if wid not in wids:
                 break
             wid += 1
-        win = window.Window(self, surface, wid)
+        win = window.Window(self, self.qtile, surface, wid)
         logger.info(f"Managing new top-level window with window ID: {wid}")
         self.windows.append(win)
         self.qtile.manage(win)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -310,12 +310,13 @@ class Core(base.Core):
         """Release the grabbed key events"""
         self.grabbed_keys.clear()
 
-    def grab_button(self, mouse: config.Mouse) -> None:
+    def grab_button(self, mouse: config.Mouse) -> int:
         """Configure the backend to grab the mouse event"""
-        keysym = wlrq.buttons.get(mouse.button)
+        keysym = wlrq.buttons.get(mouse.button.lower())
         assert keysym is not None
         mask_key = wlrq.translate_masks(mouse.modifiers)
         self.grabbed_buttons.append((keysym, mask_key))
+        return mask_key
 
     def ungrab_buttons(self) -> None:
         """Release the grabbed button events"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -218,11 +218,13 @@ class Core(base.Core):
         )
 
     def _on_cursor_motion(self, _listener, event: pointer.PointerEventMotion):
+        assert self.qtile is not None
         logger.debug("Signal: cursor motion")
         self.cursor.move(event.delta_x, event.delta_y, input_device=event.device)
         self.qtile.process_button_motion(self.cursor.x, self.cursor.y)
 
-    def _on_cursor_motion_absolute(self, _listener, event: pointer.PointerMotionAbsolute):
+    def _on_cursor_motion_absolute(self, _listener, event: pointer.PointerEventMotionAbsolute):
+        assert self.qtile is not None
         logger.debug("Signal: cursor motion_absolute")
         self.cursor.warp(
             WarpMode.AbsoluteClosest, event.x, event.y, input_device=event.device,

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -281,7 +281,8 @@ class Core(base.Core):
             self.fd = None
 
     def _poll(self) -> None:
-        self.display.flush_clients()
+        if not self.display.destroyed:
+            self.display.flush_clients()
         self.event_loop.dispatch(-1)
 
     def focus_window(self, win: window.Window, surface: Surface = None):

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -384,6 +384,9 @@ class Core(base.Core):
         """Warp the pointer to the coordinates in relative to the output layout"""
         self.cursor.warp(WarpMode.LayoutClosest, x, y)
 
+    def flush(self) -> None:
+        self._poll()
+
     def graceful_shutdown(self):
         """Try to close windows gracefully before exiting"""
         assert self.qtile is not None

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2021 Matt Colligan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import typing
+
+from pywayland.protocol.wayland import WlSeat
+from pywayland.server import Display, Listener
+from wlroots.backend import Backend
+from wlroots.renderer import Renderer
+from wlroots.wlr_types import (
+    Compositor,
+    Cursor,
+    DataDeviceManager,
+    OutputLayout,
+    Seat,
+    XCursorManager,
+    xdg_shell,
+)
+from wlroots.wlr_types.input_device import InputDeviceType
+
+from libqtile import config
+from libqtile.backend import base
+from libqtile.backend.wayland import keyboard, output, window
+from libqtile.log_utils import logger
+
+
+class Core(base.Core):
+    def __init__(self):
+        """Setup the Wayland core backend"""
+        self.display = Display()
+        self.backend = Backend(self.display)
+        self.renderer = Renderer(self.backend, self.display)
+        self.compositor = Compositor(self.display, self.renderer)
+        self.socket = self.display.add_socket()
+
+        # set up inputs
+        self.keyboards = []
+        self.device_manager = DataDeviceManager(self.display)
+        self.seat = Seat(self.display, "seat0")
+        self._on_request_set_selection_listener = Listener(self._on_request_set_selection)
+        self._on_new_input_listener = Listener(self._on_new_input)
+        self.seat.request_set_selection_event.add(self._on_request_set_selection_listener)
+        self.backend.new_input_event.add(self._on_new_input_listener)
+
+        # set up outputs
+        self.output_layout = OutputLayout()
+        self.outputs = []
+        self._on_new_output_listener = Listener(self._on_new_output)
+        self.backend.new_output_event.add(self._on_new_output_listener)
+
+        # set up cursor
+        self.cursor = Cursor(self.output_layout)
+        self.cursor_manager = XCursorManager(24)
+        self._on_request_cursor_listener = Listener(self._on_request_cursor)
+        self.seat.request_set_cursor_event.add(self._on_request_cursor_listener)
+
+        # set up shell
+        self.windows = []
+        self.xdg_shell = xdg_shell.XdgShell(self.display)
+        self._on_new_xdg_surface_listener = Listener(self._on_new_xdg_surface)
+        self.xdg_shell.new_surface_event.add(self._on_new_xdg_surface_listener)
+
+        # start
+        os.environ["WAYLAND_DISPLAY"] = self.socket.decode()
+        logger.info("Starting with WAYLAND_DISPLAY=" + self.socket.decode())
+        self.backend.start()
+
+        self.display.run()
+        self.finalize()
+
+    def finalize(self):
+        self._on_new_xdg_surface_listener.remove()
+        self._on_request_cursor_listener.remove()
+        self._on_new_output_listener.remove()
+        self._on_new_input_listener.remove()
+        self._on_request_set_selection_listener.remove()
+
+        for win in self.windows:
+            win.finalize()
+        for kb in self.keyboards:
+            kb.finalize()
+        for out in self.outputs:
+            out.finalize()
+
+        self.cursor_manager.destroy()
+        self.cursor.destroy()
+        self.output_layout.destroy()
+        self.seat.destroy()
+        self.backend.destroy()
+        self.display.destroy()
+        self.qtile = None
+
+    @property
+    def display_name(self) -> str:
+        return self.socket.decode()
+
+    def _on_request_set_selection(self, _listener, event):
+        self.seat.set_selection(event._ptr.source, event.serial)
+        logger.debug("Signal: seat request_set_selection")
+
+    def _on_new_input(self, _listener, device):
+        logger.debug("Signal: backend new_input_event")
+        if device.device_type == InputDeviceType.POINTER:
+            self._add_new_pointer(device)
+        elif device.device_type == InputDeviceType.KEYBOARD:
+            self._add_new_keyboard(device)
+
+        capabilities = WlSeat.capability.pointer
+        if len(self.keyboards) > 0:
+            capabilities |= WlSeat.capability.keyboard
+
+        logger.info("New input: " + str(device.device_type))
+        logger.info("Input capabilities: " + str(capabilities))
+
+        self.seat.set_capabilities(capabilities)
+
+    def _on_new_output(self, _listener, wlr_output):
+        logger.debug("Signal: backend new_output_event")
+        if wlr_output.modes != []:
+            mode = wlr_output.preferred_mode()
+            if mode is None:
+                logger.error("New output has no output mode")
+                return
+            wlr_output.set_mode(mode)
+            wlr_output.enable()
+
+            if not wlr_output.commit():
+                logger.error("New output cannot be committed")
+                return
+
+        self.outputs.append(output.Output(self, wlr_output))
+        self.output_layout.add_auto(wlr_output)
+
+    def _on_request_cursor(self, _listener, event):
+        logger.debug("Signal: seat request_set_cursor_event")
+        # if self._seat.pointer_state.focused_surface == event.seat_client:  # needs updating pywlroots first
+        self.cursor.set_surface(event.surface, event.hotspot)
+
+    def _on_new_xdg_surface(self, _listener, surface):
+        logger.debug("Signal: xdg_shell new_surface_event")
+        if surface.role != xdg_shell.XdgSurfaceRole.TOPLEVEL:
+            return
+
+        logger.info("Managing new top-level window")
+        self.windows.append(window.Window(self, surface))
+
+    def _add_new_pointer(self, device):
+        logger.info("Adding new pointer")
+        self.cursor.attach_input_device(device)
+
+    def _add_new_keyboard(self, device):
+        logger.info("Adding new keyboard")
+        self.keyboards.append(keyboard.Keyboard(self, device))
+        self.seat.set_keyboard(device)
+
+    def focus_window(self, win, surface=None):
+        if surface is None:
+            surface = win.surface.surface
+
+        previous_surface = self.seat.keyboard_state.focused_surface
+        if previous_surface == surface:
+            return
+
+        if previous_surface is not None:
+            # Deactivate the previously focused surface
+            previous_xdg_surface = xdg_shell.XdgSurface.from_surface(previous_surface)
+            previous_xdg_surface.set_activated(False)
+
+        # roll the given surface to the front of the list, copy and modify the
+        # list, then save back to prevent any race conditions on list
+        # modification
+        windows = self.windows[:]
+        windows.remove(win)
+        windows.append(win)
+        self.win = windows
+        # activate the new surface
+        win.surface.set_activated(True)
+        self.seat.keyboard_notify_enter(surface, self.seat.keyboard)
+        logger.debug("Focussed new window")
+
+    def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
+        """Configure the backend to grab the key event"""
+
+    def ungrab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
+        """Release the given key event"""
+
+    def ungrab_keys(self) -> None:
+        """Release the grabbed key events"""
+
+    def grab_button(self, mouse: config.Mouse) -> None:
+        """Configure the backend to grab the mouse event"""
+
+    def ungrab_buttons(self) -> None:
+        """Release the grabbed button events"""
+
+    def grab_pointer(self) -> None:
+        """Configure the backend to grab mouse events"""
+
+    def ungrab_pointer(self) -> None:
+        """Release grabbed pointer events"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -401,3 +401,10 @@ class Core(base.Core):
             self._poll()
             if not self.qtile.windows_map:
                 break
+
+    def change_vt(self, vt: int) -> bool:
+        """Change virtual terminal to that specified"""
+        success = self.backend.get_session().change_vt(vt)
+        if not success:
+            logger.warning(f"Could not change VT to: {vt}")
+        return success

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -409,3 +409,7 @@ class Core(base.Core):
         if not success:
             logger.warning(f"Could not change VT to: {vt}")
         return success
+
+    @property
+    def painter(self):
+        return wlrq.Painter(self)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -334,3 +334,7 @@ class Core(base.Core):
 
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
+
+    def warp_pointer(self, x, y) -> None:
+        """Warp the pointer to the coordinates in relative to the output layout"""
+        self.cursor.warp(WarpMode.LayoutClosest, x, y)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -45,6 +45,7 @@ from wlroots.wlr_types import (
 from wlroots.wlr_types.cursor import WarpMode
 from xkbcommon import xkb
 
+from libqtile import hook
 from libqtile.backend import base
 from libqtile.backend.wayland import keyboard, output, window, wlrq
 from libqtile.log_utils import logger
@@ -245,7 +246,12 @@ class Core(base.Core):
             focus_changed = self.seat.pointer_state.focused_surface != surface
             self.seat.pointer_notify_enter(surface, sx, sy)
             if focus_changed:
+                hook.fire("client_mouse_enter", win)
                 if self.qtile.config.follow_mouse_focus:
+                    if win.group.current_window != self:
+                        win.group.focus(win, False)
+                    if win.group.screen and self.qtile.current_screen != win.group.screen:
+                        self.qtile.focus_screen(win.group.screen.index, False)
                     self.focus_window(win, surface)
             else:
                 # The enter event contains coordinates, so we only need to

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -73,6 +73,7 @@ class Core(base.Core):
         # set up inputs
         self.keyboards: List[keyboard.Keyboard] = []
         self.grabbed_keys: List[Tuple[int, int]] = []
+        self.grabbed_buttons: List[Tuple[int, int]] = []
         self.device_manager = DataDeviceManager(self.display)
         self.seat = seat.Seat(self.display, "seat0")
         self._on_request_set_selection_listener = Listener(self._on_request_set_selection)
@@ -271,9 +272,14 @@ class Core(base.Core):
 
     def grab_button(self, mouse: config.Mouse) -> None:
         """Configure the backend to grab the mouse event"""
+        keysym = wlrq.buttons.get(mouse.button)
+        assert keysym is not None
+        mask_key = wlrq.translate_masks(mouse.modifiers)
+        self.grabbed_buttons.append((keysym, mask_key))
 
     def ungrab_buttons(self) -> None:
         """Release the grabbed button events"""
+        self.grabbed_buttons.clear()
 
     def grab_pointer(self) -> None:
         """Configure the backend to grab mouse events"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -191,8 +191,15 @@ class Core(base.Core):
         if surface.role != xdg_shell.XdgSurfaceRole.TOPLEVEL:
             return
 
-        logger.info("Managing new top-level window")
-        self.windows.append(window.Window(self, surface))
+        wid = 0
+        wids = [win.wid for win in self.windows]
+        while True:
+            if wid not in wids:
+                break
+            wid += 1
+        win = window.Window(self, surface, wid)
+        logger.info(f"Managing new top-level window with window ID: {wid}")
+        self.windows.append(win)
 
     def _on_cursor_axis(self, _listener, event: pointer.PointerEventAxis):
         logger.debug("Signal: cursor axis")

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -233,6 +233,10 @@ class Core(base.Core):
             self.desktops -= 1
         self.current_desktop = index
 
+    def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
+        """Get the screen information"""
+        return [screen.get_geometry() for screen in self.outputs]
+
     def grab_key(self, key: typing.Union[config.Key, config.KeyChord]) -> typing.Tuple[int, int]:
         """Configure the backend to grab the key event"""
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -200,6 +200,7 @@ class Core(base.Core):
         win = window.Window(self, surface, wid)
         logger.info(f"Managing new top-level window with window ID: {wid}")
         self.windows.append(win)
+        self.qtile.manage(win)
 
     def _on_cursor_axis(self, _listener, event: pointer.PointerEventAxis):
         logger.debug("Signal: cursor axis")

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -18,12 +18,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
+import typing
+
 from pywayland.server import Listener
 from wlroots import ffi, lib
 from wlroots.wlr_types.keyboard import KeyboardModifier, KeyState
 from xkbcommon import xkb
 
 from libqtile.log_utils import logger
+
+if typing.TYPE_CHECKING:
+    from wlroots.wlr_types import InputDevice
+    from wlroots.wlr_types.keyboard import KeyboardKeyEvent
+
+    from libqtile.backend.wayland.core import Core
 
 
 def _get_keysyms(xkb_state, keycode):
@@ -38,7 +48,7 @@ def _get_keysyms(xkb_state, keycode):
 
 
 class Keyboard:
-    def __init__(self, core, device):
+    def __init__(self, core: Core, device: InputDevice):
         self.core = core
         self.device = device
         self.seat = core.seat
@@ -63,15 +73,15 @@ class Keyboard:
         if self.core.keyboards and self.core.seat.keyboard._ptr == self.keyboard._ptr:
             self.seat.set_keyboard(self.core.keyboards[-1].device)
 
-    def _on_destroy(self, _listener, data):
+    def _on_destroy(self, _listener, _data):
         logger.debug("Signal: keyboard destroy")
         self.finalize()
 
-    def _on_modifier(self, _listener, event):
+    def _on_modifier(self, _listener, _data):
         logger.debug("Signal: keyboard modifier")
         self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)
 
-    def _on_key(self, _listener, event):
+    def _on_key(self, _listener, event: KeyboardKeyEvent):
         logger.debug("Signal: keyboard key")
         # TODO: handle key combinations for calling key bindings
         if event.state == KeyState.KEY_PRESSED:

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -99,7 +99,7 @@ class Keyboard:
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    self.qtile.process_key_event(keysyms, mods)
+                    self.qtile.process_key_event(keysym, mods)
                     handled = True
 
         if not handled:

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import typing
 
+from pywayland.protocol.wayland import WlKeyboard
 from pywayland.server import Listener
 from wlroots import ffi, lib
-from wlroots.wlr_types.keyboard import KeyState
 from xkbcommon import xkb
 
 from libqtile.log_utils import logger
@@ -34,6 +34,9 @@ if typing.TYPE_CHECKING:
     from wlroots.wlr_types.keyboard import KeyboardKeyEvent
 
     from libqtile.backend.wayland.core import Core
+
+KEY_PRESSED = WlKeyboard.key_state.pressed
+KEY_RELEASED = WlKeyboard.key_state.released
 
 
 def _get_keysyms(xkb_state, keycode):
@@ -92,7 +95,7 @@ class Keyboard:
             self.qtile = self.core.qtile
             assert self.qtile is not None
 
-        if event.state == KeyState.KEY_PRESSED:
+        if event.state == KEY_PRESSED:
             # translate libinput keycode -> xkbcommon
             keycode = event.keycode + 8
             keysyms = _get_keysyms(self.keyboard._ptr.xkb_state, keycode)

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2021 Matt Colligan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pywayland.server import Listener
+from wlroots import ffi, lib
+from wlroots.wlr_types.keyboard import KeyboardModifier, KeyState
+from xkbcommon import xkb
+
+from libqtile.log_utils import logger
+
+
+def _get_keysyms(xkb_state, keycode):
+    syms_out = ffi.new("const xkb_keysym_t **")
+    nsyms = lib.xkb_state_key_get_syms(xkb_state, keycode, syms_out)
+    if nsyms > 0:
+        assert syms_out[0] != ffi.NULL
+
+    syms = [syms_out[0][i] for i in range(nsyms)]
+    logger.debug(f"Got {nsyms} syms: {syms}")
+    return syms
+
+
+class Keyboard:
+    def __init__(self, core, device):
+        self.core = core
+        self.device = device
+        self.seat = core.seat
+        self.keyboard = device.keyboard
+
+        xkb_context = xkb.Context()
+        self.keyboard.set_keymap(xkb_context.keymap_new_from_names())
+        self.keyboard.set_repeat_info(25, 600)
+
+        self._on_modifier_listener = Listener(self._on_modifier)
+        self._on_key_listener = Listener(self._on_key)
+        self._on_destroy_listener = Listener(self._on_destroy)
+        self.keyboard.modifiers_event.add(self._on_modifier_listener)
+        self.keyboard.key_event.add(self._on_key_listener)
+        self.keyboard.destroy_event.add(self._on_destroy_listener)
+
+    def finalize(self):
+        self._on_modifier_listener.remove()
+        self._on_key_listener.remove()
+        self._on_destroy_listener.remove()
+        self.core.keyboards.remove(self)
+        if self.core.keyboards and self.core.seat.keyboard._ptr == self.keyboard._ptr:
+            self.seat.set_keyboard(self.core.keyboards[-1].device)
+
+    def _on_destroy(self, _listener, data):
+        logger.debug("Signal: keyboard destroy")
+        self.finalize()
+
+    def _on_modifier(self, _listener, event):
+        logger.debug("Signal: keyboard modifier")
+        self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)
+
+    def _on_key(self, _listener, event):
+        logger.debug("Signal: keyboard key")
+        # TODO: handle key combinations for calling key bindings
+        if event.state == KeyState.KEY_PRESSED:
+            if self.keyboard.modifier == KeyboardModifier.ALT:
+                # translate libinput keycode -> xkbcommon
+                keycode = event.keycode + 8
+                for keysym in _get_keysyms(self.keyboard._ptr.xkb_state, keycode):
+                    if keysym == xkb.keysym_from_name("Escape"):
+                        self.core.display.terminate()
+                        return
+
+        self.seat.keyboard_notify_key(event)

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -50,8 +50,8 @@ def _get_keysyms(xkb_state, keycode):
 class Keyboard:
     def __init__(self, core: Core, device: InputDevice):
         self.core = core
-        self.qtile = core.qtile
         self.device = device
+        self.qtile = core.qtile
         self.seat = core.seat
         self.keyboard = device.keyboard
         self.grabbed_keys = core.grabbed_keys
@@ -86,6 +86,11 @@ class Keyboard:
     def _on_key(self, _listener, event: KeyboardKeyEvent):
         logger.debug("Signal: keyboard key")
         handled = False
+
+        if self.qtile is None:
+            # shushes mypy
+            self.qtile = self.core.qtile
+            assert self.qtile is not None
 
         if event.state == KeyState.KEY_PRESSED:
             # translate libinput keycode -> xkbcommon

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2021 Matt Colligan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pywayland.server import Listener
+from wlroots.util.clock import Timespec
+from wlroots.wlr_types import Box, Matrix
+from wlroots.wlr_types import Output as wlrOutput
+
+from libqtile.log_utils import logger
+
+
+class Output:
+    def __init__(self, core, wlr_output):
+        self.core = core
+        self.renderer = core.renderer
+        self.wlr_output = wlr_output
+        self.output_layout = self.core.output_layout
+
+        self._on_destroy_listener = Listener(self._on_destroy)
+        self._on_frame_listener = Listener(self._on_frame)
+        wlr_output.destroy_event.add(self._on_destroy_listener)
+        wlr_output.frame_event.add(self._on_frame_listener)
+
+    def finalize(self):
+        self._on_destroy_listener.remove()
+        self._on_frame_listener.remove()
+
+    def _on_destroy(self, _listener, data):
+        logger.debug("Signal: output destroy")
+        self.finalize()
+        self.core.outputs.remove(self)
+
+    def _on_frame(self, _listener, data):
+        now = Timespec.get_monotonic_time()
+        wlr_output = self.wlr_output
+
+        if not wlr_output.attach_render():
+            logger.error("Could not attach renderer")
+            return
+
+        width, height = wlr_output.effective_resolution()
+        self.renderer.begin(width, height)
+        self.renderer.clear([0, 0, 0, 1])
+
+        for window in self.core.windows:
+            if window.mapped:
+                window.surface.for_each_surface(self._render_surface, (window, now))
+
+        wlr_output.render_software_cursors()
+        self.renderer.end()
+        wlr_output.commit()
+
+    def _render_surface(self, surface, sx, sy, data) -> None:
+        window, now = data
+
+        texture = surface.get_texture()
+        if texture is None:
+            return
+
+        wlr_output = self.wlr_output
+        ox, oy = self.output_layout.output_coords(wlr_output)  # every time?
+        ox += window.x + sx
+        oy += window.y + sy
+        box = Box(
+            int(ox * wlr_output.scale),
+            int(oy * wlr_output.scale),
+            int(surface.current.width * wlr_output.scale),
+            int(surface.current.height * wlr_output.scale),
+        )
+
+        inverse = wlrOutput.transform_invert(surface.current.transform)
+        matrix = Matrix.project_box(box, inverse, 0, wlr_output.transform_matrix)
+        self.renderer.render_texture_with_matrix(texture, matrix, 1)
+        surface.send_frame_done(now)

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -18,6 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
+import typing
+
 from pywayland.server import Listener
 from wlroots.util.clock import Timespec
 from wlroots.wlr_types import Box, Matrix
@@ -25,9 +29,16 @@ from wlroots.wlr_types import Output as wlrOutput
 
 from libqtile.log_utils import logger
 
+if typing.TYPE_CHECKING:
+    from typing import Tuple
+
+    from wlroots.wlr_types import Surface
+
+    from libqtile.backend.wayland.core import Core
+
 
 class Output:
-    def __init__(self, core, wlr_output):
+    def __init__(self, core: Core, wlr_output: wlrOutput):
         self.core = core
         self.renderer = core.renderer
         self.wlr_output = wlr_output
@@ -42,12 +53,12 @@ class Output:
         self._on_destroy_listener.remove()
         self._on_frame_listener.remove()
 
-    def _on_destroy(self, _listener, data):
+    def _on_destroy(self, _listener, _data):
         logger.debug("Signal: output destroy")
         self.finalize()
         self.core.outputs.remove(self)
 
-    def _on_frame(self, _listener, data):
+    def _on_frame(self, _listener, _data):
         now = Timespec.get_monotonic_time()
         wlr_output = self.wlr_output
 
@@ -67,7 +78,7 @@ class Output:
         self.renderer.end()
         wlr_output.commit()
 
-    def _render_surface(self, surface, sx, sy, data) -> None:
+    def _render_surface(self, surface: Surface, sx: int, sy: int, data) -> None:
         window, now = data
 
         texture = surface.get_texture()
@@ -90,7 +101,7 @@ class Output:
         self.renderer.render_texture_with_matrix(texture, matrix, 1)
         surface.send_frame_done(now)
 
-    def get_geometry(self)
+    def get_geometry(self) -> Tuple[int, int, int, int]:
         x, y = self.output_layout.output_coords(self.wlr_output)
         width, height = self.wlr_output.effective_resolution()
-        return x, y, width, height
+        return int(x), int(y), width, height

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -45,6 +45,8 @@ class Output:
         self.renderer = core.renderer
         self.wlr_output = wlr_output
         self.output_layout = self.core.output_layout
+        self.wallpaper = None
+        self.transform_matrix = wlr_output.transform_matrix
 
         self._on_destroy_listener = Listener(self._on_destroy)
         self._on_frame_listener = Listener(self._on_frame)
@@ -76,6 +78,9 @@ class Output:
 
         self.renderer.begin(*wlr_output.effective_resolution())
         self.renderer.clear([0, 0, 0, 1])
+
+        if self.wallpaper:
+            self.renderer.render_texture(self.wallpaper, self.transform_matrix, 0, 0, 1)
 
         for window in self._mapped_windows:
             window.surface.for_each_surface(self._render_surface, (window, now))

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -109,7 +109,7 @@ class Output:
 
         inverse = wlrOutput.transform_invert(surface.current.transform)
         matrix = Matrix.project_box(box, inverse, 0, wlr_output.transform_matrix)
-        self.renderer.render_texture_with_matrix(texture, matrix, 1)
+        self.renderer.render_texture_with_matrix(texture, matrix, window.opacity)
         surface.send_frame_done(now)
 
     def get_geometry(self) -> Tuple[int, int, int, int]:

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -89,3 +89,8 @@ class Output:
         matrix = Matrix.project_box(box, inverse, 0, wlr_output.transform_matrix)
         self.renderer.render_texture_with_matrix(texture, matrix, 1)
         surface.send_frame_done(now)
+
+    def get_geometry(self)
+        x, y = self.output_layout.output_coords(self.wlr_output)
+        width, height = self.wlr_output.effective_resolution()
+        return x, y, width, height

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -316,6 +316,54 @@ class Window(base.Window):
             fullscreen=self._float_state == FloatStates.FULLSCREEN
         )
 
+    def cmd_move_floating(self, dx: int, dy: int) -> None:
+        self._tweak_float(dx=dx, dy=dy)
+
+    def cmd_resize_floating(self, dw: int, dh: int) -> None:
+        self._tweak_float(dw=dw, dh=dh)
+
+    def cmd_set_position_floating(self, x: int, y: int) -> None:
+        self._tweak_float(x=x, y=y)
+
+    def cmd_set_size_floating(self, w: int, h: int) -> None:
+        self._tweak_float(w=w, h=h)
+
+    def cmd_place(self, x, y, width, height, borderwidth, bordercolor,
+                  above=False, margin=None):
+        self.place(x, y, width, height, borderwidth, bordercolor, above,
+                   margin)
+
+    def cmd_get_position(self) -> Tuple[int, int]:
+        return self.x, self.y
+
+    def cmd_get_size(self) -> Tuple[int, int]:
+        return self.width, self.height
+
+    def cmd_toggle_floating(self) -> None:
+        self.floating = not self.floating
+
+    def cmd_enable_floating(self):
+        self.floating = True
+
+    def cmd_disable_floating(self):
+        self.floating = False
+
+    def cmd_toggle_maximize(self) -> None:
+        self.maximized = not self.maximized
+
+    def cmd_toggle_fullscreen(self) -> None:
+        self.fullscreen = not self.fullscreen
+
+    def cmd_enable_fullscreen(self) -> None:
+        self.fullscreen = True
+
+    def cmd_disable_fullscreen(self) -> None:
+        self.fullscreen = False
+
+    def cmd_bring_to_front(self) -> None:
+        # TODO
+        pass
+
 
 class Internal(Window, base.Internal):
     pass

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -31,6 +31,8 @@ from libqtile.backend.base import FloatStates
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
+    from typing import Dict
+
     from wlroots.wlr_types import xdg_shell
 
     from libqtile.backend.wayland.core import Core
@@ -175,6 +177,22 @@ class Window(base.Window):
         if warp is None:
             warp = self.qtile.config.cursor_warp
         self.focus(warp=warp)
+
+    def cmd_info(self) -> Dict:
+        """Return a dictionary of info."""
+        return dict(
+            name=self.name,
+            x=self.x,
+            y=self.y,
+            width=self.width,
+            height=self.height,
+            group=self.group.name if self.group else None,
+            id=self.wid,
+            floating=self._float_state != FloatStates.NOT_FLOATING,
+            maximized=self._float_state == FloatStates.MAXIMIZED,
+            minimized=self._float_state == FloatStates.MINIMIZED,
+            fullscreen=self._float_state == FloatStates.FULLSCREEN
+        )
 
 
 class Internal(Window, base.Internal):

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -35,9 +35,11 @@ if typing.TYPE_CHECKING:
 
 class Window(base.Window):
     def __init__(self, core: Core, surface: xdg_shell.XdgSurface, wid: int):
+        base.Window.__init__(self)
         self.core = core
         self.surface = surface
         self._wid = wid
+        self._group = 0
         self.mapped = False
         self.x = 10
         self.y = 10
@@ -61,6 +63,14 @@ class Window(base.Window):
     @property
     def wid(self):
         return self._wid
+
+    @property
+    def group(self):
+        return self._group
+
+    @group.setter
+    def group(self, index):
+        self._group = index
 
     def _on_map(self, _listener, data):
         logger.debug("Signal: window map")

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -70,6 +70,7 @@ class Window(base.Window):
         self._on_unmap_listener.remove()
         self._on_destroy_listener.remove()
         self._on_request_fullscreen_listener.remove()
+        self.core.flush()
 
     @property
     def wid(self):

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -166,3 +166,14 @@ class Window(base.Window):
         if above:
             # TODO when general z-axis control is implemented
             pass
+
+
+class Internal(Window, base.Internal):
+    pass
+
+
+class Static(Window, base.Static):
+    pass
+
+
+WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -24,6 +24,7 @@ import typing
 
 from pywayland.server import Listener
 
+from libqtile.backend import base
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -32,7 +33,7 @@ if typing.TYPE_CHECKING:
     from libqtile.backend.wayland.core import Core
 
 
-class Window:
+class Window(base.Window):
     def __init__(self, core: Core, surface: xdg_shell.XdgSurface):
         self.core = core
         self.surface = surface

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 Matt Colligan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pywayland.server import Listener
+
+from libqtile.log_utils import logger
+
+
+class Window:
+    def __init__(self, core, surface):
+        self.core = core
+        self.surface = surface
+        self.mapped = False
+        self.x = 10
+        self.y = 10
+
+        self._on_map_listener = Listener(self._on_map)
+        self._on_unmap_listener = Listener(self._on_unmap)
+        self._on_destroy_listener = Listener(self._on_destroy)
+        self._on_request_fullscreen_listener = Listener(self._on_request_fullscreen)
+        surface.map_event.add(self._on_map_listener)
+        surface.unmap_event.add(self._on_unmap_listener)
+        surface.destroy_event.add(self._on_destroy_listener)
+        surface.toplevel.request_fullscreen_event.add(self._on_request_fullscreen_listener)
+
+    def finalize(self):
+        self._on_map_listener.remove()
+        self._on_unmap_listener.remove()
+        self._on_destroy_listener.remove()
+        self._on_request_fullscreen_listener.remove()
+        self.core.windows.remove(self)
+
+    def _on_map(self, _listener, data):
+        logger.debug("Signal: window map")
+        self.mapped = True
+        self.core.focus_window(self)
+
+    def _on_unmap(self, _listener, data):
+        logger.debug("Signal: window unmap")
+        self.mapped = False
+
+    def _on_destroy(self, _listener, data):
+        logger.debug("Signal: window destroy")
+        self.finalize()
+
+    def _on_request_fullscreen(self, _listener, data):
+        logger.debug("Signal: window request_fullscreen")
+        # TODO

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -33,7 +33,7 @@ from libqtile.backend.base import FloatStates
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, Optional, Tuple
+    from typing import Dict, List, Optional, Tuple, Union
 
     from wlroots.wlr_types import xdg_shell
 
@@ -45,7 +45,7 @@ EDGES_FLOAT = Edges.NONE
 
 
 @functools.lru_cache()
-def _rgb(color) -> ffi.CData:
+def _rgb(color: Union[str, List, Tuple]) -> ffi.CData:
     """Helper to create and cache float[4] arrays for border painting"""
     if isinstance(color, ffi.CData):
         return color

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -18,13 +18,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
+import typing
+
 from pywayland.server import Listener
 
 from libqtile.log_utils import logger
 
+if typing.TYPE_CHECKING:
+    from wlroots.wlr_types import xdg_shell
+
+    from libqtile.backend.wayland.core import Core
+
 
 class Window:
-    def __init__(self, core, surface):
+    def __init__(self, core: Core, surface: xdg_shell.XdgSurface):
         self.core = core
         self.surface = surface
         self.mapped = False
@@ -60,6 +69,6 @@ class Window:
         logger.debug("Signal: window destroy")
         self.finalize()
 
-    def _on_request_fullscreen(self, _listener, data):
+    def _on_request_fullscreen(self, _listener, data: xdg_shell.XdgTopLevelSetFullscreenEvent):
         logger.debug("Signal: window request_fullscreen")
         # TODO

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -100,6 +100,8 @@ class Window(base.Window):
     def _on_unmap(self, _listener, data):
         logger.debug("Signal: window unmap")
         self.mapped = False
+        if self.surface.surface == self.core.seat.keyboard_state.focused_surface:
+            self.core.seat.keyboard_clear_focus()
 
     def _on_destroy(self, _listener, data):
         logger.debug("Signal: window destroy")

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -78,3 +78,9 @@ class Window(base.Window):
     def _on_request_fullscreen(self, _listener, data: xdg_shell.XdgTopLevelSetFullscreenEvent):
         logger.debug("Signal: window request_fullscreen")
         # TODO
+
+    def hide(self):
+        self.surface.unmap_event.emit()
+
+    def unhide(self):
+        self.surface.map_event.emit()

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -40,6 +40,7 @@ class Window(base.Window):
         self.surface = surface
         self._wid = wid
         self._group = 0
+        self._floating = False
         self.mapped = False
         self.x = 10
         self.y = 10
@@ -94,3 +95,7 @@ class Window(base.Window):
 
     def unhide(self):
         self.surface.map_event.emit()
+
+    @property
+    def floating(self):
+        return self._floating

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -63,7 +63,6 @@ class Window(base.Window):
         self._on_unmap_listener.remove()
         self._on_destroy_listener.remove()
         self._on_request_fullscreen_listener.remove()
-        self.core.windows.remove(self)
 
     @property
     def wid(self):
@@ -138,5 +137,5 @@ class Window(base.Window):
         self.bordercolor = bordercolor
 
         if above:
-            self.core.windows.remove(self)
-            self.core.windows.insert(0, self)
+            # TODO when general z-axis control is implemented
+            pass

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -170,6 +170,12 @@ class Window(base.Window):
             # TODO when general z-axis control is implemented
             pass
 
+    def cmd_focus(self, warp=None):
+        """Focuses the window."""
+        if warp is None:
+            warp = self.qtile.config.cursor_warp
+        self.focus(warp=warp)
+
 
 class Internal(Window, base.Internal):
     pass

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -34,9 +34,10 @@ if typing.TYPE_CHECKING:
 
 
 class Window(base.Window):
-    def __init__(self, core: Core, surface: xdg_shell.XdgSurface):
+    def __init__(self, core: Core, surface: xdg_shell.XdgSurface, wid: int):
         self.core = core
         self.surface = surface
+        self._wid = wid
         self.mapped = False
         self.x = 10
         self.y = 10
@@ -56,6 +57,10 @@ class Window(base.Window):
         self._on_destroy_listener.remove()
         self._on_request_fullscreen_listener.remove()
         self.core.windows.remove(self)
+
+    @property
+    def wid(self):
+        return self._wid
 
     def _on_map(self, _listener, data):
         logger.debug("Signal: window map")

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -31,7 +31,7 @@ from libqtile.backend.base import FloatStates
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict
+    from typing import Dict, Optional, Tuple
 
     from wlroots.wlr_types import xdg_shell
 
@@ -124,6 +124,10 @@ class Window(base.Window):
 
     def kill(self):
         self.surface.send_close()
+
+    def get_wm_class(self) -> Optional[str]:
+        # TODO
+        return None
 
     @property
     def floating(self):

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -55,6 +55,7 @@ class Window(base.Window):
         self.y = 0
         self.borderwidth = 0
         self.bordercolor = None
+        self.opacity: float = 1.0
 
         self.surface.set_tiled(EDGES_TILED)
         self._float_state = FloatStates.NOT_FLOATING

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -102,6 +102,7 @@ class Window(base.Window):
 
     def _on_destroy(self, _listener, data):
         logger.debug("Signal: window destroy")
+        self.qtile.unmanage(self.wid)
         self.finalize()
 
     def _on_request_fullscreen(self, _listener, data: xdg_shell.XdgTopLevelSetFullscreenEvent):
@@ -115,6 +116,9 @@ class Window(base.Window):
     def unhide(self):
         if not self.mapped:
             self.surface.map_event.emit()
+
+    def kill(self):
+        self.surface.send_close()
 
     @property
     def floating(self):

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -21,8 +21,8 @@
 from __future__ import annotations
 
 import functools
-import typing
 import operator
+import typing
 
 from wlroots.wlr_types.keyboard import KeyboardModifier
 
@@ -40,6 +40,12 @@ ModMasks = {
     "mod3": KeyboardModifier.MOD3,
     "mod4": KeyboardModifier.LOGO,
     "mod5": KeyboardModifier.MOD5,
+}
+
+buttons = {
+    "button1": 0x110,
+    "button2": 0x111,
+    "button3": 0x112,
 }
 
 

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -43,10 +43,12 @@ ModMasks = {
 }
 
 buttons = {
-    "button1": 0x110,
-    "button2": 0x111,
-    "button3": 0x112,
+    1: 0x110,
+    2: 0x111,
+    3: 0x112,
 }
+
+buttons_inv = {v: k for k, v in buttons.items()}
 
 
 def translate_masks(modifiers: typing.List[str]) -> int:

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 Matt Colligan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import functools
+import typing
+import operator
+
+from wlroots.wlr_types.keyboard import KeyboardModifier
+
+
+class WlrQError(Exception):
+    pass
+
+
+ModMasks = {
+    "shift": KeyboardModifier.SHIFT,
+    "lock": KeyboardModifier.CAPS,
+    "control": KeyboardModifier.CTRL,
+    "mod1": KeyboardModifier.ALT,
+    "mod2": KeyboardModifier.MOD2,
+    "mod3": KeyboardModifier.MOD3,
+    "mod4": KeyboardModifier.LOGO,
+    "mod5": KeyboardModifier.MOD5,
+}
+
+
+def translate_masks(modifiers: typing.List[str]) -> int:
+    """
+    Translate a modifier mask specified as a list of strings into an or-ed
+    bit representation.
+    """
+    masks = []
+    for i in modifiers:
+        try:
+            masks.append(ModMasks[i])
+        except KeyError as e:
+            raise WlrQError("Unknown modifier: %s" % i) from e
+    if masks:
+        return functools.reduce(operator.or_, masks)
+    else:
+        return 0

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -169,27 +169,16 @@ class Core(base.Core):
         self.conn.finalize()
 
     def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
-        """Get the screen information for the current connection"""
-        # What's going on here is a little funny. What we really want is only
-        # screens that don't overlap here; overlapping screens should see the
-        # same parts of the root window (i.e. for people doing xrandr
-        # --same-as). However, the order that X gives us pseudo screens in is
-        # important, because it indicates what people have chosen via xrandr
-        # --primary or whatever. So we need to alias screens that should be
-        # aliased, but preserve order as well. See #383.
-        xywh = {}  # type: Dict[Tuple[int, int], Tuple[int, int]]
-        for screen in self.conn.pseudoscreens:
-            pos = (screen.x, screen.y)
-            width, height = xywh.get(pos, (0, 0))
-            xywh[pos] = (max(width, screen.width), max(height, screen.height))
+        info = [(s.x, s.y, s.width, s.height) for s in self.conn.pseudoscreens]
 
-        if len(xywh) == 0:
-            xywh[(0, 0)] = (
+        if not info:
+            info.append((
+                0, 0,
                 self.conn.default_screen.width_in_pixels,
                 self.conn.default_screen.height_in_pixels,
-            )
+            ))
 
-        return [(x, y, w, h) for (x, y), (w, h) in xywh.items()]
+        return info
 
     @property
     def wmname(self):

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -251,9 +251,9 @@ class Core(base.Core):
             self.qtile.manage(win)
 
     def warp_pointer(self, x, y):
-        self.root.warp_pointer(x, y)
-        self.root.set_input_focus()
-        self.root.set_property("_NET_ACTIVE_WINDOW", self.root.wid)
+        self._root.warp_pointer(x, y)
+        self._root.set_input_focus()
+        self._root.set_property("_NET_ACTIVE_WINDOW", self._root.wid)
 
     def convert_selection(self, selection_atom, _type="UTF8_STRING") -> None:
         type_atom = self.conn.atoms[_type]

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -178,6 +178,9 @@ class Core(base.Core):
                 self.conn.default_screen.height_in_pixels,
             ))
 
+        if self.qtile:
+            self._xpoll()
+
         return info
 
     @property

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -250,6 +250,11 @@ class Core(base.Core):
 
             self.qtile.manage(win)
 
+    def warp_pointer(self, x, y):
+        self.root.warp_pointer(x, y)
+        self.root.set_input_focus()
+        self.root.set_property("_NET_ACTIVE_WINDOW", self.root.wid)
+
     def convert_selection(self, selection_atom, _type="UTF8_STRING") -> None:
         type_atom = self.conn.atoms[_type]
         self.conn.conn.core.ConvertSelection(

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -22,6 +22,8 @@
 import asyncio
 import contextlib
 import os
+import signal
+import time
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -719,3 +721,43 @@ class Core(base.Core):
         d.detail = self.conn.keysym_to_keycode(keysym)[0]
         d.state = modmasks
         self.handle_KeyPress(d)
+
+    def graceful_shutdown(self):
+        """Try to close windows gracefully before exiting"""
+
+        def get_interesting_pid(win):
+            # We don't need to kill Internal or Static windows, they're qtile
+            # managed and don't have any state.
+            if not isinstance(win, base.Window):
+                return None
+            try:
+                return win.window.get_net_wm_pid()
+            except Exception:
+                logger.exception("Got an exception in getting the window pid")
+                return None
+        pids = map(get_interesting_pid, self.qtile.windows_map.values())
+        pids = list(filter(lambda x: x is not None, pids))
+
+        # Give the windows a chance to shut down nicely.
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except OSError:
+                # might have died recently
+                pass
+
+        def still_alive(pid):
+            # most pids will not be children, so we can't use wait()
+            try:
+                os.kill(pid, 0)
+                return True
+            except OSError:
+                return False
+
+        # give everyone a little time to exit and write their state. but don't
+        # sleep forever (1s).
+        for i in range(10):
+            pids = list(filter(still_alive, pids))
+            if len(pids) == 0:
+                break
+            time.sleep(0.1)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -323,7 +323,7 @@ class Core(base.Core):
                     self.qtile.stop()
                     return
                 logger.exception("Got an exception in poll loop")
-        self.conn.flush()
+        self.flush()
 
     def _get_target_chain(self, event_type: str, event) -> List[Callable]:
         """Returns a chain of targets that can handle this event
@@ -762,7 +762,10 @@ class Core(base.Core):
                 qtile.focus_screen(screen.index, warp=False)
 
         self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, e.time)
-        self.conn.conn.flush()
+        self.flush()
+
+    def flush(self):
+        self.conn.flush()
 
     def graceful_shutdown(self):
         """Try to close windows gracefully before exiting"""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -35,9 +35,9 @@ import xcffib
 import xcffib.render
 import xcffib.xproto
 
-from libqtile import config, hook, utils, window
+from libqtile import config, hook, utils
 from libqtile.backend import base
-from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11 import window, xcbq
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -96,7 +96,7 @@ class Core(base.Core):
         if len(supporting_wm_wid) > 0:
             supporting_wm_wid = supporting_wm_wid[0]
 
-            supporting_wm = xcbq.Window(self.conn, supporting_wm_wid)
+            supporting_wm = window.XWindow(self.conn, supporting_wm_wid)
             existing_wmname = supporting_wm.get_property("_NET_WM_NAME", "UTF8_STRING", unpack=str)
             if existing_wmname:
                 logger.error("not starting; existing window manager {}".format(existing_wmname))
@@ -590,7 +590,7 @@ class Core(base.Core):
             args["width"] = max(event.width, 0)
         if event.value_mask & cw.BorderWidth:
             args["borderwidth"] = max(event.border_width, 0)
-        w = xcbq.Window(self.conn, event.window)
+        w = window.XWindow(self.conn, event.window)
         w.configure(**args)
 
     def handle_MappingNotify(self, event):  # noqa: N802
@@ -603,8 +603,7 @@ class Core(base.Core):
     def handle_MapRequest(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 
-        window = xcbq.Window(self.conn, event.window)
-        self.qtile.map_window(window)
+        self.qtile.map_window(window.XWindow(self.conn, event.window))
 
     def handle_DestroyNotify(self, event) -> None:  # noqa: N802
         assert self.qtile is not None

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -403,11 +403,16 @@ class Core(base.Core):
         """The name of the connected display"""
         return self._display_name
 
-    def update_client_list(self, windows) -> None:
-        """Set the current clients to the given list of windows"""
-        self._root.set_property("_NET_CLIENT_LIST", windows)
+    def update_client_list(self, windows_map: Dict[int, base.WindowType]) -> None:
+        """Updates the client stack list
+
+        This is needed for third party tasklists and drag and drop of tabs in
+        chrome
+        """
+        wids = [wid for wid, c in windows_map.items() if c.group]
+        self._root.set_property("_NET_CLIENT_LIST", wids)
         # TODO: check stack order
-        self._root.set_property("_NET_CLIENT_LIST_STACKING", windows)
+        self._root.set_property("_NET_CLIENT_LIST_STACKING", wids)
 
     def update_desktops(self, groups, index: int) -> None:
         """Set the current desktops of the window manager

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -24,6 +24,7 @@ import os
 from typing import (
     TYPE_CHECKING,
     Callable,
+    Dict,
     Iterator,
     List,
     Optional,
@@ -42,8 +43,6 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
-    from typing import Dict
-
     from libqtile.core.manager import Qtile
 
 _IGNORED_EVENTS = {
@@ -244,9 +243,10 @@ class Core(base.Core):
             else:
                 win = window.Window(item, self.qtile)
 
-            if item.get_wm_type() == "dock" or win.reserved_space:
-                win.cmd_static(self.qtile.current_screen.index)
-                continue
+                if item.get_wm_type() == "dock" or win.reserved_space:
+                    assert self.qtile.current_screen is not None
+                    win.cmd_static(self.qtile.current_screen.index)
+                    continue
 
             self.qtile.manage(win)
 
@@ -653,9 +653,10 @@ class Core(base.Core):
         else:
             win = window.Window(xwin, self.qtile)
 
-        if xwin.get_wm_type() == "dock" or win.reserved_space:
-            win.cmd_static(self.qtile.current_screen.index)
-            return
+            if xwin.get_wm_type() == "dock" or win.reserved_space:
+                assert self.qtile.current_screen is not None
+                win.cmd_static(self.qtile.current_screen.index)
+                return
 
         self.qtile.map_window(win)
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -400,7 +400,7 @@ class Core(base.Core):
         # TODO: check stack order
         self._root.set_property("_NET_CLIENT_LIST_STACKING", windows)
 
-    def update_net_desktops(self, groups, index: int) -> None:
+    def update_desktops(self, groups, index: int) -> None:
         """Set the current desktops of the window manager
 
         The list of desktops is given by the list of groups, with the current

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -12,7 +12,7 @@ from libqtile import hook, utils
 from libqtile.backend import base
 from libqtile.backend.base import FloatStates
 from libqtile.backend.x11 import xcbq
-from libqtile.command.base import CommandError, CommandObject, ItemT
+from libqtile.command.base import CommandError, ItemT
 from libqtile.log_utils import logger
 
 # ICCM Constants
@@ -442,7 +442,7 @@ class XWindow:
             self.set_attribute(borderpixel=self.conn.color_pixel(color))
 
 
-class _Window(CommandObject):
+class _Window:
     _window_mask = 0  # override in child class
 
     def __init__(self, window, qtile):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -891,7 +891,7 @@ class _Window(CommandObject):
                 state.remove(atom)
                 self.window.set_property('_NET_WM_STATE', state)
 
-        self.qtile.root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
+        self.qtile.core._root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
         hook.fire("client_focus", self)
         return True
 
@@ -1047,7 +1047,7 @@ class Static(_Window, base.Static):
             unpack=int
         )
         if strut:
-            x_screen_dimensions = self.qtile.root.get_geometry()
+            x_screen_dimensions = self.qtile.core._root.get_geometry()
             if strut[0]:    # left
                 x = strut[0]
                 y = (strut[4] + strut[5]) / 2 or (strut[6] + strut[7]) / 2

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -798,11 +798,11 @@ class _Window:
         if send_notify:
             self.send_configure_notify(x, y, width, height)
 
-    def paint_borders(self, borderpixel, borderwidth):
-        self.borderwidth = borderwidth
-        self.bordercolor = borderpixel
-        self.window.configure(borderwidth=borderwidth)
-        self.window.paint_borders(borderpixel)
+    def paint_borders(self, color, width):
+        self.borderwidth = width
+        self.bordercolor = color
+        self.window.configure(borderwidth=width)
+        self.window.paint_borders(color)
 
     def send_configure_notify(self, x, y, width, height):
         """Send a synthetic ConfigureNotify"""

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -533,10 +533,6 @@ class _Window(CommandObject):
     def group(self):
         return self._group
 
-    @property
-    def has_focus(self):
-        return self == self.qtile.current_window
-
     def has_fixed_ratio(self):
         try:
             if ('PAspect' in self.hints['flags'] and

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -678,7 +678,7 @@ class _Window(CommandObject):
     def kill(self):
         if "WM_DELETE_WINDOW" in self.window.get_wm_protocols():
             data = [
-                self.qtile.conn.atoms["WM_DELETE_WINDOW"],
+                self.qtile.core.conn.atoms["WM_DELETE_WINDOW"],
                 xcffib.xproto.Time.CurrentTime,
                 0,
                 0,
@@ -690,14 +690,14 @@ class _Window(CommandObject):
             e = xcffib.xproto.ClientMessageEvent.synthetic(
                 format=32,
                 window=self.window.wid,
-                type=self.qtile.conn.atoms["WM_PROTOCOLS"],
+                type=self.qtile.core.conn.atoms["WM_PROTOCOLS"],
                 data=u
             )
 
             self.window.send_event(e)
         else:
             self.window.kill_client()
-        self.qtile.conn.flush()
+        self.qtile.core.conn.flush()
 
     def hide(self):
         # We don't want to get the UnmapNotify for this unmap
@@ -842,7 +842,7 @@ class _Window(CommandObject):
         # does the window want us to ask it about focus?
         if "WM_TAKE_FOCUS" in self.window.get_wm_protocols():
             data = [
-                self.qtile.conn.atoms["WM_TAKE_FOCUS"],
+                self.qtile.core.conn.atoms["WM_TAKE_FOCUS"],
                 # The timestamp here must be a valid timestamp, not CurrentTime.
                 #
                 # see https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.7
@@ -861,7 +861,7 @@ class _Window(CommandObject):
             e = xcffib.xproto.ClientMessageEvent.synthetic(
                 format=32,
                 window=self.window.wid,
-                type=self.qtile.conn.atoms["WM_PROTOCOLS"],
+                type=self.qtile.core.conn.atoms["WM_PROTOCOLS"],
                 data=u
             )
 
@@ -884,7 +884,7 @@ class _Window(CommandObject):
         if self.urgent:
             self.urgent = False
 
-            atom = self.qtile.conn.atoms["_NET_WM_STATE_DEMANDS_ATTENTION"]
+            atom = self.qtile.core.conn.atoms["_NET_WM_STATE_DEMANDS_ATTENTION"]
             state = list(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
 
             if atom in state:
@@ -977,7 +977,7 @@ class Internal(_Window, base.Internal):
 
     @classmethod
     def create(cls, qtile, x, y, width, height, opacity=1.0):
-        win = qtile.conn.create_window(x, y, width, height)
+        win = qtile.core.conn.create_window(x, y, width, height)
         win.set_property("QTILE_INTERNAL", 1)
         i = Internal(win, qtile)
         i.place(x, y, width, height, 0, None)
@@ -988,7 +988,7 @@ class Internal(_Window, base.Internal):
         return "Internal(%r, %s)" % (self.name, self.window.wid)
 
     def kill(self):
-        self.qtile.conn.conn.core.DestroyWindow(self.window.wid)
+        self.qtile.core.conn.conn.core.DestroyWindow(self.window.wid)
 
     def cmd_kill(self):
         self.kill()
@@ -1083,7 +1083,7 @@ class Static(_Window, base.Static):
             self.reserved_space = None
 
     def handle_PropertyNotify(self, e):  # noqa: N802
-        name = self.qtile.conn.atoms.get_name(e.atom)
+        name = self.qtile.core.conn.atoms.get_name(e.atom)
         if name == "_NET_WM_STRUT_PARTIAL":
             self.update_strut()
 
@@ -1120,7 +1120,7 @@ class Window(_Window, base.Window):
                 self.hide()
 
         # add window to the save-set, so it gets mapped when qtile dies
-        qtile.conn.conn.core.ChangeSaveSet(SetMode.Insert, self.window.wid)
+        qtile.core.conn.conn.core.ChangeSaveSet(SetMode.Insert, self.window.wid)
         self.update_wm_net_icon()
 
     @property
@@ -1176,7 +1176,7 @@ class Window(_Window, base.Window):
 
     @fullscreen.setter
     def fullscreen(self, do_full):
-        atom = set([self.qtile.conn.atoms["_NET_WM_STATE_FULLSCREEN"]])
+        atom = set([self.qtile.core.conn.atoms["_NET_WM_STATE_FULLSCREEN"]])
         prev_state = set(self.window.get_property('_NET_WM_STATE', 'ATOM', unpack=int))
 
         def set_state(old_state, new_state):
@@ -1479,7 +1479,7 @@ class Window(_Window, base.Window):
         hook.fire("net_wm_icon_change", self)
 
     def handle_ClientMessage(self, event):  # noqa: N802
-        atoms = self.qtile.conn.atoms
+        atoms = self.qtile.core.conn.atoms
 
         opcode = event.type
         data = event.data
@@ -1548,7 +1548,7 @@ class Window(_Window, base.Window):
             logger.info("Unhandled client message: %s", atoms.get_name(opcode))
 
     def handle_PropertyNotify(self, e):  # noqa: N802
-        name = self.qtile.conn.atoms.get_name(e.atom)
+        name = self.qtile.core.conn.atoms.get_name(e.atom)
         logger.debug("PropertyNotifyEvent: %s", name)
         if name == "WM_TRANSIENT_FOR":
             pass

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -116,7 +116,7 @@ def _float_setter(attr):
     return setter
 
 
-class XWindow(base.Window):
+class XWindow:
     def __init__(self, conn, wid):
         self.conn = conn
         self.wid = wid
@@ -526,6 +526,10 @@ class _Window(CommandObject):
         fset=_float_setter("height"),
         fget=_float_getter("height")
     )
+
+    @property
+    def wid(self):
+        return self.window.wid
 
     @property
     def has_focus(self):
@@ -958,7 +962,7 @@ class _Window(CommandObject):
         )
 
 
-class Internal(base.Internal, _Window):
+class Internal(_Window, base.Internal):
     """An internal window, that should not be managed by qtile"""
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
@@ -990,7 +994,7 @@ class Internal(base.Internal, _Window):
         self.kill()
 
 
-class Static(base.Static, _Window):
+class Static(_Window, base.Static):
     """An internal window, that should not be managed by qtile"""
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
@@ -1087,7 +1091,7 @@ class Static(base.Static, _Window):
         return "Static(%r)" % self.name
 
 
-class Window(base.Window, _Window):
+class Window(_Window, base.Window):
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
         EventMask.EnterWindow | \

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -446,11 +446,12 @@ class _Window(CommandObject):
     _window_mask = 0  # override in child class
 
     def __init__(self, window, qtile):
+        base.Window.__init__(self)
         self.window, self.qtile = window, qtile
         self.hidden = True
-        self.group = None
         self.icons = {}
         window.set_attribute(eventmask=self._window_mask)
+        self._group = None
 
         self._float_info = {
             'x': None,
@@ -474,10 +475,7 @@ class _Window(CommandObject):
             self._width = None
             self._height = None
 
-        self.borderwidth = 0
         self.bordercolor = None
-        self.name = "<no name>"
-        self.reserved_space = None
         self.state = NormalState
         self._float_state = FloatStates.NOT_FLOATING
         self._demands_attention = False
@@ -530,6 +528,10 @@ class _Window(CommandObject):
     @property
     def wid(self):
         return self.window.wid
+
+    @property
+    def group(self):
+        return self._group
 
     @property
     def has_focus(self):
@@ -820,6 +822,7 @@ class _Window(CommandObject):
 
         self.window.send_event(event, mask=EventMask.StructureNotify)
 
+    @property
     def can_steal_focus(self):
         return self.window.get_wm_type() != 'notification'
 
@@ -1101,7 +1104,6 @@ class Window(_Window, base.Window):
 
     def __init__(self, window, qtile):
         _Window.__init__(self, window, qtile)
-        self._group = None
         self.update_name()
         # add to group by position according to _NET_WM_DESKTOP property
         group = None

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -568,6 +568,13 @@ class _Window(CommandObject):
             return
         hook.fire('client_name_updated', self)
 
+    def get_wm_class(self):
+        return self.window.get_wm_class()
+
+    def is_transient_for(self):
+        """What window is this window a transient windor for?"""
+        return self.window.get_wm_transient_for()
+
     def update_hints(self):
         """Update the local copy of the window's WM_HINTS
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -894,12 +894,6 @@ class _Window(CommandObject):
         hook.fire("client_focus", self)
         return True
 
-    def _items(self, name: str) -> ItemT:
-        return None
-
-    def _select(self, name, sel):
-        return None
-
     def cmd_focus(self, warp=None):
         """Focuses the window."""
         if warp is None:

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1169,6 +1169,14 @@ class Window(_Window, base.Window):
             self.group.mark_floating(self, False)
             hook.fire('float_change')
 
+    @property
+    def wants_to_fullscreen(self):
+        try:
+            return 'fullscreen' in self.window.get_net_wm_state()
+        except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
+            pass
+        return False
+
     def toggle_floating(self):
         self.floating = not self.floating
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1727,27 +1727,6 @@ class Window(_Window, base.Window):
     def cmd_match(self, *args, **kwargs):
         return self.match(*args, **kwargs)
 
-    def cmd_opacity(self, opacity):
-        if opacity < .1:
-            self.opacity = .1
-        elif opacity > 1:
-            self.opacity = 1
-        else:
-            self.opacity = opacity
-
-    def cmd_down_opacity(self):
-        if self.opacity > .2:
-            # don't go completely clear
-            self.opacity -= .1
-        else:
-            self.opacity = .1
-
-    def cmd_up_opacity(self):
-        if self.opacity < .9:
-            self.opacity += .1
-        else:
-            self.opacity = 1
-
     def _is_in_window(self, x, y, window):
         return (window.edges[0] <= x <= window.edges[2] and
                 window.edges[1] <= y <= window.edges[3])

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1,33 +1,17 @@
-# Copyright (c) 2008, Aldo Cortesi. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 import array
 import contextlib
 import inspect
 import traceback
+from itertools import islice
 
+import xcffib
 import xcffib.xproto
 from xcffib.xproto import EventMask, SetMode, StackMode
 
 from libqtile import hook, utils
 from libqtile.backend import base
 from libqtile.backend.base import FloatStates
+from libqtile.backend.x11 import xcbq
 from libqtile.command.base import CommandError, CommandObject, ItemT
 from libqtile.log_utils import logger
 
@@ -130,6 +114,332 @@ def _float_setter(attr):
     def setter(self, value):
         self._float_info[attr] = value
     return setter
+
+
+class XWindow(base.Window):
+    def __init__(self, conn, wid):
+        self.conn = conn
+        self.wid = wid
+
+    def _property_string(self, r):
+        """Extract a string from a window property reply message"""
+        return r.value.to_string()
+
+    def _property_utf8(self, r):
+        return r.value.to_utf8()
+
+    def send_event(self, synthevent, mask=EventMask.NoEvent):
+        self.conn.conn.core.SendEvent(False, self.wid, mask, synthevent.pack())
+
+    def kill_client(self):
+        self.conn.conn.core.KillClient(self.wid)
+
+    def set_input_focus(self):
+        self.conn.conn.core.SetInputFocus(
+            xcffib.xproto.InputFocus.PointerRoot,
+            self.wid,
+            xcffib.xproto.Time.CurrentTime
+        )
+
+    def warp_pointer(self, x, y):
+        """Warps the pointer to the location `x`, `y` on the window"""
+        self.conn.conn.core.WarpPointer(
+            0, self.wid,  # src_window, dst_window
+            0, 0,         # src_x, src_y
+            0, 0,         # src_width, src_height
+            x, y          # dest_x, dest_y
+        )
+
+    def get_name(self):
+        """Tries to retrieve a canonical window name.
+
+        We test the following properties in order of preference:
+            - _NET_WM_VISIBLE_NAME
+            - _NET_WM_NAME
+            - WM_NAME.
+        """
+        r = self.get_property("_NET_WM_VISIBLE_NAME", "UTF8_STRING")
+        if r:
+            return self._property_utf8(r)
+
+        r = self.get_property("_NET_WM_NAME", "UTF8_STRING")
+        if r:
+            return self._property_utf8(r)
+
+        r = self.get_property(xcffib.xproto.Atom.WM_NAME, "UTF8_STRING")
+        if r:
+            return self._property_utf8(r)
+
+        r = self.get_property(
+            xcffib.xproto.Atom.WM_NAME,
+            xcffib.xproto.GetPropertyType.Any
+        )
+        if r:
+            return self._property_string(r)
+
+    def get_wm_hints(self):
+        wm_hints = self.get_property("WM_HINTS", xcffib.xproto.GetPropertyType.Any)
+        if wm_hints:
+            atoms_list = wm_hints.value.to_atoms()
+            flags = {k for k, v in xcbq.HintsFlags.items() if atoms_list[0] & v}
+            return {
+                "flags": flags,
+                "input": atoms_list[1] if "InputHint" in flags else None,
+                "initial_state": atoms_list[2] if "StateHing" in flags else None,
+                "icon_pixmap": atoms_list[3] if "IconPixmapHint" in flags else None,
+                "icon_window": atoms_list[4] if "IconWindowHint" in flags else None,
+                "icon_x": atoms_list[5] if "IconPositionHint" in flags else None,
+                "icon_y": atoms_list[6] if "IconPositionHint" in flags else None,
+                "icon_mask": atoms_list[7] if "IconMaskHint" in flags else None,
+                "window_group": atoms_list[8] if 'WindowGroupHint' in flags else None,
+            }
+
+    def get_wm_normal_hints(self):
+        wm_normal_hints = self.get_property(
+            "WM_NORMAL_HINTS",
+            xcffib.xproto.GetPropertyType.Any
+        )
+        if wm_normal_hints:
+            atom_list = wm_normal_hints.value.to_atoms()
+            flags = {k for k, v in xcbq.NormalHintsFlags.items() if atom_list[0] & v}
+            hints = {
+                "flags": flags,
+                "min_width": atom_list[5],
+                "min_height": atom_list[6],
+                "max_width": atom_list[7],
+                "max_height": atom_list[8],
+                "width_inc": atom_list[9],
+                "height_inc": atom_list[10],
+                "min_aspect": (atom_list[11], atom_list[12]),
+                "max_aspect": (atom_list[13], atom_list[14])
+            }
+
+            # WM_SIZE_HINTS is potentially extensible (append to the end only)
+            iterator = islice(hints, 15, None)
+            hints["base_width"] = next(iterator, hints["min_width"])
+            hints["base_height"] = next(iterator, hints["min_height"])
+            hints["win_gravity"] = next(iterator, 1)
+            return hints
+
+    def get_wm_protocols(self):
+        wm_protocols = self.get_property("WM_PROTOCOLS", "ATOM", unpack=int)
+        if wm_protocols is not None:
+            return {self.conn.atoms.get_name(wm_protocol) for wm_protocol in wm_protocols}
+        return set()
+
+    def get_wm_state(self):
+        return self.get_property("WM_STATE", xcffib.xproto.GetPropertyType.Any, unpack=int)
+
+    def get_wm_class(self):
+        """Return an (instance, class) tuple if WM_CLASS exists, or None"""
+        r = self.get_property("WM_CLASS", "STRING")
+        if r:
+            s = self._property_string(r)
+            return tuple(s.strip("\0").split("\0"))
+        return tuple()
+
+    def get_wm_window_role(self):
+        r = self.get_property("WM_WINDOW_ROLE", "STRING")
+        if r:
+            return self._property_string(r)
+
+    def get_wm_transient_for(self):
+        r = self.get_property("WM_TRANSIENT_FOR", "WINDOW", unpack=int)
+
+        if r:
+            return r[0]
+
+    def get_wm_icon_name(self):
+        r = self.get_property("_NET_WM_ICON_NAME", "UTF8_STRING")
+        if r:
+            return self._property_utf8(r)
+
+        r = self.get_property("WM_ICON_NAME", "STRING")
+        if r:
+            return self._property_utf8(r)
+
+    def get_wm_client_machine(self):
+        r = self.get_property("WM_CLIENT_MACHINE", "STRING")
+        if r:
+            return self._property_utf8(r)
+
+    def get_geometry(self):
+        q = self.conn.conn.core.GetGeometry(self.wid)
+        return q.reply()
+
+    def get_wm_desktop(self):
+        r = self.get_property("_NET_WM_DESKTOP", "CARDINAL", unpack=int)
+
+        if r:
+            return r[0]
+
+    def get_wm_type(self):
+        """
+        http://standards.freedesktop.org/wm-spec/wm-spec-latest.html#id2551529
+        """
+        r = self.get_property('_NET_WM_WINDOW_TYPE', "ATOM", unpack=int)
+        if r:
+            name = self.conn.atoms.get_name(r[0])
+            return xcbq.WindowTypes.get(name, name)
+
+    def get_net_wm_state(self):
+        r = self.get_property('_NET_WM_STATE', "ATOM", unpack=int)
+        if r:
+            names = [self.conn.atoms.get_name(p) for p in r]
+            return [xcbq.WindowStates.get(n, n) for n in names]
+        return []
+
+    def get_net_wm_pid(self):
+        r = self.get_property("_NET_WM_PID", unpack=int)
+        if r:
+            return r[0]
+
+    def configure(self, **kwargs):
+        """
+        Arguments can be: x, y, width, height, border, sibling, stackmode
+        """
+        mask, values = xcbq.ConfigureMasks(**kwargs)
+        # older versions of xcb pack everything into unsigned ints "=I"
+        # since 1.12, uses switches to pack things sensibly
+        if float(".".join(xcffib.__xcb_proto_version__.split(".")[0: 2])) < 1.12:
+            values = [i & 0xffffffff for i in values]
+        return self.conn.conn.core.ConfigureWindow(self.wid, mask, values)
+
+    def set_attribute(self, **kwargs):
+        mask, values = xcbq.AttributeMasks(**kwargs)
+        self.conn.conn.core.ChangeWindowAttributesChecked(
+            self.wid, mask, values
+        )
+
+    def set_cursor(self, name):
+        cursor_id = self.conn.cursors[name]
+        mask, values = xcbq.AttributeMasks(cursor=cursor_id)
+        self.conn.conn.core.ChangeWindowAttributesChecked(
+            self.wid, mask, values
+        )
+
+    def set_property(self, name, value, type=None, format=None):
+        """
+        Parameters
+        ==========
+        name : String Atom name
+        type : String Atom name
+        format : 8, 16, 32
+        """
+        if name in xcbq.PropertyMap:
+            if type or format:
+                raise ValueError(
+                    "Over-riding default type or format for property."
+                )
+            type, format = xcbq.PropertyMap[name]
+        else:
+            if None in (type, format):
+                raise ValueError(
+                    "Must specify type and format for unknown property."
+                )
+
+        try:
+            if isinstance(value, str):
+                # xcffib will pack the bytes, but we should encode them properly
+                value = value.encode()
+            else:
+                # if this runs without error, the value is already a list, don't wrap it
+                next(iter(value))
+        except StopIteration:
+            # The value was an iterable, just empty
+            value = []
+        except TypeError:
+            # the value wasn't an iterable and wasn't a string, so let's
+            # wrap it.
+            value = [value]
+
+        try:
+            self.conn.conn.core.ChangePropertyChecked(
+                xcffib.xproto.PropMode.Replace,
+                self.wid,
+                self.conn.atoms[name],
+                self.conn.atoms[type],
+                format,  # Format - 8, 16, 32
+                len(value),
+                value
+            ).check()
+        except xcffib.xproto.WindowError:
+            logger.debug(
+                'X error in SetProperty (wid=%r, prop=%r), ignoring',
+                self.wid, name)
+
+    def get_property(self, prop, type=None, unpack=None):
+        """Return the contents of a property as a GetPropertyReply
+
+        If unpack is specified, a tuple of values is returned.  The type to
+        unpack, either `str` or `int` must be specified.
+        """
+        if type is None:
+            if prop not in xcbq.PropertyMap:
+                raise ValueError(
+                    "Must specify type for unknown property."
+                )
+            else:
+                type, _ = xcbq.PropertyMap[prop]
+
+        try:
+            r = self.conn.conn.core.GetProperty(
+                False, self.wid,
+                self.conn.atoms[prop]
+                if isinstance(prop, str)
+                else prop,
+                self.conn.atoms[type]
+                if isinstance(type, str)
+                else type,
+                0, (2 ** 32) - 1
+            ).reply()
+        except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
+            logger.debug(
+                'X error in GetProperty (wid=%r, prop=%r), ignoring',
+                self.wid, prop)
+            if unpack:
+                return []
+            return None
+
+        if not r.value_len:
+            if unpack:
+                return []
+            return None
+        elif unpack:
+            # Should we allow more options for unpacking?
+            if unpack is int:
+                return r.value.to_atoms()
+            elif unpack is str:
+                return r.value.to_string()
+        else:
+            return r
+
+    def list_properties(self):
+        r = self.conn.conn.core.ListProperties(self.wid).reply()
+        return [self.conn.atoms.get_name(i) for i in r.atoms]
+
+    def map(self):
+        self.conn.conn.core.MapWindow(self.wid)
+
+    def unmap(self):
+        self.conn.conn.core.UnmapWindowUnchecked(self.wid)
+
+    def get_attributes(self):
+        return self.conn.conn.core.GetWindowAttributes(self.wid).reply()
+
+    def query_tree(self):
+        q = self.conn.conn.core.QueryTree(self.wid).reply()
+        root = None
+        parent = None
+        if q.root:
+            root = XWindow(self.conn, q.root)
+        if q.parent:
+            parent = XWindow(self.conn, q.parent)
+        return root, parent, [XWindow(self.conn, i) for i in q.children]
+
+    def paint_borders(self, color):
+        if color:
+            self.set_attribute(borderpixel=self.conn.color_pixel(color))
 
 
 class _Window(CommandObject):
@@ -387,7 +697,7 @@ class _Window(CommandObject):
 
     def hide(self):
         # We don't want to get the UnmapNotify for this unmap
-        with self.disable_mask(xcffib.xproto.EventMask.StructureNotify):
+        with self.disable_mask(EventMask.StructureNotify):
             self.window.unmap()
         self.state = IconicState
         self.hidden = True

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -50,6 +50,7 @@ from xcffib.xfixes import SelectionEventMask
 from xcffib.xproto import CW, EventMask, WindowClass
 
 from libqtile import xkeysyms
+from libqtile.backend import base
 from libqtile.backend.x11.xcursors import Cursors
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError, hex
@@ -432,7 +433,7 @@ class NetWmState:
         return
 
 
-class Window:
+class Window(base.Window):
     def __init__(self, conn, wid):
         self.conn = conn
         self.wid = wid

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -52,12 +52,12 @@ from xcffib.xproto import CW, EventMask, WindowClass
 from libqtile import xkeysyms
 from libqtile.backend.x11.xcursors import Cursors
 from libqtile.log_utils import logger
-from libqtile.utils import hex
+from libqtile.utils import QtileError, hex
 
 keysyms = xkeysyms.keysyms
 
 
-class XCBQError(Exception):
+class XCBQError(QtileError):
     pass
 
 

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -220,7 +220,7 @@ class Bar(Gap, configurable.Configurable):
 
             self.drawer = drawer.Drawer(
                 self.qtile,
-                self.window.window.wid,
+                self.window.wid,
                 self.width,
                 self.height
             )
@@ -232,7 +232,7 @@ class Bar(Gap, configurable.Configurable):
             self.window.handle_EnterNotify = self.handle_EnterNotify
             self.window.handle_LeaveNotify = self.handle_LeaveNotify
             self.window.handle_MotionNotify = self.handle_MotionNotify
-            qtile.windows_map[self.window.window.wid] = self.window
+            qtile.windows_map[self.window.wid] = self.window
             self.window.unhide()
 
             self.crashed_widgets = []
@@ -429,7 +429,7 @@ class Bar(Gap, configurable.Configurable):
             height=self.height,
             position=self.position,
             widgets=[i.info() for i in self.widgets],
-            window=self.window.window.wid
+            window=self.window.wid
         )
 
     def is_show(self):

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -20,7 +20,8 @@
 
 from typing import Union
 
-from libqtile import configurable, drawer, window
+from libqtile import configurable, drawer
+from libqtile.backend.x11 import window
 from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -38,7 +38,8 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import xcffib.xproto
 
-from libqtile import configurable, hook, utils, window
+from libqtile import configurable, hook, utils
+from libqtile.backend.x11 import window
 from libqtile.bar import BarType
 from libqtile.command.base import CommandObject, ItemT
 from libqtile.lazy import lazy

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -398,7 +398,7 @@ class Screen(CommandObject):
         if name == "layout" and self.group is not None:
             return True, list(range(len(self.group.layouts)))
         elif name == "window" and self.group is not None:
-            return True, [i.window.wid for i in self.group.windows]
+            return True, [i.wid for i in self.group.windows]
         elif name == "bar":
             return False, [x.position for x in self.gaps]
         return None
@@ -414,7 +414,7 @@ class Screen(CommandObject):
                 return self.group.current_window
             else:
                 for i in self.group.windows:
-                    if i.window.wid == sel:
+                    if i.wid == sel:
                         return i
         elif name == "bar":
             return getattr(self, sel)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -36,8 +36,6 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
-import xcffib.xproto
-
 from libqtile import configurable, hook, utils
 from libqtile.backend.x11 import window
 from libqtile.bar import BarType
@@ -373,7 +371,7 @@ class Screen(CommandObject):
             if old_group is None:
                 ctx = contextlib.nullcontext()
             else:
-                ctx = old_group.disable_mask(xcffib.xproto.EventMask.EnterWindow)
+                ctx = self.qtile.core.masked()
             with ctx:
                 # display clients of the new group and then hide from old group
                 # to remove the screen flickering

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -154,10 +154,6 @@ class Qtile(CommandObject):
         self._process_screens()
         self.current_screen = self.screens[0]
 
-        self.conn.flush()
-        self.conn.xsync()
-        self.core._xpoll()
-
         # Map and Grab keys
         for key in self.config.keys:
             self.grab_key(key)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -37,7 +37,8 @@ import xcffib.xproto
 
 import libqtile
 from libqtile import confreader, hook, ipc, utils
-from libqtile.backend.x11 import window, xcbq
+from libqtile.backend import base
+from libqtile.backend.x11 import window
 from libqtile.command import interface
 from libqtile.command.base import CommandError, CommandException, CommandObject
 from libqtile.command.client import InteractiveCommandClient
@@ -77,7 +78,7 @@ class Qtile(CommandObject):
         self.mouse_map: Dict[Tuple[int, int], List[Union[Click, Drag]]] = {}
         self.mouse_position = (0, 0)
 
-        self.windows_map: Dict[int, window._Window] = {}
+        self.windows_map: Dict[int, base.WindowType] = {}
         self.widgets_map: Dict[str, _Widget] = {}
         self.groups_map: Dict[str, _Group] = {}
         self.groups: List[_Group] = []
@@ -546,7 +547,7 @@ class Qtile(CommandObject):
     def free_reserved_space(self, reserved_space, screen):
         self.reserve_space([-i for i in reserved_space], screen)
 
-    def map_window(self, window: window.XWindow) -> None:
+    def map_window(self, window: base.WindowType) -> None:
         c = self.manage(window)
         if c and (not c.group or not c.group.screen):
             return
@@ -612,7 +613,7 @@ class Qtile(CommandObject):
         c = self.windows_map.get(win)
         if c:
             hook.fire("client_killed", c)
-            if isinstance(c, window.Static):
+            if isinstance(c, base.Static):
                 self.free_reserved_space(c.reserved_space, c.screen)
             if getattr(c, "group", None):
                 c.group.remove(c)
@@ -631,7 +632,7 @@ class Qtile(CommandObject):
         def get_interesting_pid(win):
             # We don't need to kill Internal or Static windows, they're qtile
             # managed and don't have any state.
-            if not isinstance(win, window.Window):
+            if not isinstance(win, base.Window):
                 return None
             try:
                 return win.window.get_net_wm_pid()
@@ -1304,14 +1305,14 @@ class Qtile(CommandObject):
         """Return info for each client window"""
         return [
             i.info() for i in self.windows_map.values()
-            if not isinstance(i, window.Internal)
+            if not isinstance(i, base.Internal)
         ]
 
     def cmd_internal_windows(self):
         """Return info for each internal window (bars, for example)"""
         return [
             i.info() for i in self.windows_map.values()
-            if isinstance(i, window.Internal)
+            if isinstance(i, base.Internal)
         ]
 
     def cmd_qtile_info(self):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -776,21 +776,21 @@ class Qtile(CommandObject):
         event queue to the server after func is called. """
         def f():
             func(*args)
-            self.core.conn.flush()
+            self.core.flush()
         return self._eventloop.call_soon(f)
 
     def call_soon_threadsafe(self, func, *args):
         """ Another event loop proxy, see `call_soon`. """
         def f():
             func(*args)
-            self.core.conn.flush()
+            self.core.flush()
         return self._eventloop.call_soon_threadsafe(f)
 
     def call_later(self, delay, func, *args):
         """ Another event loop proxy, see `call_soon`. """
         def f():
             func(*args)
-            self.core.conn.flush()
+            self.core.flush()
         return self._eventloop.call_later(delay, f)
 
     def run_in_executor(self, func, *args):
@@ -1127,8 +1127,11 @@ class Qtile(CommandObject):
         return "OK"
 
     def cmd_sync(self):
-        """Sync the X display. Should only be used for development"""
-        self.core.conn.flush()
+        """
+        Sync the event queue (with the X server, or flush the wayland event queue.
+        Should only be used for development.
+        """
+        self.core.flush()
 
     def cmd_to_screen(self, n):
         """Warp focus to screen n, where n is a 0-based screen number

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -330,7 +330,8 @@ class Qtile(CommandObject):
                     group.hide()
 
     def paint_screen(self, screen, image_path, mode=None):
-        self.core.painter.paint(screen, image_path, mode)
+        if hasattr(self.core, "painter"):
+            self.core.painter.paint(screen, image_path, mode)
 
     def process_key_event(self, keysym: int, mask: int) -> None:
         key = self.keys_map.get((keysym, mask), None)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1472,3 +1472,9 @@ class Qtile(CommandObject):
     def cmd_run_extension(self, extension):
         """Run extensions"""
         extension.run()
+
+    def cmd_change_vt(self, vt: int) -> bool:
+        """Run extensions"""
+        if hasattr(self.core, "change_vt"):
+            return self.core.change_vt(vt)
+        raise CommandError("Backend does not support changing VT.")

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -203,10 +203,6 @@ class Qtile(CommandObject):
         return socket_path
 
     @property
-    def root(self):
-        return self.core._root
-
-    @property
     def conn(self):
         return self.core.conn
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -294,7 +294,14 @@ class Qtile(CommandObject):
             screen_info = [(s.x, s.y, s.width, s.height) for s in self.config.fake_screens]
             config = self.config.fake_screens
         else:
-            screen_info = self.core.get_screen_info()
+            # Alias screens with the same x and y coordinates, taking largest
+            xywh = {}  # type: Dict[Tuple[int, int], Tuple[int, int]]
+            for sx, sy, sw, sh in self.core.get_screen_info():
+                pos = (sx, sy)
+                width, height = xywh.get(pos, (0, 0))
+                xywh[pos] = (max(width, sw), max(height, sh))
+
+            screen_info = [(x, y, w, h) for (x, y), (w, h) in xywh.items()]
             config = self.config.screens
 
         for i, (x, y, w, h) in enumerate(screen_info):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -38,7 +38,6 @@ import xcffib.xproto
 import libqtile
 from libqtile import confreader, hook, ipc, utils
 from libqtile.backend import base
-from libqtile.backend.x11 import window
 from libqtile.command import interface
 from libqtile.command.base import CommandError, CommandException, CommandObject
 from libqtile.command.client import InteractiveCommandClient
@@ -531,21 +530,7 @@ class Qtile(CommandObject):
         c = self.manage(win)
         if c and (not c.group or not c.group.screen):
             return
-        win.window.map()
-
-    def unmap_window(self, window_id) -> None:
-        c = self.windows_map.get(window_id)
-        if c and getattr(c, "group", None):
-            try:
-                c.window.unmap()
-                c.state = window.WithdrawnState
-            except xcffib.xproto.WindowError:
-                # This means that the window has probably been destroyed,
-                # but we haven't yet seen the DestroyNotify (it is likely
-                # next in the queue). So, we just let these errors pass
-                # since the window is dead.
-                pass
-        self.unmanage(window_id)
+        win.unhide()
 
     def manage(self, win: base.WindowType):
         if isinstance(win, base.Internal):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -911,11 +911,11 @@ class Qtile(CommandObject):
                 return utils.lget(self.screens, sel)
 
     def list_wids(self):
-        return [i.window.wid for i in self.windows_map.values()]
+        return [i.wid for i in self.windows_map.values()]
 
     def client_from_wid(self, wid):
         for i in self.windows_map.values():
-            if i.window.wid == wid:
+            if i.wid == wid:
                 return i
         return None
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -440,15 +440,6 @@ class Qtile(CommandObject):
 
         self.core.update_desktops(self.groups, index)
 
-    def update_client_list(self) -> None:
-        """Updates the client stack list
-
-        This is needed for third party tasklists and drag and drop of tabs in
-        chrome
-        """
-        windows = [wid for wid, c in self.windows_map.items() if c.group]
-        self.core.update_client_list(windows)
-
     def add_group(self, name, layout=None, layouts=None, label=None):
         if name not in self.groups_map.keys():
             g = _Group(name, layout, label=label)
@@ -573,7 +564,7 @@ class Qtile(CommandObject):
         # Window may have been bound to a group in the hook.
         if not win.group:
             self.current_screen.group.add(win, focus=win.can_steal_focus())
-        self.update_client_list()
+        self.core.update_client_list(self.windows_map)
         hook.fire("client_managed", win)
         return win
 
@@ -586,9 +577,7 @@ class Qtile(CommandObject):
             if getattr(c, "group", None):
                 c.group.remove(c)
             del self.windows_map[win]
-            self.update_client_list()
-        if self.current_window is None:
-            self.core.conn.fixup_focus()
+            self.core.update_client_list(self.windows_map)
 
     def graceful_shutdown(self):
         """

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -821,9 +821,7 @@ class Qtile(CommandObject):
     def warp_to_screen(self):
         if self.current_screen:
             scr = self.current_screen
-            self.root.warp_pointer(scr.x + scr.dwidth // 2, scr.y + scr.dheight // 2)
-            self.root.set_input_focus()
-            self.root.set_property("_NET_ACTIVE_WINDOW", self.root.wid)
+            self.core.warp_pointer(scr.x + scr.dwidth // 2, scr.y + scr.dheight // 2)
 
     def focus_screen(self, n, warp=True):
         """Have Qtile move to screen and put focus there"""

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -110,7 +110,8 @@ class Qtile(CommandObject):
             widgets = self.config.screens[0].bottom.widgets
             widgets.insert(0, TextBox('Config Err!'))
 
-        self.core.wmname = getattr(self.config, "wmname", "qtile")
+        if hasattr(self.core, "wmname"):
+            self.core.wmname = getattr(self.config, "wmname", "qtile")
 
         self.dgroups = DGroups(self, self.config.groups, self.config.dgroups_key_binder)
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -547,7 +547,7 @@ class Qtile(CommandObject):
             return
         self.windows_map[win.wid] = win
         # Window may have been bound to a group in the hook.
-        if not win.group:
+        if not win.group and self.current_screen and self.current_screen.group:
             self.current_screen.group.add(win, focus=win.can_steal_focus)
         self.core.update_client_list(self.windows_map)
         hook.fire("client_managed", win)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -189,8 +189,8 @@ class Qtile(CommandObject):
             for screen in self.screens:
                 screen.group.layout_all()
         self._state = None
-        self.update_net_desktops()
-        hook.subscribe.setgroup(self.update_net_desktops)
+        self.update_desktops()
+        hook.subscribe.setgroup(self.update_desktops)
 
         if self.config.reconfigure_screens:
             hook.subscribe.screen_change(self.cmd_reconfigure_screens)
@@ -427,7 +427,7 @@ class Qtile(CommandObject):
         for mouse in self.config.mouse:
             self.core.grab_button(mouse)
 
-    def update_net_desktops(self) -> None:
+    def update_desktops(self) -> None:
         try:
             index = self.groups.index(self.current_group)
         # TODO: we should really only except ValueError here, AttributeError is
@@ -438,7 +438,7 @@ class Qtile(CommandObject):
         except (ValueError, AttributeError):
             index = 0
 
-        self.core.update_net_desktops(self.groups, index)
+        self.core.update_desktops(self.groups, index)
 
     def update_client_list(self) -> None:
         """Updates the client stack list
@@ -459,7 +459,7 @@ class Qtile(CommandObject):
             self.groups_map[name] = g
             hook.fire("addgroup", name)
             hook.fire("changegroup")
-            self.update_net_desktops()
+            self.update_desktops()
 
             return True
         return False
@@ -487,7 +487,7 @@ class Qtile(CommandObject):
             del(self.groups_map[name])
             hook.fire("delgroup", name)
             hook.fire("changegroup")
-            self.update_net_desktops()
+            self.update_desktops()
 
     def register_widget(self, w):
         """Register a bar widget

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -36,8 +36,8 @@ import xcffib.xinerama
 import xcffib.xproto
 
 import libqtile
-from libqtile import confreader, hook, ipc, utils, window
-from libqtile.backend.x11 import xcbq
+from libqtile import confreader, hook, ipc, utils
+from libqtile.backend.x11 import window, xcbq
 from libqtile.command import interface
 from libqtile.command.base import CommandError, CommandException, CommandObject
 from libqtile.command.client import InteractiveCommandClient
@@ -546,7 +546,7 @@ class Qtile(CommandObject):
     def free_reserved_space(self, reserved_space, screen):
         self.reserve_space([-i for i in reserved_space], screen)
 
-    def map_window(self, window: xcbq.Window) -> None:
+    def map_window(self, window: window.XWindow) -> None:
         c = self.manage(window)
         if c and (not c.group or not c.group.screen):
             return

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -203,10 +203,6 @@ class Qtile(CommandObject):
         return socket_path
 
     @property
-    def conn(self):
-        return self.core.conn
-
-    @property
     def selection(self):
         return self.core._selection
 
@@ -591,7 +587,7 @@ class Qtile(CommandObject):
             del self.windows_map[win]
             self.update_client_list()
         if self.current_window is None:
-            self.conn.fixup_focus()
+            self.core.conn.fixup_focus()
 
     def graceful_shutdown(self):
         """
@@ -721,7 +717,7 @@ class Qtile(CommandObject):
             if self.config.bring_front_click and (
                 self.config.bring_front_click != "floating_only" or getattr(window, "floating", False)
             ):
-                self.conn.conn.core.ConfigureWindow(
+                self.core.conn.conn.core.ConfigureWindow(
                     wid, xcffib.xproto.ConfigWindow.StackMode, [xcffib.xproto.StackMode.Above]
                 )
 
@@ -742,8 +738,8 @@ class Qtile(CommandObject):
             if screen:
                 self.focus_screen(screen.index, warp=False)
 
-        self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, e.time)
-        self.conn.conn.flush()
+        self.core.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, e.time)
+        self.core.conn.conn.flush()
 
     def process_button_click(self, button_code, modmask, x, y, event) -> None:
         self.mouse_position = (x, y)
@@ -894,21 +890,21 @@ class Qtile(CommandObject):
         event queue to the server after func is called. """
         def f():
             func(*args)
-            self.conn.flush()
+            self.core.conn.flush()
         return self._eventloop.call_soon(f)
 
     def call_soon_threadsafe(self, func, *args):
         """ Another event loop proxy, see `call_soon`. """
         def f():
             func(*args)
-            self.conn.flush()
+            self.core.conn.flush()
         return self._eventloop.call_soon_threadsafe(f)
 
     def call_later(self, delay, func, *args):
         """ Another event loop proxy, see `call_soon`. """
         def f():
             func(*args)
-            self.conn.flush()
+            self.core.conn.flush()
         return self._eventloop.call_later(delay, f)
 
     def run_in_executor(self, func, *args):
@@ -1246,7 +1242,7 @@ class Qtile(CommandObject):
 
     def cmd_sync(self):
         """Sync the X display. Should only be used for development"""
-        self.conn.flush()
+        self.core.conn.flush()
 
     def cmd_to_screen(self, n):
         """Warp focus to screen n, where n is a 0-based screen number

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -548,7 +548,7 @@ class Qtile(CommandObject):
         self.windows_map[win.wid] = win
         # Window may have been bound to a group in the hook.
         if not win.group:
-            self.current_screen.group.add(win, focus=win.can_steal_focus())
+            self.current_screen.group.add(win, focus=win.can_steal_focus)
         self.core.update_client_list(self.windows_map)
         hook.fire("client_managed", win)
         return win

--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -248,26 +248,26 @@ class Drawer:
         return self._pixmap
 
     def _create_gc(self):
-        gc = self.qtile.conn.conn.generate_id()
-        self.qtile.conn.conn.core.CreateGC(
+        gc = self.qtile.core.conn.conn.generate_id()
+        self.qtile.core.conn.conn.core.CreateGC(
             gc,
             self.wid,
             xcffib.xproto.GC.Foreground | xcffib.xproto.GC.Background,
             [
-                self.qtile.conn.default_screen.black_pixel,
-                self.qtile.conn.default_screen.white_pixel,
+                self.qtile.core.conn.default_screen.black_pixel,
+                self.qtile.core.conn.default_screen.white_pixel,
             ],
         )
         return gc
 
     def _free_gc(self):
         if self._gc is not None:
-            self.qtile.conn.conn.core.FreeGC(self._gc)
+            self.qtile.core.conn.conn.core.FreeGC(self._gc)
             self._gc = None
 
     def _create_xcb_surface(self):
         surface = cairocffi.XCBSurface(
-            self.qtile.conn.conn,
+            self.qtile.core.conn.conn,
             self._pixmap,
             self.find_root_visual(),
             self.width,
@@ -290,9 +290,9 @@ class Drawer:
         self.ctx = self.new_ctx()
 
     def _create_pixmap(self):
-        pixmap = self.qtile.conn.conn.generate_id()
-        self.qtile.conn.conn.core.CreatePixmap(
-            self.qtile.conn.default_screen.root_depth,
+        pixmap = self.qtile.core.conn.conn.generate_id()
+        self.qtile.core.conn.conn.core.CreatePixmap(
+            self.qtile.core.conn.default_screen.root_depth,
             pixmap,
             self.wid,
             self.width,
@@ -302,7 +302,7 @@ class Drawer:
 
     def _free_pixmap(self):
         if self._pixmap is not None:
-            self.qtile.conn.conn.core.FreePixmap(self._pixmap)
+            self.qtile.core.conn.conn.core.FreePixmap(self._pixmap)
             self._pixmap = None
 
     @property
@@ -414,7 +414,7 @@ class Drawer:
         self._paint()
 
         # Finally, copy XCBSurface's underlying pixmap to the window.
-        self.qtile.conn.conn.core.CopyArea(
+        self.qtile.core.conn.conn.core.CopyArea(
             self._pixmap,
             self.wid,
             self._gc,
@@ -425,9 +425,9 @@ class Drawer:
         )
 
     def find_root_visual(self):
-        for i in self.qtile.conn.default_screen.allowed_depths:
+        for i in self.qtile.core.conn.default_screen.allowed_depths:
             for v in i.visuals:
-                if v.visual_id == self.qtile.conn.default_screen.root_visual:
+                if v.visual_id == self.qtile.core.conn.default_screen.root_visual:
                     return v
 
     def new_ctx(self):

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -26,11 +26,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import contextlib
-
-import xcffib
-import xcffib.xproto
-
 from libqtile import hook, utils
 from libqtile.backend.base import FloatStates
 from libqtile.command.base import CommandObject, ItemT
@@ -148,7 +143,7 @@ class _Group(CommandObject):
         to it.
         """
         if self.screen and self.windows:
-            with self.disable_mask(xcffib.xproto.EventMask.EnterWindow):
+            with self.qtile.core.masked():
                 normal = [x for x in self.windows if not x.floating]
                 floating = [
                     x for x in self.windows
@@ -184,20 +179,10 @@ class _Group(CommandObject):
 
     def hide(self):
         self.screen = None
-        with self.disable_mask(xcffib.xproto.EventMask.EnterWindow |
-                               xcffib.xproto.EventMask.FocusChange |
-                               xcffib.xproto.EventMask.LeaveWindow):
+        with self.qtile.core.masked():
             for i in self.windows:
                 i.hide()
             self.layout.hide()
-
-    @contextlib.contextmanager
-    def disable_mask(self, mask):
-        for i in self.windows:
-            i._disable_mask(mask)
-        yield
-        for i in self.windows:
-            i._reset_mask()
 
     def focus(self, win, warp=True, force=False):
         """Focus the given window

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -252,17 +252,10 @@ class _Group(CommandObject):
         hook.fire("group_window_add", self, win)
         self.windows.add(win)
         win.group = self
-        try:
-            if 'fullscreen' in win.window.get_net_wm_state() and \
-                    self.qtile.config.auto_fullscreen:
-                win._float_state = FloatStates.FULLSCREEN
-            elif self.floating_layout.match(win):
-                # !!! tell it to float, can't set floating
-                # because it's too early
-                # so just set the flag underneath
-                win._float_state = FloatStates.FLOATING
-        except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
-            pass  # doesn't matter
+        if self.qtile.config.auto_fullscreen and win.wants_to_fullscreen:
+            win._float_state = FloatStates.FULLSCREEN
+        elif self.floating_layout.match(win):
+            win._float_state = FloatStates.FLOATING
         if win.floating:
             self.floating_layout.add(win)
         else:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -332,7 +332,7 @@ class _Group(CommandObject):
         if name == "screen" and self.screen is not None:
             return True, []
         if name == "window":
-            return self.current_window is not None, [i.window.wid for i in self.windows]
+            return self.current_window is not None, [i.wid for i in self.windows]
         return None
 
     def _select(self, name, sel):
@@ -346,7 +346,7 @@ class _Group(CommandObject):
             if sel is None:
                 return self.current_window
             for i in self.windows:
-                if i.window.wid == sel:
+                if i.wid == sel:
                     return i
         raise RuntimeError("Invalid selection: {}".format(name))
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -31,7 +31,8 @@ import contextlib
 import xcffib
 import xcffib.xproto
 
-from libqtile import hook, utils, window
+from libqtile import hook, utils
+from libqtile.backend.base import FloatStates
 from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
 
@@ -254,12 +255,12 @@ class _Group(CommandObject):
         try:
             if 'fullscreen' in win.window.get_net_wm_state() and \
                     self.qtile.config.auto_fullscreen:
-                win._float_state = window.FULLSCREEN
+                win._float_state = FloatStates.FULLSCREEN
             elif self.floating_layout.match(win):
                 # !!! tell it to float, can't set floating
                 # because it's too early
                 # so just set the flag underneath
-                win._float_state = window.FLOATING
+                win._float_state = FloatStates.FLOATING
         except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
             pass  # doesn't matter
         if win.floating:

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -178,7 +178,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` object
+            * ``Window`` object
 
         Examples
         --------
@@ -202,7 +202,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` object of the managed window
+            * ``Window`` object of the managed window
         """
         return self._subscribe("client_managed", func)
 
@@ -211,7 +211,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` object of the killed window.
+            * ``Window`` object of the killed window.
         """
         return self._subscribe("client_killed", func)
 
@@ -220,7 +220,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` object of the new focus.
+            * ``Window`` object of the new focus.
         """
         return self._subscribe("client_focus", func)
 
@@ -229,7 +229,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` of window entered
+            * ``Window`` of window entered
         """
         return self._subscribe("client_mouse_enter", func)
 
@@ -238,7 +238,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` of client with updated name
+            * ``Window`` of client with updated name
         """
         return self._subscribe("client_name_updated", func)
 
@@ -247,7 +247,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` of client with hint change
+            * ``Window`` of client with hint change
         """
         return self._subscribe("client_urgent_hint_changed", func)
 
@@ -266,7 +266,7 @@ class Subscribe:
 
         **Arguments**
 
-            * ``window.Window`` of client with changed icon
+            * ``Window`` of client with changed icon
         """
         return self._subscribe("net_wm_icon_change", func)
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -221,7 +221,7 @@ class Floating(Layout):
             client.y = screen_rect.y + client.y
         if not client.has_user_set_position() or not self.on_screen(client, screen_rect):
             # client has not been properly placed before or it is off screen
-            transient_for = client.window.get_wm_transient_for()
+            transient_for = client.is_transient_for()
             win = client.group.qtile.windows_map.get(transient_for)
             if win is not None:
                 # if transient for a window, place in the center of the window
@@ -263,7 +263,7 @@ class Floating(Layout):
 
         # 'sun-awt-X11-XWindowPeer' is a dropdown used in Java application,
         # don't reposition it anywhere, let Java app to control it
-        cls = client.window.get_wm_class() or ''
+        cls = client.get_wm_class() or ''
         is_java_dropdown = 'sun-awt-X11-XWindowPeer' in cls
         if is_java_dropdown:
             client.paint_borders(bc, bw)

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -468,7 +468,7 @@ class TreeTab(Layout):
         self._create_drawer(screen_rect)
         self._panel.handle_Expose = self._handle_Expose
         self._panel.handle_ButtonPress = self._handle_ButtonPress
-        self.group.qtile.windows_map[self._panel.window.wid] = self._panel
+        self.group.qtile.windows_map[self._panel.wid] = self._panel
         hook.subscribe.client_name_updated(self.draw_panel)
         hook.subscribe.focus_change(self.draw_panel)
 
@@ -719,7 +719,7 @@ class TreeTab(Layout):
         if self._drawer is None:
             self._drawer = drawer.Drawer(
                 self.group.qtile,
-                self._panel.window.wid,
+                self._panel.wid,
                 self.panel_width,
                 screen_rect.height
             )

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -29,7 +29,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import drawer, hook, window
+from libqtile import drawer, hook
+from libqtile.backend.x11 import window
 from libqtile.layout.base import Layout
 
 to_superscript = dict(zip(map(ord, u'0123456789'), map(ord, u'⁰¹²³⁴⁵⁶⁷⁸⁹')))

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -53,10 +53,10 @@ class Popup(configurable.Configurable):
         win = qtile.conn.create_window(x, y, width, height)
         win.set_property("QTILE_INTERNAL", 1)
         self.win = window.Internal(win, qtile)
-        self.qtile.windows_map[self.win.window.wid] = self.win
+        self.qtile.windows_map[self.win.wid] = self.win
         self.win.opacity = self.opacity
         self.drawer = drawer.Drawer(
-            self.qtile, self.win.window.wid, width, height,
+            self.qtile, self.win.wid, width, height,
         )
         self.layout = self.drawer.textlayout(
             text='',

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -50,7 +50,7 @@ class Popup(configurable.Configurable):
         self.add_defaults(Popup.defaults)
         self.qtile = qtile
 
-        win = qtile.conn.create_window(x, y, width, height)
+        win = qtile.core.conn.create_window(x, y, width, height)
         win.set_property("QTILE_INTERNAL", 1)
         self.win = window.Internal(win, qtile)
         self.qtile.windows_map[self.win.wid] = self.win

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -21,7 +21,8 @@
 
 from xcffib.xproto import StackMode
 
-from libqtile import configurable, drawer, pangocffi, window
+from libqtile import configurable, drawer, pangocffi
+from libqtile.backend.x11 import window
 
 
 class Popup(configurable.Configurable):

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -111,7 +111,7 @@ class WindowVisibilityToggler:
             # add hooks to determine if focus get lost
             if self.on_focus_lost_hide:
                 if self.warp_pointer:
-                    win.window.warp_pointer(win.width // 2, win.height // 2)
+                    win.qtile.core.warp_pointer(win.x + win.width // 2, win.y + win.height // 2)
                 hook.subscribe.client_focus(self.on_focus_change)
                 hook.subscribe.setgroup(self.on_focus_change)
 

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -20,7 +20,8 @@
 
 from typing import Dict, List
 
-from libqtile import config, group, hook, window
+from libqtile import config, group, hook
+from libqtile.backend.base import FloatStates
 
 
 class WindowVisibilityToggler:
@@ -100,7 +101,7 @@ class WindowVisibilityToggler:
             win = self.window
             # always set the floating state before changing group
             # to avoid disturbance of tiling layout
-            win._float_state = window.TOP
+            win._float_state = FloatStates.TOP
             # add to group and bring it to front.
             win.togroup()
             win.cmd_bring_to_front()

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -132,6 +132,6 @@ def add_subcommand(subparsers, parents):
         default='x11',
         dest='backend',
         choices=libqtile.backend.CORES,
-        help='Use specified backend. Currently only x11 is implemented.',
+        help='Use specified backend. Wayland backend is currently for development only.',
     )
     parser.set_defaults(func=start)

--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -66,7 +66,7 @@ class Clipboard(base._TextBox):
         if owner_id in self.qtile.windows_map:
             owner = self.qtile.windows_map[owner_id].window
         else:
-            owner = xcbq.Window(self.qtile.conn, owner_id)
+            owner = xcbq.Window(self.qtile.core.conn, owner_id)
 
         owner_class = owner.get_wm_class()
         if owner_class:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -594,7 +594,7 @@ class Prompt(base._TextBox):
     def _alert(self):
         # Fire an alert (audible or visual), if bell style is not None.
         if self.bell_style == "audible":
-            self.qtile.conn.conn.core.Bell(0)
+            self.qtile.core.conn.conn.core.Bell(0)
         elif self.bell_style == "visual":
             self.background = self.visual_bell_color
             self.timeout_add(self.visual_bell_time, self._stop_visual_alert)
@@ -667,7 +667,7 @@ class Prompt(base._TextBox):
         mask = xcbq.ModMasks["shift"] | xcbq.ModMasks["lock"]
         state = 1 if e.state & mask else 0
 
-        keysym = self.qtile.conn.code_to_syms[e.detail][state]
+        keysym = self.qtile.core.conn.code_to_syms[e.detail][state]
 
         handle_key = self._get_keyhandler(keysym)
 
@@ -681,7 +681,7 @@ class Prompt(base._TextBox):
             pass
         d = Dummy()
         keysym = xcbq.keysyms[key]
-        d.detail = self.qtile.conn.keysym_to_keycode(keysym)[0]
+        d.detail = self.qtile.core.conn.keysym_to_keycode(keysym)[0]
         d.state = 0
         self.handle_KeyPress(d)
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -204,13 +204,13 @@ class Systray(window._Window, base._Widget):
                     self.qtile.conn.atoms["_XEMBED_EMBEDDED_NOTIFY"],
                     xcffib.xproto.Time.CurrentTime,
                     0,
-                    self.bar.window.window.wid,
+                    self.bar.window.wid,
                     XEMBED_PROTOCOL_VERSION
                 ]
                 u = xcffib.xproto.ClientMessageData.synthetic(data, "I" * 5)
                 event = xcffib.xproto.ClientMessageEvent.synthetic(
                     format=32,
-                    window=icon.window.wid,
+                    window=icon.wid,
                     type=self.qtile.conn.atoms["_XEMBED"],
                     data=u
                 )

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -34,8 +34,8 @@ from xcffib.xproto import (
     SetMode,
 )
 
-from libqtile import bar, window
-from libqtile.backend.x11 import xcbq
+from libqtile import bar
+from libqtile.backend.x11 import window
 from libqtile.widget import base
 
 XEMBED_PROTOCOL_VERSION = 0
@@ -123,7 +123,7 @@ class Systray(window._Window, base._Widget):
             return
 
         win = qtile.conn.create_window(-1, -1, 1, 1)
-        window._Window.__init__(self, xcbq.Window(qtile.conn, win.wid), qtile)
+        window._Window.__init__(self, window.XWindow(qtile.conn, win.wid), qtile)
         qtile.windows_map[win.wid] = self
 
         # Even when we have multiple "Screen"s, we are setting up as the system
@@ -165,7 +165,7 @@ class Systray(window._Window, base._Widget):
         parent = self.bar.window.window
 
         if opcode == atoms['_NET_SYSTEM_TRAY_OPCODE'] and message == 0:
-            w = xcbq.Window(self.qtile.conn, wid)
+            w = window.XWindow(self.qtile.conn, wid)
             icon = Icon(w, self.qtile, self)
             self.icons[wid] = icon
             self.qtile.windows_map[wid] = icon

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -74,7 +74,7 @@ class Icon(window._Window):
         return False
 
     def handle_PropertyNotify(self, e):  # noqa: N802
-        name = self.qtile.conn.atoms.get_name(e.atom)
+        name = self.qtile.core.conn.atoms.get_name(e.atom)
         if name == "_XEMBED_INFO":
             info = self.window.get_property('_XEMBED_INFO', unpack=int)
             if info and info[1]:
@@ -122,8 +122,9 @@ class Systray(window._Window, base._Widget):
         if self.configured:
             return
 
-        win = qtile.conn.create_window(-1, -1, 1, 1)
-        window._Window.__init__(self, window.XWindow(qtile.conn, win.wid), qtile)
+        self.conn = conn = qtile.core.conn
+        win = conn.create_window(-1, -1, 1, 1)
+        window._Window.__init__(self, window.XWindow(conn, win.wid), qtile)
         qtile.windows_map[win.wid] = self
 
         # Even when we have multiple "Screen"s, we are setting up as the system
@@ -132,9 +133,9 @@ class Systray(window._Window, base._Widget):
         if qtile.current_screen:
             self.screen = qtile.current_screen.index
         self.bar = bar
-        atoms = qtile.conn.atoms
+        atoms = conn.atoms
 
-        qtile.conn.conn.core.SetSelectionOwner(
+        conn.conn.core.SetSelectionOwner(
             win.wid,
             atoms['_NET_SYSTEM_TRAY_S{:d}'.format(self.screen)],
             xcffib.CurrentTime
@@ -154,25 +155,24 @@ class Systray(window._Window, base._Widget):
         qtile.core._root.send_event(event, mask=EventMask.StructureNotify)
 
     def handle_ClientMessage(self, event):  # noqa: N802
-        atoms = self.qtile.conn.atoms
+        atoms = self.conn.atoms
 
         opcode = event.type
         data = event.data.data32
         message = data[1]
         wid = data[2]
 
-        conn = self.qtile.conn.conn
         parent = self.bar.window.window
 
         if opcode == atoms['_NET_SYSTEM_TRAY_OPCODE'] and message == 0:
-            w = window.XWindow(self.qtile.conn, wid)
+            w = window.XWindow(self.conn, wid)
             icon = Icon(w, self.qtile, self)
             self.icons[wid] = icon
             self.qtile.windows_map[wid] = icon
 
-            conn.core.ChangeSaveSet(SetMode.Insert, wid)
-            conn.core.ReparentWindow(wid, parent.wid, 0, 0)
-            conn.flush()
+            self.conn.conn.core.ChangeSaveSet(SetMode.Insert, wid)
+            self.conn.conn.core.ReparentWindow(wid, parent.wid, 0, 0)
+            self.conn.conn.flush()
 
             info = icon.window.get_property('_XEMBED_INFO', unpack=int)
 
@@ -201,7 +201,7 @@ class Systray(window._Window, base._Widget):
             if icon.hidden:
                 icon.unhide()
                 data = [
-                    self.qtile.conn.atoms["_XEMBED_EMBEDDED_NOTIFY"],
+                    self.conn.atoms["_XEMBED_EMBEDDED_NOTIFY"],
                     xcffib.xproto.Time.CurrentTime,
                     0,
                     self.bar.window.wid,
@@ -211,7 +211,7 @@ class Systray(window._Window, base._Widget):
                 event = xcffib.xproto.ClientMessageEvent.synthetic(
                     format=32,
                     window=icon.wid,
-                    type=self.qtile.conn.atoms["_XEMBED"],
+                    type=self.conn.atoms["_XEMBED"],
                     data=u
                 )
                 self.window.send_event(event)
@@ -220,8 +220,8 @@ class Systray(window._Window, base._Widget):
 
     def finalize(self):
         base._Widget.finalize(self)
-        atoms = self.qtile.conn.atoms
-        self.qtile.conn.conn.core.SetSelectionOwner(
+        atoms = self.conn.atoms
+        self.conn.conn.core.SetSelectionOwner(
             0,
             atoms['_NET_SYSTEM_TRAY_S{:d}'.format(self.screen)],
             xcffib.CurrentTime,

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -147,11 +147,11 @@ class Systray(window._Window, base._Widget):
         union = ClientMessageData.synthetic(data, "I" * 5)
         event = ClientMessageEvent.synthetic(
             format=32,
-            window=qtile.root.wid,
+            window=qtile.core._root.wid,
             type=atoms['MANAGER'],
             data=union
         )
-        qtile.root.send_event(event, mask=EventMask.StructureNotify)
+        qtile.core._root.send_event(event, mask=EventMask.StructureNotify)
 
     def handle_ClientMessage(self, event):  # noqa: N802
         atoms = self.qtile.conn.atoms

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -305,7 +305,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             self.bar.draw()
 
     def remove_icon_cache(self, window):
-        wid = window.window.wid
+        wid = window.wid
         if wid in self._icons_cache:
             self._icons_cache.pop(wid)
 
@@ -384,7 +384,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         if not window.icons:
             return None
 
-        cache = self._icons_cache.get(window.window.wid)
+        cache = self._icons_cache.get(window.wid)
         if cache:
             return cache
 
@@ -412,7 +412,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             width /= sp
             scaler.scale(sp, sp)
         surface.set_matrix(scaler)
-        self._icons_cache[window.window.wid] = surface
+        self._icons_cache[window.wid] = surface
         return surface
 
     def draw_icon(self, surface, offset):

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,3 +127,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-libqtile.widget._pulse_audio]
 ignore_missing_imports = True
+[mypy-xkbcommon.*]
+ignore_missing_imports = True
+[mypy-pywayland.*]
+ignore_missing_imports = True
+[mypy-wlroots.*]
+ignore_missing_imports = True

--- a/test/backend/x11/test_xcbq.py
+++ b/test/backend/x11/test_xcbq.py
@@ -4,7 +4,7 @@ import pytest
 import xcffib
 import xcffib.testing
 
-from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11 import window, xcbq
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -16,7 +16,7 @@ def xdisplay(request):
 def test_new_window(xdisplay):
     conn = xcbq.Connection(xdisplay)
     win = conn.create_window(1, 2, 640, 480)
-    assert isinstance(win, xcbq.Window)
+    assert isinstance(win, window.XWindow)
     geom = win.get_geometry()
     assert geom.x == 1
     assert geom.y == 2

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -38,8 +38,7 @@ import libqtile.confreader
 import libqtile.hook
 import libqtile.layout
 import libqtile.widget
-import libqtile.window
-from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11 import window, xcbq
 from libqtile.command.client import SelectError
 from libqtile.command.interface import CommandError, CommandException
 from libqtile.config import Match
@@ -468,7 +467,7 @@ def test_change_state_via_message(manager):
     window_info = manager.c.window.info()
     conn = xcbq.Connection(manager.display)
 
-    data = xcffib.xproto.ClientMessageData.synthetic([libqtile.window.IconicState, 0, 0, 0, 0], "IIIII")
+    data = xcffib.xproto.ClientMessageData.synthetic([window.IconicState, 0, 0, 0, 0], "IIIII")
     ev = xcffib.xproto.ClientMessageEvent.synthetic(
         32, window_info["id"], conn.atoms['WM_CHANGE_STATE'], data
     )
@@ -476,7 +475,7 @@ def test_change_state_via_message(manager):
     conn.xsync()
     assert manager.c.window.info()["minimized"]
 
-    data = xcffib.xproto.ClientMessageData.synthetic([libqtile.window.NormalState, 0, 0, 0, 0], "IIIII")
+    data = xcffib.xproto.ClientMessageData.synthetic([window.NormalState, 0, 0, 0, 0], "IIIII")
     ev = xcffib.xproto.ClientMessageEvent.synthetic(
         32, window_info["id"], conn.atoms['WM_CHANGE_STATE'], data
     )
@@ -1540,8 +1539,8 @@ def test_strut_handling(manager):
         assert manager.c.window.info()['x'] == 820
         assert manager.c.window.info()['y'] == 0
     finally:
-        for window in w:
-            window.kill_client()
+        for win in w:
+            win.kill_client()
         conn.finalize()
 
     test_initial_state()

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1208,7 +1208,7 @@ def test_labelgroup(manager):
 
 @manager_config
 def test_color_pixel(manager):
-    (success, e) = manager.c.eval("self.conn.color_pixel(\"ffffff\")")
+    (success, e) = manager.c.eval("self.core.conn.color_pixel(\"ffffff\")")
     assert success, e
 
 

--- a/test/test_popup.py
+++ b/test/test_popup.py
@@ -31,8 +31,9 @@ def test_popup_focus(manager):
     manager.test_xeyes()
     manager.windows_map = {}
 
-    # we have to add .conn so that Popup thinks this is libqtile.qtile
-    manager.conn = xcbq.Connection(manager.display)
+    # ugly hack: we have to add .core.conn so that Popup thinks this is libqtile.qtile
+    manager.core = manager
+    manager.core.conn = xcbq.Connection(manager.display)
 
     try:
         popup = Popup(manager)

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -114,6 +114,7 @@ def test_complete(manager):
     sh = QSh(command)
     assert sh._complete("c", "c") == [
         "cd",
+        "change_vt",
         "commands",
         "critical",
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,11 @@ deps =
     setuptools >= 40.5.0
     xcffib >= 0.8.1
     bowler
+    xkbcommon
+    pywayland
+# pywayland has to be installed before pywlroots
 commands =
+    pip install pywlroots
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -82,7 +86,8 @@ deps =
     xcffib >= 0.8.1
     pytest >= 6.2.1
 commands =
-    pip install -r requirements.txt
+    pip install -r requirements.txt pywayland xkbcommon
+    pip install pywlroots
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
This adds a standalone wayland core to the backends. Though the core is
not integrated into the rest of libqtile yet, it can be run directly
(either from TTY or within a running x11/wayland session) and will
provide a base wayland compositor:

    >> from libqtile.backend.wayland.core import Core
    >> Core()

This backend uses pywlroots by @flacjacket, which depends on pywayland,
python-xkbcommon, and wlroots.

The code is heavily based on pywlroots' tiny example, which is in turn
based on the tinyWL example that is part of wlroots.

Some todos (if anybody wants to help out these are good places to start 😉):

- [x]  Fix mypy dependencies so type checking works
- [x]  Move X-related code from `Qtile.process_button_click` to backend
- [x]  Move backend-agnostic Window methods to a base Window class for backends to build on. Or instead do we keep Window's `window` attribute and have two levels of windows?