### PR TITLE
Remove rogue comment symbol

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -693,7 +693,7 @@ class Core(base.Core, wlrq.HasListeners):
         return xkb.keysym_from_name(name, case_insensitive=True)
 
     def simulate_keypress(self, modifiers: List[str], key: str) -> None:
-        #"""Simulates a keypress on the focused window."""
+        """Simulates a keypress on the focused window."""
         keysym = xkb.keysym_from_name(key, case_insensitive=True)
         mods = wlrq.translate_masks(modifiers)
 


### PR DESCRIPTION
Comment symbol at the start of docstring needs to be removed.