### PR TITLE
Add actions and NotificationClosed method to notifier and notify widget

### DIFF
--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -40,6 +40,13 @@ SERVICE_PATH = '/org/freedesktop/Notifications'
 
 notifier: Any = None
 
+
+class ClosedReason:
+    expired = 1
+    dismissed = 2
+    method = 3  # CloseNotification method
+
+
 if has_dbus:
     class NotificationService(ServiceInterface):
         def __init__(self, manager):
@@ -69,12 +76,16 @@ if has_dbus:
             return self.manager.add(notif)
 
         @method()
-        def CloseNotification(self, _id: 'u'):  # type:ignore  # noqa: N802, F821
-            pass
+        def CloseNotification(self, nid: 'u'):  # type:ignore  # noqa: N802, F821
+            self.manager.close(nid)
 
         @signal()
-        def NotificationClosed(self, _id_in, _reason_in):  # noqa: N802
-            pass
+        def NotificationClosed(self, nid: 'u', reason: 'u') -> 'uu':  # type:ignore  # noqa: N802, F821
+            return [nid, reason]
+
+        @signal()
+        def ActionInvoked(self, nid: 'u', action_key: 's') -> 'us':  # type:ignore  # noqa: N802, F821
+            return [nid, action_key]
 
         @method()
         def GetServerInformation(self) -> 'ssss':  # type:ignore  # noqa: N802, F821
@@ -96,6 +107,7 @@ if has_dbus:
         def __init__(self):
             self.notifications = []
             self.callbacks = []
+            self.close_callbacks = []
             self._service = None
 
         async def service(self):
@@ -110,7 +122,7 @@ if has_dbus:
                     self._service = None
             return self._service
 
-        async def register(self, callback, capabilities=None):
+        async def register(self, callback, capabilities=None, on_close=None):
             service = await self.service()
             if not service:
                 logger.warning(
@@ -120,6 +132,8 @@ if has_dbus:
             self.callbacks.append(callback)
             if capabilities:
                 self._service.register_capabilities(capabilities)
+            if on_close:
+                self.close_callbacks.append(on_close)
 
         def add(self, notif):
             self.notifications.append(notif)
@@ -134,6 +148,15 @@ if has_dbus:
         def show(self, *args, **kwargs):
             notif = Notification(*args, **kwargs)
             return (notif, self.add(notif))
+
+        def close(self, nid):
+            notif = self.notifications[nid]
+
+            for callback in self.close_callbacks:
+                try:
+                    callback(notif)
+                except Exception:
+                    logger.exception("Exception in notifier close callback")
 
     notifier = NotificationManager()
 

--- a/test/widgets/test_notify.py
+++ b/test/widgets/test_notify.py
@@ -34,7 +34,7 @@ from libqtile.widget import notify
 
 # Bit of a hack... when we log a timer, save the delay in an attribute
 # We'll use this to check message timeouts are being honoured.
-def log_timeout(self, delay, func):
+def log_timeout(self, delay, func, method_args=None):
     self.delay = delay
     self.qtile.call_later(delay, func)
 


### PR DESCRIPTION
This adds action handling to the notifier, which uses the
`ActionInvoked` signal on the notification service. This is bound to
button3 on the Notify widget. This will do things such as take Firefox
to the tab that sent a notification.

This also fixes the `NotificationClosed` signal which needs to return
the values it is passed to work. This signal is emitted when a
notification is closed and tells listeners of the reason, which can be
one of: expired (due to timeout), dismissed (the user cleared it) or
method (it was cleared by the dbus client via the CloseNotification
method). The CloseNotification method is given a basic implementation
whereby code registered with the notifier can pass an on_close callback
to `notifier.register` which will get executed when a dbus client calls
this method.