### PR TITLE
Delete deprecated

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import contextlib
 import os.path
 import sys
-import warnings
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import xcffib.xproto
@@ -463,13 +462,6 @@ class Screen(CommandObject):
         """Switch to the selected group or to the previously active one"""
         group = self.qtile.groups_map.get(group_name)
         self.toggle_group(group)
-
-    def cmd_togglegroup(self, groupName=None):  # noqa
-        """Switch to the selected group or to the previously active one
-
-        Deprecated: use toggle_group()"""
-        warnings.warn("togglegroup is deprecated, use toggle_group", DeprecationWarning)
-        self.cmd_toggle_group(groupName)
 
 
 class Group:

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -28,11 +28,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import warnings
+from typing import List, Optional
 
 from libqtile.config import Match
 from libqtile.layout.base import Layout
-from libqtile.log_utils import logger
+from libqtile.window import Window
 
 
 class Floating(Layout):
@@ -65,7 +65,7 @@ class Floating(Layout):
         ("fullscreen_border_width", 0, "Border width for fullscreen."),
     ]
 
-    def __init__(self, float_rules=None, no_reposition_rules=None, **config):
+    def __init__(self, float_rules: Optional[List[Match]] = None, no_reposition_rules=None, **config):
         """
         If you have certain apps that you always want to float you can provide
         ``float_rules`` to do so. ``float_rules`` are a list of
@@ -90,32 +90,12 @@ class Floating(Layout):
         correct location on the screen.
         """
         Layout.__init__(self, **config)
-        self.clients = []
+        self.clients: List[Window] = []
         self.focused = None
         self.group = None
 
         if float_rules is None:
             float_rules = self.default_float_rules
-        else:
-            warned = False
-            for index, rule in enumerate(float_rules):
-                if isinstance(rule, Match):
-                    continue
-
-                if not warned:
-                    message = "Non-config.Match objects in float_rules are " \
-                              "deprecated"
-                    warnings.warn(message, DeprecationWarning)
-                    logger.warning(message)
-                    warned = True
-
-                match = Match(
-                    title=rule.get("wname"), wm_class=rule.get("wmclass"),
-                    role=rule.get("role"), wm_type=rule.get("wm_type"),
-                    wm_instance_class=rule.get("wm_instance_class"),
-                    net_wm_pid=rule.get("net_wm_pid"))
-
-                float_rules[index] = match
 
         self.float_rules = float_rules
         self.no_reposition_rules = no_reposition_rules or []

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -36,14 +36,7 @@ class Image(base._Widget, base.MarginMixin):
         ("filename", None, "Image filename. Can contain '~'"),
     ]
 
-    def __init__(self, length=bar.CALCULATED, width=None, **config):
-        # 'width' was replaced by 'length' since the widget can be installed in
-        # vertical bars
-        if width is not None:
-            logger.warning('width kwarg or positional argument is '
-                           'deprecated. Please use length.')
-            length = width
-
+    def __init__(self, length=bar.CALCULATED, **config):
         base._Widget.__init__(self, length, **config)
         self.add_defaults(Image.defaults)
         self.add_defaults(base.MarginMixin.defaults)

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -165,8 +165,7 @@ class Mpd2(base.ThreadPoolText):
         ('host', 'localhost', 'Host of mpd server'),
         ('port', 6600, 'Port of mpd server'),
         ('password', None, 'Password for auth on mpd server'),
-        ('keys', keys, 'mouse button mapping. action -> b_num. deprecated.'),
-        ('mouse_buttons', {}, 'b_num -> action. replaces keys.'),
+        ('mouse_buttons', {}, 'b_num -> action.'),
         ('play_states', play_states, 'Play state mapping'),
         ('format_fns', format_fns, 'Dictionary of format methods'),
         ('command', default_cmd,
@@ -195,14 +194,6 @@ class Mpd2(base.ThreadPoolText):
         self.client.idletimeout = self.idletimeout
         if self.color_progress:
             self.color_progress = utils.hex(self.color_progress)
-
-        # remap self.keys as mouse_buttons for new button_press functionality.
-        # so we don't break existing configurations.
-        # TODO: phase out use of self.keys in favor of self.mouse_buttons
-        if self.mouse_buttons == {}:
-            for k in self.keys:
-                if self.keys[k] is not None:
-                    self.mouse_buttons[self.keys[k]] = k
 
     @property
     def connected(self):

--- a/libqtile/widget/sep.py
+++ b/libqtile/widget/sep.py
@@ -23,7 +23,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -41,14 +40,7 @@ class Sep(base._Widget):
         ),
     ]
 
-    def __init__(self, height_percent=None, **config):
-        # 'height_percent' was replaced by 'size_percent' since the widget can
-        # be installed in vertical bars
-        if height_percent is not None:
-            logger.warning('height_percent kwarg or positional argument is '
-                           'deprecated. Please use size_percent.')
-            config["size_percent"] = height_percent
-
+    def __init__(self, **config):
         length = config.get("padding", 2) * 2 + config.get("linewidth", 1)
         base._Widget.__init__(self, length, **config)
         self.add_defaults(Sep.defaults)

--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -25,7 +25,6 @@
 # SOFTWARE.
 
 from libqtile import bar
-from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -48,16 +47,9 @@ class Spacer(base._Widget):
         ("background", None, "Widget background color")
     ]
 
-    def __init__(self, length=bar.STRETCH, width=None, **config):
+    def __init__(self, length=bar.STRETCH, **config):
         """
         """
-        # 'width' was replaced by 'length' since the widget can be installed in
-        # vertical bars
-        if width is not None:
-            logger.warning('width kwarg or positional argument is '
-                           'deprecated. Please use length.')
-            length = width
-
         base._Widget.__init__(self, length, **config)
         self.add_defaults(Spacer.defaults)
 


### PR DESCRIPTION
Let's delete a bunch of deprecated stuff (and in some cases, add type enforcement for things that have been deprecated).

Note that this does not deprecate command_, since that makes the auto-migration tests fail, which means that nobody would ever get the benefit of those migrations (which is maybe ok...). A commit to do that is here, if we want to add it: https://github.com/tych0/qtile/commit/5e058270c4770774240e99022dc0da8432b6760d