### PR TITLE
wayland: Let pywlroots handle failed wlr_output.commit

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -188,10 +188,7 @@ class Core(base.Core):
                 return
             wlr_output.set_mode(mode)
             wlr_output.enable()
-
-            if not wlr_output.commit():
-                logger.error("New output cannot be committed")
-                return
+            wlr_output.commit()
 
         self.outputs.append(output.Output(self, wlr_output))
         self.output_layout.add_auto(wlr_output)


### PR DESCRIPTION
pywlroots commit e13ca1e changes the return value of
`pywlroots.wlr_types.Output` to `None` from `bool` as part of it
implementing its own error handling. We no longer need to do this, and
our handling of checking the old `bool` now always fails (because it
returns `None`).