### PR TITLE
Forward unhandled keybindings to client window

### DIFF
--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -105,7 +105,7 @@ class Keyboard(HasListeners):
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    self.qtile.process_key_event(keysym, mods)
-                    return
+                    if self.qtile.process_key_event(keysym, mods):
+                        return
 
         self.seat.keyboard_notify_key(event)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -336,12 +336,13 @@ class Qtile(CommandObject):
     ) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(self, keysym: int, mask: int) -> None:
+    def process_key_event(self, keysym: int, mask: int) -> bool:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.info("Ignoring unknown keysym: {keysym}, mask: {mask}".format(keysym=keysym, mask=mask))
-            return
+            return False
 
+        handled = False
         if isinstance(key, KeyChord):
             self.grab_chord(key)
         else:
@@ -352,9 +353,11 @@ class Qtile(CommandObject):
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("KB command error %s: %s" % (cmd.name, val))
+                    handled = True
             if self.chord_stack and (self.chord_stack[-1].mode == "" or key.key == "Escape"):
                 self.cmd_ungrab_chord()
-            return
+                handled = True
+        return handled
 
     def grab_keys(self) -> None:
         """Re-grab all of the keys configured in the key map


### PR DESCRIPTION
Keybindings can be conditional, e.g. upon the current layout:

```
    lazy.function(func).when(layout='max')
```

We grab the appropriate keys as normal but we swallow these
unconditionally. Instead, if Qtile does not execute the binding because
the conditions were not met, we should not be swallowing these key press
events.

Fixes #324