### PR TITLE
WL: Update float_width and height if they are still 0

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -288,6 +288,9 @@ class Window(base.Window, HasListeners):
         if do_float and self._float_state == FloatStates.NOT_FLOATING:
             if self.group and self.group.screen:
                 screen = self.group.screen
+                if not self._float_width:  # These might start as 0
+                    self._float_width = self.width
+                    self._float_height = self.height
                 self._enablefloating(
                     screen.x + self.float_x,
                     screen.y + self.float_y,


### PR DESCRIPTION
When Window is instantiated the float_width and float_height can be 0 if
the values are not yet configured by the client. When we make the window
float and then resize the window to be smaller, it fails because it is
trying to apply a negative value. Instead we should check these are
still 0 when doing that and get their values from self.width and
self.height.