### PR TITLE
Don't AttributeError when set_group-ing Screen with no group

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -346,13 +346,16 @@ class Screen(CommandObject):
             # g2 (new_group) <-> s2 to
             # g1 <-> s2
             # g2 <-> s1
-            g1 = self.group
+            g1 = getattr(self, "group", None)
             s1 = self
             g2 = new_group
             s2 = new_group.screen
 
-            s2.group = g1
-            g1._set_screen(s2)
+            if g1 is None:
+                del s2.group
+            else:
+                s2.group = g1
+                g1._set_screen(s2)
             s1.group = g2
             g2._set_screen(s1)
         else:


### PR DESCRIPTION
`cmd_reconfigure_screens` can error:

```
    File "/home/mcol/git/qtile/libqtile/core/manager.py", line 325, in cmd_reconfigure_screens
	self._process_screens()
    File "/home/mcol/git/qtile/libqtile/core/manager.py", line 312, in _process_screens
	scr._configure(self, i, x, y, w, h, grp)
    File "/home/mcol/git/qtile/libqtile/config.py", line 290, in _configure
	self.set_group(group)
    File "/home/mcol/git/qtile/libqtile/config.py", line 349, in set_group
	g1 = self.group
AttributeError: 'Screen' object has no attribute 'group'
```

This happens if `Screen.set_group` is called when that screen has no
group, as rather than the group being `None` it is absent if the screen
has no group, and we need to handle that slightly differently.