### PR TITLE
Remove Qtile.selection

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -192,10 +192,6 @@ class Qtile(CommandObject):
 
         return socket_path
 
-    @property
-    def selection(self):
-        return self.core._selection
-
     def loop(self) -> None:
         asyncio.run(self.async_loop())
 


### PR DESCRIPTION
The `Qtile` object has a `selection` property that is not used anywhere.
Let's remove it as dead code.