### PR TITLE
Fix margin_on_single so it works with [N E S W] coords

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -120,7 +120,7 @@ class Columns(Layout):
         ("border_width", 2, "Border width."),
         ("border_on_single", False, "Draw a border when there is one only window."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])."),
-        ("margin_on_single", -1, "Margin when only one window. `-1` means use `margin`."),
+        ("margin_on_single", None, "Margin when only one window. (int or list of ints [N E S W])"),
         ("split", True, "New columns presentation mode."),
         ("num_columns", 2, "Preferred number of columns."),
         ("grow_amount", 10, "Amount by which to grow a window/column."),
@@ -235,7 +235,7 @@ class Columns(Layout):
         if len(self.columns) == 1 and (len(col) == 1 or not col.split):
             if not self.border_on_single:
                 border = 0
-            if self.margin_on_single > -1:
+            if self.margin_on_single is not None:
                 margin_size = self.margin_on_single
         width = int(
             0.5 + col.width * screen_rect.width * 0.01 / len(self.columns))

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -22,6 +22,7 @@ import pytest
 import libqtile.config
 from libqtile import layout
 from libqtile.confreader import Config
+from test import conftest
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
@@ -36,6 +37,8 @@ class ColumnsConfig(Config):
     ]
     layouts = [
         layout.Columns(num_columns=3),
+        layout.Columns(margin_on_single=10),
+        layout.Columns(margin_on_single=[10, 20, 30, 40]),
     ]
     floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
@@ -139,3 +142,31 @@ def test_columns_swap_column_right(manager):
     assert columns[0]['clients'] == ['2']
     assert columns[1]['clients'] == ['1']
     assert columns[2]['clients'] == ['4', '3']
+
+
+@columns_config
+def test_columns_margins_single(manager):
+    manager.test_window("1")
+
+    # no margin
+    info = manager.c.window.info()
+    assert info['x'] == 0
+    assert info['y'] == 0
+    assert info['width'] == conftest.WIDTH
+    assert info['height'] == conftest.HEIGHT
+
+    # single margin for all sides
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info['x'] == 10
+    assert info['y'] == 10
+    assert info['width'] == conftest.WIDTH - 20
+    assert info['height'] == conftest.HEIGHT - 20
+
+    # one margin for each side (N E S W)
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info['x'] == 40
+    assert info['y'] == 10
+    assert info['width'] == conftest.WIDTH - 60
+    assert info['height'] == conftest.HEIGHT - 40


### PR DESCRIPTION
Fix Columns layout's `margin_on_single` so it accepts a list of values for each margin, instead of just a single integer for all sides. This is based on how monadtall's `single_margin` works. In fact, I considered renaming `margin_on_single` as `single_margin` so there would be one name for the same behavior across layouts, but it would be a breaking change and I wasn't sure if it would be appropriate. I still can do it, however, if a maintainer green-lights it.

I also tried to add new tests to cover the changes, but I couldn't figure out how to do it. Any pointers would be appreciated.