### PR TITLE
README: drop coveralls stat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 **A full-featured, hackable tiling window manager written and configured in Python**
 
-|website| |pypi| |ci| |rtd| |coveralls| |license|
+|website| |pypi| |ci| |rtd| |license|
 
 Features
 ========
@@ -52,9 +52,6 @@ and `guidelines`_ for contributing in the documentation.
 .. |rtd| image:: https://readthedocs.org/projects/qtile/badge/?version=latest
     :alt: Read the Docs
     :target: http://docs.qtile.org/en/latest/
-.. |coveralls| image:: https://coveralls.io/repos/github/qtile/qtile/badge.svg?branch=master
-    :alt: Coveralls
-    :target: https://coveralls.io/github/qtile/qtile?branch=master
 .. |license| image:: https://img.shields.io/github/license/qtile/qtile.svg
     :alt: License
     :target: https://github.com/qtile/qtile/blob/master/LICENSE


### PR DESCRIPTION
1. I think coverage is kind of a silly metric
2. the coveralls stats haven't been updated since we switched to github
   actions.

Further, I don't really think our coverage stats are actually that
accurate. Most of the testing happens in a process that's forked from the
main process, and I don't think the coverage stuff quite handles this.

Perhaps we should delete the coverage infrastructure all together, but we
should definitely at least remove this until someone bothers to fix it.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>