### PR TITLE
Wayland: implement support for wlr-layer-shell, xdg-decorations, and clean up listener code

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -42,6 +42,7 @@ from wlroots.wlr_types import (
     layer_shell_v1,
     pointer,
     seat,
+    xdg_decoration_v1,
 )
 from wlroots.wlr_types.cursor import WarpMode
 from wlroots.wlr_types.virtual_keyboard_v1 import (
@@ -118,6 +119,11 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(
             self._virtual_keyboard_manager_v1.new_virtual_keyboard_event,
             self._on_new_virtual_keyboard
+        )
+        xdg_decoration_manager_v1 = xdg_decoration_v1.XdgDecorationManagerV1.create(self.display)
+        self.add_listener(
+            xdg_decoration_manager_v1.new_toplevel_decoration_event,
+            self._on_new_toplevel_decoration,
         )
 
         # start
@@ -244,6 +250,12 @@ class Core(base.Core, wlrq.HasListeners):
         win = window.Static(self, self.qtile, layer_surface, wid)
         logger.info(f"Managing new layer_shell window with window ID: {wid}")
         self.qtile.manage(win)
+
+    def _on_new_toplevel_decoration(
+        self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
+    ):
+        logger.debug("Signal: xdg_decoration new_top_level_decoration")
+        decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
 
     def _process_cursor_motion(self, time):
         self.qtile.process_button_motion(self.cursor.x, self.cursor.y)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -308,7 +308,8 @@ class Core(base.Core, wlrq.HasListeners):
     def _poll(self) -> None:
         if not self.display.destroyed:
             self.display.flush_clients()
-        self.event_loop.dispatch(-1)
+            self.event_loop.dispatch(0)
+            self.display.flush_clients()
 
     def focus_window(self, win: window.WindowType, surface: Surface = None):
         if self.seat.destroyed:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -202,18 +202,15 @@ class Core(base.Core, wlrq.HasListeners):
         self.qtile.manage(win)
 
     def _on_cursor_axis(self, _listener, event: pointer.PointerEventAxis):
-        logger.debug("Signal: cursor axis")
         self.seat.pointer_notify_axis(
             event.time_msec, event.orientation, event.delta, event.delta_discrete, event.source,
         )
 
     def _on_cursor_frame(self, _listener, _data):
-        logger.debug("Signal: cursor frame")
         self.seat.pointer_notify_frame()
 
     def _on_cursor_button(self, _listener, event: pointer.PointerEventButton):
         assert self.qtile is not None
-        logger.debug("Signal: cursor button")
         self.seat.pointer_notify_button(
             event.time_msec, event.button, event.button_state
         )
@@ -227,13 +224,11 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_motion(self, _listener, event: pointer.PointerEventMotion):
         assert self.qtile is not None
-        logger.debug("Signal: cursor motion")
         self.cursor.move(event.delta_x, event.delta_y, input_device=event.device)
         self._process_cursor_motion(event.time_msec)
 
     def _on_cursor_motion_absolute(self, _listener, event: pointer.PointerEventMotionAbsolute):
         assert self.qtile is not None
-        logger.debug("Signal: cursor motion_absolute")
         self.cursor.warp(
             WarpMode.AbsoluteClosest, event.x, event.y, input_device=event.device,
         )

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -52,10 +52,10 @@ ModMasks = {
     "mod5": KeyboardModifier.MOD5,
 }
 
+# from linux/input-event-codes.h
 buttons = {
-    1: 0x110,
-    2: 0x111,
-    3: 0x112,
+    1 + i: 0x110 + i
+    for i in range(8)
 }
 
 buttons_inv = {v: k for k, v in buttons.items()}

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -995,7 +995,7 @@ class Internal(_Window, base.Internal):
 
 
 class Static(_Window, base.Static):
-    """An internal window, that should not be managed by qtile"""
+    """An static window, belonging to a screen rather than a group"""
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
         EventMask.EnterWindow | \

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -552,7 +552,7 @@ class Qtile(CommandObject):
         c = self.windows_map.get(win)
         if c:
             hook.fire("client_killed", c)
-            if isinstance(c, base.Static):
+            if isinstance(c, base.Static) and c.reserved_space:
                 self.free_reserved_space(c.reserved_space, c.screen)
             if getattr(c, "group", None):
                 c.group.remove(c)

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.2.7
+  pywlroots>=0.2.8
 
 [options.package_data]
 libqtile.resources =

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots
+  pywlroots>=0.2.7
 
 [options.package_data]
 libqtile.resources =

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots
+    pip install pywlroots>=0.2.7
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -87,7 +87,7 @@ deps =
     pytest >= 6.2.1
 commands =
     pip install -r requirements.txt pywayland xkbcommon
-    pip install pywlroots
+    pip install pywlroots>=0.2.7
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.2.7
+    pip install pywlroots>=0.2.8
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -87,7 +87,7 @@ deps =
     pytest >= 6.2.1
 commands =
     pip install -r requirements.txt pywayland xkbcommon
-    pip install pywlroots>=0.2.7
+    pip install pywlroots>=0.2.8
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
    This adds support for the layer shell protocol. This allows for "layer"
    surfaces to be created by clients, used for applications such as status
    bars, overlays, third-party wallpapers (such as swaybg), and other tools
    like dmenu, rofi etc (their wayland clones that is).
    
    These clients are managed by Qtile as Static windows and are bound to an
    output rather than a group, and are not tiled.
    
    Part of layer shell protocol allows clients to request "exclusive
    zones", however this is not implemented in this commit.
    
    This depends on pywlroots>=0.2.7, which is reflected in tox.ini and
    setup.cfg.

--

This is another commit on top of #2418 but figured I should open a new PR for it as the other commits have already been reviewed once.

This also depends on a commit just merged into pywlroots that exposes this protocol which isn't available yet in a release. @flacjacket do you think it would be OK to make a new release with the layer shell commit?