### PR TITLE
Wayland: implement damage tracking of outputs

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -42,6 +42,7 @@ from wlroots.wlr_types import (
     layer_shell_v1,
     pointer,
     seat,
+    xdg_decoration_v1,
 )
 from wlroots.wlr_types.cursor import WarpMode
 from wlroots.wlr_types.virtual_keyboard_v1 import (
@@ -118,6 +119,11 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(
             self._virtual_keyboard_manager_v1.new_virtual_keyboard_event,
             self._on_new_virtual_keyboard
+        )
+        xdg_decoration_manager_v1 = xdg_decoration_v1.XdgDecorationManagerV1.create(self.display)
+        self.add_listener(
+            xdg_decoration_manager_v1.new_toplevel_decoration_event,
+            self._on_new_toplevel_decoration,
         )
 
         # start
@@ -244,6 +250,12 @@ class Core(base.Core, wlrq.HasListeners):
         win = window.Static(self, self.qtile, layer_surface, wid)
         logger.info(f"Managing new layer_shell window with window ID: {wid}")
         self.qtile.manage(win)
+
+    def _on_new_toplevel_decoration(
+        self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
+    ):
+        logger.debug("Signal: xdg_decoration new_top_level_decoration")
+        decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
 
     def _process_cursor_motion(self, time):
         self.qtile.process_button_motion(self.cursor.x, self.cursor.y)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -39,20 +39,22 @@ from wlroots.wlr_types import (
     XCursorManager,
     XdgOutputManagerV1,
     input_device,
+    layer_shell_v1,
     pointer,
     seat,
-    xdg_shell,
 )
 from wlroots.wlr_types.cursor import WarpMode
 from wlroots.wlr_types.virtual_keyboard_v1 import (
     VirtualKeyboardManagerV1,
     VirtualKeyboardV1,
 )
+from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
 
 from libqtile import hook
 from libqtile.backend import base
-from libqtile.backend.wayland import keyboard, output, window, wlrq
+from libqtile.backend.wayland import keyboard, window, wlrq
+from libqtile.backend.wayland.output import Output
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -91,7 +93,7 @@ class Core(base.Core):
 
         # set up outputs
         self.output_layout = OutputLayout()
-        self.outputs: List[output.Output] = []
+        self.outputs: List[Output] = []
         self._on_new_output_listener = Listener(self._on_new_output)
         self.backend.new_output_event.add(self._on_new_output_listener)
 
@@ -112,9 +114,12 @@ class Core(base.Core):
         self.cursor.motion_absolute_event.add(self._on_cursor_motion_absolute_listener)
 
         # set up shell
-        self.xdg_shell = xdg_shell.XdgShell(self.display)
+        self.xdg_shell = XdgShell(self.display)
         self._on_new_xdg_surface_listener = Listener(self._on_new_xdg_surface)
         self.xdg_shell.new_surface_event.add(self._on_new_xdg_surface_listener)
+        self.layer_shell = layer_shell_v1.LayerShellV1(self.display)
+        self._on_new_layer_surface_listener = Listener(self._on_new_layer_surface)
+        self.layer_shell.new_surface_event.add(self._on_new_layer_surface_listener)
 
         # Add support for additional protocols
         XdgOutputManagerV1(self.display, self.output_layout)
@@ -138,6 +143,7 @@ class Core(base.Core):
         self._on_new_input_listener.remove()
         self._on_request_set_selection_listener.remove()
         self._on_new_virtual_keyboard_listener.remove()
+        self._on_new_layer_surface_listener.remove()
 
         for kb in self.keyboards:
             kb.finalize()
@@ -187,7 +193,7 @@ class Core(base.Core):
             wlr_output.enable()
             wlr_output.commit()
 
-        self.outputs.append(output.Output(self, wlr_output))
+        self.outputs.append(Output(self, wlr_output))
         self.output_layout.add_auto(wlr_output)
 
     def _on_request_cursor(self, _listener, event: seat.PointerRequestSetCursorEvent):
@@ -195,19 +201,14 @@ class Core(base.Core):
         # if self._seat.pointer_state.focused_surface == event.seat_client:  # needs updating pywlroots first
         self.cursor.set_surface(event.surface, event.hotspot)
 
-    def _on_new_xdg_surface(self, _listener, surface: xdg_shell.XdgSurface):
+    def _on_new_xdg_surface(self, _listener, surface: XdgSurface):
         logger.debug("Signal: xdg_shell new_surface_event")
         assert self.qtile is not None
 
-        if surface.role != xdg_shell.XdgSurfaceRole.TOPLEVEL:
+        if surface.role != XdgSurfaceRole.TOPLEVEL:
             return
 
-        wid = 0
-        wids = self.qtile.windows_map.keys()
-        while True:
-            if wid not in wids:
-                break
-            wid += 1
+        wid = max(self.qtile.windows_map.keys()) + 1
         win = window.Window(self, self.qtile, surface, wid)
         logger.info(f"Managing new top-level window with window ID: {wid}")
         self.qtile.manage(win)
@@ -253,6 +254,15 @@ class Core(base.Core):
     def _on_new_virtual_keyboard(self, _listener, virtual_keyboard: VirtualKeyboardV1):
         self._add_new_keyboard(virtual_keyboard.input_device)
 
+    def _on_new_layer_surface(self, _listener, layer_surface: layer_shell_v1.LayerSurfaceV1):
+        logger.debug("Signal: layer_shell new_surface_event")
+        assert self.qtile is not None
+
+        wid = max(self.qtile.windows_map.keys()) + 1
+        win = window.Static(self, self.qtile, layer_surface, wid)
+        logger.info(f"Managing new layer_shell window with window ID: {wid}")
+        self.qtile.manage(win)
+
     def _process_cursor_motion(self, time):
         self.qtile.process_button_motion(self.cursor.x, self.cursor.y)
         found = self._under_pointer()
@@ -263,7 +273,7 @@ class Core(base.Core):
             if focus_changed:
                 hook.fire("client_mouse_enter", win)
                 if self.qtile.config.follow_mouse_focus:
-                    if win.group.current_window != self:
+                    if win.group.current_window != win:
                         win.group.focus(win, False)
                     if win.group.screen and self.qtile.current_screen != win.group.screen:
                         self.qtile.focus_screen(win.group.screen.index, False)
@@ -306,23 +316,34 @@ class Core(base.Core):
             self.display.flush_clients()
         self.event_loop.dispatch(-1)
 
-    def focus_window(self, win: window.Window, surface: Surface = None):
-        if surface is None:
+    def focus_window(self, win: window.WindowType, surface: Surface = None):
+        if self.seat.destroyed:
+            return
+
+        if surface is None and win is not None:
             surface = win.surface.surface
 
         previous_surface = self.seat.keyboard_state.focused_surface
         if previous_surface == surface:
             return
+        self.seat.keyboard_clear_focus()
 
         if previous_surface is not None and previous_surface.is_xdg_surface:
             # Deactivate the previously focused surface
-            previous_xdg_surface = xdg_shell.XdgSurface.from_surface(previous_surface)
+            previous_xdg_surface = XdgSurface.from_surface(previous_surface)
             previous_xdg_surface.set_activated(False)
 
-        # activate the new surface
-        win.surface.set_activated(True)
+        if not win:
+            return
+
+        if isinstance(win.surface, layer_shell_v1.LayerSurfaceV1):
+            if not win.mapped or not win.surface.current.keyboard_interactive:
+                return
+
+        logger.debug("Focussing new window")
+        if surface.is_xdg_surface and isinstance(win.surface, XdgSurface):
+            win.surface.set_activated(True)
         self.seat.keyboard_notify_enter(surface, self.seat.keyboard)
-        logger.debug("Focussed new window")
 
     def focus_by_click(self, event) -> None:
         found = self._under_pointer()
@@ -434,3 +455,12 @@ class Core(base.Core):
     @property
     def painter(self):
         return wlrq.Painter(self)
+
+    def output_from_wlr_output(self, wlr_output: wlrOutput) -> Output:
+        matched = []
+        for output in self.outputs:
+            if output.wlr_output == wlr_output:
+                matched.append(output)
+
+        assert len(matched) == 1
+        return matched[0]

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -23,8 +23,10 @@ from __future__ import annotations
 import typing
 
 from wlroots.util.clock import Timespec
+from wlroots.util.region import PixmanRegion32
 from wlroots.wlr_types import Box, Matrix
 from wlroots.wlr_types import Output as wlrOutput
+from wlroots.wlr_types import OutputDamage
 from wlroots.wlr_types.layer_shell_v1 import (
     LayerShellV1Layer,
     LayerSurfaceV1,
@@ -51,12 +53,13 @@ class Output(HasListeners):
         self.renderer = core.renderer
         self.wlr_output = wlr_output
         self.output_layout = self.core.output_layout
+        self.damage = OutputDamage.create(wlr_output)
         self.wallpaper = None
         self.transform_matrix = wlr_output.transform_matrix
         self.x, self.y = self.output_layout.output_coords(wlr_output)
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)
-        self.add_listener(wlr_output.frame_event, self._on_frame)
+        self.add_listener(self.damage.frame_event, self._on_frame)
 
         self._mapped_windows: Set[WindowType] = set()
         hook.subscribe.setgroup(self._get_windows)
@@ -69,6 +72,7 @@ class Output(HasListeners):
 
     def finalize(self):
         self.finalize_listeners()
+        self.damage.destroy()
 
     def _on_destroy(self, _listener, _data):
         logger.debug("Signal: output destroy")
@@ -76,15 +80,27 @@ class Output(HasListeners):
         self.core.outputs.remove(self)
 
     def _on_frame(self, _listener, _data):
-        now = Timespec.get_monotonic_time()
         wlr_output = self.wlr_output
 
-        with wlr_output:
-            self.renderer.begin(*wlr_output.effective_resolution())
-            self.renderer.clear([0, 0, 0, 1])
+        with PixmanRegion32() as damage:
+            if not self.damage.attach_render(damage):
+                # no new frame needed
+                wlr_output.rollback()
+                return
+
+            now = Timespec.get_monotonic_time()
+            renderer = self.renderer
+            renderer.begin(*wlr_output.effective_resolution())
+
+            if not damage.not_empty():
+                # No damage, only buffer swap needed
+                wlr_output.commit()
+                return
 
             if self.wallpaper:
-                self.renderer.render_texture(self.wallpaper, self.transform_matrix, 0, 0, 1)
+                renderer.render_texture(self.wallpaper, self.transform_matrix, 0, 0, 1)
+            else:
+                renderer.clear([0, 0, 0, 1])
 
             for window in self._mapped_windows:
                 rdata = (
@@ -97,8 +113,9 @@ class Output(HasListeners):
                 )
                 window.surface.for_each_surface(self._render_surface, rdata)
 
-            wlr_output.render_software_cursors()
-            self.renderer.end()
+            wlr_output.render_software_cursors(damage=damage)
+            renderer.end()
+            wlr_output.commit()
 
     def _render_surface(self, surface: Surface, sx: int, sy: int, rdata: Tuple) -> None:
         now, window, wx, wy, opacity, scale = rdata
@@ -111,7 +128,7 @@ class Output(HasListeners):
         y = (wy + sy) * scale
         width = surface.current.width * scale
         height = surface.current.height * scale
-        transform_matrix = self.wlr_output.transform_matrix
+        transform_matrix = self.transform_matrix
 
         if surface == window.surface.surface and window.borderwidth:
             bw = window.borderwidth * scale
@@ -207,3 +224,18 @@ class Output(HasListeners):
                 win.place(x, y, ww, wh, 0, None)
 
         self._get_windows()
+
+    def contains(self, win: WindowType) -> bool:
+        """Returns whether the given window is visible on this output."""
+        if win.x + win.width < self.x:
+            return False
+        if win.y + win.height < self.y:
+            return False
+
+        ow, oh = self.wlr_output.effective_resolution()
+        if self.x + ow < win.x:
+            return False
+        if self.y + oh < win.y:
+            return False
+
+        return True

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -85,10 +85,10 @@ class Window(base.Window, HasListeners):
         self.add_listener(surface.unmap_event, self._on_unmap)
         self.add_listener(surface.destroy_event, self._on_destroy)
         self.add_listener(surface.toplevel.request_fullscreen_event, self._on_request_fullscreen)
+        self.add_listener(surface.surface.commit_event, self._on_commit)
 
     def finalize(self):
         self.finalize_listeners()
-        self.core.flush()
 
     @property
     def wid(self):
@@ -118,6 +118,7 @@ class Window(base.Window, HasListeners):
     def _on_unmap(self, _listener, data):
         logger.debug("Signal: window unmap")
         self.mapped = False
+        self.damage()
         seat = self.core.seat
         if not seat.destroyed:
             if self.surface.surface == seat.keyboard_state.focused_surface:
@@ -132,6 +133,15 @@ class Window(base.Window, HasListeners):
         logger.debug("Signal: window request_fullscreen")
         if self.qtile.config.auto_fullscreen:
             self.fullscreen = event.fullscreen
+
+    def _on_commit(self, _listener, data):
+        logger.debug("Signal: window commit")
+        self.damage()
+
+    def damage(self) -> None:
+        for output in self.core.outputs:
+            if output.contains(self):
+                output.damage.add_whole()
 
     def hide(self):
         if self.mapped:
@@ -254,12 +264,14 @@ class Window(base.Window, HasListeners):
 
         self.x = x
         self.y = y
-        self.surface.set_size(width, height)
+        self.surface.set_size(int(width), int(height))
         self.paint_borders(bordercolor, borderwidth)
 
         if above:
             # TODO when general z-axis control is implemented
             pass
+
+        self.damage()
 
     def _tweak_float(self, x=None, y=None, dx=0, dy=0, w=None, h=None, dw=0, dh=0):
         if x is None:
@@ -421,12 +433,13 @@ class Static(Window, base.Static):
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)
         self.add_listener(surface.destroy_event, self._on_destroy)
