### PR TITLE
Add widget decorations

### DIFF
--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -358,6 +358,20 @@ from top to bottom.
     setting a completely transparent bar will result in the contents of the widget (text etc.)
     also being transparent.
 
+Decorations
+-----------
+
+If you want your widget to be able to display decorations and your widget has its own ``draw``
+method (i.e. it's not using the ``draw`` method from an inherited class) then you need to include
+the following line after the background (see above):
+
+.. code:: python
+
+    self.draw_decorations()
+
+The rest of your widget should then be drawn after that point (so the contents is drawn above the
+decoration).
+
 Updating the widget
 ===================
 

--- a/docs/manual/ref/widgets.rst
+++ b/docs/manual/ref/widgets.rst
@@ -7,3 +7,53 @@ Built-in Widgets
 .. qtile_module:: libqtile.widget
     :baseclass: libqtile.widget.base._Widget
     :no-commands:
+
+Widget decorations
+==================
+
+Widgets can also be configured with ``Decoration`` objects to add additional
+eye-candy.
+
+The classes need to be imported into the user's config and can then be added to
+widgets as follows:
+
+::
+
+    from libqtile.widget.decorations import RectDecoration
+
+
+
+    decoration_config = {
+        "decorations": [
+            BorderDecoration(
+                padding=2,
+                padding_y=5,
+                filled=True,
+                dec_colour="#005555"
+            )
+        ],
+        "padding": 6, 
+    }
+
+
+    screens = [
+        Screen(
+            bottom=bar.Bar(
+                [
+                    widget.Prompt(),
+                    widget.Sep(),
+                    widget.WindowName(),
+                    widget.Sep(),
+                    widget.Clock(format='%H:%M:%S %d.%m.%Y', **decoration_config),
+                    widget.QuickExit(**decoration_config)
+                ],
+            24,
+            ),
+        )
+    ]
+
+The following decorations are available:
+
+.. qtile_module:: libqtile.widget.decorations
+    :baseclass: libqtile.widget.decorations._Decoration
+    :no-commands:

--- a/docs/manual/ref/widgets.rst
+++ b/docs/manual/ref/widgets.rst
@@ -21,15 +21,27 @@ widgets as follows:
 
     from libqtile.widget.decorations import RectDecoration
 
+    decorated_widget = widget.WindowName(
+        decorations=[
+            RectDecoration(
+                colour="#660066",
+                radius=2,
+                filled=True
+            )
+        ]
+    )
 
+Alternatively, the same instance of the decoration can be passed to multiple widgets:
+
+::
+
+    from libqtile.widget.decorations import BorderDecoration
 
     decoration_config = {
         "decorations": [
             BorderDecoration(
-                padding=2,
-                padding_y=5,
-                filled=True,
-                dec_colour="#005555"
+                colour="#660000",
+                border_width=[0, 0, 2, 0]
             )
         ],
         "padding": 6, 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -193,6 +193,15 @@ class _Widget(CommandObject, configurable.Configurable):
         self.bar = bar
         self.drawer = bar.window.create_drawer(self.bar.width, self.bar.height)
         if not self.configured:
+
+            # Give each widget a copy of the decoration objects
+            temp_decs = []
+            for i, dec in enumerate(self.decorations):
+                cloned_dec = dec.clone()
+                cloned_dec._configure(self)
+                temp_decs.append(cloned_dec)
+            self.decorations = temp_decs
+
             self.qtile.call_soon(self.timer_setup)
             self.qtile.call_soon(asyncio.create_task, self._config_async())
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -116,6 +116,7 @@ class _Widget(CommandObject, configurable.Configurable):
     defaults = [
         ("background", None, "Widget background color"),
         ("mouse_callbacks", {}, "Dict of mouse button press callback functions."),
+        ("decorations", [], "Decorations for widgets")
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, length, **config):
@@ -269,6 +270,15 @@ class _Widget(CommandObject, configurable.Configurable):
             changed. If it has, you must call bar.draw instead.
         """
         raise NotImplementedError
+
+    def draw_decorations(self):
+        """
+            Method that draws decorations underneath widget. This should be
+            called in a widget's `draw` method immediately after painting the
+            background but before the widget's contents.
+        """
+        for decoration in self.decorations:
+            decoration.draw(self)
 
     def calculate_length(self):
         """
@@ -427,6 +437,8 @@ class _TextBox(_Widget):
         if not self.can_draw():
             return
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
+
         self.layout.draw(
             self.actual_padding or 0,
             int(self.bar.height / 2.0 - self.layout.height / 2.0) + 1

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -287,7 +287,7 @@ class _Widget(CommandObject, configurable.Configurable):
             background but before the widget's contents.
         """
         for decoration in self.decorations:
-            decoration.draw(self)
+            decoration.draw()
 
     def calculate_length(self):
         """

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -500,6 +500,7 @@ class BatteryIcon(base._Widget):
 
     def draw(self) -> None:
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         self.drawer.ctx.set_source(self.surfaces[self.current_icon])
         self.drawer.ctx.paint()
         self.drawer.draw(offsetx=self.offset, width=self.length)

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -144,6 +144,7 @@ class CurrentLayoutIcon(base._TextBox):
                 ))
             else:
                 self.drawer.clear(self.background or self.bar.background)
+                self.draw_decorations()
                 self.drawer.ctx.set_source(surface)
                 self.drawer.ctx.paint()
                 self.drawer.draw(offsetx=self.offset, width=self.length)

--- a/libqtile/widget/decorations.py
+++ b/libqtile/widget/decorations.py
@@ -17,10 +17,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
 import copy
 import math
 from typing import Any, List, Tuple
 
+from cairocffi import Context
+
+from libqtile.backend.base import Drawer
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -39,26 +44,26 @@ class _Decoration(base.PaddingMixin):
         base.PaddingMixin.__init__(self, **config)
         self.add_defaults(_Decoration.defaults)
 
-    def _configure(self, parent):
+    def _configure(self, parent: base._Widget) -> None:
         self.parent = parent
 
-    def clone(self):
+    def clone(self) -> _Decoration:
         return copy.copy(self)
 
     @property
-    def height(self):
+    def height(self) -> int:
         return self.parent.height
 
     @property
-    def width(self):
+    def width(self) -> int:
         return self.parent.width
 
     @property
-    def drawer(self):
+    def drawer(self) -> Drawer:
         return self.parent.drawer
 
     @property
-    def ctx(self):
+    def ctx(self) -> Context:
         return self.parent.drawer.ctx
 
 
@@ -83,7 +88,7 @@ class RectDecoration(_Decoration):
         _Decoration.__init__(self, **config)
         self.add_defaults(RectDecoration.defaults)
 
-    def draw(self):
+    def draw(self) -> None:
         box_height = self.height - 2 * self.padding_y
         box_width = self.width - 2 * self.padding_x
 
@@ -183,7 +188,7 @@ class BorderDecoration(_Decoration):
 
         self.borders = [n, e, s, w]
 
-    def draw(self):
+    def draw(self) -> None:
         top, right, bottom, left = self.borders
 
         self.drawer.set_source_rgb(self.colour)
@@ -228,7 +233,7 @@ class BorderDecoration(_Decoration):
                 left
             )
 
