### PR TITLE
Add text parsing/modifying option for window name/tab, task list widgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ jobs:
     build:
         runs-on: ubuntu-20.04
         name: "python ${{ matrix.python-version }}"
+        env:
+          WAYLAND: 1.19.0
+          WAYLAND_PROTOCOLS: 1.21
+          WLROOTS: 0.14.0
+          SEATD: 0.5.0
+          LIBDRM: 2.4.105
         strategy:
             matrix:
                 # if you change one of these, be sure to update
@@ -15,37 +21,56 @@ jobs:
                 python-version: [pypy-3.7, 3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v2
-            - name: Set up python ${{ matrix.python-version}}
+            - name: Set up python ${{ matrix.python-version }}
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
               run: |
                 sudo apt update
-                sudo apt install libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 \
-                  graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors libwlroots-dev git ninja-build
-                pip install tox tox-gh-actions
-                # we want wlroots' dependencies only, so remove the packages (these are outdated in ubuntu's repos)
-                sudo dpkg -r --force-depends wlroots libwayland-dev
+                sudo apt install --no-install-recommends \
+                  libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz \
+                  imagemagick libpulse-dev lm-sensors git xserver-xephyr xterm xvfb x11-apps ninja-build libegl1-mesa-dev \
+                  libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev
+                sudo pip -q install tox tox-gh-actions meson
             - name: Build wayland
-              env:
-                WAYLAND: 1.19.0
               run: |
-                wget --no-check-certificate https://wayland.freedesktop.org/releases/wayland-$WAYLAND.tar.xz
+                wget -q --no-check-certificate https://wayland.freedesktop.org/releases/wayland-$WAYLAND.tar.xz
                 tar -xJf wayland-$WAYLAND.tar.xz
                 cd wayland-$WAYLAND
-                ./configure --disable-documentation
-                make
-                sudo make install
-            - name: Build wlroots
-              env:
-                WLROOTS: 0.13.0
+                meson build -Ddocumentation=false --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build wayland-protocols
               run: |
-                wget --no-check-certificate https://github.com/swaywm/wlroots/archive/$WLROOTS.tar.gz
+                wget -q --no-check-certificate https://wayland.freedesktop.org/releases/wayland-protocols-$WAYLAND_PROTOCOLS.tar.xz
+                tar -xJf wayland-protocols-$WAYLAND_PROTOCOLS.tar.xz
+                cd wayland-protocols-$WAYLAND_PROTOCOLS
+                meson build -Dtests=false --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build seatd
+              run: |
+                wget -q --no-check-certificate https://git.sr.ht/~kennylevinsen/seatd/archive/$SEATD.tar.gz
+                tar -xzf $SEATD.tar.gz
+                cd seatd-$SEATD
+                meson build --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build libdrm
+              run: |
+                wget -q --no-check-certificate https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-$LIBDRM/drm-libdrm-$LIBDRM.tar.gz
+                tar -xzf drm-libdrm-$LIBDRM.tar.gz
+                cd drm-libdrm-$LIBDRM
+                meson build --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build wlroots
+              run: |
+                wget -q --no-check-certificate https://github.com/swaywm/wlroots/archive/$WLROOTS.tar.gz
                 tar -xzf $WLROOTS.tar.gz
-                sudo pip install meson
                 cd wlroots-$WLROOTS
-                meson build
+                meson build -Dexamples=false --prefix=/usr
                 ninja -C build
                 sudo ninja -C build install
             - name: run tests

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,9 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
         stale-issue-label: 'stale'
-        exempt-issue-labels: 'in progress,task,bug,enhancement'
+        exempt-issue-labels: 'task,bug,enhancement'
         stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
         stale-pr-label: 'stale'
-        exempt-pr-labels: 'in progress,task,bug,enhancement'
         days-before-stale: 90
         days-before-close: 30
     - uses: actions/stale@v2.0.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,9 @@ Qtile 0.x.x, released xxxx-xx-xx:
         - added new argument for CheckUpdates widget: `custom_command_modify` which allows user to modify the
           the line count of the output of `custom_command` with a lambda function (i.e. `lambda x: x-3`).
           Argument defaults to `lambda x: x` and is overridden by `distro` argument's internal lambda.
+        - added new argument for the WindowName, WindowTabs and Tasklist widgets: `parse_text` which allows users to
+          define a function that takes a window name as an input, modify it in some way (e.g. str.replace(), str.upper() or regex)
+          and show that modification on screen.
         - A Wayland backend has been added which can be used by calling `qtile start -b wayland` directly in your TTY.
           It requires the latest releases of wlroots, python-xkbcommon, pywayland and pywlroots. It is expected to be
           unstable so please let us know if you find any bugs!

--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,10 @@ Maintainers
 | `@ramnes`_ GPG: ``99CC A84E 2C8C 74F3 2E12  AD53 8C17 0207 0803 487A``
 | `@m-col`_ GPG: ``35D9 2E7C C735 7A81 173E  A1C9 74F9 FDD2 0984 FBEC``
 | `@flacjacket`_ GPG: ``58B5 F350 8339 BFE5 CA93  AC9F 439D 9701 E7EA C588``
+| `@elParaguayo`_ GPG: ``A6BA A1E1 7D26 64AD B97B  2C6F 58A9 AA7C 8672 7DF7``
 
 .. _`@tych0`: https://github.com/tych0
 .. _`@ramnes`: https://github.com/ramnes
 .. _`@m-col`: https://github.com/m-col
 .. _`@flacjacket`: https://github.com/flacjacket
+.. _`@elParaguayo`: https://github.com/elparaguayo

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -36,11 +36,6 @@ class Drawer(base.Drawer):
             context.set_source_rgba(*utils.rgb("#000000"))
             context.paint()
 
-        for output in qtile.core.outputs:  # type: ignore
-            if output.contains(win):
-                break  # Internals only show on one output
-        self._output = output
-
     def paint_to(self, drawer):
         drawer.ctx.set_source_surface(self._source)
         drawer.ctx.paint()
@@ -86,7 +81,7 @@ class Drawer(base.Drawer):
             dst_x=offsetx,
             dst_y=offsety,
         )
