### PR TITLE
WL: Minor bugfixes for internal window events

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -380,8 +380,11 @@ class Core(base.Core, wlrq.HasListeners):
         if found:
             win, surface, sx, sy = found
             if isinstance(win, window.Internal):
-                if self._hovered_internal:
-                    win.process_pointer_motion(self.cursor.x, self.cursor.y)
+                if self._hovered_internal is win:
+                    win.process_pointer_motion(
+                        self.cursor.x - self._hovered_internal.x,
+                        self.cursor.y - self._hovered_internal.y
+                    )
                 else:
                     self.seat.pointer_clear_focus()
                     win.process_pointer_enter(self.cursor.x, self.cursor.y)


### PR DESCRIPTION
Fixes issue where mouse events were sent to wrong internal window when windows were overlapping.

Pass relative mouse co-ordinates for pointer_motion events.

See: https://github.com/qtile/qtile/discussions/2580#discussioncomment-948679