### PR TITLE
Don't warp cursor when changing group via GroupBox

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -252,7 +252,7 @@ class Window(_Window, metaclass=ABCMeta):
         """Paint the window borders with the given color and width"""
 
     @abstractmethod
-    def cmd_focus(self, warp: Optional[bool] = None) -> None:
+    def cmd_focus(self, warp: bool = True) -> None:
         """Focuses the window."""
 
     @abstractmethod

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -444,11 +444,9 @@ class Window(base.Window, HasListeners):
                 self.group.mark_floating(self, True)
             hook.fire('float_change')
 
-    def cmd_focus(self, warp=None):
+    def cmd_focus(self, warp: bool = True) -> None:
         """Focuses the window."""
-        if warp is None:
-            warp = self.qtile.config.cursor_warp
-        self.focus(warp=warp)
+        self.focus(warp)
 
     def cmd_info(self) -> Dict:
         """Return a dictionary of info."""

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -935,11 +935,9 @@ class _Window:
         self.qtile.core._root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
         hook.fire("client_focus", self)
 
-    def cmd_focus(self, warp=None):
+    def cmd_focus(self, warp: bool = True) -> None:
         """Focuses the window."""
-        if warp is None:
-            warp = self.qtile.config.cursor_warp
-        self.focus(warp=warp)
+        self.focus(warp)
 
     def cmd_info(self):
         """Returns a dictionary of info for this object"""

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -339,7 +339,7 @@ class Screen(CommandObject):
     def get_rect(self):
         return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
 
-    def set_group(self, new_group, save_prev=True):
+    def set_group(self, new_group, save_prev=True, warp=True):
         """Put group on this screen"""
         if new_group is None:
             return
@@ -361,9 +361,9 @@ class Screen(CommandObject):
             s2 = new_group.screen
 
             s2.group = g1
-            g1._set_screen(s2)
+            g1.set_screen(s2, warp)
             s1.group = g2
-            g2._set_screen(s1)
+            g2.set_screen(s1, warp)
         else:
             if hasattr(self, "group"):
                 old_group = self.group
@@ -375,10 +375,10 @@ class Screen(CommandObject):
             with ctx:
                 # display clients of the new group and then hide from old group
                 # to remove the screen flickering
-                new_group._set_screen(self)
+                new_group.set_screen(self, warp)
 
                 if old_group is not None:
-                    old_group._set_screen(None)
+                    old_group.set_screen(None, warp)
 
         hook.fire("setgroup")
         hook.fire("focus_change")
@@ -386,11 +386,11 @@ class Screen(CommandObject):
                   self.group.layouts[self.group.current_layout],
                   self.group)
 
-    def toggle_group(self, group=None):
+    def toggle_group(self, group=None, warp=True):
         """Switch to the selected group or to the previously active one"""
         if group in (self.group, None) and hasattr(self, "previous_group"):
             group = self.previous_group
-        self.set_group(group)
+        self.set_group(group, warp=warp)
 
     def _items(self, name: str) -> ItemT:
         if name == "layout" and self.group is not None:
@@ -452,16 +452,16 @@ class Screen(CommandObject):
         self.set_group(n)
         return n.name
 
-    def cmd_prev_group(self, skip_empty=False, skip_managed=False):
+    def cmd_prev_group(self, skip_empty=False, skip_managed=False, warp=True):
         """Switch to the previous group"""
         n = self.group.get_previous_group(skip_empty, skip_managed)
-        self.set_group(n)
+        self.set_group(n, warp=warp)
         return n.name
 
-    def cmd_toggle_group(self, group_name=None):
+    def cmd_toggle_group(self, group_name=None, warp=True):
         """Switch to the selected group or to the previously active one"""
         group = self.qtile.groups_map.get(group_name)
-        self.toggle_group(group)
+        self.toggle_group(group, warp=warp)
 
     def cmd_togglegroup(self, groupName=None):  # noqa
         """Switch to the selected group or to the previously active one

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -162,7 +162,7 @@ class _Group(CommandObject):
                         self.screen == self.qtile.current_screen:
                     self.current_window.focus(warp)
 
-    def _set_screen(self, screen):
+    def set_screen(self, screen, warp=True):
         """Set this group's screen to screen"""
         if screen == self.screen:
             return
@@ -170,7 +170,7 @@ class _Group(CommandObject):
         if self.screen:
             # move all floating guys offset to new screen
             self.floating_layout.to_screen(self, self.screen)
-            self.layout_all(warp=self.qtile.config.cursor_warp)
+            self.layout_all(warp=warp and self.qtile.config.cursor_warp)
             screen_rect = self.screen.get_rect()
             self.floating_layout.show(screen_rect)
             self.layout.show(screen_rect)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -31,6 +31,7 @@
 # SOFTWARE.
 
 import itertools
+from functools import partial
 from typing import Any, List, Tuple
 
 from libqtile import bar, hook
@@ -132,7 +133,7 @@ class AGroupBox(_GroupBase):
 
     def _configure(self, qtile, bar):
         _GroupBase._configure(self, qtile, bar)
-        self.add_callbacks({'Button1': self.bar.screen.cmd_next_group})
+        self.add_callbacks({'Button1': partial(self.bar.screen.cmd_next_group, warp=False)})
 
     def calculate_length(self):
         return self.box_width(self.qtile.groups) + self.margin_x * 2
@@ -309,9 +310,9 @@ class GroupBox(_GroupBase):
     def go_to_group(self, group):
         if group:
             if self.bar.screen.group != group or not self.disable_drag:
-                self.bar.screen.set_group(group)
+                self.bar.screen.set_group(group, warp=False)
             else:
-                self.bar.screen.toggle_group(group)
+                self.bar.screen.toggle_group(group, warp=False)
 
     def button_release(self, x, y, button):
         self.click = x


### PR DESCRIPTION
Partially fixes #2474. Disables cursor warp when the user clicks on the
groupbox widget the change the group by providing a warp=True kwarg to
some of the Screen and Group methods for group changing.

Also group._set_screen -> group.set_screen because it isn't being used
as a private method.