### PR TITLE
Set the default value of json key to False for wttr widget.

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -215,8 +215,8 @@ create your own ``~/.xsession``. There are several examples of user defined
 <https://github.com/qtile/qtile-examples>`_ repository.
 
 If there is no display manager such as SDDM, LightDM or other and there is need
-to start Qtile directly from ``~/.xinitrc`` do that by adding ``exec qtile`` at
-the end.
+to start Qtile directly from ``~/.xinitrc`` do that by adding 
+``exec qtile start`` at the end.
 
 In very special cases, ex. Qtile crashing during session, then suggestion would
 be to start through a loop to save running applications::

--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -78,7 +78,7 @@ class Wttr(GenPollUrl):
     ]
 
     def __init__(self, **config):
-        GenPollUrl.__init__(self, **config)
+        GenPollUrl.__init__(self, json=False, **config)
         self.add_defaults(Wttr.defaults)
         self.url = self._get_url()
 


### PR DESCRIPTION
At the moment, the default value of the json key is `True` and with this value the widget cannot operate correctly without the user setting the json key to `False` in its config. This is not intuitive as the documentation indicates that the default value of this key is `False`.
The first commit set the default value to False for this key.
Originated from : https://groups.google.com/g/qtile-dev/c/ErfiUphv-So

The second commit just corrects a not related typo of the documentation.