-    def _draw_border(self, x1, y1, x2, y2, line_width):
+    def _draw_border(self, x1: float, y1: float, x2: float, y2: float, line_width: float) -> None:
         self.ctx.move_to(x1, y1)
         self.ctx.line_to(x2, y2)
         self.ctx.set_line_width(line_width)

--- a/libqtile/widget/decorations.py
+++ b/libqtile/widget/decorations.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import copy
 import math
 from typing import Any, List, Tuple
 
@@ -38,6 +39,12 @@ class _Decoration(base.PaddingMixin):
         base.PaddingMixin.__init__(self, **config)
         self.add_defaults(_Decoration.defaults)
 
+    def _configure(self, parent):
+        self.parent = parent
+
+    def clone(self):
+        return copy.copy(self)
+
     @property
     def height(self):
         return self.parent.height
@@ -54,8 +61,8 @@ class _Decoration(base.PaddingMixin):
     def ctx(self):
         return self.parent.drawer.ctx
 
-    def draw(self, parent):
-        self.parent = parent
+    # def draw(self, parent):
+    #     self.parent = parent
 
 
 class RectDecoration(_Decoration):
@@ -80,8 +87,6 @@ class RectDecoration(_Decoration):
         self.add_defaults(RectDecoration.defaults)
 
     def draw(self, parent):
-        _Decoration.draw(self, parent)
-
         box_height = self.height - 2 * self.padding_y
         box_width = self.width - 2 * self.padding_x
 
@@ -174,8 +179,6 @@ class BorderDecoration(_Decoration):
         self.borders = [tp, bm, lt, rt]
 
     def draw(self, parent):
-        _Decoration.draw(self, parent)
-
         top, bottom, left, right = self.borders
 
         self.drawer.set_source_rgb(self.colour)

