### PR TITLE
Fix 'qtile run-cmd' bug with no command

### DIFF
--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -38,7 +38,11 @@ def run_cmd(opts) -> None:
     client = ipc.Client(socket)
     root = graph.CommandGraphRoot()
 
-    proc = subprocess.Popen(opts.cmd)
+    cmd = [opts.cmd]
+    if opts.args:
+        cmd.extend(opts.args)
+
+    proc = subprocess.Popen(cmd)
     match_args = {"net_wm_pid": proc.pid}
     rule_args = {"float": opts.float, "intrusive": opts.intrusive,
                  "group": opts.group, "break_on_match": not opts.dont_break}
@@ -86,6 +90,11 @@ def add_subcommand(subparsers, parents):
         help='Set the window group.')
     parser.add_argument(
         'cmd',
+        help='Command to execute.'),
+    parser.add_argument(
+        'args',
         nargs=argparse.REMAINDER,
-        help='Command to execute')
+        metavar='[args ...]',
+        help='Optional arguments to pass to command.'
+    )
     parser.set_defaults(func=run_cmd)


### PR DESCRIPTION
Executing `qtile run-cmd` with no arguments results in an ugly exception with no explanation of the problem. This is because
the script tries to execute the `cmd` argument and errors when there's no command.

The problem is that the script uses `argparse.REMAINDER` to catch the command and appropriate arguments but `REMAINDER` allows no matches whereas we need at least one.

This PR tries to address that by splitting the `cmd` and `args` element to force the `cmd` to be required.

The only downside here is that, when run with no arguments, the script produces the following output:
```
usage: qtile run-cmd [-h] [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-s SOCKET] [-i] [-f] [-b] [-g GROUP] cmd ...
qtile run-cmd: error: the following arguments are required: cmd, [args ...]
```
`args` is not shown in the first line but is shown as a "required" argument in the second. I've tried to address this by putting `args` in square brackets.

This should close bug in #2566 (although that wasn't primary issue reported).