### PR TITLE
WL: don't manage windows until they map

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -158,6 +158,12 @@ class Window(base.Window, HasListeners):
 
     def _on_map(self, _listener, _data):
         logger.debug("Signal: window map")
+
+        if self in self.core.pending_windows:
+            self.core.pending_windows.remove(self)
+            logger.debug(f"Managing new top-level window with window ID: {self.wid}")
+            self.qtile.manage(self)
+
         if self.group.screen:
             self.mapped = True
             self.core.focus_window(self)


### PR DESCRIPTION
Some clients might not map right away, and we don't want to give
unmapped windows a group otherwise the tiling layout will have a blank
space or in the worst case an internal wlroots assertion will make qtile
crash. This is what appears to be happening with wl-clipboard. Instead
we should wait until their first map event and then manage them.

Fixes #2521.