### PR TITLE
Atomically apply new Qtile.screens when reconfiguring screens

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -261,7 +261,7 @@ class Qtile(CommandObject):
 
     def _process_screens(self) -> None:
         current_groups = [screen.group for screen in self.screens if screen.group]
-        self.screens = []
+        screens = []
 
         if hasattr(self.config, 'fake_screens'):
             screen_info = [(s.x, s.y, s.width, s.height) for s in self.config.fake_screens]
@@ -299,7 +299,9 @@ class Qtile(CommandObject):
                         break
 
             scr._configure(self, i, x, y, w, h, grp)
-            self.screens.append(scr)
+            screens.append(scr)
+
+        self.screens = screens
 
     def cmd_reconfigure_screens(self, ev=None):
         """


### PR DESCRIPTION
Currently `Qtile._process_screens` can be racy as it can be called a
second time when the X server is polled half through the function via
`self.core.get_screen_info()`. The two simultaneous calls then append to
`self.screens` resulting in duplicate items within `self.screens`. By
creating a function-local list of screens and appending to that, and
then setting it as `self.screens = screens` when it is complete, the
resulting `self.screens` will always be correct.

Ideally this would be avoided altogether but for some reason the X
server likes to emit two screen change notify events when the
configuration is changed with arandr.