### PR TITLE
Added Gentoo support in CheckUpdates Widget

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -89,7 +89,7 @@ class Window(base.Window, HasListeners):
         self.opacity: float = 1.0
 
         assert isinstance(surface, XdgSurface)
-        self._app_id: str = surface.toplevel.app_id
+        self._app_id: Optional[str] = surface.toplevel.app_id
         surface.set_tiled(EDGES_TILED)
         self._float_state = FloatStates.NOT_FLOATING
         self.float_x = self.x
@@ -234,7 +234,9 @@ class Window(base.Window, HasListeners):
         return pid[0]
 
     def get_wm_class(self) -> Optional[List]:
-        return [self._app_id]
+        if self._app_id:
+            return [self._app_id]
+        return None
 
     def togroup(self, group_name=None, *, switch_group=False):
         """Move window to a specified group

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo" : ("eix -u# --world", 0),
+                         "Gentoo_eix" : ("eix -u# --world", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo_eix" : ("EIX_LIMIT=0 eix -u# --world", 0),
+                         "Gentoo_eix": ("EIX_LIMIT=0 eix -u# --world", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo_eix" : ("eix -u# --world", 0),
+                         "Gentoo_eix" : ("EIX_LIMIT=0 eix -u# --world", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo": ("emerge -qupDN world", 0),
+                         "Gentoo" : ("eix -u# --world", 0)
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,6 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
+                         "Gentoo": ("emerge -upvDN world", 6),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo" : ("eix -u# --world", 0)
+                         "Gentoo" : ("eix -u# --world", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -54,7 +54,7 @@ class CheckUpdates(base.ThreadPoolText):
                          "Arch_Sup": ("pacman -Sup", 1),
                          "Arch_yay": ("yay -Qu", 0),
                          "Debian": ("apt-show-versions -u -b", 0),
-                         "Gentoo": ("emerge -upvDN world", 6),
+                         "Gentoo": ("emerge -qupDN world", 0),
                          "Ubuntu": ("aptitude search ~U", 0),
                          "Fedora": ("dnf list updates -q", 1),
                          "FreeBSD": ("pkg_version -I -l '<'", 0),


### PR DESCRIPTION
Pretty much the title.
The output of `emerge -upvDN world` is 6 lines when there is no update:
```

These are the packages that would be merged, in order:

Calculating dependencies  . ....... done!

Total: 0 packages, Size of downloads: 0 KiB
```
The output is one line longer per update:
```

These are the packages that would be merged, in order:

Calculating dependencies  .... done!
[ebuild     U  ] dev-lang/python-3.9.5_p2:3.9::gentoo [3.9.5_p1:3.9::gentoo] USE="bluetooth gdbm ipv6 ncurses readline sqlite ssl xml -build -examples -hardened -test -tk -verify-sig -wininst" 15 KiB
[ebuild     U  ] dev-libs/libinput-1.18.0:0/10::gentoo [1.17.3:0/10::gentoo] USE="-doc -test" INPUT_DEVICES="-wacom" 603 KiB

Total: 2 packages (2 upgrades), Size of downloads: 617 KiB
```