### PR TITLE
Update link for complete lists of special keys in docs

### DIFF
--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -171,7 +171,7 @@ Special keys
 ============
 
 These are most commonly used special keys. For complete list please see
-`the code <https://github.com/qtile/qtile/blob/master/libqtile/xkeysyms.py>`_.
+`the code <https://github.com/qtile/qtile/blob/master/libqtile/backend/x11/xkeysyms.py>`_.
 You can create bindings on them just like for the regular keys. For example
 ``Key(["mod1"], "F4", lazy.window.kill())``.
 


### PR DESCRIPTION
The old one was `https://github.com/qtile/qtile/blob/master/libqtile/xkeysyms.py` which didn't exist now.