### PR TITLE
Add get_wm_type as base Window method

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -159,6 +159,15 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
     def get_wm_class(self) -> Optional[List]:
         """Return the class(es) of the window"""
+        return None
+
+    def get_wm_type(self) -> Optional[str]:
+        """Return the type of the window"""
+        return None
+
+    def get_wm_role(self) -> Optional[str]:
+        """Return the role of the window"""
+        return None
 
     @property
     def can_steal_focus(self):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -572,6 +572,12 @@ class _Window:
     def get_wm_class(self):
         return self.window.get_wm_class()
 
+    def get_wm_type(self):
+        return self.window.get_wm_type()
+
+    def get_wm_role(self):
+        return self.window.get_wm_window_role()
+
     def is_transient_for(self):
         """What window is this window a transient windor for?"""
         return self.window.get_wm_transient_for()

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -36,7 +36,6 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
-import libqtile
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
 from libqtile.bar import BarType
@@ -613,12 +612,10 @@ class Match:
         if func is not None:
             self._rules["func"] = func
 
-        if libqtile.qtile is None or libqtile.qtile.core.name == "x11":  # X11-only rules
-            # qtile is None when the default config is loaded during startup
-            if role is not None:
-                self._rules["role"] = role
-            if wm_type is not None:
-                self._rules["wm_type"] = wm_type
+        if role is not None:
+            self._rules["role"] = role
+        if wm_type is not None:
+            self._rules["wm_type"] = wm_type
 
     @staticmethod
     def _get_property_predicate(name, value):
@@ -650,13 +647,13 @@ class Match:
                 else:
                     value = wm_class
             elif property_name == 'role':
-                value = client.window.get_wm_window_role()
+                value = client.get_wm_role()
             elif property_name == 'func':
                 return rule_value(client)
             elif property_name == 'net_wm_pid':
                 value = client.get_pid()
             else:
-                value = client.window.get_wm_type()
+                value = client.get_wm_type()
 
             # Some of the window.get_...() functions can return None
             if value is None:


### PR DESCRIPTION
This lets us keep the wm_type Match entries in the default float rules,
which makes sense, while making these matches a no-op under other
backends.