### PR TITLE
qtile cmd-obj: convert integer arguments into ints

### DIFF
--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -125,8 +125,12 @@ def get_object(client: CommandClient, argv: List[str]) -> CommandClient:
     return client
 
 
-def run_function(client: CommandClient, funcname: str, args: List[str]) -> str:
+def run_function(client: CommandClient, funcname: str, args: List[str, int]) -> str:
     "Run command with specified args on given object."
+    for i, arg in enumerate(args):
+        if arg.lstrip("-").isdigit():
+            args[i] = int(arg)
+
     try:
         ret = client.call(funcname, *args)
     except SelectError:


### PR DESCRIPTION
This checks through the argument list as passed from the shell when
using `qtile cmd-obj ... -a <arguments>` and converts any arguments that
appear to be integers into `int`s. This makes the commands that expect
`int`s receive `int`s, rather than `str`s. Fixes #2433.