-        self._output.damage.add_whole()
+        self._win.damage()  # type: ignore
 
         # Clear RecordingSurface of operations
         self._reset_surface()

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -53,12 +53,29 @@ ModMasks = {
 }
 
 # from linux/input-event-codes.h
-buttons = {
-    1 + i: 0x110 + i
-    for i in range(8)
-}
+_KEY_MAX = 0x2ff
+# These are mouse buttons 1-9
+BTN_LEFT = 0x110
+BTN_MIDDLE = 0x112
+BTN_RIGHT = 0x111
+SCROLL_UP = _KEY_MAX + 1
+SCROLL_DOWN = _KEY_MAX + 2
+SCROLL_LEFT = _KEY_MAX + 3
+SCROLL_RIGHT = _KEY_MAX + 4
+BTN_SIDE = 0x113
+BTN_EXTRA = 0x114
 
-buttons_inv = {v: k for k, v in buttons.items()}
+buttons = [
+    BTN_LEFT,
+    BTN_MIDDLE,
+    BTN_RIGHT,
+    SCROLL_UP,
+    SCROLL_DOWN,
+    SCROLL_LEFT,
+    SCROLL_RIGHT,
+    BTN_SIDE,
+    BTN_EXTRA,
+]
 
 # from drm_fourcc.h
 DRM_FORMAT_ARGB8888 = 875713089
@@ -129,7 +146,8 @@ class Painter:
                 screen.height,
                 cairocffi.cairo.cairo_image_surface_get_data(surface._pointer)
             )
-            self.core.outputs[screen.index].wallpaper = texture
+            outputs = [output for output in self.core.outputs if output.wlr_output.enabled]
+            outputs[screen.index].wallpaper = texture
 
 
 class HasListeners:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -608,7 +608,7 @@ class Core(base.Core):
             self.focus_by_click(event)
 
         self.qtile.process_button_click(
-            button_code, state, event.event_x, event.event_y, event
+            button_code, state, event.event_x, event.event_y
         )
         self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -33,7 +33,7 @@ import tempfile
 from typing import TYPE_CHECKING
 
 import libqtile
