### PR TITLE
Some floating improvements

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -201,6 +201,11 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
 class Window(_Window, metaclass=ABCMeta):
     """A regular Window belonging to a client."""
+
+    # If float_x or float_y are None, the window has never floated
+    float_x: Optional[int]
+    float_y: Optional[int]
+
     def __repr__(self):
         return "Window(name=%r, wid=%i)" % (self.name, self.wid)
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -250,7 +250,7 @@ class Window(_Window, metaclass=ABCMeta):
         return False
 
     def is_transient_for(self) -> Optional["WindowType"]:
-        """What window is this window a transient windor for?"""
+        """What window is this window a transient window for?"""
         return None
 
     @abstractmethod

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -31,6 +31,7 @@ from pywayland.protocol.wayland import WlSeat
 from pywayland.server import Display
 from wlroots.wlr_types import (
     Cursor,
+    DataControlManagerV1,
     DataDeviceManager,
     GammaControlManagerV1,
     OutputLayout,
@@ -109,7 +110,8 @@ class Core(base.Core, wlrq.HasListeners):
         self.keyboards: List[keyboard.Keyboard] = []
         self.grabbed_keys: List[Tuple[int, int]] = []
         self.grabbed_buttons: List[Tuple[int, int]] = []
-        self.device_manager = DataDeviceManager(self.display)
+        DataDeviceManager(self.display)
+        DataControlManagerV1(self.display)
         self.seat = seat.Seat(self.display, "seat0")
         self.add_listener(self.seat.request_set_selection_event, self._on_request_set_selection)
         self.add_listener(self.backend.new_input_event, self._on_new_input)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -219,6 +219,16 @@ class Window(base.Window, HasListeners):
             0 < state.min_height == state.max_height
         )
 
+    def is_transient_for(self) -> Optional[base.WindowType]:
+        """What window is this window a transient window for?"""
+        assert isinstance(self.surface, XdgSurface)
+        parent = self.surface.toplevel.parent
+        if parent:
+            for win in self.qtile.windows_map.values():
+                if not isinstance(win, Internal) and win.surface == parent:  # type: ignore
+                    return win
+        return None
+
     def damage(self) -> None:
         for output in self.core.outputs:
             if output.contains(self):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -245,6 +245,7 @@ class XWindow:
             return self._property_string(r)
 
     def get_wm_transient_for(self):
+        """Returns the WID of the parent window"""
         r = self.get_property("WM_TRANSIENT_FOR", "WINDOW", unpack=int)
 
         if r:
@@ -580,7 +581,8 @@ class _Window:
 
     def is_transient_for(self):
         """What window is this window a transient windor for?"""
-        return self.window.get_wm_transient_for()
+        wid = self.window.get_wm_transient_for()
+        return self.qtile.windows_map.get(wid)
 
     def update_hints(self):
         """Update the local copy of the window's WM_HINTS
@@ -1175,10 +1177,9 @@ class Window(_Window, base.Window):
         if index is not None and index < len(qtile.groups):
             group = qtile.groups[index]
         elif index is None:
-            transient_for = window.get_wm_transient_for()
-            win = qtile.windows_map.get(transient_for)
-            if win is not None:
-                group = win._group
+            transient_for = self.is_transient_for()
+            if transient_for is not None:
+                group = transient_for._group
         if group is not None:
             group.add(self)
             self._group = group

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -166,7 +166,8 @@ class Subscribe:
 
         **Arguments**
 
-        None
+            * ``Group`` receiving the new window
+            * ``Window`` added to the group
         """
         return self._subscribe("group_window_add", func)
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -142,15 +142,12 @@ class Floating(Layout):
             elif win.fullscreen:
                 win.fullscreen = True
             else:
-                # catch if the client hasn't been configured
-                try:
+                # If the window hasn't been floated before, it will be configured in
+                # .configure()
+                if win.float_x is not None and win.float_y is not None:
                     # By default, place window at same offset from top corner
                     new_x = new_screen.x + win.float_x
                     new_y = new_screen.y + win.float_y
-                except AttributeError:
-                    # this will be handled in .configure()
-                    pass
-                else:
                     # make sure window isn't off screen left/right...
                     new_x = min(new_x, new_screen.x + new_screen.width - win.width)
                     new_x = max(new_x, new_screen.x)
@@ -282,10 +279,7 @@ class Floating(Layout):
             above = False
 
             # We definitely have a screen here, so let's be sure we'll float on screen
-            try:
-                client.float_x
-                client.float_y
-            except AttributeError:
+            if client.float_x is None or client.float_y is None:
                 # this window hasn't been placed before, let's put it in a sensible spot
                 above = self.compute_client_position(client, screen_rect)
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -81,6 +81,11 @@ class Floating(Layout):
             from libqtile.config import Match
             float_rules=[Match(wm_class="skype"), Match(wm_class="gimp")]
 
+        The following ``Match`` will float all windows that are transient windows for a
+        parent window:
+
+            Match(func=lambda c: bool(c.is_transient_for()))
+
         Specify these in the ``floating_layout`` in your config.
 
         Floating layout will try to center most of floating windows by default,
@@ -222,11 +227,10 @@ class Floating(Layout):
         if not client.has_user_set_position() or not self.on_screen(client, screen_rect):
             # client has not been properly placed before or it is off screen
             transient_for = client.is_transient_for()
-            win = client.group.qtile.windows_map.get(transient_for)
-            if win is not None:
+            if transient_for is not None:
                 # if transient for a window, place in the center of the window
-                center_x = win.x + win.width / 2
-                center_y = win.y + win.height / 2
+                center_x = transient_for.x + transient_for.width / 2
+                center_y = transient_for.y + transient_for.height / 2
                 above = False
             else:
                 center_x = screen_rect.x + screen_rect.width / 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.13.3
+  pywlroots>=0.13.4
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pywayland >= 0.4.4
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.13.3
+    pip install pywlroots>=0.13.4
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing {posargs}
@@ -90,7 +90,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.13.3
+    pip install pywlroots>=0.13.4
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
1. Implement Window.is_transient for for wayland windows. This method is changed slightly to return the parent `Window` rather than just that window's WID (in fact the base class signature already said this, but the x11 implementation just return WID... just goes to show what mypy might catch if the x11 backend was typed). This change is made to reduce a couple lines of extra code if the backend needs to get the Window anyway. This change needs the next pywlroots release from yesterday.
2. Adds wlr_data_control_manager_v1. This is unrelated to floating but i added it here because it also needs the new pywlroots and so the PRs would conflict :smile: 
3. Fix a docstring error in group_window_add hook
4. Unify float_x and float_y usage between backends and clean it up a bit