### PR TITLE
Added group function to switching windows

### DIFF
--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -74,6 +74,10 @@ Group functions
       - Move to the group on the left
     * - ``lazy.screen.toggle_group()``
       - Move to the last visited group
+    * - ``lazy.group.next_window()``
+      - Switch window focus to next window in group
+    * - ``lazy.group.prev_window()``
+      - Switch window focus to previous window in group
     * - ``lazy.group["group_name"].toscreen()``
       - Move to the group called ``group_name``.
         Takes an optional ``toggle`` parameter (defaults to True).


### PR DESCRIPTION
I have been looking for a way to switch focus to non-tiling windows (Floating, Maximized, Minimized, Full-screen) as lazy.layout.up/down/left/right/next/prev() only target windows that have not had their layouts changed and I count not find a function for that anywhere in the documentation.
Did manage to find it in an 11 year old issue so decided to propose to have it added to the documentation
Apologies in advance if this is not the best page to add it to or if the description is lacking.