### PR TITLE
Fix cmus crash with unescaped text

### DIFF
--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -17,6 +17,7 @@
 import subprocess
 from functools import partial
 
+from libqtile import pangocffi
 from libqtile.widget import base
 
 
@@ -101,7 +102,7 @@ class Cmus(base.ThreadPoolText):
                     now_playing = title
             if now_playing:
                 now_playing = "♫ {0}".format(now_playing)
-        return now_playing
+        return pangocffi.markup_escape_text(now_playing)
 
     def play(self):
         """Play music if stopped, else toggle pause."""

--- a/test/widgets/test_cmus.py
+++ b/test/widgets/test_cmus.py
@@ -80,6 +80,15 @@ class MockCmusRemoteProcess:
                 "tag title It's Not Unusual",
                 "stream tomjones"
             ],
+            [
+                "status playing",
+                "file /playing/file/always.mp3",
+                "duration 222",
+                "position 14",
+                "tag artist Above & Beyond",
+                "tag album Anjunabeats 14",
+                "tag title Always - Tinlicker Extended Mix"
+            ],
         ]
         cls.index = 0
         cls.is_error = False
@@ -221,3 +230,20 @@ def test_cmus_error_handling(fake_qtile, patched_cmus, fake_window):
     # Widget does nothing with error message so text is blank
     # TODO: update widget to show error?
     assert text == ""
+
+
+def test_escape_text(fake_qtile, patched_cmus, fake_window):
+    widget = patched_cmus.Cmus()
+
+    # Set track to a stopped item
+    MockCmusRemoteProcess.index = 3
+    fakebar = Bar([widget], 24)
+    fakebar.window = fake_window
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = no_op
+    widget._configure(fake_qtile, fakebar)
+    text = widget.poll()
+
+    # It's stopped so colour should reflect this
+    assert text == "♫ Above &amp; Beyond - Always - Tinlicker Extended Mix"


### PR DESCRIPTION
Widget crashes if text contains an ampersand as it is passed directly to `pangocffi.parse_markup` without escaping.

Fixes #2649