### PR TITLE
Bump wlroots build in CI to 0.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ jobs:
     build:
         runs-on: ubuntu-20.04
         name: "python ${{ matrix.python-version }}"
+        env:
+          WAYLAND: 1.19.0
+          WAYLAND_PROTOCOLS: 1.21
+          WLROOTS: 0.14.0
+          SEATD: 0.5.0
+          LIBDRM: 2.4.105
         strategy:
             matrix:
                 # if you change one of these, be sure to update
@@ -15,37 +21,56 @@ jobs:
                 python-version: [pypy-3.7, 3.7, 3.8, 3.9]
         steps:
             - uses: actions/checkout@v2
-            - name: Set up python ${{ matrix.python-version}}
+            - name: Set up python ${{ matrix.python-version }}
               uses: actions/setup-python@v2
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies
               run: |
                 sudo apt update
-                sudo apt install libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 \
-                  graphviz imagemagick x11-apps xserver-xephyr xterm xvfb libpulse-dev lm-sensors libwlroots-dev git ninja-build
-                pip install tox tox-gh-actions
-                # we want wlroots' dependencies only, so remove the packages (these are outdated in ubuntu's repos)
-                sudo dpkg -r --force-depends wlroots libwayland-dev
+                sudo apt install --no-install-recommends \
+                  libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz \
+                  imagemagick libpulse-dev lm-sensors git xserver-xephyr xterm xvfb x11-apps ninja-build libegl1-mesa-dev \
+                  libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev
+                sudo pip -q install tox tox-gh-actions meson
             - name: Build wayland
-              env:
-                WAYLAND: 1.19.0
               run: |
-                wget --no-check-certificate https://wayland.freedesktop.org/releases/wayland-$WAYLAND.tar.xz
+                wget -q --no-check-certificate https://wayland.freedesktop.org/releases/wayland-$WAYLAND.tar.xz
                 tar -xJf wayland-$WAYLAND.tar.xz
                 cd wayland-$WAYLAND
-                ./configure --disable-documentation
-                make
-                sudo make install
-            - name: Build wlroots
-              env:
-                WLROOTS: 0.13.0
+                meson build -Ddocumentation=false --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build wayland-protocols
               run: |
-                wget --no-check-certificate https://github.com/swaywm/wlroots/archive/$WLROOTS.tar.gz
+                wget -q --no-check-certificate https://wayland.freedesktop.org/releases/wayland-protocols-$WAYLAND_PROTOCOLS.tar.xz
+                tar -xJf wayland-protocols-$WAYLAND_PROTOCOLS.tar.xz
+                cd wayland-protocols-$WAYLAND_PROTOCOLS
+                meson build -Dtests=false --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build seatd
+              run: |
+                wget -q --no-check-certificate https://git.sr.ht/~kennylevinsen/seatd/archive/$SEATD.tar.gz
+                tar -xzf $SEATD.tar.gz
+                cd seatd-$SEATD
+                meson build --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build libdrm
+              run: |
+                wget -q --no-check-certificate https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-$LIBDRM/drm-libdrm-$LIBDRM.tar.gz
+                tar -xzf drm-libdrm-$LIBDRM.tar.gz
+                cd drm-libdrm-$LIBDRM
+                meson build --prefix=/usr
+                ninja -C build
+                sudo ninja -C build install
+            - name: Build wlroots
+              run: |
+                wget -q --no-check-certificate https://github.com/swaywm/wlroots/archive/$WLROOTS.tar.gz
                 tar -xzf $WLROOTS.tar.gz
-                sudo pip install meson
                 cd wlroots-$WLROOTS
-                meson build
+                meson build -Dexamples=false --prefix=/usr
                 ninja -C build
                 sudo ninja -C build install
             - name: run tests


### PR DESCRIPTION
wlroots released 0.14.0 recently, and pywlroots has released
accordingly. We should bump up wlroots' version in the CI (pywlroots
always just gets the latest via pip).

The new version has support for running wlroots headlessly, meaning that
it should run as expected in GitHub actions so we can start putting
together tests for the Wayland backend. One downside to this is that
some of the dependencies need to be built manually as Ubuntu's repos are
very outdated. For now, adding more manual builds to the GA setup works
fine, but if in the future we foresee this list growing we could
consider a different approach such as running an up-to-date distro in a
docker container and installing these dependencies from their repos.