### PR TITLE
Update shell scripts documentation

### DIFF
--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -121,6 +121,8 @@ specifies the group belonging to the screen that belongs to group "b":
 This amout of connectivity makes it easy to reach out from a given object when
 callbacks and events fire on that object to related objects.
 
+.. _object_graph_keys:
+
 Keys
 ====
 

--- a/docs/manual/commands/shell/qshell.rst
+++ b/docs/manual/commands/shell/qshell.rst
@@ -23,20 +23,53 @@ builtin "cd" and "ls" commands act like their familiar shell counterparts:
     > ls
     layout/  widget/  screen/  bar/     window/  group/
 
-    > cd bar
+    > cd screen
+    layout/  window/  bar/  widget/
 
-    bar> ls
-    bottom/
-
-    bar> cd bottom
-
-    bar['bottom']> ls
-    screen/
-
-    bar['bottom']> cd ../..
+    > cd ..
+    /
 
     > ls
     layout/  widget/  screen/  bar/     window/  group/
+
+If you try to access an object that has no "default" value then you will see an
+error message:
+
+.. code-block:: bash
+
+    > ls
+    layout/  widget/  screen/  bar/     window/  group/
+
+    > cd bar
+    Item required for bar
+
+    > ls bar
+    bar[bottom]/
+
+    > cd bar/bottom
+    bar['bottom']> ls
+    screen/  widget/
+
+Please refer to :ref:`object_graph_keys` for a summary of which objects need a
+specified selector and the type of selector required. Using ``ls`` will show
+which selectors are available for an object. Please see below for an explanation
+about how Qtile displays shell paths.
+
+Alternatively, the ``items()`` command can be run on the parent object to show which
+selectors are available. The first value shows whether a selector is optional
+(``False`` means that a selector is required) and the second value is a list of
+selectors:
+
+.. code-block:: bash
+
+    > ls
+    layout/  widget/  screen/  bar/     window/  group/
+
+    > items(bar)
+    (False, ['bottom'])
+
+Displaying the shell path
+=========================
 
 Note that the shell provides a "short-hand" for specifying node keys (as
 opposed to children). The following is a valid shell path:

--- a/docs/manual/commands/shell/qtile-cmd.rst
+++ b/docs/manual/commands/shell/qtile-cmd.rst
@@ -4,6 +4,51 @@ qtile cmd-obj
 This is a simple tool to expose qtile.command functionality to shell.
 This can be used standalone or in other shell scripts.
 
+How it works
+------------
+
+``qtile cmd-obj`` works by selecting a command object and calling a specified function of that object.
+
+As per :ref:`commands-api`, Qtile's object graph has seven nodes: ``layout``, ``window``, ``group``,
+``bar``, ``widget``, ``screen``, and a special ``root`` node. These are the objects that can be accessed
+via ``qtile cmd-obj`` (NB the root node is called ``cmd`` when using the ``cmd-obj`` script to give it
+an addressable name).
+
+Running the command against a selected object without a function (``-f``) will run the ``help``
+command and list the commands available to the object. Commands shown with an asterisk ("*") require
+arguments to be passed via the ``-a`` flag.
+
+Selecting an object
+~~~~~~~~~~~~~~~~~~~
+
+With the exception of ``cmd``, all objects need an identifier so the correct object can be selected. Refer to
+:ref:`object_graph_keys` for more information.
+
+.. note::
+
+    You will see from the graph on :ref:`commands-api` that certain objects can be accessed from other objects.
+    For example, ``qtile cmd-obj -o group term layout`` will list the commands for the current layout on the
+    ``term`` group.
+
+Information on functions
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Running a function with the ``-i`` flag will provide additional detail about that function (i.e. what it does and what
+arguments it expects).
+
+
+Passing arguments to functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Arguments can be passed to a function by using the ``-a`` flag. For example, to change the label for the group named "1"
+to "A", you would run ``qtile cmd-obj -o group 1 -f set_label -a A``.
+
+.. warning::
+
+    It is not currently possible to pass non-string arguments to functions via ``qtile cmd-obj``. Doing so will
+    result in an error.
+
+
 Examples:
 ---------
 
@@ -35,6 +80,8 @@ Output of ``qtile cmd-obj -h``
      qtile cmd-obj -o cmd -f prev_layout -i
      qtile cmd-obj -o cmd -f prev_layout -a 3 # prev_layout on group 3
      qtile cmd-obj -o group 3 -f focus_back
+     qtile cmd-obj -o widget textbox -f update -a "New text"
+     qtile cmd-obj -o cmd -f restart # restart qtile
 
 Output of ``qtile cmd-obj -o group 3``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/manual/commands/shell/qtile-top.rst
+++ b/docs/manual/commands/shell/qtile-top.rst
@@ -2,4 +2,16 @@
 qtile top
 =========
 
-Is a top like to measure memory usage of Qtile's internals.
+``qtile top`` is a ``top``-like tool to measure memory usage of Qtile's internals.
+
+.. note::
+
+  To use ``qtile shell`` you need to have ``tracemalloc`` enabled. You can do this by
+  setting the environmental variable ``PYTHONTRACEMALLOC=1`` before starting qtile.
+  Alternatively, you can force start ``tracemalloc`` but you will lose early traces:
+
+  .. code-block::
+
+    >>> from libqtile.command.client import InteractiveCommandClient
+    >>> i=InteractiveCommandClient()
+    >>> i.eval("import tracemalloc;tracemalloc.start()")

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -162,7 +162,14 @@ def cmd_obj(args) -> None:
         obj = get_object(cmd_client, args.obj_spec)
 
         if args.function == "help":
-            print_commands("-o " + " ".join(args.obj_spec), obj)
+            try:
+                print_commands("-o " + " ".join(args.obj_spec), obj)
+            except CommandError:
+                if len(args.obj_spec) == 1:
+                    print(f"{args.obj_spec} object needs a specified identifier e.g. '-o bar top'.")
+                    sys.exit(1)
+                else:
+                    raise
         elif args.info:
             print(args.function + get_formated_info(obj, args.function, args=True, short=False))
         else:


### PR DESCRIPTION
It seems people are unclear how to use `cmd-obj`. This commit adds more detail to the documentation and provides some better error handling where object identifiers are missing.

Would appreciate a review of this to make sure I've understood it correctly.

I've also edited the documentation for `qtile shell` and `qtile top`