### PR TITLE
WL: only deactivate previously focussed xdg_surface if it isn't next

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -543,7 +543,8 @@ class Core(base.Core, wlrq.HasListeners):
         if previous_surface is not None and previous_surface.is_xdg_surface:
             # Deactivate the previously focused surface
             previous_xdg_surface = XdgSurface.from_surface(previous_surface)
-            previous_xdg_surface.set_activated(False)
+            if not win or win.surface != previous_xdg_surface:
+                previous_xdg_surface.set_activated(False)
 
         if not win:
             self.seat.keyboard_clear_focus()


### PR DESCRIPTION
Determining when to deactivate the previously focussed xdg_surface is
based on the seat's focussed wlr_surface, so if the next and current
wlr_surfaces differ but belong to the same xdg_surface we end up with a
focussed window with a deactivated xdg_surface. This results in the
'unfocussed look' used by GTK programs, for example, even when focussed.