### PR TITLE
Don't always set IconicState when hiding window

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -708,7 +708,6 @@ class _Window:
         # We don't want to get the UnmapNotify for this unmap
         with self.disable_mask(EventMask.StructureNotify):
             self.window.unmap()
-        self.state = IconicState
         self.hidden = True
 
     def unhide(self):
@@ -1314,6 +1313,7 @@ class Window(_Window, base.Window):
 
     def _reconfigure_floating(self, new_float_state=FloatStates.FLOATING):
         if new_float_state == FloatStates.MINIMIZED:
+            self.state = IconicState
             self.hide()
         else:
             width = self.width


### PR DESCRIPTION
Commit f0a67e8bd4ebda97f310de6c235f1cbd72a0dc7d moved `self.state = IconicState` into `Window.hide`. However, we do not always want to set the IconicState when hiding the window because this causes problems with window state, resulting in mis-rendered windows when hiding them.

Fixes #2480