### PR TITLE
migrate: always be interactive

### DIFF
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -162,7 +162,7 @@ def do_migrate(args):
 
     for m in MIGRATIONS:
         q = bowler.Query(config_dir)
-        m(q).execute(interactive=args.interactive, write=True)
+        m(q).execute(interactive=not args.yes, write=True)
 
     changed = False
     for py, backup in file_and_backup(config_dir):
@@ -193,8 +193,8 @@ def add_subcommand(subparsers, parents):
         help="Use the specified configuration file (migrates every .py file in this directory)",
     )
     parser.add_argument(
-        "--interactive",
+        "--yes",
         action="store_true",
-        help="Interactively apply diff (similar to git add -p)",
+        help="Automatically apply diffs with no confirmation",
     )
     parser.set_defaults(func=do_migrate)

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -13,7 +13,7 @@ from test.test_check import have_mypy, run_qtile_check
 
 def run_qtile_migrate(config):
     cmd = os.path.join(os.path.dirname(__file__), '..', 'bin', 'qtile')
-    argv = [cmd, "migrate", "-c", config]
+    argv = [cmd, "migrate", "--yes", "-c", config]
     subprocess.check_call(argv)
 
 


### PR DESCRIPTION
This way people can reject changes to their configs that they don't want
(or are potentially incorrect, viz. the discussion in #2567).

Closes #2353 (we're relying on people to reject incorrect migrations for
now)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>