### PR TITLE
Don't do anything involving groups with Static windows and add Wayland Window.cmd_static

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -129,12 +129,9 @@ class _Window(CommandObject, metaclass=ABCMeta):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
         self.reserved_space: Optional[Tuple[int, int, int, int]] = None
+        # Window.cmd_static sets this in case it is hooked to client_new to stop the
+        # Window object from being managed, now that a Static is being used instead
         self.defunct: bool = False
-
-    @property
-    @abstractmethod
-    def group(self) -> Optional[_Group]:
-        """The group to which this window belongs."""
 
     @property
     @abstractmethod
@@ -203,6 +200,11 @@ class Window(_Window, metaclass=ABCMeta):
     """A regular Window belonging to a client."""
     def __repr__(self):
         return "Window(name=%r, wid=%i)" % (self.name, self.wid)
+
+    @property
+    @abstractmethod
+    def group(self) -> Optional[_Group]:
+        """The group to which this window belongs."""
 
     @property
     def floating(self) -> bool:

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -368,6 +368,21 @@ class Window(_Window, metaclass=ABCMeta):
     def cmd_kill(self) -> None:
         """Kill the window. Try to be polite."""
 
+    @abstractmethod
+    def cmd_static(
+        self,
+        screen: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
+        """Makes this window a static window, attached to a Screen.
+
+        Values left unspecified are taken from the existing window state.
+        """
+        self.defunct = True
+
 
 class Internal(_Window, metaclass=ABCMeta):
     """An Internal window belonging to Qtile."""
@@ -398,7 +413,7 @@ class Internal(_Window, metaclass=ABCMeta):
 
 
 class Static(_Window, metaclass=ABCMeta):
-    """A Window not bound to a single Group."""
+    """A window bound to a screen rather than a group."""
     screen: config.Screen
 
     def __repr__(self):

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -504,8 +504,8 @@ class Core(base.Core, wlrq.HasListeners):
                 if self.qtile.config.bring_front_click != "floating_only" or not win.floating:
                     win.cmd_bring_to_front()
 
-            if not isinstance(win, window.Internal):
-                if isinstance(win, window.Window):
+            if not isinstance(win, base.Internal):
+                if not isinstance(win, base.Static):
                     if win.group and win.group.screen is not self.qtile.current_screen:
                         self.qtile.focus_screen(win.group.screen.index, warp=False)
                     self.qtile.current_group.focus(win, False)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -534,7 +534,6 @@ class Internal(base.Internal, Window):
     ):
         self.core = core
         self.qtile = qtile
-        self._group: Optional[_Group] = None
         self._mapped: bool = False
         self._wid: int = self.core.new_wid()
         self.x: int = x
@@ -622,7 +621,6 @@ class Static(base.Static, Window):
         base.Static.__init__(self)
         self.core = core
         self.qtile = qtile
-        self._group: Optional[_Group] = None
         self.surface = surface
         self.subsurfaces: List[SubSurface] = []
         self._wid = wid
@@ -633,9 +631,7 @@ class Static(base.Static, Window):
         self.bordercolor: ffi.CData = _rgb((0, 0, 0, 1))
         self.opacity: float = 1.0
         self._float_state = FloatStates.FLOATING
-        self.defunct = True
         self.is_layer = False
-        self.screen = qtile.current_screen
 
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import array
 import contextlib
 import inspect
 import traceback
 from itertools import islice
+from typing import TYPE_CHECKING
 
 import xcffib
 import xcffib.xproto
@@ -15,6 +18,9 @@ from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.drawer import Drawer
 from libqtile.command.base import CommandError, ItemT
 from libqtile.log_utils import logger
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 # ICCM Constants
 NoValue = 0x0000
@@ -1333,7 +1339,14 @@ class Window(_Window, base.Window):
     def toggle_minimize(self):
         self.minimized = not self.minimized
 
-    def cmd_static(self, screen=None, x=None, y=None, width=None, height=None):
+    def cmd_static(
+        self,
+        screen: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
         """Makes this window a static window, attached to a Screen
 
         If any of the arguments are left unspecified, the values given by the

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1163,8 +1163,6 @@ class Window(_Window, base.Window):
         EventMask.PropertyChange | \
         EventMask.EnterWindow | \
         EventMask.FocusChange
-    # Set when this object is being retired.
-    defunct = False
 
     def __init__(self, window, qtile):
         _Window.__init__(self, window, qtile)

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -28,6 +28,7 @@
 import collections
 
 import libqtile.hook
+from libqtile.backend.base import Static
 from libqtile.command import lazy
 from libqtile.config import Group, Key, Match, Rule
 from libqtile.log_utils import logger
@@ -153,7 +154,7 @@ class DGroups:
             self.timeout.pop(client).cancel()
 
         # ignore static windows
-        if client.defunct:
+        if isinstance(client, Static):
             return
 
         # ignore windows whose groups is already set (e.g. from another hook or
@@ -233,6 +234,10 @@ class DGroups:
             libqtile.hook.fire("changegroup")
 
     def _del(self, client):
+        # ignore static windows
+        if isinstance(client, Static):
+            return
+
         group = client.group
 
         def delete_client():


### PR DESCRIPTION
Static windows shouldn't be treated the same as regular Windows in
places that involve groups, as the former is not bound to a group.

This fixes a bug where focus is unexpectedly taken from a focussed
scratchpad window when a Static window is destroyed.