### PR TITLE
WL: Clear pointer focus when leaving non-Internal window

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -392,6 +392,7 @@ class Core(base.Core, wlrq.HasListeners):
                 if self._hovered_internal:
                     win.process_pointer_motion(self.cursor.x, self.cursor.y)
                 else:
+                    self.seat.pointer_clear_focus()
                     win.process_pointer_enter(self.cursor.x, self.cursor.y)
                     self._hovered_internal = win
                 return


### PR DESCRIPTION
When the pointer leaves a window onto the desktop the pointer focus
clears so that click events don't propagate into the previously focussed
windows. This is currently only happening when the pointer moves onto
the desktop, but it should also be done when the pointer moves from a
client window onto an Internal window otherwise clicks will be sent to
the client window too.