### PR TITLE
x11: Always focus upon button 1 click in window

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -143,8 +143,6 @@ class Qtile(CommandObject):
                 self.groups.append(sp)
                 self.groups_map[sp.name] = sp
 
-        self.config.mouse += (Click([], "Button1", focus="after"),)
-
     def dump_state(self, buf) -> None:
         try:
             pickle.dump(QtileState(self), buf, protocol=0)


### PR DESCRIPTION
We need to grab button 1 so that we can focus the window below the
pointer. Currently we do this by appending a `Click` to `config.mouse`
internally and using the root window's button grab (for the `Click`) to
focus the window below the pointer upon button event. This causes
problems with where the events are propagated. This commit replaces this
mechanism to instead grab button 1 manually when a window is managed,
using that window as the grabbing window, rather than the root window.
EnterNotify events are created upon such clicks and their `mode`
attribute tells us which buttons were involved, so we can check for
`e.mode == 1` and focus the window if needed. Simple!

(possibly) related issues: #2404, #2483, #1809, #1824, #1792.