### PR TITLE
Add `pytest-timeout` plugin to fail when hanging.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,13 @@ envlist =
 [testenv]
 # This is required in order to get UTF-8 output inside of the subprocesses
 # that our tests use.
-setenv = LC_CTYPE = en_US.UTF-8
+setenv =
+    LC_CTYPE = en_US.UTF-8
+    PYTEST_TIMEOUT = 600
+    # PYTEST_METHOD = both  # pytest-timeout doesn't check this
+    PYTEST_KILL_DELAY = 20
+    PYTEST_FUNC_ONLY = False
+    PYTEST_TIMEOUT_TIMING = long
 # Pass Display down to have it for the tests available
 passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals=convert
@@ -25,13 +31,15 @@ whitelist_externals=convert
 deps =
     pytest >= 6.2.1
     pytest-cov >= 2.10.1
+    # pytest-timeout >= 1.4.1
     setuptools >= 40.5.0
     xcffib >= 0.8.1
     bowler
 commands =
+    python3 -m pip install git+https://www.github.com/ep12/pytest-timeout@timing_enhancements
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
-    python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
+    python3 -m pytest -W error --timeout-method both --cov libqtile --cov-report term-missing {posargs}
 
 [testenv:packaging]
 deps =


### PR DESCRIPTION
Related: #2331.
If the changes from #2331 were upstream, this would be the way to go.

This commit adds `pytest-timeout` (with a timeout of 10min = 600s for a
test to complete) to the test suite.
Although timings can be obtained with `tox -e <ENVNAME> --
--durations=0`, this only prints them after all tests succeed or fail in
a nominal way. If the process is killed (Ctrl-C, GitHub Actions
execution time limit exceeded), the acquired duration data will not be
printed. Hence it makes sense to print a rough estimation right after
each test ends, resulting in either `PASSED (12.3ms)` or `FAILED (6.28s)`
to be printed. In case of a timeout, `TIMEOUT` will be printed instead.
This should help identify how long each test takes to execute.

Example output:
```
  test/layouts/test_common.py::test_remove_floating[Tile] PASSED (113ms+1.17s+35.5ms=1.31s) [ 77%]
  test/layouts/test_common.py::test_remove_floating[TreeTab] PASSED (120ms+1.29s+40.5ms=1.46s) [ 77%]
  test/layouts/test_common.py::test_remove_floating[VerticalTile] PASSED (112ms+1.17s+35.5ms=1.32s) [ 77%]
  test/layouts/test_common.py::test_remove_floating[Zoomy] PASSED (113ms+1.15s+37.3ms=1.30s) [ 78%]
  test/layouts/test_common.py::test_desktop_notifications[Bsp] PASSED (111ms+1.27s+35.9ms=1.41s) [ 78%]
  test/layouts/test_common.py::test_desktop_notifications[Columns] PASSED (111ms+1.28s+35.9ms=1.43s) [ 78%]
```