### PR TITLE
migrate: work with multiple files in a directory

### DIFF
--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -43,6 +43,19 @@ def read_file(p):
         return f.read()
 
 
+def test_extra_files_are_ok():
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_file = os.path.join(tempdir, "config.py")
+        with open(config_file, "w") as config:
+            config.write("from .bar import CommandGraphRoot\n")
+        bar_py = os.path.join(tempdir, "bar.py")
+        with open(bar_py, "w") as config:
+            config.write("from libqtile.command_graph import CommandGraphRoot\n")
+        run_qtile_migrate(config_file)
+        assert os.path.exists(bar_py + BACKUP_SUFFIX)
+        assert read_file(bar_py) == "from libqtile.command.graph import CommandGraphRoot\n"
+
+
 def check_migrate(orig, expected):
     with tempfile.TemporaryDirectory() as tempdir:
         config_path = os.path.join(tempdir, "config.py")


### PR DESCRIPTION
Much like when I wrote `qtile check`, `qtile migrate` only supported
configs that were a single file, because that's how mine is. However, I
know it is reasonably common for people to have configs that are spread
across files, so this implements support for that. The patch itself is
fairly simple, because bowler by default if you pass it a directory selects
everything with *.py in that directory to refactor, so we end up
refactoring everything in the directory the config is in.

This isn't completely accurate for a couple of reasons: people may have
non-qtile files in the same directory as their config, and people may have
configs spread out across subdirectories using submodules. I have to say I
really can't be bothered to support the second case :)

The first case is potentially problematic, as there isn't a good way to
address it, besides perhaps passing migrate an explicit list of files that
you'd like to migrate. Perhaps we could go that route, depending on what
people think.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>