### PR TITLE
Small fixes for Popups and Internals I found while debugging

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -620,9 +620,11 @@ class Internal(base.Internal, Window):
 
     def hide(self) -> None:
         self.mapped = False
+        self.damage()
 
     def unhide(self) -> None:
         self.mapped = True
+        self.damage()
 
     def kill(self) -> None:
         self.hide()
@@ -630,16 +632,20 @@ class Internal(base.Internal, Window):
 
     def place(self, x, y, width, height, borderwidth, bordercolor,
               above=False, margin=None, respect_hints=False):
-        if above:
+        if above and self._mapped:
             self.core.mapped_windows.remove(self)
             self.core.mapped_windows.append(self)
             self.core.stack_windows()
 
         self.x = x
         self.y = y
+        needs_reset = width != self.width or height != self.height
         self.width = width
         self.height = height
-        self._reset_texture()
+
+        if needs_reset:
+            self._reset_texture()
+
         self.damage()
 
 

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -125,7 +125,10 @@ if has_dbus:
             self.notifications.append(notif)
             notif.id = len(self.notifications)
             for callback in self.callbacks:
-                callback(notif)
+                try:
+                    callback(notif)
+                except Exception:
+                    logger.exception("Exception in notifier callback")
             return len(self.notifications)
 
         def show(self, *args, **kwargs):

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -69,8 +69,10 @@ class Popup(configurable.Configurable):
         self.win: Any = qtile.core.create_internal(x, y, width, height)  # TODO: better annotate Internal
         self.win.opacity = self.opacity
         self.win.process_button_click = self.process_button_click
+        self.win.process_window_expose = self.draw
 
         self.drawer: Drawer = self.win.create_drawer(width, height)
+        self.clear()
         self.layout = self.drawer.textlayout(
             text='',
             colour=self.foreground,
@@ -84,9 +86,6 @@ class Popup(configurable.Configurable):
 
         if self.border_width and self.border:
             self.win.paint_borders(self.border, self.border_width)
-
-        self.win.process_window_expose = self.draw
-        self.win.process_button_click = self.process_button_click
 
         self.x = self.win.x
         self.y = self.win.y
@@ -168,3 +167,5 @@ class Popup(configurable.Configurable):
 
     def kill(self) -> None:
         self.win.kill()
+        self.layout.finalize()
+        self.drawer.finalize()


### PR DESCRIPTION
I was updating my notification server which I hadn't used since I moved to Wayland and came across some bugs. Here are 3 commits:

 - minor Wayland `Internal` improvements
 - libqtile.notify.notifier should catch and log exceptions raised by callbacks without stopping further callbacks from being called
 - minor `Popup` improvements