### PR TITLE
X11: only respect aspect ratios when window is floating

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -769,7 +769,7 @@ class _Window:
             if "PMaxSize" in flags:
                 width = min(width, self.hints.get('max_width', 0)) or width
                 height = min(height, self.hints.get('max_height', 0)) or height
-            if "PAspect" in flags:
+            if "PAspect" in flags and self._float_state == FloatStates.FLOATING:
                 min_aspect = self.hints["min_aspect"]
                 max_aspect = self.hints["max_aspect"]
                 if width / height < min_aspect[0] / min_aspect[1]:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -696,6 +696,18 @@ def test_default_float(manager):
     try:
         manager.create_window(size_hints)
         assert manager.c.window.info()['floating'] is True
+        info = manager.c.window.info()
+        assert info['width'] == 10
+        assert info['height'] == 10
+        manager.c.window.toggle_floating()
+        assert manager.c.window.info()['floating'] is False
+        info = manager.c.window.info()
+        assert info['width'] == 398
+        assert info['height'] == 578
+        manager.c.window.toggle_fullscreen()
+        info = manager.c.window.info()
+        assert info['width'] == 800
+        assert info['height'] == 600
     finally:
         w.kill_client()
         conn.finalize()


### PR DESCRIPTION
The aspect ratio hint provided by a client should not be respected when
the window is any of tiling, fullscreen, maximized etc, and should only
be used when the window is floating.

Fixes #2512