### PR TITLE
Transparency in X11 and Wayland

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Qtile 0.x.x, released xxxx-xx-xx:
     !!! deprecation warning !!!
         - 'main' config functions, deprecated in 0.16.1, will no longer be executed.
     * features
+        - added transparency in x11 and wayland backends
         - added measure_mem and measure_swap attributes to memory widget to allow user to choose measurement units.
         - memory widget can now be displayed with decimal values
         - new "qtile migrate" command, which will attempt to upgrade previous

--- a/docs/manual/config/screens.rst
+++ b/docs/manual/config/screens.rst
@@ -38,6 +38,17 @@ background="#000000")` will give you a black back ground (the default), while
 :code:`bar.Bar(..., background=["#000000", "#FFFFFF"])` will give you a
 background that fades from black to white.
 
+Bars (and widgets) also support transparency by adding an alpha value to the
+desired color. For example, :code:`bar.Bar(..., background="#00000000")` will
+result in a fully transparent bar. Widget contents will not be impacted i.e.
+this is different to the ``opacity`` parameter which sets the transparency of the
+entire window.
+
+.. note::
+    In X11 backends, transparency will be disabled in a bar if the ``background``
+    color is fully opaque.
+
+
 Fake Screens
 ============
 

--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -352,12 +352,6 @@ background. Usually this is done by including the following line at the start of
 The background can be a single colour or a list of colours which will result in a linear gradient
 from top to bottom.
 
-.. note:
-
-    Opacity is currently set at the window level and applies to the whole bar. As a result,
-    setting a completely transparent bar will result in the contents of the widget (text etc.)
-    also being transparent.
-
 Updating the widget
 ===================
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -551,7 +551,6 @@ class Drawer:
         self.set_source_rgb(colour)
         self.ctx.rectangle(0, 0, self.width, self.height)
         self.ctx.fill()
-        self.ctx.stroke()
 
     def textlayout(
         self, text, colour, font_family, font_size, font_shadow, markup=False, **kw

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -417,6 +417,10 @@ class Drawer:
     We stage drawing operations locally in memory using a cairo RecordingSurface before
     finally drawing all operations to a backend-specific target.
     """
+    # We need to track extent of drawing to know when to redraw.
+    previous_rect: Tuple[int, int, Optional[int], Optional[int]]
+    current_rect: Tuple[int, int, Optional[int], Optional[int]]
+
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         self.qtile = qtile
         self._win = win
@@ -427,12 +431,28 @@ class Drawer:
         self.ctx: cairocffi.Context
         self._reset_surface()
 
-        self.clear((0, 0, 1))
+        self.mirrors: Dict[Drawer, bool] = {}
+
+        self.current_rect = (0, 0, 0, 0)
+        self.previous_rect = (-1, -1, -1, -1)
 
     def finalize(self):
         """Destructor/Clean up resources"""
         self.surface = None
         self.ctx = None
+
+    def add_mirror(self, mirror: Drawer):
+        """Keep details of other drawers that are mirroring this one."""
+        self.mirrors[mirror] = False
+
+    def reset_mirrors(self):
+        """Reset the drawn status of mirrors."""
+        self.mirrors = {m: False for m in self.mirrors}
+
+    @property
+    def mirrors_drawn(self) -> bool:
+        """Returns True if all mirrors have been drawn with the current surface."""
+        return all(v for v in self.mirrors.values())
 
     @property
     def width(self) -> int:
@@ -458,8 +478,27 @@ class Drawer:
         )
         self.ctx = self.new_ctx()
 
+    @property
+    def needs_update(self) -> bool:
+        # We can't test for the surface's ink_extents here on its own as a completely
+        # transparent background would not show any extents but we may still need to
+        # redraw (e.g. if a Spacer widget has changed position and/or size)
+        # Check if the size of the area being drawn has changed
+        rect_changed = self.current_rect != self.previous_rect
+
+        # Check if draw has content (would be False for completely transparent drawer)
+        ink_changed = any(not math.isclose(0.0, i) for i in self.surface.ink_extents())
+
+        return ink_changed or rect_changed
+
     def paint_to(self, drawer: Drawer) -> None:
-        """Paint to another Drawer instance"""
+        drawer.ctx.set_source_surface(self.surface)
+        drawer.ctx.paint()
+        self.mirrors[drawer] = True
+
+        if self.mirrors_drawn:
+            self._reset_surface()
+            self.reset_mirrors()
 
     def _rounded_rect(self, x, y, width, height, linewidth):
         aspect = 1.0
@@ -526,13 +565,17 @@ class Drawer:
     def new_ctx(self):
         return pangocffi.patch_cairo_context(cairocffi.Context(self.surface))
 
-    def set_source_rgb(self, colour: Union[ColorType, List[ColorType]]):
+    def set_source_rgb(self, colour: Union[ColorType, List[ColorType]], ctx: cairocffi.Context = None):
+        # If an alternate context is not provided then we draw to the
+        # drawer's default context
+        if ctx is None:
+            ctx = self.ctx
         if isinstance(colour, list):
             if len(colour) == 0:
                 # defaults to black
-                self.ctx.set_source_rgba(*utils.rgb("#000000"))
+                ctx.set_source_rgba(*utils.rgb("#000000"))
             elif len(colour) == 1:
-                self.ctx.set_source_rgba(*utils.rgb(colour[0]))
+                ctx.set_source_rgba(*utils.rgb(colour[0]))
             else:
                 linear = cairocffi.LinearGradient(0.0, 0.0, 0.0, self.height)
                 step_size = 1.0 / (len(colour) - 1)
@@ -543,9 +586,9 @@ class Drawer:
                         rgb_col[3] = 1
                     linear.add_color_stop_rgba(step, *rgb_col)
                     step += step_size
-                self.ctx.set_source(linear)
+                ctx.set_source(linear)
         else:
-            self.ctx.set_source_rgba(*utils.rgb(colour))
+            ctx.set_source_rgba(*utils.rgb(colour))
 
     def clear(self, colour):
         self.set_source_rgb(colour)

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -9,7 +9,7 @@ from libqtile import utils
 from libqtile.backend import base
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Optional, Tuple
 
     from libqtile.backend.wayland.window import Internal
     from libqtile.core.manager import Qtile
@@ -23,6 +23,10 @@ class Drawer(base.Drawer):
     2. Then apply these operations to our ImageSurface self._source
     3. Then copy the pixels onto the wlr_texture self._target
     """
+
+    # We need to track extent of drawing to know when to redraw.
+    previous_rect: Tuple[int, int, Optional[int], Optional[int]]
+
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         base.Drawer.__init__(self, qtile, win, width, height)
 
@@ -35,6 +39,8 @@ class Drawer(base.Drawer):
             # Initialise surface to all black
             context.set_source_rgba(*utils.rgb("#000000"))
             context.paint()
+
+        self.previous_rect = (-1, -1, -1, -1)
 
     def paint_to(self, drawer):
         drawer.ctx.set_source_surface(self._source)
@@ -50,12 +56,22 @@ class Drawer(base.Drawer):
         if offsetx > self._win.width:  # type: ignore
             return
 
-        # Only attempt to run RecordingSurface's operations if it actually has
-        # some. self.surface.ink_extents() computes the bounds of the current
-        # list of operations. If any of the bounds are not 0.0 then the surface
-        # has operations and we should paint them.
-        if not any(not math.isclose(0.0, i) for i in self.surface.ink_extents()):
+        # We can't test for the surface's ink_extents here on its own as a completely
+        # transparent background would not show any extents but we may still need to
+        # redraw (e.g. if a Spacer widget has changed position and/or size)
+
+        # Check if current rect has changed since previous draw
+        current_rect = (offsetx, offsety, width, height)
+        rect_changed = current_rect != self.previous_rect
+
+        # Check if draw has content (would be False for completely transparent drawer)
+        ink_changed = any(not math.isclose(0.0, i) for i in self.surface.ink_extents())
+
+        if not ink_changed and not rect_changed:
             return
+
+        # Keep track of latest rect covered by this drawwer
+        self.previous_rect = current_rect
 
         # Make sure geometry doesn't extend beyond texture
         if width is None:
@@ -85,3 +101,24 @@ class Drawer(base.Drawer):
 
         # Clear RecordingSurface of operations
         self._reset_surface()
+
+    def clear(self, colour):
+        # Some hacks needed for transparency
+
+        # Check if any colour is not fully opaque
+        if utils.has_transparency(colour):
+
+            # RecordingSurface won't write clear operation to surface so we
+            # need to clear that surface directly.
+            if getattr(self, "_source", None) is not None:
+                ctx = cairocffi.Context(self._source)
+                ctx.save()
+                ctx.set_operator(cairocffi.OPERATOR_CLEAR)
+                ctx.paint()
+                ctx.restore()
+
+        self.ctx.save()
+        self.ctx.set_operator(cairocffi.OPERATOR_SOURCE)
+        self.set_source_rgb(colour)
+        self.ctx.paint()
+        self.ctx.restore()

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -541,11 +541,12 @@ class Core(base.Core):
         for i in self.qtile.windows_map.values():
             i._reset_mask()
 
-    def create_internal(self, x: int, y: int, width: int, height: int) -> base.Internal:
+    def create_internal(self, x: int, y: int, width: int, height: int,
+                        desired_depth: Optional[int] = 32) -> base.Internal:
         assert self.qtile is not None
 
-        win = self.conn.create_window(x, y, width, height)
-        internal = window.Internal(win, self.qtile)
+        win = self.conn.create_window(x, y, width, height, desired_depth)
+        internal = window.Internal(win, self.qtile, desired_depth)
         internal.place(x, y, width, height, 0, None)
         self.qtile.manage(internal)
         return internal

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -30,6 +30,7 @@ class Drawer(base.Drawer):
         self._xcb_surface = None
         self._pixmap = None
         self._gc = None
+        self._depth, self._visual = qtile.core.conn.default_screen._get_depth_and_visual(win._depth)  # type: ignore
 
     def finalize(self):
         self._free_xcb_surface()
@@ -89,7 +90,7 @@ class Drawer(base.Drawer):
         surface = cairocffi.XCBSurface(
             self.qtile.core.conn.conn,
             self._pixmap,
-            self.qtile.core.conn.default_screen.default_visual,
+            self._visual,
             self.width,
             self.height,
         )
@@ -103,7 +104,7 @@ class Drawer(base.Drawer):
     def _create_pixmap(self):
         pixmap = self.qtile.core.conn.conn.generate_id()
         self.qtile.core.conn.conn.core.CreatePixmap(
-            self.qtile.core.conn.default_screen.default_depth,
+            self._depth,
             pixmap,
             self._win.wid,
             self.width,
@@ -176,7 +177,7 @@ class Drawer(base.Drawer):
     def clear(self, colour):
         # If the drawer is 32 bit then we need to do some extra work to clear it
         # before drawing semi-opaque content
-        if utils.has_transparency(colour) and self.qtile.core.conn.default_screen.default_depth == 32:
+        if utils.has_transparency(colour) and self._depth == 32:
 
             # RecordingSurface won't write clear operation to surface so we
             # need to clear that surface directly.
@@ -193,7 +194,7 @@ class Drawer(base.Drawer):
 
     def set_source_rgb(self, colour):
         # Remove transparency from non-32 bit windows
-        if utils.has_transparency(colour) and self.qtile.core.conn.default_screen.default_depth != 32:
+        if utils.has_transparency(colour) and self._depth != 32:
             colour = utils.remove_transparency(colour)
 
         base.Drawer.set_source_rgb(self, colour)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -997,9 +997,10 @@ class Internal(_Window, base.Internal):
         EventMask.ButtonRelease | \
         EventMask.KeyPress
 
-    def __init__(self, win, qtile):
+    def __init__(self, win, qtile, desired_depth=32):
         _Window.__init__(self, win, qtile)
         win.set_property("QTILE_INTERNAL", 1)
+        self._depth = desired_depth
 
     def create_drawer(self, width: int, height: int) -> base.Drawer:
         """Create a Drawer that draws to this window."""

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -25,6 +25,7 @@ import typing
 from libqtile import configurable
 from libqtile.command.base import CommandObject, ItemT
 from libqtile.log_utils import logger
+from libqtile.utils import has_transparency
 
 if typing.TYPE_CHECKING:
     from libqtile.widget.base import _Widget
@@ -215,9 +216,22 @@ class Bar(Gap, configurable.Configurable):
         else:
             # Whereas we won't have a window if we're startup up for the first time or
             # the window has been killed by us no longer using the bar's screen
-            self.window = self.qtile.core.create_internal(
-                self.x, self.y, self.width, self.height
-            )
+
+            # X11 only:
+            # To preserve correct display of SysTray widget, we need a 24-bit
+            # window where the user requests an opaque bar.
+            if self.qtile.core.name == "x11":
+                depth = 32 if has_transparency(self.background) else self.qtile.core.conn.default_screen.root_depth
+
+                self.window = self.qtile.core.create_internal(
+                    self.x, self.y, self.width, self.height, depth
+                )
+
+            else:
+                self.window = self.qtile.core.create_internal(
+                    self.x, self.y, self.width, self.height
+                )
+
             self.window.opacity = self.opacity
             self.window.unhide()
 

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -216,7 +216,7 @@ class Bar(Gap, configurable.Configurable):
             # Whereas we won't have a window if we're startup up for the first time or
             # the window has been killed by us no longer using the bar's screen
             self.window = self.qtile.core.create_internal(
-                self.x, self.y, self.width, self.height,
+                self.x, self.y, self.width, self.height
             )
             self.window.opacity = self.opacity
             self.window.unhide()

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from random import randint
 from shutil import which
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 try:
     from dbus_next import Message, Variant  # type: ignore
@@ -108,6 +108,43 @@ def rgb(x):
 def hex(x):
     r, g, b, _ = rgb(x)
     return '#%02x%02x%02x' % (int(r * 255), int(g * 255), int(b * 255))
+
+
+def has_transparency(colour: Union[ColorType, List[ColorType]]):
+    """
+    Returns True if the colour is not fully opaque.
+
+    Where a list of colours is passed, returns True if any
+    colour is not fully opaque.
+    """
+    def has_alpha(col):
+        return rgb(col)[3] < 1
+
+    if isinstance(colour, (str, tuple)):
+        return has_alpha(colour)
+
+    elif isinstance(colour, list):
+        print([c for c in colour])
+        return any([has_transparency(c) for c in colour])
+
+    return False
+
+
+def remove_transparency(colour: Union[ColorType, List[ColorType]]):
+    """
+    Returns a tuple of (r, g, b) with no alpha.
+    """
+    def remove_alpha(col):
+        stripped = tuple(x * 255.0 for x in rgb(col)[:3])
+        return stripped
+
+    if isinstance(colour, (str, tuple)):
+        return remove_alpha(colour)
+
+    elif isinstance(colour, list):
+        return [remove_transparency(c) for c in colour]
+
+    return (0, 0, 0)
 
 
 def scrub_to_utf8(text):

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -30,6 +30,7 @@
 # SOFTWARE.
 
 import asyncio
+import copy
 import subprocess
 from typing import Any, List, Tuple
 
@@ -304,7 +305,10 @@ class _Widget(CommandObject, configurable.Configurable):
             logger.exception('got exception from widget timer')
 
     def create_mirror(self):
-        return Mirror(self)
+        return Mirror(self, background=self.background)
+
+    def clone(self):
+        return copy.copy(self)
 
     def mouse_enter(self, x, y):
         pass
@@ -629,11 +633,18 @@ class Mirror(_Widget):
     their contents. Currently, this is all widgets except for `Systray`.
     """
 
-    def __init__(self, reflection):
-        _Widget.__init__(self, reflection.length)
+    def __init__(self, reflection, **config):
+        _Widget.__init__(self, reflection.length, **config)
         reflection.draw = self.hook(reflection.draw)
         self.reflects = reflection
         self._length = 0
+
+    def _configure(self, qtile, bar):
+        _Widget._configure(self, qtile, bar)
+        self.reflects.drawer.add_mirror(self.drawer)
+        # We need to fill the background once before `draw` is called so, if
+        # there's no reflection, the mirror matches its parent bar.
+        self.drawer.clear(self.background or self.bar.background)
 
     @property
     def length(self):
@@ -654,7 +665,12 @@ class Mirror(_Widget):
             self._length = self.length
             self.bar.draw()
         else:
-            self.reflects.drawer.paint_to(self.drawer)
+            # We only update the mirror's drawer if the parent widget has
+            # contents in its RecordingSurface. If this is False then the widget
+            # wil just show the existing drawer contents.
+            if self.reflects.drawer.needs_update:
+                self.drawer.clear(self.background or self.bar.background)
+                self.reflects.drawer.paint_to(self.drawer)
             self.drawer.draw(offsetx=self.offset, width=self.width)
 
     def button_press(self, x, y, button):

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -100,9 +100,20 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
             ]
         else:
             pad_y = self.padding_y
+
+        if bordercolor is None:
+            # border colour is set to None when we don't want to draw a border at all
+            # Rather than dealing with alpha blending issues, we just set border width
+            # to 0.
+            border_width = 0
+            framecolor = self.background or self.bar.background
+        else:
+            border_width = self.borderwidth
+            framecolor = bordercolor
+
         framed = self.layout.framed(
-            self.borderwidth,
-            bordercolor,
+            border_width,
+            framecolor,
             0,
             pad_y,
             highlight_color
@@ -113,7 +124,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
                 if t[0] == 'margin':
                     y += (self.bar.height - framed.height) / 2 - t[1]
                     break
-        if block:
+        if block and bordercolor is not None:
             framed.draw_fill(offset, y, rounded)
         elif line:
             framed.draw_line(offset, y, highlighted)
@@ -350,7 +361,7 @@ class GroupBox(_GroupBase):
 
             if g.screen:
                 if self.highlight_method == 'text':
-                    border = self.bar.background
+                    border = None
                     text_color = self.this_current_screen_border
                 else:
                     if self.block_highlight_text_color:
@@ -374,7 +385,7 @@ class GroupBox(_GroupBase):
                 elif self.urgent_alert_method == 'line':
                     is_line = True
             else:
-                border = self.background or self.bar.background
+                border = None
 
             self.drawbox(
                 offset,

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -92,12 +92,14 @@ class Systray(window._Window, base._Widget):
     """
     A widget that manages system tray.
 
-    Note: icons will not render correctly where the bar/widget is
-    drawn with a semi-transparent background. Instead, icons will be
-    drawn with a transparent background.
+    .. note::
+        Icons will not render correctly where the bar/widget is
+        drawn with a semi-transparent background. Instead, icons
+        will be drawn with a transparent background.
 
-    If using this widget it is therefore recommended to use a fully opaque
-    background colour, or a fully transparent one.
+        If using this widget it is therefore recommended to use
+        a fully opaque background colour or a fully transparent
+        one.
     """
 
     _window_mask = EventMask.StructureNotify | \
@@ -169,7 +171,7 @@ class Systray(window._Window, base._Widget):
             xcffib.xproto.Atom.VISUALID,
             32,
             1,
-            [self.qtile.core.conn.default_screen.default_visual.visual_id]
+            [self.drawer._visual.visual_id]
         )
 
     def handle_ClientMessage(self, event):  # noqa: N802

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -89,7 +89,16 @@ class Icon(window._Window):
 
 
 class Systray(window._Window, base._Widget):
-    """A widget that manages system tray"""
+    """
+    A widget that manages system tray.
+
+    Note: icons will not render correctly where the bar/widget is
+    drawn with a semi-transparent background. Instead, icons will be
+    drawn with a transparent background.
+
+    If using this widget it is therefore recommended to use a fully opaque
+    background colour, or a fully transparent one.
+    """
 
     _window_mask = EventMask.StructureNotify | \
         EventMask.Exposure
@@ -149,6 +158,19 @@ class Systray(window._Window, base._Widget):
             data=union
         )
         qtile.core._root.send_event(event, mask=EventMask.StructureNotify)
+
+        # We need tray to tell icons which visual to use.
+        # This needs to be the same as the bar/widget.
+        # This mainly benefits transparent bars.
+        conn.conn.core.ChangeProperty(
+            xcffib.xproto.PropMode.Replace,
+            win.wid,
+            atoms["_NET_SYSTEM_TRAY_VISUAL"],
+            xcffib.xproto.Atom.VISUALID,
+            32,
+            1,
+            [self.qtile.core.conn.default_screen.default_visual.visual_id]
+        )
 
     def handle_ClientMessage(self, event):  # noqa: N802
         atoms = self.conn.atoms

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -348,13 +348,23 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         icon_padding = (self.icon_size + self.padding_x) if icon else 0
         padding_x = [self.padding_x + icon_padding, self.padding_x]
 
+        if bordercolor is None:
+            # border colour is set to None when we don't want to draw a border at all
+            # Rather than dealing with alpha blending issues, we just set border width
+            # to 0.
+            border_width = 0
+            framecolor = self.background or self.bar.background
+        else:
+            border_width = self.borderwidth
+            framecolor = bordercolor
+
         framed = self.layout.framed(
-            self.borderwidth,
-            bordercolor,
+            border_width,
+            framecolor,
             padding_x,
             self.padding_y
         )
-        if block:
+        if block and bordercolor is not None:
             framed.draw_fill(offset, self.margin_y, rounded)
         else:
             framed.draw(offset, self.margin_y, rounded)
@@ -450,12 +460,11 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
                 border = self.border
                 text_color = border
             else:
-                border = self.unfocused_border or (self.background or
-                                                   self.bar.background)
+                border = self.unfocused_border or None
                 text_color = self.foreground
 
             if self.highlight_method == 'text':
-                border = self.bar.background
+                border = None
             else:
                 text_color = self.foreground
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -63,6 +63,35 @@ def test_rgb_from_base10_tuple_with_alpha():
     assert utils.rgb([255, 255, 0, 0.5]) == (1, 1, 0, 0.5)
 
 
+def test_has_transparency():
+    colours = [
+        ("#00000000", True),
+        ("#000000ff", False),
+        ("#ff00ff.5", True),
+        ((255, 255, 255, 0.5), True),
+        ((255, 255, 255), False),
+        (["#000000", "#ffffff"], False),
+        (["#000000", "#ffffffaa"], True)
+    ]
+
+    for colour, expected in colours:
+        assert utils.has_transparency(colour) == expected
+
+
+def test_remove_transparency():
+    colours = [
+        ("#00000000", (0.0, 0.0, 0.0)),
+        ("#ffffffff", (255.0, 255.0, 255.0)),
+        ((255, 255, 255, 0.5), (255.0, 255.0, 255.0)),
+        ((255, 255, 255), (255.0, 255.0, 255.0)),
+        (["#000000", "#ffffff"], [(0.0, 0.0, 0.0), (255.0, 255.0, 255.0)]),
+        (["#000000", "#ffffffaa"], [(0.0, 0.0, 0.0), (255.0, 255.0, 255.0)])
+    ]
+
+    for colour, expected in colours:
+        assert utils.remove_transparency(colour) == expected
+
+
 def test_scrub_to_utf8():
     assert utils.scrub_to_utf8(b"foo") == "foo"
 


### PR DESCRIPTION
This PR adds 32-bit colour depth for X11 which allows transparent windows (e.g. the bar). This PR aims to address some existing issues (#900, #1320, #1722, #1934 and probably some others) but will need more work before it can be merged. I'm uploading it now in case people want to test it.

It does look pretty good though:
![20210606_212211](https://user-images.githubusercontent.com/946265/120939211-d1e75380-c70e-11eb-83fe-97ed77028216.png)

There's a discussion about getting transparency to work here: https://github.com/qtile/qtile/discussions/2508

This is based on the work of frostidaho from a number of years ago - so big kudos to them for doing most of the legwork.

I'm assuming the system tray will be an issue so I'll look at that next...

Wayland would also need to be looked at separately.

EDIT: systray may be ok:
![20210607_075722](https://user-images.githubusercontent.com/946265/120972786-0803f200-c766-11eb-95d9-46e2aec6ffa9.png)

EDIT 2: To do list

- [x] Handle redrawing of semi-opaque drawers. Overlay mode results in increasing opacity.
- [x] X11 - check if 32 bit enabled and adjust transparency if not (getting some rendering issues with 24-bit depth)
- [x] Testing
  - [x] Check systray widget
    - [x] Confirm transparency for icons
    - [x] Note: SysTray only works for fully opaque/fully transparent bar. Won't fix for semi-opaque.
  - [x] Check more widgets (graphs, images etc.)
    - [x] Fix groupbox widget 
    - [x] Check tasklist (this is the only widget that looks like it may have a similar issue to groupbox)
  - [x] Check whether gradient fill still works
  - [x] Add tests!
- [x] Wayland
  - [x] Check that Wayland backend not broken by these changes 
  - [x] Get transparency working in Wayland too!