### PR TITLE
Add min/max hint respecting for wayland windows

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -382,7 +382,14 @@ class Window(base.Window, HasListeners):
             width -= margin[1] + margin[3]
             height -= margin[0] + margin[2]
 
-        # TODO: Can we get min/max size, resizing increments etc and respect them?
+        if respect_hints:
+            state = self.surface.toplevel._ptr.current
+            width = max(width, state.min_width)
+            height = max(height, state.min_height)
+            if state.max_width:
+                width = min(width, state.max_width)
+            if state.max_height:
+                height = min(height, state.max_height)
 
         # save x and y float offset
         if self.group is not None and self.group.screen is not None:

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -293,6 +293,7 @@ class Floating(Layout):
                 bw,
                 bc,
                 above,
+                respect_hints=True,
             )
         client.unhide()
 


### PR DESCRIPTION
This adds handlers for min and max width and height to Wayland's
`Window.place` for when `respect_hints` is True.

The second commit makes the floating layout always respect these hints. I'm a bit less sure about this one. In it's curret form, without this flag set, windows under wayland will not respect these and this can cause unexpected behaviour. However if similar results would be seen under X then surely this would have been set before. However this works quite well.