### PR TITLE
Fix moving bar when screens reconfigured

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -65,6 +65,7 @@ class Gap(CommandObject):
     def _configure(self, qtile, screen):
         self.qtile = qtile
         self.screen = screen
+        self.size = self.initial_size
         # If both horizontal and vertical gaps are present, screen corners are
         # given to the horizontal ones
         if screen.top is self:


### PR DESCRIPTION
Bug where Bar has a defined margin and screen is reconfigured resulting in bar being moved. Issue arises because when a Gap
is reconfigured, the size is adjusted by the margins but these adjustments should be made to the initial size, not the previously
adjusted size.

Fixes #2639