### PR TITLE
WL: shutdown internal windows more cleanly

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -607,7 +607,8 @@ class Core(base.Core, wlrq.HasListeners):
         """Try to close windows gracefully before exiting"""
         assert self.qtile is not None
 
-        for win in self.qtile.windows_map.values():
+        # Copy in case the dictionary changes during the loop
+        for win in self.qtile.windows_map.copy().values():
             win.kill()
 
         # give everyone a little time to exit and write their state. but don't

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -605,7 +605,7 @@ class Internal(base.Internal, Window):
 
     def kill(self) -> None:
         self.hide()
-        self.qtile.call_soon(self.qtile.unmanage, self)
+        del self.qtile.windows_map[self.wid]
 
     def place(self, x, y, width, height, borderwidth, bordercolor,
               above=False, margin=None, respect_hints=False):


### PR DESCRIPTION
Internal windows don't need to go through `Qtile.unmanage` and can just
delete themselves from `Qtile.windows_map` directly. Doing this in the
same event loop task as `win.kill` during shutdown lets Qtile exit
sooner than before as previously it would wait the full second for
windows to die because Internal windows needed another task to be
removed from windows_map.