### PR TITLE
Revert "Forward unhandled keybindings to client window"

### DIFF
--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -105,8 +105,8 @@ class Keyboard(HasListeners):
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    if self.qtile.process_key_event(keysym, mods):
-                        return
+                    self.qtile.process_key_event(keysym, mods)
+                    return
 
             if self.core.focused_internal:
                 self.core.focused_internal.process_key_press(keysym)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -465,7 +465,7 @@ class Core(base.Core):
                     modmask | amask,
                     code,
                     xcffib.xproto.GrabMode.Async,
-                    xcffib.xproto.GrabMode.Sync,
+                    xcffib.xproto.GrabMode.Async,
                 )
         return keysym, modmask & self._valid_mask
 
@@ -596,22 +596,11 @@ class Core(base.Core):
             except IndexError:
                 logger.info("Invalid Desktop Index: %s" % index)
 
-    def handle_KeyPress(self, event, *, simulated=False) -> None:  # noqa: N802
+    def handle_KeyPress(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 
         keysym = self.conn.code_to_syms[event.detail][0]
-        handled = self.qtile.process_key_event(keysym, event.state & self._valid_mask)
-
-        if simulated:
-            # Simulated key press are currently for internal use only
-            return
-
-        if handled:
-            # Swallow the event
-            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.SyncKeyboard, event.time)
-        else:
-            # Forward the event to any focussed client
-            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayKeyboard, event.time)
+        self.qtile.process_key_event(keysym, event.state & self._valid_mask)
 
     def handle_ButtonPress(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
@@ -747,7 +736,7 @@ class Core(base.Core):
         d = DummyEv()
         d.detail = self.conn.keysym_to_keycode(keysym)[0]
         d.state = modmasks
-        self.handle_KeyPress(d, simulated=True)
+        self.handle_KeyPress(d)
 
     def focus_by_click(self, e, window=None):
         """Bring a window to the front

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -341,13 +341,12 @@ class Qtile(CommandObject):
     ) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(self, keysym: int, mask: int) -> bool:
+    def process_key_event(self, keysym: int, mask: int) -> None:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.info("Ignoring unknown keysym: {keysym}, mask: {mask}".format(keysym=keysym, mask=mask))
-            return False
+            return
 
-        handled = False
         if isinstance(key, KeyChord):
             self.grab_chord(key)
         else:
@@ -358,11 +357,9 @@ class Qtile(CommandObject):
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("KB command error %s: %s" % (cmd.name, val))
-                    handled = True
             if self.chord_stack and (self.chord_stack[-1].mode == "" or key.key == "Escape"):
                 self.cmd_ungrab_chord()
-                handled = True
-        return handled
+            return
 
     def grab_keys(self) -> None:
         """Re-grab all of the keys configured in the key map


### PR DESCRIPTION
This reverts commit 620d12d2d9189e2f76c21a697cd0e1ac60a1dc64, which does
not perfectly handle X keyboard events.