### PR TITLE
Move _TextBox max_chars handling

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -357,6 +357,8 @@ class _TextBox(_Widget):
 
     @text.setter
     def text(self, value):
+        if len(value) > self.max_chars > 0:
+            value = value[:self.max_chars] + "…"
         self._text = value
         if self.layout:
             self.layout.text = self.formatted_text
@@ -467,8 +469,6 @@ class _TextBox(_Widget):
             text = ""
 
         old_width = self.layout.width
-        if len(text) > self.max_chars > 0:
-            text = text[:self.max_chars] + "…"
         self.text = text
 
         # If our width hasn't changed, we just draw ourselves. Otherwise,


### PR DESCRIPTION
Users can specify number of `max_chars` for `_TextBox` based widgets. Where text exceeds this length, it is truncated and an ellipsis is appended.

However, the truncation was only applied when the `update` method was called. Widgets that set the `text` attribute directly would not have the text truncated if necessary.

This PR ensures that the truncation is applied in both scenarios.

Fixes #2374.