### PR TITLE
Update widget keyboard grabbing and prompt widget to be backend-agnostic

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -109,6 +109,10 @@ class Core(metaclass=ABCMeta):
     def simulate_keypress(self, modifiers: List[str], key: str) -> None:
         """Simulate a keypress with given modifiers"""
 
+    def keysym_from_name(self, name: str) -> int:
+        """Get the keysym for a key from its name"""
+        raise NotImplementedError
+
     def change_vt(self, vt: int) -> bool:
         """Change virtual terminal, returning success."""
         return False

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -399,6 +399,9 @@ class Internal(_Window, metaclass=ABCMeta):
     def process_pointer_motion(self, x: int, y: int) -> None:
         """Handle pointer motion within the window."""
 
+    def process_key_press(self, keycode: int) -> None:
+        """Handle a key press."""
+
 
 class Static(_Window, metaclass=ABCMeta):
     """A Window not bound to a single Group."""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -681,3 +681,7 @@ class Core(base.Core, wlrq.HasListeners):
             self.keyboards[-1].set_keymap(layout, options)
         else:
             logger.warning("Could not set keymap: no keyboards set up.")
+
+    def keysym_from_name(self, name: str) -> int:
+        """Get the keysym for a key from its name"""
+        return xkb.keysym_from_name(name, case_insensitive=True)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -96,6 +96,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.socket = self.display.add_socket()
         self.fd = None
         self._hovered_internal: Optional[window.Internal] = None
+        self.focused_internal: Optional[window.Internal] = None
 
         # These windows have not been mapped yet; they'll get managed when mapped
         self.pending_windows: List[window.WindowType] = []
@@ -496,7 +497,14 @@ class Core(base.Core, wlrq.HasListeners):
             return
 
         if surface is None and win is not None:
+            if isinstance(win, base.Internal):
+                self.focused_internal = win
+                self.seat.keyboard_clear_focus()
+                return
             surface = win.surface.surface
+
+        if self.focused_internal:
+            self.focused_internal = None
 
         previous_surface = self.seat.keyboard_state.focused_surface
         if previous_surface == surface:

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -108,4 +108,8 @@ class Keyboard(HasListeners):
                     self.qtile.process_key_event(keysym, mods)
                     return
 
+            if self.core.focused_internal:
+                self.core.focused_internal.process_key_press(keysym)
+                return
+
         self.seat.keyboard_notify_key(event)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -387,6 +387,9 @@ class Window(base.Window, HasListeners):
 
     def focus(self, warp: bool) -> None:
         self.core.focus_window(self)