+        self.add_listener(surface.surface.commit_event, self._on_commit)
 
         if isinstance(surface, LayerSurfaceV1):
             self.is_layer = True
             if surface.output is None:
                 surface.output = core.output_layout.output_at(core.cursor.x, core.cursor.y)
-            self.output = self.core.output_from_wlr_output(surface.output)
+            self.output = core.output_from_wlr_output(surface.output)
             self.output.layers[surface.client_pending.layer].append(self)
             self.output.organise_layers()
 
@@ -438,6 +451,7 @@ class Static(Window, base.Static):
     def _on_map(self, _listener, data):
         logger.debug("Signal: window map")
         self.mapped = True
+        self.damage()
         if self.is_layer:
             self.output.organise_layers()
 
@@ -448,11 +462,7 @@ class Static(Window, base.Static):
             self.core.seat.keyboard_clear_focus()
         if self.is_layer:
             self.output.organise_layers()
-
-    def _on_destroy(self, _listener, data):
-        logger.debug("Signal: window destroy")
-        self.qtile.unmanage(self.wid)
-        self.finalize()
+        self.damage()
 
     def kill(self):
         if self.is_layer:
@@ -460,12 +470,21 @@ class Static(Window, base.Static):
         else:
             self.surface.send_close()
 
+    def damage(self) -> None:
+        if self.is_layer:
+            self.output.damage.add_whole()
+        else:
+            for output in self.core.outputs:
+                if output.contains(self):
+                    output.damage.add_whole()
+
     def place(self, x, y, width, height, borderwidth, bordercolor,
               above=False, margin=None):
         self.x = x
         self.y = y
         self.surface.configure(width, height)
         self.paint_borders(bordercolor, borderwidth)