-from libqtile import confreader, hook, ipc, utils
+from libqtile import bar, confreader, hook, ipc, utils
 from libqtile.backend import base
 from libqtile.command import interface
 from libqtile.command.base import (
@@ -261,9 +261,8 @@ class Qtile(CommandObject):
                 layout.finalize()
 
             for screen in self.screens:
-                for bar in [screen.top, screen.bottom, screen.left, screen.right]:
-                    if bar is not None:
-                        bar.finalize()
+                for gap in screen.gaps:
+                    gap.finalize()
         except:  # noqa: E722
             logger.exception('exception during finalize')
         finally:
@@ -311,6 +310,12 @@ class Qtile(CommandObject):
 
             scr._configure(self, i, x, y, w, h, grp)
             screens.append(scr)
+
+        for screen in self.screens:
+            if screen not in screens:
+                for gap in screen.gaps:
+                    if isinstance(gap, bar.Bar) and gap.window:
+                        gap.kill_window()
 
         self.screens = screens
 
@@ -524,19 +529,17 @@ class Qtile(CommandObject):
         """
         Reserve some space at the edge(s) of a screen.
         """
-        from libqtile.bar import Bar, Gap
-
         for i, pos in enumerate(["left", "right", "top", "bottom"]):
             if reserved_space[i]:
-                bar = getattr(screen, pos)
-                if isinstance(bar, Bar):
-                    bar.adjust_for_strut(reserved_space[i])
-                elif isinstance(bar, Gap):
-                    bar.size += reserved_space[i]
-                    if bar.size <= 0:
+                gap = getattr(screen, pos)
+                if isinstance(gap, bar.Bar):
+                    gap.adjust_for_strut(reserved_space[i])
+                elif isinstance(gap, bar.Gap):
+                    gap.size += reserved_space[i]
+                    if gap.size <= 0:
                         setattr(screen, pos, None)
                 else:
-                    setattr(screen, pos, Gap(reserved_space[i]))
+                    setattr(screen, pos, bar.Gap(reserved_space[i]))
         screen.resize()
 
     def free_reserved_space(
@@ -659,7 +662,7 @@ class Qtile(CommandObject):
         return closest_screen
 
     def process_button_click(
-        self, button_code: int, modmask: int, x: int, y: int, event: Any,
+        self, button_code: int, modmask: int, x: int, y: int
     ) -> None:
         for m in self.mouse_map.get(button_code, []):
             if not m.modmask == modmask:

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -120,7 +120,7 @@ class Columns(Layout):
         ("border_width", 2, "Border width."),
         ("border_on_single", False, "Draw a border when there is one only window."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])."),
-        ("margin_on_single", -1, "Margin when only one window. `-1` means use `margin`."),
+        ("margin_on_single", None, "Margin when only one window. (int or list of ints [N E S W])"),
         ("split", True, "New columns presentation mode."),
         ("num_columns", 2, "Preferred number of columns."),
         ("grow_amount", 10, "Amount by which to grow a window/column."),
@@ -235,7 +235,7 @@ class Columns(Layout):
         if len(self.columns) == 1 and (len(col) == 1 or not col.split):
             if not self.border_on_single:
                 border = 0
-            if self.margin_on_single > -1:
+            if self.margin_on_single is not None:
                 margin_size = self.margin_on_single
         width = int(
             0.5 + col.width * screen_rect.width * 0.01 / len(self.columns))

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -125,7 +125,10 @@ if has_dbus:
             self.notifications.append(notif)
             notif.id = len(self.notifications)
             for callback in self.callbacks:
-                callback(notif)
+                try:
+                    callback(notif)
+                except Exception:
+                    logger.exception("Exception in notifier callback")
             return len(self.notifications)
 
         def show(self, *args, **kwargs):

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -69,8 +69,10 @@ class Popup(configurable.Configurable):
         self.win: Any = qtile.core.create_internal(x, y, width, height)  # TODO: better annotate Internal
         self.win.opacity = self.opacity
         self.win.process_button_click = self.process_button_click
+        self.win.process_window_expose = self.draw
 
         self.drawer: Drawer = self.win.create_drawer(width, height)
+        self.clear()
         self.layout = self.drawer.textlayout(
             text='',
             colour=self.foreground,
@@ -84,9 +86,6 @@ class Popup(configurable.Configurable):
 
         if self.border_width and self.border:
             self.win.paint_borders(self.border, self.border_width)
-
-        self.win.process_window_expose = self.draw
-        self.win.process_button_click = self.process_button_click
 
         self.x = self.win.x
         self.y = self.win.y
@@ -168,3 +167,5 @@ class Popup(configurable.Configurable):
 
     def kill(self) -> None:
         self.win.kill()
+        self.layout.finalize()
+        self.drawer.finalize()

--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -38,7 +38,11 @@ def run_cmd(opts) -> None:
     client = ipc.Client(socket)
     root = graph.CommandGraphRoot()
 
-    proc = subprocess.Popen(opts.cmd)
+    cmd = [opts.cmd]
+    if opts.args:
+        cmd.extend(opts.args)
+
+    proc = subprocess.Popen(cmd)
     match_args = {"net_wm_pid": proc.pid}
     rule_args = {"float": opts.float, "intrusive": opts.intrusive,
                  "group": opts.group, "break_on_match": not opts.dont_break}
@@ -86,6 +90,11 @@ def add_subcommand(subparsers, parents):
         help='Set the window group.')
     parser.add_argument(
         'cmd',
+        help='Command to execute.'),
+    parser.add_argument(
+        'args',
         nargs=argparse.REMAINDER,
-        help='Command to execute')
+        metavar='[args ...]',
+        help='Optional arguments to pass to command.'
+    )
     parser.set_defaults(func=run_cmd)

