### PR TITLE
Remove unnecessary Qtile.mouse_position

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -803,3 +803,10 @@ class Core(base.Core):
             if len(pids) == 0:
                 break
             time.sleep(0.1)
+
+    def get_mouse_position(self) -> Tuple[int, int]:
+        """
+        Get mouse coordinates.
+        """
+        reply = self.conn.conn.core.QueryPointer(self._root.wid).reply()
+        return reply.root_x, reply.root_y

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1735,10 +1735,10 @@ class Window(_Window, base.Window):
         if self.floating:
             self.tweak_float(x, y)
             return
+        curx, cury = self.qtile.core.get_mouse_position()
         for window in self.group.windows:
             if window == self or window.floating:
                 continue
-            curx, cury = self.qtile.get_mouse_position()
             if self._is_in_window(curx, cury, window):
                 clients = self.group.layout.clients
                 index1 = clients.index(self)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -69,7 +69,6 @@ class Qtile(CommandObject):
 
         self._drag: Optional[Tuple] = None
         self.mouse_map: Dict[int, List[Union[Click, Drag]]] = {}
-        self.mouse_position = (0, 0)
 
         self.windows_map: Dict[int, base.WindowType] = {}
         self.widgets_map: Dict[str, _Widget] = {}
@@ -624,7 +623,6 @@ class Qtile(CommandObject):
         return closest_screen
 
     def process_button_click(self, button_code, modmask, x, y, event) -> None:
-        self.mouse_position = (x, y)
         for m in self.mouse_map.get(button_code, []):
             if not m.modmask == modmask:
                 continue
@@ -667,8 +665,6 @@ class Qtile(CommandObject):
                 return
 
     def process_button_motion(self, x, y):
-        self.mouse_position = (x, y)
-
         if self._drag is None:
             return
         ox, oy, rx, ry, cmd = self._drag
@@ -835,9 +831,6 @@ class Qtile(CommandObject):
             groups()
         """
         return {i.name: i.info() for i in self.groups}
-
-    def get_mouse_position(self):
-        return self.mouse_position
 
     def cmd_display_kb(self, *args):
         """Display table of key bindings"""


### PR DESCRIPTION
The `Qtile` object currently keeps track of mouse position in an
attribute at `self.mouse_position`, which is updated upon every mouse
event. However, it is only ever accessed in one place, in the x11
backend's `Window.cmd_set_position` to find a window under the pointer
to operate manipulate. Instead of constantly tracking and updating this
attribute we can query the pointer coordinates on demand from the X
server.