### PR TITLE
WL: Use client-side geometry values, first then our own

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -86,6 +86,10 @@ class Window(base.Window, HasListeners):
         self.bordercolor: ffi.CData = _rgb((0, 0, 0, 1))
         self.opacity: float = 1.0
 
+        # These start as None and are set in the first place() call
+        self._width: Optional[int] = None
+        self._height: Optional[int] = None
+
         assert isinstance(surface, XdgSurface)
         if surface.toplevel.title:
             self.name = surface.toplevel.title
@@ -119,11 +123,23 @@ class Window(base.Window, HasListeners):
 
     @property
     def width(self) -> int:
-        return self.surface.surface.current.width
+        if self._width is None:
+            return self.surface.surface.current.width
+        return self._width
+
+    @width.setter
+    def width(self, width: int) -> None:
+        self._width = width
 
     @property
     def height(self) -> int:
-        return self.surface.surface.current.height
+        if self._height is None:
+            return self.surface.surface.current.height
+        return self._height
+
+    @height.setter
+    def height(self, height: int) -> None:
+        self._height = height
 
     @property
     def group(self) -> Optional[_Group]:
@@ -402,6 +418,8 @@ class Window(base.Window, HasListeners):
         self.x = x
         self.y = y
         self.surface.set_size(int(width), int(height))
+        self._width = int(width)
+        self._height = int(height)
         self.paint_borders(bordercolor, borderwidth)
 
         if above and self._mapped:
@@ -554,8 +572,8 @@ class Internal(base.Internal, Window):
         self.x: int = x
         self.y: int = y
         self.opacity: float = 1.0
-        self.width: int = width
-        self.height: int = height
+        self._width: int = width
+        self._height: int = height
         self._reset_texture()
 
     def finalize(self):


### PR DESCRIPTION
This partially reverts a recent change as it didn't completely fix the
issue.

The first problem was that when first created, clients were providing
width and height of 0 before being configured, and when transient_for
windows were positioned centred on their parent window, the incorrect
values causes the new windows to have their top left corner in the
centre of the parent window.

We were taking these 0s as the initial values of `Window._width` and
_height when the client was created and then updating these values in
`place` and not getting them from the client. The bad fix for this was
to _always_ get these values from the client so that `Window.width` and
height returned data taken directly from the client. The problem with
this is that if we call `place()` twice before the client can respond
(e.g. show scratchpad and group.layout_all) then the data is wrong the
second time and windows have the wrong size.

The solution is a balance: we shouldn't take dimensions right away when
the client is created and only get them from the client the first time
they are accessed - and only if we haven't given it a width/height
already. Once we have given a client a width/height, that value is the
most up-to-date state whether the client has responded or not.