### PR TITLE
WL: set window name before managing

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -89,6 +89,8 @@ class Window(base.Window, HasListeners):
         self.opacity: float = 1.0
 
         assert isinstance(surface, XdgSurface)
+        if surface.toplevel.title:
+            self.name = surface.toplevel.title
         self._app_id: Optional[str] = surface.toplevel.app_id
         surface.set_tiled(EDGES_TILED)
         self._float_state = FloatStates.NOT_FLOATING


### PR DESCRIPTION
Some XdgSurface top-levels have their title strings set before we get
them so we can take these and set `Window.name` when instantiated rather
than just when they then later set it. This improves auto-float
functionality as the name is correctly set.