+        if isinstance(self, base.Internal):
+            # self.core.focus_window is enough for internal windows
+            return
 
         if warp and self.qtile.config.cursor_warp:
             self.core.warp_pointer(

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -43,6 +43,7 @@ from xcffib.xproto import EventMask, StackMode
 from libqtile import config, hook, utils
 from libqtile.backend import base
 from libqtile.backend.x11 import window, xcbq
+from libqtile.backend.x11.xkeysyms import keysyms
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -814,3 +815,7 @@ class Core(base.Core):
         """
         reply = self.conn.conn.core.QueryPointer(self._root.wid).reply()
         return reply.root_x, reply.root_y
+
+    def keysym_from_name(self, name: str) -> int:
+        """Get the keysym for a key from its name"""
+        return keysyms[name]

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -898,6 +898,9 @@ class _Window:
         did_focus = self._do_focus()
         if not did_focus:
             return
+        if isinstance(self, base.Internal):
+            # self._do_focus is enough for internal windows
+            return
 
         # now, do all the other WM stuff since the focus actually changed
         if warp and self.qtile.config.cursor_warp:
@@ -1028,6 +1031,12 @@ class Internal(_Window, base.Internal):
 
     def handle_MotionNotify(self, e):  # noqa: N802
         self.process_pointer_motion(e.event_x, e.event_y)
+
+    def handle_KeyPress(self, e):  # noqa: N802
+        mask = xcbq.ModMasks["shift"] | xcbq.ModMasks["lock"]
+        state = 1 if e.state & mask else 0
+        keysym = self.qtile.core.conn.code_to_syms[e.detail][state]
+        self.process_key_press(keysym)
 
 
 class Static(_Window, base.Static):

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -230,6 +230,7 @@ class Bar(Gap, configurable.Configurable):
             self.window.process_pointer_enter = self.process_pointer_enter
             self.window.process_pointer_leave = self.process_pointer_leave
             self.window.process_pointer_motion = self.process_pointer_motion
+            self.window.process_key_press = self.process_key_press
 
         self.crashed_widgets = []
         if self._configured:
@@ -388,23 +389,27 @@ class Bar(Gap, configurable.Configurable):
             )
         self.cursor_in = widget
 
+    def process_key_press(self, keycode: int) -> None:
+        if self.has_keyboard:
+            self.has_keyboard.process_key_press(keycode)
+
     def widget_grab_keyboard(self, widget):
         """
             A widget can call this method to grab the keyboard focus
             and receive keyboard messages. When done,
             widget_ungrab_keyboard() must be called.
         """
-        self.window.handle_KeyPress = widget.handle_KeyPress
+        self.has_keyboard = widget
         self.saved_focus = self.qtile.current_window
-        self.window.window.set_input_focus()
+        self.window.focus(False)
 
     def widget_ungrab_keyboard(self):
         """
-            Removes the widget's keyboard handler.
+            Removes keyboard focus from the widget.
         """
-        del self.window.handle_KeyPress
         if self.saved_focus is not None:
-            self.saved_focus.window.set_input_focus()
+            self.saved_focus.focus(False)
+        self.has_keyboard = None
 
     def draw(self):
         if not self.widgets:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -40,7 +40,6 @@ from collections import deque
 from typing import List, Optional, Tuple
 
 from libqtile import bar, hook, pangocffi, utils
-from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.xkeysyms import keysyms
 from libqtile.command.base import CommandObject, SelectError
 from libqtile.command.client import InteractiveCommandClient
@@ -660,16 +659,11 @@ class Prompt(base._TextBox):
                 self.completer.reset()
             return self.keyhandlers[k]
 
-    def handle_KeyPress(self, e):  # noqa: N802
-        """KeyPress handler for the minibuffer.
+    def process_key_press(self, keysym: int):
+        """Key press handler for the minibuffer.
 
         Currently only supports ASCII characters.
         """
-        mask = xcbq.ModMasks["shift"] | xcbq.ModMasks["lock"]
-        state = 1 if e.state & mask else 0
-
-        keysym = self.qtile.core.conn.code_to_syms[e.detail][state]
-
         handle_key = self._get_keyhandler(keysym)
 
         if handle_key:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -348,7 +348,7 @@ class Prompt(base._TextBox):
                  "Don't store duplicates in history"),
                 ("bell_style", "audible",
                  "Alert at the begin/end of the command history. " +
-                 "Possible values: 'audible', 'visual' and None."),
+                 "Possible values: 'audible' (X11 only), 'visual' and None."),
                 ("visual_bell_color", "ff0000",
                  "Color for the visual bell (changes prompt background)."),
                 ("visual_bell_time", 0.2,
@@ -360,9 +360,6 @@ class Prompt(base._TextBox):
         self.name = name
         self.active = False
         self.completer = None  # type: Optional[AbstractCompleter]
-
-        if self.bell_style == "visual":
-            self.original_background = self.background
 
         # If history record is on, get saved history or create history record
         if self.record_history:
@@ -430,6 +427,13 @@ class Prompt(base._TextBox):
                       chr(x) in string.printable}
         self.keyhandlers.update(printables)
         self.tab = qtile.core.keysym_from_name("Tab")
+
+        self.bell_style: str
+        if self.bell_style == "audible" and qtile.core.name != "x11":
+            self.bell_style = "visual"
+            logger.warning("Prompt widget only supports audible bell under X11")
+        if self.bell_style == "visual":
+            self.original_background = self.background
 
     def start_input(self, prompt, callback, complete=None,
                     strict_completer=False, allow_empty_input=False) -> None:


### PR DESCRIPTION
This updates the code that handles keyboard-grabbing by widgets (and Internal windows in general) so that any backend can do it. The `Bar` and prompt widget are updated to use this approach, and the prompt widget uses a non-x11 specific way to ask for the keysyms to which it binds its methods when it has grabbed the keyboard.

Everything appears to be working as expected under both Wayland and X11 backends, but I'm not a user of the prompt widget (though I've been considering adding it to my bar recently!) so if anyone uses it lots maybe they could give it a test run for a day or so just to check it works as before?