### PR TITLE
Fix keyboardkbdd widget colour error (pt 2)

### DIFF
--- a/libqtile/widget/keyboardkbdd.py
+++ b/libqtile/widget/keyboardkbdd.py
@@ -91,7 +91,7 @@ class KeyboardKbdd(base.ThreadPoolText):
             try:
                 self.layout.colour = self.colours[index]
             except IndexError:
-                self._setColour(index - 1)
+                self._set_colour(index - 1)
         else:
             logger.error('variable "colours" should be a list, to set a\
                             colour for all layouts, use "foreground".')


### PR DESCRIPTION
Following on from #2400 there's another bug in the `_set_colour` method. 

Just goes to show why we need tests!

ps @m-col sorry, didn't realise there were two bugs in this method. I've tested this change against my test and it does work.