### PR TITLE
simplify base widget call_process method

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -294,9 +294,7 @@ class _Widget(CommandObject, configurable.Configurable):
             and return the string from stdout, which is decoded when using
             Python 3.
         """
-        output = subprocess.check_output(command, **kwargs)
-        output = output.decode()
-        return output
+        return subprocess.check_output(command, **kwargs, encoding="utf-8")
 
     def _wrapper(self, method, *method_args):
         try:


### PR DESCRIPTION
removes unnecessary temp variable and method call
see issue https://github.com/qtile/qtile/issues/2607 