### PR TITLE
Fix send_notification util

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -222,7 +222,7 @@ async def _notify(title, message, urgency, timeout, id):
                     "",  # icon
                     title,  # summary
                     message,  # body
-                    [""],  # actions
+                    [],  # actions
                     {"urgency": Variant("y", urgency)},  # hints
                     timeout]  # timeout
 


### PR DESCRIPTION
send_notification did not comply with specification. `actions` is defined as a list of strings and the previous response was to return a single string. However, according to the spec, actions are sent over as a list of pairs so a single string is incorrect.

This behaviour causes:
- no issue with the qtile Notify widget as actions are ignored
- warnings in dunst
- crash in xfce4notifyd

Fixes #2527


One of my best diffs!