### PR TITLE
x11: ignore mouse button modifiers when handling bindings

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -161,7 +161,7 @@ class Core(base.Core):
 
         numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])[0]
         self._numlock_mask = xcbq.ModMasks.get(self.conn.get_modifier(numlock_code), 0)
-        self._valid_mask = ~(self._numlock_mask | xcbq.ModMasks["lock"])
+        self._valid_mask = ~(self._numlock_mask | xcbq.ModMasks["lock"] | xcbq.AllButtonsMask)
 
     @property
     def name(self):
@@ -602,9 +602,7 @@ class Core(base.Core):
         assert self.qtile is not None
 
         button_code = event.detail
-        state = event.state
-        state |= self._numlock_mask
-        state &= self._valid_mask
+        state = event.state & self._valid_mask
 
         if not event.child:  # The client's handle_ButtonPress will focus it
             self.focus_by_click(event)
@@ -618,8 +616,7 @@ class Core(base.Core):
         assert self.qtile is not None
 
         button_code = event.detail
-        state = event.state | self._numlock_mask
-        state &= self._valid_mask & ~xcbq.AllButtonsMask
+        state = event.state & self._valid_mask
         self.qtile.process_button_release(button_code, state)
 
     def handle_MotionNotify(self, event) -> None:  # noqa: N802


### PR DESCRIPTION
Currently we ignore numlock as a modifier, and remove its mask from key
and button events before processing the event and handling bindings. We
need to do the same thing for mouse buttons, which also have modmasks
associated with them. Not doing so causes an issue where keybindings
cannot be executed when a mouse button is held down.

Closes #2525

This commit also removes a redundant `|= self._numlock_mask` from these
event handlers.

--

@matheusfillipe please could you run with this patch to confirm it's all working as expected and that all key and mouse bindings continue to work fine? In particular, I'd like confirm that the keypad bindings still work.