### PR TITLE
Extend Object Graph

### DIFF
--- a/docs/_static/diagrams/object-graph-orig.dot
+++ b/docs/_static/diagrams/object-graph-orig.dot
@@ -32,6 +32,7 @@ digraph G {
     root -> window;
 
     bar -> screen;
+    bar -> widget;
 
     group -> layout;
     group -> screen;
@@ -44,6 +45,7 @@ digraph G {
     screen -> bar;
     screen -> layout;
     screen -> window;
+    screen -> widget;
 
     widget -> bar;
     widget -> group;

--- a/docs/_static/diagrams/object-graph-orig.dot
+++ b/docs/_static/diagrams/object-graph-orig.dot
@@ -35,7 +35,7 @@ digraph G {
     bar -> widget [dir=both];
 
     group -> layout [dir=both];
-    group -> screen;
+    group -> screen [dir=both];
     group -> window [dir=both];
 
     layout -> screen [dir=both];

--- a/docs/_static/diagrams/object-graph-orig.dot
+++ b/docs/_static/diagrams/object-graph-orig.dot
@@ -43,6 +43,4 @@ digraph G {
 
     screen -> window [dir=both];
     screen -> widget [dir=both];
-
-    widget -> group;
 }

--- a/docs/_static/diagrams/object-graph-orig.dot
+++ b/docs/_static/diagrams/object-graph-orig.dot
@@ -31,27 +31,18 @@ digraph G {
     root -> widget;
     root -> window;
 
-    bar -> screen;
-    bar -> widget;
+    bar -> screen [dir=both];
+    bar -> widget [dir=both];
 
-    group -> layout;
+    group -> layout [dir=both];
     group -> screen;
-    group -> window;
+    group -> window [dir=both];
 
-    layout -> group;
-    layout -> screen;
-    layout -> window;
+    layout -> screen [dir=both];
+    layout -> window [dir=both];
 
-    screen -> bar;
-    screen -> layout;
-    screen -> window;
-    screen -> widget;
+    screen -> window [dir=both];
+    screen -> widget [dir=both];
 
-    widget -> bar;
     widget -> group;
-    widget -> screen;
-
-    window -> group;
-    window -> screen;
-    window -> layout;
 }

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -291,6 +291,22 @@ class Bar(Gap, configurable.Configurable):
             self.widgets.insert(index, crash)
             self.widgets.remove(i)
 
+    def _items(self, name: str) -> ItemT:
+        if name == "screen" and self.screen is not None:
+            return True, []
+        elif name == "widget" and self.widgets:
+            return False, [w.name for w in self.widgets]
+        return None
+
+    def _select(self, name, sel):
+        if name == "screen":
+            return self.screen
+        elif name == "widget":
+            for widget in self.widgets:
+                if widget.name == sel:
+                    return widget
+        return None
+
     def finalize(self):
         self.drawer.finalize()
 

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -270,6 +270,11 @@ def _normalize_item(object_type: Optional[str], item: str) -> Union[str, int]:
     if object_type in ["group", "widget", "bar"]:
         return str(item)
     elif object_type in ["layout", "window", "screen"]:
-        return int(item)
+        try:
+            return int(item)
+        except ValueError:
+            # A value error could arise because the next selector has been passed
+            raise SelectError(f"Unexpected index {item}. Is this an object_type?",
+                              str(object_type), [(str(object_type), str(item))])
     else:
         return item

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -193,7 +193,7 @@ class _ScreenGraphNode(CommandGraphObject):
 
 class _WidgetGraphNode(CommandGraphObject):
     object_type = "widget"
-    children = ["bar", "screen", "group"]
+    children = ["bar", "screen"]
 
 
 class _WindowGraphNode(CommandGraphObject):

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -173,7 +173,7 @@ class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
 
 class _BarGraphNode(CommandGraphObject):
     object_type = "bar"
-    children = ["screen"]
+    children = ["screen", "widget"]
 
 
 class _GroupGraphNode(CommandGraphObject):
@@ -188,7 +188,7 @@ class _LayoutGraphNode(CommandGraphObject):
 
 class _ScreenGraphNode(CommandGraphObject):
     object_type = "screen"
-    children = ["layout", "window", "bar"]
+    children = ["layout", "window", "bar", "widget"]
 
 
 class _WidgetGraphNode(CommandGraphObject):

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -188,7 +188,7 @@ class _LayoutGraphNode(CommandGraphObject):
 
 class _ScreenGraphNode(CommandGraphObject):
     object_type = "screen"
-    children = ["layout", "window", "bar", "widget"]
+    children = ["layout", "window", "bar", "widget", "group"]
 
 
 class _WidgetGraphNode(CommandGraphObject):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -391,6 +391,8 @@ class Screen(CommandObject):
             return False, [x.position for x in self.gaps]
         elif name == "widget":
             return False, [w.name for g in self.gaps for w in g.widgets if isinstance(g, Bar)]
+        elif name == "group":
+            return True, [self.group.name]
         return None
 
     def _select(self, name, sel):
@@ -415,6 +417,11 @@ class Screen(CommandObject):
                 for widget in gap.widgets:
                     if widget.name == sel:
                         return widget
+        elif name == "group":
+            if sel is None:
+                return self.group
+            else:
+                return self.group if sel == self.group.name else None
 
     def resize(self, x=None, y=None, w=None, h=None):
         if x is None:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
-from libqtile.bar import BarType
+from libqtile.bar import Bar, BarType
 from libqtile.command.base import CommandObject, ItemT
 
 if TYPE_CHECKING:
@@ -389,6 +389,8 @@ class Screen(CommandObject):
             return True, [i.wid for i in self.group.windows]
         elif name == "bar":
             return False, [x.position for x in self.gaps]
+        elif name == "widget":
+            return False, [w.name for g in self.gaps for w in g.widgets if isinstance(g, Bar)]
         return None
 
     def _select(self, name, sel):
@@ -406,6 +408,13 @@ class Screen(CommandObject):
                         return i
         elif name == "bar":
             return getattr(self, sel)
+        elif name == "widget":
+            for gap in self.gaps:
+                if not isinstance(gap, Bar):
+                    continue
+                for widget in gap.widgets:
+                    if widget.name == sel:
+                        return widget
 
     def resize(self, x=None, y=None, w=None, h=None):
         if x is None:

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -251,11 +251,15 @@ class _Widget(CommandObject, configurable.Configurable):
     def _items(self, name: str) -> ItemT:
         if name == "bar":
             return True, []
+        elif name == "screen":
+            return True, []
         return None
 
     def _select(self, name, sel):
         if name == "bar":
             return self.bar
+        elif name == "screen":
+            return self.bar.screen
 
     def cmd_info(self):
         """

--- a/test/test_command_graph.py
+++ b/test/test_command_graph.py
@@ -31,7 +31,7 @@ def test_resolve_nodes():
     assert isinstance(node_2, CommandGraphObject)
 
     with pytest.raises(KeyError, match="Given node is not an object"):
-        node_1.navigate("widget", None)
+        node_1.navigate("group", None)
 
 
 def test_resolve_selections():

--- a/test/test_command_graph.py
+++ b/test/test_command_graph.py
@@ -31,7 +31,7 @@ def test_resolve_nodes():
     assert isinstance(node_2, CommandGraphObject)
 
     with pytest.raises(KeyError, match="Given node is not an object"):
-        node_1.navigate("group", None)
+        node_1.navigate("root", None)
 
 
 def test_resolve_selections():

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -74,7 +74,7 @@ def test_ls(manager):
 
     assert sh.do_cd("layout") == "layout"
     assert sh.do_ls(None) == "group/   window/  screen/"
-    assert sh.do_ls("screen") == "screen/layout/  screen/window/  screen/bar/     screen/widget/"
+    assert sh.do_ls("screen") == "screen/layout/  screen/window/  screen/bar/     screen/widget/  screen/group/ "
 
 
 @sh_config

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -74,7 +74,7 @@ def test_ls(manager):
 
     assert sh.do_cd("layout") == "layout"
     assert sh.do_ls(None) == "group/   window/  screen/"
-    assert sh.do_ls("screen") == "screen/layout/  screen/window/  screen/bar/   "
+    assert sh.do_ls("screen") == "screen/layout/  screen/window/  screen/bar/     screen/widget/"
 
 
 @sh_config


### PR DESCRIPTION
This commit allows you to select widgets from the parent `Bar` or `Screen` object i.e. show widgets in a selected `Bar` or on a selected `Screen` (which could contain multiple `Bar`s).

It never made sense to me that you couldn't access the widgets from their parents. 

I also wasted a good 45 mins re-drawing the object graph diagram for the docs and then saw that it's generated automatically!

I should add a test for this...