### PR TITLE
widget: fix widget hangs on network blips

### DIFF
--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, List, Tuple
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from libqtile.log_utils import logger
@@ -78,7 +79,10 @@ class GenPollUrl(base.ThreadPoolText):
         if not self.parse or not self.url:
             return "Invalid config"
 
-        body = self.fetch()
+        try:
+            body = self.fetch()
+        except URLError:
+            return "No network"
 
         try:
             text = self.parse(body)


### PR DESCRIPTION
I turn off and on a VPN for work from time to time, which causes
intermittent network blips. Sometimes, if those network blips are in the
middle of a qtile poll, I get a bunch of noise:

2021-05-08 11:29:33,282 ERROR libqtile base.py:on_done():L557 poll() raised exceptions, not rescheduling
Traceback (most recent call last):
  File "/usr/lib/python3.8/urllib/request.py", line 1350, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/usr/lib/python3.8/http/client.py", line 1255, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1301, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1250, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.8/http/client.py", line 1010, in _send_output
    self.send(msg)
  File "/usr/lib/python3.8/http/client.py", line 950, in send
    self.connect()
  File "/usr/lib/python3.8/http/client.py", line 921, in connect
    self.sock = self._create_connection(
  File "/usr/lib/python3.8/socket.py", line 787, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/base.py", line 554, in on_done
    result = future.result()
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/generic_poll_text.py", line 85, in poll
    body = self.fetch(self.url, data, headers, self.json, self.xml)
  File "/home/tycho/.local/lib/python3.8/site-packages/libqtile/widget/generic_poll_text.py", line 58, in fetch
    res = urlopen(req)
  File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.8/urllib/request.py", line 525, in open
    response = self._open(req, data)
  File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.8/urllib/request.py", line 1379, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.8/urllib/request.py", line 1353, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno -2] Name or service not known>
2021-05-08 11:29:33,285 WARNING libqtile base.py:on_done():L571 poll() returned None, not rescheduling

Let's ignore URLErrors, which are just these kinds of (hopefully temporary)
errors network errors (http status errors, which are probably a widget or
configuration bug that we should surface, are rendered as
urllib.error.HTTPError).

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>