### PR TITLE
Tidy up dbus dependent widget docs

### DIFF
--- a/libqtile/widget/bluetooth.py
+++ b/libqtile/widget/bluetooth.py
@@ -35,6 +35,10 @@ class Bluetooth(base._TextBox):
     Displays bluetooth status or connected device.
 
     Uses dbus to communicate with the system bus.
+
+    Widget requirements: dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
 
     orientations = base.ORIENTATION_HORIZONTAL

--- a/libqtile/widget/keyboardkbdd.py
+++ b/libqtile/widget/keyboardkbdd.py
@@ -34,6 +34,10 @@ class KeyboardKbdd(base.ThreadPoolText):
 
     kbdd should be installed and running, you can get it from:
     https://github.com/qnikst/kbdd
+
+    The widget also requires dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -33,10 +33,12 @@ class Mpris2(base._TextBox):
     """An MPRIS 2 widget
 
     A widget which displays the current track/artist of your favorite MPRIS
-    player. It should work with all MPRIS 2 compatible players which implement
-    a reasonably correct version of MPRIS, though I have only tested it with
-    audacious.  This widget scrolls the text if neccessary and information that
+    player. This widget scrolls the text if neccessary and information that
     is displayed is configurable.
+
+    Widget requirements: dbus-next_.
+
+    .. _dbus-next: https://pypi.org/project/dbus-next/
     """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [


### PR DESCRIPTION
In advance of the next release, update docstrings for widgets that rely on dbus-next to highlight dependency.