### PR TITLE
Add test for notify widget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
                 sudo apt install --no-install-recommends \
                   libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz \
                   imagemagick libpulse-dev lm-sensors git xserver-xephyr xterm xvfb x11-apps ninja-build libegl1-mesa-dev \
-                  libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev
+                  libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev \
+                  dbus-x11 libnotify-bin
                 sudo pip -q install tox tox-gh-actions meson
             - name: Build wayland
               run: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ Qtile 0.x.x, released xxxx-xx-xx:
         - `libqtile.window` has been moved to `libqtile.backend.x11.window`; a migration has been added for this.
     !!! deprecation warning !!!
         - 'main' config functions, deprecated in 0.16.1, will no longer be executed.
+    !!! Notice for packagers - new dependencies !!!
+        - Tests now require the 'dbus-next' python module plus 'dbus-launch' and 'notify-send' applications
     * features
         - added measure_mem and measure_swap attributes to memory widget to allow user to choose measurement units.
         - memory widget can now be displayed with decimal values

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -75,7 +75,7 @@ class Notify(base._TextBox):
 
     def set_notif_text(self, notif):
         self.text = pangocffi.markup_escape_text(notif.summary)
-        urgency = notif.hints.get('urgency', 1)
+        urgency = getattr(notif.hints.get('urgency'), "value", 1)
         if urgency != 1:
             self.text = '<span color="%s">%s</span>' % (
                 utils.hex(

--- a/test/widgets/conftest.py
+++ b/test/widgets/conftest.py
@@ -1,4 +1,7 @@
 import os
+import shutil
+import signal
+import subprocess
 
 import pytest
 
@@ -74,3 +77,44 @@ def minimal_conf_noscreen():
         screens = []
 
     return MinimalConf
+
+
+@pytest.fixture(scope='function')
+def dbus(monkeypatch):
+    # for Github CI/Ubuntu, dbus-launch is provided by "dbus-x11" package
+    launcher = shutil.which("dbus-launch")
+
+    # If dbus-launch can't be found then tests will fail so we
+    # need to skip
+    if launcher is None:
+        pytest.skip("dbus-launch must be installed")
+
+    # dbus-launch prints two lines which should be set as
+    # environmental variables
+    result = subprocess.run(launcher, capture_output=True)
+
+    pid = None
+    for line in result.stdout.decode().splitlines():
+
+        # dbus server addresses can have multiple "=" so
+        # we use partition to split by the first one onle
+        var, _, val = line.partition("=")
+
+        # Use monkeypatch to set these variables so they are
+        # removed at end of test.
+        monkeypatch.setitem(os.environ, var, val)
+
+        # We want the pid so we can kill the process when the
+        # test is finished
+        if var == "DBUS_SESSION_BUS_PID":
+            try:
+                pid = int(val)
+            except ValueError:
+                pass
+
+    # Environment is set and dbus server should be running
+    yield
+
+    # Test is over so kill dbus session
+    if pid:
+        os.kill(pid, signal.SIGTERM)

--- a/test/widgets/test_keyboardkbdd.py
+++ b/test/widgets/test_keyboardkbdd.py
@@ -26,6 +26,7 @@
 # This test file covers the remaining widget code
 
 import sys
+from importlib import reload
 from types import ModuleType
 
 import pytest
@@ -35,6 +36,10 @@ from libqtile.bar import Bar
 
 def no_op(*args, **kwargs):
     pass
+
+
+async def mock_signal_receiver(*args, **kwargs):
+    return True
 
 
 class Mockconstants(ModuleType):
@@ -63,10 +68,12 @@ class MockMessage:
 def patched_widget(monkeypatch):
     monkeypatch.setitem(sys.modules, "dbus_next.constants", Mockconstants("dbus_next.constants"))
     from libqtile.widget import keyboardkbdd
+    reload(keyboardkbdd)
 
     # The next line shouldn't be necessary but I got occasional failures without it when testing locally
     monkeypatch.setattr("libqtile.widget.keyboardkbdd.MessageType", Mockconstants.MessageType)
     monkeypatch.setattr("libqtile.widget.keyboardkbdd.KeyboardKbdd.call_process", MockSpawn.call_process)
+    monkeypatch.setattr("libqtile.widget.keyboardkbdd.add_signal_receiver", mock_signal_receiver)
     return keyboardkbdd
 
 

--- a/test/widgets/test_mpris2widget.py
+++ b/test/widgets/test_mpris2widget.py
@@ -33,6 +33,10 @@ def no_op(*args, **kwargs):
     pass
 
 
+async def mock_signal_receiver(*args, **kwargs):
+    return True
+
+
 def fake_timer(interval, func, *args, **kwargs):
     class TimerObj:
         def cancel(self):
@@ -110,6 +114,7 @@ def patched_module(monkeypatch):
     # This may only be needed if dbus_next is installed on testing system so helpful for
     # local tests.
     reload(mpris2widget)
+    monkeypatch.setattr("libqtile.widget.mpris2widget.add_signal_receiver", mock_signal_receiver)
     return mpris2widget
 
 

--- a/test/widgets/test_notify.py
+++ b/test/widgets/test_notify.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2021 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# NOTE: This test only tests the functionality of the widget and parts of the manager
+# The notification service (in libqtile/notify.py) is tested separately
+# TO DO: notification service test ;)
+
+import shutil
+import subprocess
+
+import pytest
+
+import libqtile.config
+from libqtile.bar import Bar
+from libqtile.widget import notify
+
+
+# Bit of a hack... when we log a timer, save the delay in an attribute
+# We'll use this to check message timeouts are being honoured.
+def log_timeout(self, delay, func):
+    self.delay = delay
+    self.qtile.call_later(delay, func)
+
+
+def notification(subject, body, urgency=None, timeout=None):
+    '''Function to build notification text and command list'''
+    cmds = []
+
+    urgs = {0: "low", 1: "normal", 2: "critical"}
+    urg_level = urgs.get(urgency, "normal")
+    if urg_level != "normal":
+        cmds += ["-u", urg_level]
+
+    if timeout:
+        cmds += ["-t", "{}".format(timeout)]
+
+    cmds += [subject, body]
+
+    text = '<span weight="bold">'
+    if urg_level != "normal":
+        text += '<span color="{{colour}}">'
+    text += '{subject}'
+    if urg_level != "normal":
+        text += '</span>'
+    text += '</span> - {body}'
+
+    text = text.format(subject=subject, body=body)
+
+    return text, cmds
+
+
+# for Github CI/Ubuntu, "notify-send" is provided by libnotify-bin package
+NS = shutil.which("notify-send")
+
+URGENT = "#ff00ff"
+LOW = "#cccccc"
+DEFAULT_TIMEOUT = 3.0
+
+MESSAGE_1, NOTIFICATION_1 = notification("Message 1",
+                                         "Test Message 1",
+                                         timeout=5000)
+MESSAGE_2, NOTIFICATION_2 = notification("Urgent Message",
+                                         "This is not a test!",
+                                         urgency=2,
+                                         timeout=10000)
+MESSAGE_3, NOTIFICATION_3 = notification("Low priority",
+                                         "Windows closed unexpectedly",
+                                         urgency=0)
+
+
+@pytest.mark.skipif(
+    shutil.which("notify-send") is None,
+    reason="notify-send not installed."
+    )
+@pytest.mark.usefixtures("dbus")
+def test_notifications(manager_nospawn, minimal_conf_noscreen, monkeypatch):
+    notify.Notify.timeout_add = log_timeout
+    widget = notify.Notify(foreground_urgent=URGENT,
+                           foreground_low=LOW,
+                           default_timeout=DEFAULT_TIMEOUT)
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=Bar([widget], 10)
+        )
+    ]
+
+    manager_nospawn.start(config)
+    obj = manager_nospawn.c.widget["notify"]
+
+    # Send first notification and check time and display time
+    notif_1 = [NS]
+    notif_1.extend(NOTIFICATION_1)
+    subprocess.run(notif_1)
+    assert obj.info()["text"] == MESSAGE_1
+
+    _, timeout = obj.eval("self.delay")
+    assert timeout == "5.0"
+
+    # Send second notification and check time and display time
+    notif_2 = [NS]
+    notif_2.extend(NOTIFICATION_2)
+    subprocess.run(notif_2)
+    assert obj.info()["text"] == MESSAGE_2.format(colour=URGENT)
+
+    _, timeout = obj.eval("self.delay")
+    assert timeout == "10.0"
+
+    # Send third notification and check time and display time
+    notif_3 = [NS]
+    notif_3.extend(NOTIFICATION_3)
+    subprocess.run(notif_3)
+    assert obj.info()["text"] == MESSAGE_3.format(colour=LOW)
+
+    _, timeout = obj.eval("self.delay")
+    assert timeout == str(DEFAULT_TIMEOUT)
+
+    # Navigation tests
+
+    # Hitting next while on last message should not change display
+    obj.next()
+    assert obj.info()["text"] == MESSAGE_3.format(colour=LOW)
+
+    # Show previous
+    obj.prev()
+    assert obj.info()["text"] == MESSAGE_2.format(colour=URGENT)
+
+    # Show previous
+    obj.prev()
+    assert obj.info()["text"] == MESSAGE_1
+
+    # Show previous while on first message should stay on first
+    obj.prev()
+    assert obj.info()["text"] == MESSAGE_1
+
+    # Show next
+    obj.next()
+    assert obj.info()["text"] == MESSAGE_2.format(colour=URGENT)
+
+    # Toggle display (clear)
+    obj.toggle()
+    assert obj.info()["text"] == ""
+
+    # Toggle display - restoring display shows last notification
+    obj.toggle()
+    assert obj.info()["text"] == MESSAGE_3.format(colour=LOW)
+
+    # Clear the dispay
+    obj.clear()
+    assert obj.info()["text"] == ""
+
+    # Show the display
+    obj.display()
+    assert obj.info()["text"] == MESSAGE_3.format(colour=LOW)

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     bowler
     xkbcommon >= 0.3
     pywayland >= 0.4.4
+    dbus-next
 # pywayland has to be installed before pywlroots
 commands =
     pip install pywlroots>=0.13.4


### PR DESCRIPTION
Following the discussion in #2414, I've added `dbus-next` to the test environment and added the packages needed to provide `dbus-launch` and `notify-send`.

The test for the notify widget now activates a dbus session, sends notifications over the bus and checks the output in the widget.

This PR also fixes two bugs that arise in two other dbus widgets (mpris2 and keyboardkbdd) that arise as a result of `dbus-next` now being installed in the testing environment.

Would be good to get feedback on the `dbus` fixture in `conftest.py` as I haven't accounted for the scenario where `dbus-launch` is not available as it should always be on CI but, theoretically, may be unavailable on people's systems which could create issues when running tests locally.