### PR TITLE
Move window __repr__ methods to base classes

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -204,6 +204,10 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
 
 class Window(_Window, metaclass=ABCMeta):
+    """A regular Window belonging to a client."""
+    def __repr__(self):
+        return "Window(name=%r, wid=%i)" % (self.name, self.wid)
+
     @property
     def floating(self) -> bool:
         """Whether this window is floating."""
@@ -368,6 +372,10 @@ class Window(_Window, metaclass=ABCMeta):
 
 
 class Internal(_Window, metaclass=ABCMeta):
+    """An Internal window belonging to Qtile."""
+    def __repr__(self):
+        return "Internal(wid=%s)" % self.wid
+
     @abstractmethod
     def create_drawer(self, width: int, height: int) -> Drawer:
         """Create a Drawer that draws to this window."""
@@ -392,8 +400,11 @@ class Internal(_Window, metaclass=ABCMeta):
 
 
 class Static(_Window, metaclass=ABCMeta):
+    """A Window not bound to a single Group."""
     screen: config.Screen
-    pass
+
+    def __repr__(self):
+        return "Static(name=%r, wid=%s)" % (self.name, self.wid)
 
 
 WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -523,7 +523,7 @@ class Window(base.Window, HasListeners):
         self.kill()
 
 
-class Internal(Window, base.Internal):
+class Internal(base.Internal, Window):
     """
     Internal windows are simply textures controlled by the compositor.
     """
@@ -607,7 +607,7 @@ class Internal(Window, base.Internal):
         self.damage()
 
 
-class Static(Window, base.Static):
+class Static(base.Static, Window):
     """
     Static windows represent both regular windows made static by the user and layer
     surfaces created as part of the wlr layer shell protocol.

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1019,9 +1019,6 @@ class Internal(_Window, base.Internal):
         _Window.__init__(self, win, qtile)
         win.set_property("QTILE_INTERNAL", 1)
 
-    def __repr__(self):
-        return "Internal(%r, %s)" % (self.name, self.window.wid)
-
     def create_drawer(self, width: int, height: int) -> base.Drawer:
         """Create a Drawer that draws to this window."""
         return Drawer(self.qtile, self, width, height)
@@ -1145,9 +1142,6 @@ class Static(_Window, base.Static):
         name = self.qtile.core.conn.atoms.get_name(e.atom)
         if name == "_NET_WM_STRUT_PARTIAL":
             self.update_strut()
-
-    def __repr__(self):
-        return "Static(%r)" % self.name
 
 
 class Window(_Window, base.Window):
@@ -1645,9 +1639,6 @@ class Window(_Window, base.Window):
                 return utils.lget(self.group.layouts, sel)
         elif name == "screen":
             return self.group.screen
-
-    def __repr__(self):
-        return "Window(%r)" % self.name
 
     def cmd_kill(self):
         """Kill this window


### PR DESCRIPTION
This also slghtly changes the string returned by `Internal.__repr__`,
because previously it used `self.name` but `Internal` windows don't have
names.