### PR TITLE
Fixes for mypy 0.901

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -521,8 +521,8 @@ class Drawer:
     def new_ctx(self):
         return pangocffi.patch_cairo_context(cairocffi.Context(self.surface))
 
-    def set_source_rgb(self, colour: ColorType):
-        if type(colour) == list:
+    def set_source_rgb(self, colour: Union[ColorType, List[ColorType]]):
+        if isinstance(colour, list):
             if len(colour) == 0:
                 # defaults to black
                 self.ctx.set_source_rgba(*utils.rgb("#000000"))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,9 @@ flake8
 flake8-isort
 flake8-tidy-imports
 mypy
+types-python-dateutil
+types-pytz
+types-pkg_resources
 pep8-naming
 psutil
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,9 @@ deps =
     bowler
     xcffib >= 0.8.1
     pytest >= 6.2.1
+    types-python-dateutil
+    types-pytz
+    types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
     pip install pywlroots>=0.13.3


### PR DESCRIPTION
mypy just updated and we need to update to match it.

1. They no longer ship third party stubs so for three packages
   (dateutil, pytz & pkg_resources) we need to install their respective
   types-* package for the mypy tests. These are added to tox.ini::mypy
   as well as requirements-dev.txt

2. Improvements to type checking found a error; ColorType does not
   include List and so a check for `type(color) == list` is adjusted
   accordingly.