### PR TITLE
Also find wayland socket files with ipc.find_sockfile

### DIFF
--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -42,17 +42,49 @@ HDRLEN = struct.calcsize(HDRFORMAT)
 SOCKBASE = "qtilesocket.%s"
 
 
-def find_sockfile(display: str = None):
-    """Finds the appropriate socket file for the given display"""
-    display = display or os.environ.get("DISPLAY") or ":0.0"
-    if "." not in display:
-        display += ".0"
-    cache_directory = get_cache_dir()
-    return os.path.join(cache_directory, SOCKBASE % display)
-
-
 class IPCError(Exception):
     pass
+
+
+def find_sockfile(display: str = None):
+    """
+    Finds the appropriate socket file for the given display.
+
+    If unspecified, the socket file is determined as follows:
+
+        - If WAYLAND_DISPLAY is set, use it.
+        - else if DISPLAY is set, use that.
+        - else check for the existence of a socket file for WAYLAND_DISPLAY=wayland-0
+          and if it exists, use it.
+        - else check for the existence of a socket file for DISPLAY=:0.0
+          and if it exists, use it.
+        - else raise an IPCError.
+
+    """
+    cache_directory = get_cache_dir()
+
+    if display:
+        return os.path.join(cache_directory, SOCKBASE % display)
+
+    display = os.environ.get("WAYLAND_DISPLAY")
+    if display:
+        return os.path.join(cache_directory, SOCKBASE % display)
+
+    display = os.environ.get("DISPLAY")
+    if display:
+        if "." not in display:
+            display += ".0"
+        return os.path.join(cache_directory, SOCKBASE % display)
+
+    sockfile = os.path.join(cache_directory, SOCKBASE % "wayland-0")
+    if os.path.exists(sockfile):
+        return sockfile
+
+    sockfile = os.path.join(cache_directory, SOCKBASE % ":0.0")
+    if os.path.exists(sockfile):
+        return sockfile
+
+    raise IPCError("Could not find socket file.")
 
 
 class _IPC:


### PR DESCRIPTION
This makes `ipc.find_sockfile` also find Wayland socket files so that
IPC can work when Qtile is being run with the Wayland backend. This
algorithm is used to identify a socket file when the `display` is not
specified.

    - If WAYLAND_DISPLAY is set, use it.
    - else if DISPLAY is set, use that.
    - else check for the existence of a socket file for
      WAYLAND_DISPLAY=wayland-0 and if it exists, use it.
    - else check for the existence of a socket file for DISPLAY=:0.0 and
      if it exists, use it.
    - else raise IPCError