### PR TITLE
Ensure test_check runs on CI

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -428,6 +428,10 @@ class Internal(_Window, metaclass=ABCMeta):
 class Static(_Window, metaclass=ABCMeta):
     """A window bound to a screen rather than a group."""
     screen: config.Screen
+    x: Any
+    y: Any
+    width: Any
+    height: Any
 
     def __repr__(self):
         return "Static(name=%r, wid=%s)" % (self.name, self.wid)

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
     pytest-cov >= 2.10.1
     setuptools >= 40.5.0
     xcffib >= 0.10.1
+    mypy
     bowler
     xkbcommon >= 0.3
     pywayland >= 0.4.4


### PR DESCRIPTION
`test_check` was being skipped because `mypy` was not installed in the test environment. Once `mypy` is installed, there was an error in `backend/base.py` which was identified.

`test_check` takes 5.5 mins to complete on my system. It's slooow! (EDIT: seems to run quicker on CI)

Also, I've probably used the wrong type hinting here but I want to see if the test runs successfully on CI (EDIT: It does!).

Happy to correct the hinting afterwards.