### PR TITLE
Better handling of incompatible widgets (e.g. Systray on Wayland)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ Qtile x.xx.x, released XXXX-XX-XX:
     * features
         - Add ability to draw borders and add margins to the `Max` layout.
     * bugfixes
+        - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
+          as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message
+          included in the logs.
 
 Qtile 0.21.0, released 2022-03-23:
     * features

--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -54,6 +54,10 @@ qtile_class_template = Template('''
     .. compound::
 
         Supported bar orientations: {{ obj.orientations }}
+
+        {% if supported_backends %}
+        Only available on the following backends: {{ ", ".join(obj.supported_backends) }}
+        {% endif %}
     {% endif %}
     {% if is_widget and screen_shots %}
     .. raw:: html
@@ -132,6 +136,7 @@ class QtileClass(SimpleDirectiveMixin, Directive):
         obj = import_class(module, class_name)
         is_configurable = ':no-config:' not in arguments
         is_commandable = ':no-commands:' not in arguments
+        is_widget = issubclass(obj, widget.base._Widget)
         arguments = [i for i in arguments if i not in (':no-config:', ':no-commands:')]
 
         # build up a dict of defaults using reverse MRO
@@ -178,7 +183,8 @@ class QtileClass(SimpleDirectiveMixin, Directive):
             'commandable': is_commandable and issubclass(obj, command.base.CommandObject),
             'is_widget': is_widget,
             'extra_arguments': arguments,
-            'screen_shots': widget_shots
+            'screen_shots': widget_shots,
+            'supported_backends': is_widget and obj.supported_backends
         }
         if context['commandable']:
             context['commands'] = [

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -138,6 +138,8 @@ screens = [
                 ),
                 widget.TextBox("default config", name="default"),
                 widget.TextBox("Press &lt;M-r&gt; to spawn", foreground="#d75f5f"),
+                # NB Systray is incompatible with Wayland, consider using StatusNotifier instead
+                # widget.StatusNotifier(),
                 widget.Systray(),
                 widget.Clock(format="%Y-%m-%d %a %I:%M %p"),
                 widget.QuickExit(),

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -131,6 +131,11 @@ class _Widget(CommandObject, configurable.Configurable):
     """
 
     orientations = ORIENTATION_BOTH
+
+    # Default (empty set) is for all backends to be supported. Widgets can override this
+    # to explicitly confirm which backends are supported
+    supported_backends: set[str] = set()
+
     offsetx: int = 0
     offsety: int = 0
     defaults = [

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -118,6 +118,8 @@ class Systray(window._Window, base._Widget):
 
     orientations = base.ORIENTATION_BOTH
 
+    supported_backends = {"x11"}
+
     defaults = [
         ("icon_size", 20, "Icon width"),
         ("padding", 5, "Padding between icons"),


### PR DESCRIPTION
Now that we've got a Wayland backend we should remove Systray from the default config as it doesn't run on Wayland.