+        self.damage()
 
 
 WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -52,10 +52,10 @@ ModMasks = {
     "mod5": KeyboardModifier.MOD5,
 }
 
+# from linux/input-event-codes.h
 buttons = {
-    1: 0x110,
-    2: 0x111,
-    3: 0x112,
+    1 + i: 0x110 + i
+    for i in range(8)
 }
 
 buttons_inv = {v: k for k, v in buttons.items()}

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -995,7 +995,7 @@ class Internal(_Window, base.Internal):
 
 
 class Static(_Window, base.Static):
-    """An internal window, that should not be managed by qtile"""
+    """An static window, belonging to a screen rather than a group"""
     _window_mask = EventMask.StructureNotify | \
         EventMask.PropertyChange | \
         EventMask.EnterWindow | \

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -552,7 +552,7 @@ class Qtile(CommandObject):
         c = self.windows_map.get(win)
         if c:
             hook.fire("client_killed", c)
-            if isinstance(c, base.Static):
+            if isinstance(c, base.Static) and c.reserved_space:
                 self.free_reserved_space(c.reserved_space, c.screen)
             if getattr(c, "group", None):
                 c.group.remove(c)

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.2.7
+  pywlroots>=0.2.8
 
 [options.package_data]
 libqtile.resources =

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots
+  pywlroots>=0.2.7
 
 [options.package_data]
 libqtile.resources =

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots
+    pip install pywlroots>=0.2.7
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -87,7 +87,7 @@ deps =
     pytest >= 6.2.1
 commands =
     pip install -r requirements.txt pywayland xkbcommon
