### PR TITLE
Set group.current_window to self in Window.focus

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -394,6 +394,8 @@ class Window(base.Window, HasListeners):
                 self.y + self.height // 2,
             )
 
+        if self.group:
+            self.group.current_window = self
         hook.fire("client_focus", self)
 
     def place(self, x, y, width, height, borderwidth, bordercolor,

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -914,6 +914,9 @@ class _Window:
                 self.window.set_property('_NET_WM_STATE', state)
 
         self.qtile.core._root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
+
+        if self.group:
+            self.group.current_window = self
         hook.fire("client_focus", self)
 
     def cmd_focus(self, warp=None):


### PR DESCRIPTION
This lets the group update its focus history.

Fixes #2495