--- a/libqtile/widget/decorations.py
+++ b/libqtile/widget/decorations.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2021, elParaguayo. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import math
+from typing import Any, List, Tuple
+
+from libqtile.log_utils import logger
+from libqtile.widget import base
+
+
+class _Decoration(base.PaddingMixin):
+    """
+        Base decoration class. Should not be called by
+        configs directly.
+    """
+
+    defaults = [
+        ("padding", 0, "Default padding")
+    ]  # type: List[Tuple[str, Any, str]]
+
+    def __init__(self, **config):
+        base.PaddingMixin.__init__(self, **config)
+        self.add_defaults(_Decoration.defaults)
+
+    @property
+    def height(self):
+        return self.parent.height
+
+    @property
+    def width(self):
+        return self.parent.width
+
+    @property
+    def drawer(self):
+        return self.parent.drawer
+
+    @property
+    def ctx(self):
+        return self.parent.drawer.ctx
+
+    def draw(self, parent):
+        self.parent = parent
+
+
+class RectDecoration(_Decoration):
+    """
+        Widget decoration that draws a rectangle behind the widget contents.
+
+        Only one colour can be set but decorations can be layered to achieve
+        multi-coloured effects.
+
+        Rectangles can be drawn as just the the outline or filled. Curved corners
+        can be obtained by setting the ``radius`` parameter.
+    """
+    defaults = [
+        ("filled", False, "Whether to fill shape"),
+        ("radius", 4, "Radius for corners (0 for square)"),
+        ("dec_colour", "#000000", "Colour for decoration"),
+        ("linewidth", 2, "Line width for decoration")
+    ]  # type: List[Tuple[str, Any, str]]
+
+    def __init__(self, **config):
+        _Decoration.__init__(self, **config)
+        self.add_defaults(RectDecoration.defaults)
+
+    def draw(self, parent):
+        _Decoration.draw(self, parent)
+
+        box_height = self.height - 2 * self.padding_y
+        box_width = self.width - 2 * self.padding_x
+
+        self.drawer.set_source_rgb(self.dec_colour)
+
+        degrees = math.pi / 180.0
+
+        self.ctx.new_sub_path()
+
+        delta = self.radius + self.linewidth / 2
+
+        self.ctx.arc(
+            self.padding_x + box_width - delta,
+            self.padding_y + delta,
+            self.radius,
+            -90 * degrees,
+            0 * degrees
+        )
+
+        self.ctx.arc(
+            self.padding_x + box_width - delta,
+            self.padding_y + box_height - delta,
+            self.radius,
+            0 * degrees,
+            90 * degrees
+        )
+
+        self.ctx.arc(
+            self.padding_x + delta,
+            self.padding_y + box_height - delta,
+            self.radius,
+            90 * degrees,
+            180 * degrees
+        )
+        self.ctx.arc(
+            self.padding_x + delta,
+            self.padding_y + delta,
+            self.radius,
+            180 * degrees,
+            270 * degrees
+        )
+
+        self.ctx.close_path()
+
+        if self.filled:
+            self.ctx.fill()
+        else:
+            self.ctx.set_line_width(self.linewidth)
+            self.ctx.stroke()
+
+
+class BorderDecoration(_Decoration):
+    """
+        Widget decoration that draws a straight line on the widget border.
+        Padding can be used to adjust the position of the border further.
+
+        Only one colour can be set but decorations can be layered to achieve
+        multi-coloured effects.
+    """
+    defaults = [
+        ("colour", "#000000", "Border colour"),
+        (
+            "border_width",
+            2,
+            "Border width. Single number is all edges, or [top/bottom, left/right] or [top, bottom, left, right]"
+        )
+    ]  # type: List[Tuple[str, Any, str]]
+
+    def __init__(self, **config):
+        _Decoration.__init__(self, **config)
+        self.add_defaults(BorderDecoration.defaults)
+
+        if type(self.border_width) in [float, int]:
+            tp = bm = lt = rt = self.border_width
+        elif type(self.border_width) in [tuple, list]:
+            if len(self.border_width) == 1:
+                tp = bm = lt = rt = self.border_width[0]
+            elif len(self.border_width) == 2:
+                tp = bm = self.border_width[0]
+                lt = rt = self.border_width[1]
+            elif len(self.border_width) == 4:
+                tp, bm, lt, rt = self.border_width
+            else:
+                logger.info("Border width should be a single number or a list of 1, 2 or 4 values")
+                tp = bm = lt = rt = 0
+        else:
+            logger.info("Border width should be a single number or a list of 1, 2 or 4 values")
+            tp = bm = lt = rt = 0
+
+        self.borders = [tp, bm, lt, rt]
+
+    def draw(self, parent):
+        _Decoration.draw(self, parent)
+
+        top, bottom, left, right = self.borders
+
+        self.drawer.set_source_rgb(self.colour)
+
+        if top:
+            offset = top // 2
+            self._draw_border(
+                offset + self.padding_x,
+                offset + self.padding_y,
+                self.width - offset - self.padding_x,
+                offset + self.padding_y,
+                top
+            )
+
+        if bottom:
+            offset = bottom // 2
+            self._draw_border(
+                offset + self.padding_x,
+                self.height - offset - self.padding_y,
+                self.width - offset - self.padding_y,
+                self.height - offset - self.padding_y,
+                bottom
+            )
+
+        if left:
+            offset = left // 2
+            self._draw_border(
+                offset + self.padding_x,
+                offset + self.padding_y,
+                offset + self.padding_x,
+                self.height - offset - self.padding_y,
+                left
+            )
+
+        if right:
+            offset = right // 2
+            self._draw_border(
+                self.width - offset - self.padding_x,
+                offset + self.padding_y,
+                self.width - offset - self.padding_x,
+                self.height - offset - self.padding_y,
+                right
+            )
+
+    def _draw_border(self, x1, y1, x2, y2, linewidth):
+        self.ctx.move_to(x1, y1)
+        self.ctx.line_to(x2, y2)
+        self.ctx.set_line_width(linewidth)
+        self.ctx.stroke()

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -148,6 +148,7 @@ class _Graph(base._Widget):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         if self.border_width:
             self.drawer.set_source_rgb(self.border_color)
             self.drawer.ctx.set_line_width(self.border_width)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -139,6 +139,7 @@ class AGroupBox(_GroupBase):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         e = next(
             i for i in self.qtile.groups
             if i.name == self.bar.screen.group.name
@@ -332,6 +333,7 @@ class GroupBox(_GroupBase):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
 
         offset = self.margin_x
         for i, g in enumerate(self.groups):

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -82,6 +82,7 @@ class Image(base._Widget, base.MarginMixin):
             return
 
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         self.drawer.ctx.save()
         self.drawer.ctx.translate(self.margin_x, self.margin_y)
         self.drawer.ctx.set_source(self.img.pattern)

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -196,6 +196,7 @@ class LaunchBar(base._Widget):
     def draw(self):
         """ Draw the icons in the widget. """
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         xoffset = 0
         for i in sorted(self.progs.keys()):
             self.icons_offsets[i] = xoffset + self.padding

--- a/libqtile/widget/sep.py
+++ b/libqtile/widget/sep.py
@@ -56,6 +56,7 @@ class Sep(base._Widget):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         if self.bar.horizontal:
             margin_top = (self.bar.height / float(100) * (100 - self.size_percent)) / 2.0
             self.drawer.draw_vbar(

--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -64,6 +64,7 @@ class Spacer(base._Widget):
     def draw(self):
         if self.length > 0:
             self.drawer.clear(self.background or self.bar.background)
+            self.draw_decorations()
             if self.bar.horizontal:
                 self.drawer.draw(offsetx=self.offset, width=self.length)
             else:

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -184,6 +184,7 @@ class Systray(window._Window, base._Widget):
     def draw(self):
         xoffset = self.padding
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         self.drawer.draw(offsetx=self.offset, width=self.length)
         for pos, icon in enumerate(self.icons.values()):
             icon.window.set_attribute(backpixmap=self.drawer.pixmap)

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -437,6 +437,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
         offset = self.margin_x
 
         self._box_end_positions = []

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -187,6 +187,7 @@ class Volume(base._TextBox):
 
     def draw(self):
         if self.theme_path:
+            self.draw_decorations()
             self.drawer.draw(offsetx=self.offset, width=self.length)
         else:
             base._TextBox.draw(self)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -179,6 +179,7 @@ class WidgetBox(base._Widget):
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
+        self.draw_decorations()
 
         self.layout.draw(0,
                          int(self.bar.height / 2.0 -


### PR DESCRIPTION
Adding background decorations to widgets as per #2473. This commit adds a base `_Decoration` class and two implementations. Method to draw decorations is added to all widgets and documentation also updated.

This is just eye-candy, no functional improvements. Pushing this for discussion.

Probably needs a test...

This is what this PR does:
![20210524_182135](https://user-images.githubusercontent.com/946265/120071969-61df2a80-c089-11eb-8d89-60c36bd26428.png)
![20210524_182926](https://user-images.githubusercontent.com/946265/120071970-63105780-c089-11eb-8d04-f118cd7fbc3c.png)
![20210524_191450](https://user-images.githubusercontent.com/946265/120071971-63a8ee00-c089-11eb-9d73-6c804c0dd257.png)
![20210626_211952](https://user-images.githubusercontent.com/946265/123527584-bd2c2900-d6d8-11eb-900e-c30aa3f1d212.png)

Combining this with transparency in #2513 and you can do this:
![20210627_184010](https://user-images.githubusercontent.com/946265/123554322-5578eb00-d777-11eb-97ae-0631cb9344ea.png)


