### PR TITLE
Fix keyboardkbdd widget colour bug

### DIFF
--- a/libqtile/widget/keyboardkbdd.py
+++ b/libqtile/widget/keyboardkbdd.py
@@ -90,7 +90,7 @@ class KeyboardKbdd(base.ThreadPoolText):
         if isinstance(self.colours, list):
             try:
                 self.layout.colour = self.colours[index]
-            except ValueError:
+            except IndexError:
                 self._setColour(index - 1)
         else:
             logger.error('variable "colours" should be a list, to set a\


### PR DESCRIPTION
KeyboardKbdd takes an optional list of colours that can be used for different layouts. If the list is the wrong length, the code tries a previous index until it finds a colour.

However, the code listens for a ValueError rather than the correct IndexError so the widget crashes if the list is too short.