### PR TITLE
Document font update pitfall

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -163,7 +163,10 @@ configuration variables that control specific aspects of Qtile's behavior:
       - dict(font='sans',
              fontsize=12,
              padding=3)
-      - Default settings for bar widgets.
+      - Default settings for bar widgets.  Note: if the font file
+        associated with the font selected here is modified while Qtile
+        is running, Qtile may segfault (for details see `issue #2656
+        <https://github.com/qtile/qtile/issues/2656>`_).
     * - reconfigure_screens
       - True
       - Controls whether or not to automatically reconfigure screens when there


### PR DESCRIPTION
If a font file associated to a font used by Qtile is updated, Qtile may crash.  The resulting logs might be somewhat confusing.  This commit documents this pitfall in three places, including the default Qtile configuration file so that users are aware of it and can avoid it.

This adresses #2656.