### PR TITLE
migrate: add a migration_count to config files

### DIFF
--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -28,6 +28,7 @@ from sys import exit
 import libqtile.backend
 from libqtile import confreader
 from libqtile.log_utils import logger
+from libqtile.scripts.migrate import set_migration_count
 
 
 def rename_process():
@@ -58,6 +59,7 @@ def make_qtile(options):
                                             "resources",
                                             "default_config.py")
             copyfile(default_config_path, options.configfile)
+            set_migration_count(options.configfile)
             logger.info('Copied default_config.py to %s', options.configfile)
         except Exception as e:
             logger.exception('Failed to copy default_config.py to %s: (%s)',


### PR DESCRIPTION
Here's some code implementing the migrate_count discussion from #2353.
We write a variable into users' configs with the number of total
migrations performed. This number is structured so that it always
monotonically increases, so we never run the same message twice.

There are two interesting scenarios here: when we add a new migration for
the next version, and when we want to remove old migrations.

The first scenario looks something like this:

```diff
diff --git a/libqtile/scripts/migrate.py b/libqtile/scripts/migrate.py
index 157a2d74..daa3c47a 100644
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -117,6 +117,10 @@ def new_at_current_to_new_client_position(query):
     )

+def fancy_new_migration(query):
+    ...
+
+
 MIGRATIONS = [
     # from 0.17.0
     client_name_updated,
@@ -125,6 +129,9 @@ MIGRATIONS = [
     pacman_to_checkupdates,
     hook_main_function,
     new_at_current_to_new_client_position,
+
+    # from 0.18.0
+    fancy_new_migration,
 ]
```
and the second something like this (though obviously we'd remove all the
migrations from 0.17.0 at the same time, I've just removed one here for
brevity):

```diff
diff --git a/libqtile/scripts/migrate.py b/libqtile/scripts/migrate.py
index 157a2d74..d7aa2924 100644
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -41,11 +41,6 @@ def rename_hook(query, fro, to):
     return q.rename(to)

-def client_name_updated(query):
-    """ Rename window_name_change -> client_name_updated"""
-    return rename_hook(query, "window_name_change", "client_name_updated")
-
-
 def tile_master_windows_rename(query):
     return (
         query
@@ -118,8 +113,6 @@ def new_at_current_to_new_client_position(query):

 MIGRATIONS = [
-    # from 0.17.0
-    client_name_updated,
     tile_master_windows_rename,
     threaded_poll_text_rename,
     pacman_to_checkupdates,
@@ -148,7 +141,7 @@ for (fro, to) in MODULE_RENAMES:

 # Number of migrations that have been removed.
-PREVIOUS_MIGRATIONS = 0
+PREVIOUS_MIGRATIONS = 1

 MIGRATION_COUNT_PATTERN = re.compile(r"^migration_count\s*=\s*(\d+)\s*")
```

It's not clear to me that we necessarily want this complexity, since the
motivating use case from #2353 never arrived, but I'll leave that decision up
to reviewers :)

Closes #2353

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>