### PR TITLE
WL: Map Button1-9 codes to correct mouse events

### DIFF
--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -53,12 +53,29 @@ ModMasks = {
 }
 
 # from linux/input-event-codes.h
-buttons = {
-    1 + i: 0x110 + i
-    for i in range(8)
-}
+_KEY_MAX = 0x2ff
+# These are mouse buttons 1-9
+BTN_LEFT = 0x110
+BTN_MIDDLE = 0x112
+BTN_RIGHT = 0x111
+SCROLL_UP = _KEY_MAX + 1
+SCROLL_DOWN = _KEY_MAX + 2
+SCROLL_LEFT = _KEY_MAX + 3
+SCROLL_RIGHT = _KEY_MAX + 4
+BTN_SIDE = 0x113
+BTN_EXTRA = 0x114
 
-buttons_inv = {v: k for k, v in buttons.items()}
+buttons = [
+    BTN_LEFT,
+    BTN_MIDDLE,
+    BTN_RIGHT,
+    SCROLL_UP,
+    SCROLL_DOWN,
+    SCROLL_LEFT,
+    SCROLL_RIGHT,
+    BTN_SIDE,
+    BTN_EXTRA,
+]
 
 # from drm_fourcc.h
 DRM_FORMAT_ARGB8888 = 875713089

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -608,7 +608,7 @@ class Core(base.Core):
             self.focus_by_click(event)
 
         self.qtile.process_button_click(
-            button_code, state, event.event_x, event.event_y, event
+            button_code, state, event.event_x, event.event_y
         )
         self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -659,7 +659,7 @@ class Qtile(CommandObject):
         return closest_screen
 
     def process_button_click(
-        self, button_code: int, modmask: int, x: int, y: int, event: Any,
+        self, button_code: int, modmask: int, x: int, y: int
     ) -> None:
         for m in self.mouse_map.get(button_code, []):
             if not m.modmask == modmask:


### PR DESCRIPTION
The current button codes used for binding button events to
`config.Mouse` "ButtonX" strings are inconsistent with X11 and by
extension what people expect. This aligns how we define buttons 1-9 with
how Sway does this, which is consistent with how X11 does it.

Buttons 1-3 and 8-9 are true "buttons" whereas buttons 4-7 map to scroll
events (up, down, left, right), which are received via cursor axis
events and are then converted to buttons and processed by us as buttons
in case there are things bound to them. As the scroll "buttons" are
mimicked by us, their values are defined as above `KEY_MAX` so that no
button events that we receive can trigger these events.