### PR TITLE
Remove quotation marks from docs descriptions

### DIFF
--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -63,7 +63,7 @@ qtile_class_template = Template('''
         {% for key, default, description in defaults %}
         * - ``{{ key }}``
           - ``{{ default }}``
-          - {{ description }}
+          - {{ description[1:-1] }}
         {% endfor %}
     {% endif %}
     {% if commandable %}


### PR DESCRIPTION
There have been several comments about single and double quotation marks in our docs and how it looks a bit untidy (e.g. #1679). This commit removes them.