### PR TITLE
Fix CI Test errors

### DIFF
--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -26,8 +26,8 @@
 from typing import Any
 
 try:
-    from dbus_next.aio import MessageBus  # type: ignore
-    from dbus_next.service import ServiceInterface  # type: ignore
+    from dbus_next.aio import MessageBus
+    from dbus_next.service import ServiceInterface
     from dbus_next.service import method, signal
     has_dbus = True
 except ImportError:

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -31,9 +31,9 @@ from shutil import which
 from typing import List, Tuple, Union
 
 try:
-    from dbus_next import Message, Variant  # type: ignore
-    from dbus_next.aio import MessageBus  # type: ignore
-    from dbus_next.constants import BusType, MessageType  # type: ignore
+    from dbus_next import Message, Variant
+    from dbus_next.aio import MessageBus
+    from dbus_next.constants import BusType, MessageType
     has_dbus = True
 except ImportError:
     has_dbus = False

--- a/libqtile/widget/bluetooth.py
+++ b/libqtile/widget/bluetooth.py
@@ -18,8 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from dbus_next.aio import MessageBus  # type: ignore
-from dbus_next.constants import BusType  # type: ignore
+from dbus_next.aio import MessageBus
+from dbus_next.constants import BusType
 
 from libqtile.widget import base
 

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from dbus_next.constants import MessageType  # type: ignore
+from dbus_next.constants import MessageType
 
 from libqtile.log_utils import logger
 from libqtile.utils import add_signal_receiver


### PR DESCRIPTION
dbus-next released a new version which is PEP561 compliant meaning we shouldn't be using "# type: ignore" for dbus-next imports.