-    pip install pywlroots
+    pip install pywlroots>=0.2.7
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.2.7
+    pip install pywlroots>=0.2.8
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -87,7 +87,7 @@ deps =
     pytest >= 6.2.1
 commands =
     pip install -r requirements.txt pywayland xkbcommon
-    pip install pywlroots>=0.2.7
+    pip install pywlroots>=0.2.8
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
```
This implements damage tracking so that new frames are only rendered
when there has been a change of pixel contents, and only the regions
with changes are rendered.
```

--

This PR is sat atop #2429. I'm posting it as a draft because I could do with a little help if anyone's interested (with the damage tracking commit).

I'm pretty certain that the code that sets damage is perfectly fine, but I'm less certain that the rendering code is a fine. If the entire output is re-rendered when there is any damage (still a significant improvement from rendering any time a new frame can be rendered) then everything looks good, which is why I specifically think the code that selects only damaged regions to be re-rendered is the problem.

As far as I can tell, the rendering code mirrors the steps sway uses to select damaged regions and only render them. However, I see rendering artifacts where the damage is e.g. when I drag a window around. The damaged regions are cleared with black pixels and should immediately (before the frame is committed) be regenerated with the contents, but I still see black shapes when moving the window around. The window itself looks good, just not some areas around the edges it's moving to/from.