### PR TITLE
Adds temporary proxy module libqtile.window

### DIFF
--- a/libqtile/window.py
+++ b/libqtile/window.py
@@ -1,0 +1,12 @@
+# This is a temporary module that redirects imports from `libqtile.window` to
+# `libqtile.backend.x11.window` to reduce config breakages due to the removal of
+# `libqtile.window`. This can be removed after release.
+
+import warnings
+
+from libqtile.backend.x11.window import *  # noqa: F401,F403
+
+warnings.warn(
+    "libqtile.window is deprecated, use libqtile.backend.x11.window",
+    DeprecationWarning,
+)


### PR DESCRIPTION
This adds a `libqtile.window` module that forwards all imports to
`libqtile.backend.x11.window` so that configs that import from the
former do not break upon next release.