### PR TITLE
Changed ThermalSensor to use psutil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
                 sudo apt update
                 sudo apt install --no-install-recommends \
                   libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz \
-                  imagemagick libpulse-dev lm-sensors git xserver-xephyr xterm xvfb ninja-build libegl1-mesa-dev \
+                  imagemagick libpulse-dev git xserver-xephyr xterm xvfb ninja-build libegl1-mesa-dev \
                   libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev \
                   dbus-x11 libnotify-bin
                 sudo pip -q install tox tox-gh-actions meson PyGObject

--- a/test/widgets/test_misc.py
+++ b/test/widgets/test_misc.py
@@ -56,22 +56,3 @@ def test_textbox_color_change(manager):
     manager.c.widget["colorchanger"].update('f')
     assert manager.c.widget["colorchanger"].info()["foreground"] == "ff0000"
 
-
-def test_thermalsensor_regex_compatibility():
-    sensors = ThermalSensor()
-    test_sensors_output = """
-    coretemp-isa-0000
-    Adapter: ISA adapter
-    Physical id 0:  +61.0°C  (high = +86.0°C, crit = +100.0°C)
-    Core 0:         +54.0°C  (high = +86.0°C, crit = +100.0°C)
-    Core 1:         +56.0°C  (high = +86.0°C, crit = +100.0°C)
-    Core 2:         +58.0°C  (high = +86.0°C, crit = +100.0°C)
-    Core 3:         +61.0°C  (high = +86.0°C, crit = +100.0°C)
-    """
-    sensors_detected = sensors._format_sensors_output(test_sensors_output)
-    assert sensors_detected["Physical id 0"] == ("61.0", "°C")
-    assert sensors_detected["Core 0"] == ("54.0", "°C")
-    assert sensors_detected["Core 1"] == ("56.0", "°C")
-    assert sensors_detected["Core 2"] == ("58.0", "°C")
-    assert sensors_detected["Core 3"] == ("61.0", "°C")
-    assert not ("Adapter" in sensors_detected.keys())


### PR DESCRIPTION
ThermalSensor widget now uses psutil instead of the sensors command via
subprocess.
This also fixes a bug on gentoo which rendered the widget unusable due
to a utf-8 decoding error.