### PR TITLE
Remove "Wayland is for development only" message from qtile start

### DIFF
--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -132,6 +132,6 @@ def add_subcommand(subparsers, parents):
         default='x11',
         dest='backend',
         choices=libqtile.backend.CORES,
-        help='Use specified backend. Wayland backend is currently for development only.',
+        help='Use specified backend.',
     )
     parser.set_defaults(func=start)


### PR DESCRIPTION
Let's remove this as it's ready for regular usage(TM).