### PR TITLE
WL: don't give pointer focus when hovering borders

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -399,8 +399,11 @@ class Core(base.Core, wlrq.HasListeners):
                 return
 
             focus_changed = self.seat.pointer_state.focused_surface != surface
-            self.seat.pointer_notify_enter(surface, sx, sy)
+            if surface is not None:
+                self.seat.pointer_notify_enter(surface, sx, sy)
             if focus_changed:
+                if surface is None:
+                    self.seat.pointer_clear_focus()
                 if win is not self.qtile.current_window:
                     hook.fire("client_mouse_enter", win)
 
@@ -536,7 +539,7 @@ class Core(base.Core, wlrq.HasListeners):
                     if win.x <= cx and win.y <= cy:
                         bw *= 2
                         if cx <= win.x + win.width + bw and cy <= win.y + win.height + bw:
-                            return win, win.surface.surface, 0, 0
+                            return win, None, 0, 0
         return None
 
     def stack_windows(self) -> None:


### PR DESCRIPTION
Currently if the pointer is above a window's border that window gets
pointer focus. Because the pointer coordinates are outside of the
window's geometry, the window considers the pointer to be at (0, 0), and
clicks will pass into that corner causing unexpected effects. Instead we
should only give pointer focus to a window when the pointer is above the
window itself.