### PR TITLE
Stop dragging only when mouse button is released

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -110,6 +110,7 @@ class Mouse:
         self.button_code = int(self.button.replace('Button', ''))
         for k, v in kwargs.items():
             setattr(self, k, v)
+        self.modmask: int = 0
 
 
 class Drag(Mouse):


### PR DESCRIPTION
This lets drags continue for as long as the mouse button is held down,
even if modifier keys are released. This is old behaviour that was
broken by 373ad55. Fixes #2440.