### PR TITLE
Fix for checkupdates widget on Fedora & disqualify negative numbers o…

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -55,7 +55,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
-                         "Fedora": ("dnf list updates", 3),
+                         "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),
                          "Mandriva": ("urpmq --auto-select", 0)
                          }
@@ -86,6 +86,8 @@ class CheckUpdates(base.ThreadPoolText):
             updates = ""
         num_updates = self.custom_command_modify(len(updates.splitlines()))
 
+        if num_updates < 0:
+            num_updates = 0
         if num_updates == 0:
             self.layout.colour = self.colour_no_updates
             return self.no_update_string


### PR DESCRIPTION
issue #2488 widget.CheckUpdates on Fedora: show the correct number of updates

On Fedora `dnf list updates -q` returns no output when there aren't updates available.
If there are updates, "available updates" text added on top of the package list.

This should fix that. And as a side effect, rules out negative update numbers on all distros.

closes #2488 