### PR TITLE
WL: make default output background black

### DIFF
--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -104,7 +104,7 @@ class Output(HasListeners):
                 if self.wallpaper:
                     renderer.render_texture(self.wallpaper, self.transform_matrix, 0, 0, 1)
                 else:
-                    renderer.clear([1, 0, 1, 1])
+                    renderer.clear([0, 0, 0, 1])
 
                 mapped = self.layers[LayerShellV1Layer.BACKGROUND] \
                     + self.layers[LayerShellV1Layer.BOTTOM] \


### PR DESCRIPTION
Currently if no wallpaper is specified (or no 3rd party wallpaper tool
using the layer surface protocol is being used e.g. swaybg) then the
default colour of the background is magenta. This was useful debugging
during development due to its high contrast but for the same reason it
looks jarring and like something is broken when displayed. Lets change
this to black, like the X server.