### PR TITLE
window: make WM_CHANGE_STATE code configurable

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -59,6 +59,7 @@ class Config:
         ("bring_front_click", "bool"),
         ("reconfigure_screens", "bool"),
         ("wmname", "str"),
+        ("respect_minimize_requests", "bool"),
     ]
 
     def __init__(self, file_path=None, **settings):

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -175,6 +175,10 @@ auto_fullscreen = True
 focus_on_window_activation = "smart"
 reconfigure_screens = True
 
+# If things like steam games want to auto-minimize themselves when losing
+# focus, should we respect this or not?
+respect_minimize_requests = True
+
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the
 # mailing lists, GitHub issues, and other WM documentation that suggest setting

--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1212,7 +1212,7 @@ class Window(_Window):
                     logger.warning("Invalid value for focus_on_window_activation: {}".format(focus_behavior))
         elif atoms["_NET_CLOSE_WINDOW"] == opcode:
             self.kill()
-        elif atoms["WM_CHANGE_STATE"] == opcode:
+        elif atoms["WM_CHANGE_STATE"] == opcode and self.qtile.config.respect_minimize_requests:
             state = data.data32[0]
             if state == NormalState:
                 self.minimized = False


### PR DESCRIPTION
This behavior really annoys me, so I'd like to make it configurable that we
do this at all.

As an alternative, I'm open to some code that "resurrects" these windows,
but frankly I don't love that either, and would rather they just stick
around when not focused.

Closes #2149

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>