### PR TITLE
WL: add wlr_primary_selection_v1 manager

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -34,6 +34,7 @@ from wlroots.wlr_types import (
     DataDeviceManager,
     GammaControlManagerV1,
     OutputLayout,
+    PrimarySelectionV1DeviceManager,
     ScreencopyManagerV1,
     Surface,
     XCursorManager,
@@ -139,6 +140,7 @@ class Core(base.Core, wlrq.HasListeners):
         XdgOutputManagerV1(self.display, self.output_layout)
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)
+        PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(
             self._virtual_keyboard_manager_v1.new_virtual_keyboard_event,

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.13.2
+  pywlroots>=0.13.3
 
 [options.package_data]
 libqtile.resources =

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland >= 0.4.4
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.13.2
+    pip install pywlroots>=0.13.3
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -87,7 +87,7 @@ deps =
     pytest >= 6.2.1
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon 
-    pip install pywlroots>=0.13.2
+    pip install pywlroots>=0.13.3
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
This exposes wlroots' implementation of a primary selection clipboard,
used by clients (such as some terminals) to set a basic text-only
clipboard.

Requires pywlroots 0.13.3