### PR TITLE
Fix the PulseVolume widget disappearance from the doc.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ class Mock(MagicMock):
 MOCK_MODULES = [
     'libqtile._ffi_pango',
     'libqtile.backend.x11._ffi_xcursors',
+    'libqtile.widget._pulse_audio',
     'cairocffi',
     'cairocffi.xcb',
     'cairocffi.pixbuf',

--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -212,7 +212,7 @@ Any call can be resolved from a given node.  In addition, each node knows about
 all of the children objects that can be reached from it and have the ability to
 ``.navigate()`` to the other nodes in the command graph.  Each of the object
 types are represented as ``CommandGraphObject`` types and the root node of the
-graph, the ``CommandGraphRoot`` reresents the Qtile instance.  When a call is
+graph, the ``CommandGraphRoot`` represents the Qtile instance.  When a call is
 performed on an object, it returns a ``CommandGraphCall``.  Each call will know
 its own name as well as be able to resolve the path through the command graph
 to be able to find itself.
@@ -273,7 +273,7 @@ command graph, and traversal is done by creating a new command client starting
 from the new node.  When a command is executed against a node, that command is
 dispatched to the held command interface.  The key decision here is how to
 perform the traversal.  The command client exists in two different flavors: the
-standard ``ComandClient`` which is useful for handling more programatic
+standard ``CommandClient`` which is useful for handling more programatic
 traversal of the graph, calling methods to traverse the graph, and the
 ``InteractiveCommandClient`` which behaves more like a standard Python object,
 traversing by accessing properties and performing key lookups.


### PR DESCRIPTION
Add the _pulse_audio module imported by the widget to the mocked modules
of sphinx.

Corrects 2 typos.

--------------------------
**To be clear**, as I do not reproduce locally, I was not able to check the efficiency of this fix.
I still submit this PR based on a similar issue (#2449) which was fixed this way.