### PR TITLE
Disable icons in TaskList when using Wayland backend

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -519,6 +519,9 @@ class Window(base.Window, HasListeners):
     def cmd_toggle_maximize(self) -> None:
         self.maximized = not self.maximized
 
+    def cmd_toggle_minimize(self) -> None:
+        self.minimized = not self.minimized
+
     def cmd_toggle_fullscreen(self) -> None:
         self.fullscreen = not self.fullscreen
 

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -28,6 +28,7 @@ import re
 import cairocffi
 
 from libqtile import bar, hook, pangocffi
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -282,6 +283,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
+
+        if qtile.core.name == "wayland" and self.icon_size != 0:
+            # Disable icons
+            self.icon_size = 0
+            logger.warning("TaskList icons not supported in Wayland.")
+
         if self.icon_size is None:
             self.icon_size = self.bar.height - 2 * (self.borderwidth +
                                                     self.margin_y)
@@ -378,7 +385,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
                 if window.floating:
                     window.cmd_bring_to_front()
             else:
-                window.toggle_minimize()
+                window.cmd_toggle_minimize()
 
     def get_window_icon(self, window):
         if not window.icons:


### PR DESCRIPTION
Wayland does not currently support any kind of icons for clients, so
TaskList cannot use icons. Let's stop that causing exceptions and log a
warning.

To stop another error with the widget under Wayland, this adds
`cmd_toggle_minimize` which was missing from the Wayland `Window` class.