### PR TITLE
WL: fix bug where layer surfaces are included in all layers

### DIFF
--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -63,7 +63,7 @@ class Output(HasListeners):
         self.add_listener(self.damage.frame_event, self._on_frame)
 
         # The layers enum indexes into this list to get a list of surfaces
-        self.layers: List[List[Static]] = [[]] * len(LayerShellV1Layer)
+        self.layers: List[List[Static]] = [[] for _ in range(len(LayerShellV1Layer))]
 
     def finalize(self):
         self.core.outputs.remove(self)


### PR DESCRIPTION
Layer surfaces exist within one of four layers. `Output.layers` is a
list of four lists, where each inner list corresponds to one of these
layers, and contains whichever surfaces are in that layer. WHen layer
surfaces are mapped they append themselves to one of these four inner
lists.

However, this list of lists is created with:
```
self.layers: List[List[Static]] = [[]] * len(LayerShellV1Layer)
```
Each of the four items in the outer list is the same item! It's 4
references to the same list, so appending to one inner list puts the
surface into all four layers. Brilliant. This causes issues such as
rendering your wallpaper (background layer) on top of all windows
(overlay layer, rendered last).