--- a/libqtile/widget/bluetooth.py
+++ b/libqtile/widget/bluetooth.py
@@ -35,6 +35,10 @@ class Bluetooth(base._TextBox):
     Displays bluetooth status or connected device.
 
     Uses dbus to communicate with the system bus.
+
+    Widget requirements: dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
 
     orientations = base.ORIENTATION_HORIZONTAL

--- a/libqtile/widget/keyboardkbdd.py
+++ b/libqtile/widget/keyboardkbdd.py
@@ -34,6 +34,10 @@ class KeyboardKbdd(base.ThreadPoolText):
 
     kbdd should be installed and running, you can get it from:
     https://github.com/qnikst/kbdd
+
+    The widget also requires dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -33,10 +33,12 @@ class Mpris2(base._TextBox):
     """An MPRIS 2 widget
 
     A widget which displays the current track/artist of your favorite MPRIS
-    player. It should work with all MPRIS 2 compatible players which implement
-    a reasonably correct version of MPRIS, though I have only tested it with
-    audacious.  This widget scrolls the text if neccessary and information that
+    player. This widget scrolls the text if neccessary and information that
     is displayed is configurable.
+
+    Widget requirements: dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -85,6 +85,16 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             "Defaults to None, the normal behaviour."
         ),
         (
+            "parse_text", None, "Function to parse and modify window names. "
+            "e.g. function in config that removes excess "
+            "strings from window name: "
+            "def my_func(text)"
+            "    for string in [\" - Chromium\", \" - Firefox\"]:"
+            "        text = text.replace(string, \"\")"
+            "   return text"
+            "then set option parse_text=my_func"
+        ),
+        (
             "spacing",
             None,
             "Spacing between tasks."
@@ -208,6 +218,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             markup_str = self.markup_focused
 
         window_name = window.name if window and window.name else "?"
+
+        if callable(self.parse_text):
+            try:
+                window_name = self.parse_text(window_name)
+            except:
+                logger.exception("parse_text function failed:")
 
         # Emulate default widget behavior if markup_str is None
         if enforce_markup and markup_str is None:

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -26,6 +26,7 @@
 
 from libqtile import bar, hook, pangocffi
 from libqtile.widget import base
+from libqtile.log_utils import logger
 
 
 class WindowName(base._TextBox):
@@ -35,6 +36,14 @@ class WindowName(base._TextBox):
         ('for_current_screen', False, 'instead of this bars screen use currently active screen'),
         ('empty_group_string', ' ', 'string to display when no windows are focused on current group'),
         ('format', '{state}{name}', 'format of the text'),
+        ('parse_text', None, 'Function to parse and modify window names. '
+         'e.g. function in config that removes excess '
+         'strings from window name: '
+         'def my_func(text)'
+         '    for string in [\" - Chromium\", \" - Firefox\"]:'
+         '        text = text.replace(string, \"\")'
+         '   return text'
+         'then set option parse_text=my_func'),
     ]
 
     def __init__(self, width=bar.STRETCH, **config):
@@ -68,6 +77,11 @@ class WindowName(base._TextBox):
             var = {}
             var["state"] = state
             var["name"] = w.name
+            if callable(self.parse_text):
+                try:
+                    var["name"] = self.parse_text(var["name"])
+                except:
+                    logger.exception("parse_text function failed:")
             wm_class = w.get_wm_class()
             var["class"] = wm_class[0] if wm_class else ""
             unescaped = self.format.format(**var)

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -24,6 +24,7 @@
 
 from libqtile import bar, hook
 from libqtile.widget import base
+from libqtile.log_utils import logger
 
 
 class WindowTabs(base._TextBox):
@@ -36,6 +37,14 @@ class WindowTabs(base._TextBox):
     defaults = [
         ("separator", " | ", "Task separator text."),
         ("selected", ("<b>", "</b>"), "Selected task indicator"),
+        ("parse_text", None, "Function to parse and modify window names. "
+         "e.g. function in config that removes excess "
+         "strings from window name: "
+         "def my_func(text)"
+         "    for string in [\" - Chromium\", \" - Firefox\"]:"
+         "        text = text.replace(string, \"\")"
+         "   return text"
+         "then set option parse_text=my_func"),
     ]
 
     def __init__(self, **config):
@@ -66,4 +75,9 @@ class WindowTabs(base._TextBox):
                 task = task.join(self.selected)
             names.append(task)
         self.text = self.separator.join(names)
+        if callable(self.parse_text):
+            try:
+                self.text = self.parse_text(self.text)
+            except:
+                logger.exception("parse_text function failed:")
         self.bar.draw()

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -22,6 +22,7 @@ import pytest
 import libqtile.config
 from libqtile import layout
 from libqtile.confreader import Config
+from test import conftest
 from test.conftest import no_xinerama
 from test.layouts.layout_utils import assert_focus_path, assert_focused
 
@@ -36,6 +37,8 @@ class ColumnsConfig(Config):
     ]
     layouts = [
         layout.Columns(num_columns=3),
+        layout.Columns(margin_on_single=10),
+        layout.Columns(margin_on_single=[10, 20, 30, 40]),
     ]
     floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
@@ -139,3 +142,31 @@ def test_columns_swap_column_right(manager):
     assert columns[0]['clients'] == ['2']
     assert columns[1]['clients'] == ['1']
     assert columns[2]['clients'] == ['4', '3']
+
+
+@columns_config
+def test_columns_margins_single(manager):
+    manager.test_window("1")
+
+    # no margin
+    info = manager.c.window.info()
+    assert info['x'] == 0
+    assert info['y'] == 0
+    assert info['width'] == conftest.WIDTH
+    assert info['height'] == conftest.HEIGHT
+
+    # single margin for all sides
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info['x'] == 10
+    assert info['y'] == 10
+    assert info['width'] == conftest.WIDTH - 20
+    assert info['height'] == conftest.HEIGHT - 20
+
+    # one margin for each side (N E S W)
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info['x'] == 40
+    assert info['y'] == 10
+    assert info['width'] == conftest.WIDTH - 60
+    assert info['height'] == conftest.HEIGHT - 40


### PR DESCRIPTION
Adds `text_filter` as a config option for the windowname, windowtabs and tasklist widgets.
The option takes a list of strings that will be removed from the displayed version of window names.
for example the window name:
`"Comparing qtile:master...yobleck:text_filter · qtile/qtile - Chromium"`
has the text `" - Chromium"` which takes up space and isn't necessary for many users (ms windows doesn't even display text anymore, only the program icon).

This allows users to remove text they don't want or need to see without relying on the arbitrary cut off ellipses caused by running out of screen space.

Other examples of text that users might want to remove includes "\u2014 " + Konsole, Dolphin, Kate or any other program that tasks its name onto the end of the windows wm_name. This option can also be used to hide sensitive information, enhancing privacy in public settings.

Edit: changed to more general user defined function. Above is one example of how it can be used