### PR TITLE
Clean log generated by cmus widget.

### DIFF
--- a/libqtile/widget/caps_num_lock_indicator.py
+++ b/libqtile/widget/caps_num_lock_indicator.py
@@ -40,7 +40,7 @@ class CapsNumLockIndicator(base.ThreadPoolText):
         try:
             output = self.call_process(['xset', 'q'])
         except subprocess.CalledProcessError as err:
-            output = err.output.decode()
+            output = err.output
         if output.startswith("Keyboard"):
             indicators = re.findall(r"(Caps|Num)\s+Lock:\s*(\w*)", output)
             return indicators

--- a/libqtile/widget/caps_num_lock_indicator.py
+++ b/libqtile/widget/caps_num_lock_indicator.py
@@ -41,6 +41,7 @@ class CapsNumLockIndicator(base.ThreadPoolText):
             output = self.call_process(['xset', 'q'])
         except subprocess.CalledProcessError as err:
             output = err.output
+            return []
         if output.startswith("Keyboard"):
             indicators = re.findall(r"(Caps|Num)\s+Lock:\s*(\w*)", output)
             return indicators

--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -57,7 +57,7 @@ class Cmus(base.ThreadPoolText):
         try:
             output = self.call_process(['cmus-remote', '-C', 'status'])
         except subprocess.CalledProcessError as err:
-            output = err.output.decode()
+            output = err.output
         if output.startswith("status"):
             output = output.splitlines()
             info = {'status': "",

--- a/libqtile/widget/moc.py
+++ b/libqtile/widget/moc.py
@@ -57,7 +57,7 @@ class Moc(base.ThreadPoolText):
         try:
             output = self.call_process(['mocp', '-i'])
         except subprocess.CalledProcessError as err:
-            output = err.output.decode()
+            output = err.output
         if output.startswith("State"):
             output = output.splitlines()
             info = {'State': "",

--- a/test/widgets/test_caps_num_lock_indicator.py
+++ b/test/widgets/test_caps_num_lock_indicator.py
@@ -1,0 +1,134 @@
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Widget specific tests
+
+import subprocess
+from typing import List
+
+import pytest
+
+from libqtile.bar import Bar
+from libqtile.widget import caps_num_lock_indicator
+
+
+class MockCapsNumLockIndicator:
+    CalledProcessError = None
+
+    info: List[List[str]] = []
+    is_error = False
+    index = 0
+
+    @classmethod
+    def reset(cls):
+        cls.info = [
+            [
+                "Keyboard Control:",
+                "  auto repeat:  on    key click percent:  0    LED mask:  00000002",
+                "  XKB indicators:",
+                "    00: Caps Lock:   off    01: Num Lock:    on     02: Scroll Lock: off",
+                "    03: Compose:     off    04: Kana:        off    05: Sleep:       off",
+            ],
+            [
+                "Keyboard Control:",
+                "  auto repeat:  on    key click percent:  0    LED mask:  00000002",
+                "  XKB indicators:",
+                "    00: Caps Lock:   on     01: Num Lock:    on     02: Scroll Lock: off",
+                "    03: Compose:     off    04: Kana:        off    05: Sleep:       off",
+            ],
+        ]
+        cls.index = 0
+        cls.is_error = False
+
+    @classmethod
+    def call_process(cls, cmd):
+        if cls.is_error:
+            raise subprocess.CalledProcessError(
+                -1,
+                cmd=cmd,
+                output="Couldn't call xset."
+            )
+
+        if cmd[1:] == ["q"]:
+            track = cls.info[cls.index]
+            output = "\n".join(track)
+            return output
+
+
+def no_op(*args, **kwargs):
+    pass
+
+
+@pytest.fixture
+def patched_cnli(monkeypatch):
+    MockCapsNumLockIndicator.reset()
+    monkeypatch.setattr("libqtile.widget.caps_num_lock_indicator.subprocess", MockCapsNumLockIndicator)
+    monkeypatch.setattr("libqtile.widget.caps_num_lock_indicator.subprocess.CalledProcessError",
+                        subprocess.CalledProcessError)
+
+    monkeypatch.setattr("libqtile.widget.caps_num_lock_indicator.base.ThreadPoolText.call_process",
+                        MockCapsNumLockIndicator.call_process)
+    return caps_num_lock_indicator
+
+
+def test_cnli(fake_qtile, patched_cnli, fake_window):
+    widget = patched_cnli.CapsNumLockIndicator()
+    fakebar = Bar([widget], 24)
+    fakebar.window = fake_window
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = no_op
+    widget._configure(fake_qtile, fakebar)
+    text = widget.poll()
+
+    assert text == "Caps off Num on"
+
+
+def test_cnli_caps_on(fake_qtile, patched_cnli, fake_window):
+    widget = patched_cnli.CapsNumLockIndicator()
+
+    # Simulate Caps on
+    MockCapsNumLockIndicator.index = 1
+
+    fakebar = Bar([widget], 24)
+    fakebar.window = fake_window
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = no_op
+    widget._configure(fake_qtile, fakebar)
+    text = widget.poll()
+
+    assert text == "Caps on Num on"
+
+
+def test_cnli_error_handling(fake_qtile, patched_cnli, fake_window):
+    widget = patched_cnli.CapsNumLockIndicator()
+
+    # Simulate a CalledProcessError exception
+    MockCapsNumLockIndicator.is_error = True
+
+    fakebar = Bar([widget], 24)
+    fakebar.window = fake_window
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = no_op
+    widget._configure(fake_qtile, fakebar)
+    text = widget.poll()
+
+    # Widget does nothing with error message so text is blank
+    assert text == ""

--- a/test/widgets/test_cmus.py
+++ b/test/widgets/test_cmus.py
@@ -99,7 +99,7 @@ class MockCmusRemoteProcess:
             raise subprocess.CalledProcessError(
                 -1,
                 cmd=cmd,
-                output=b"Couldn't connet to cmus"
+                output="Couldn't connect to cmus."
             )
 
         if cmd[1:] == ["-C", "status"]:

--- a/test/widgets/test_moc.py
+++ b/test/widgets/test_moc.py
@@ -64,7 +64,11 @@ class MockMocpProcess:
     @classmethod
     def run(cls, cmd):
         if cls.is_error:
-            subprocess.call(["exit", "1"])
+            raise subprocess.CalledProcessError(
+                -1,
+                cmd=cmd,
+                output="Couldn't connect to moc."
+            )
 
         arg = cmd[1]
 
@@ -185,3 +189,9 @@ def test_moc_button_presses(manager_nospawn, minimal_conf_noscreen, monkeypatch)
     topbar.fake_button_press(0, "top", 0, 0, button=5)
     manager_nospawn.c.widget["moc"].eval("self.update(self.poll())")
     assert info()["text"] == "♫ Neil Diamond - Sweet Caroline"
+
+
+def test_moc_error_handling(patched_moc):
+    MockMocpProcess.is_error = True
+    # Widget does nothing with error message so text is blank
+    assert patched_moc.poll() == ""


### PR DESCRIPTION
Since 5f7e1436, the cmus widget pollutes my log when cmus is not running.
This PR adapts the widget and its test to the subprocess.CalledProcessError.output type induced by this commit.

Snippet of log generated :
```
2021-08-21 17:26:00,935 ERROR libqtile base.py:on_done():L553 poll() raised exceptions, not rescheduling
Traceback (most recent call last):
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/cmus.py", line 58, in get_info
    output = self.call_process(['cmus-remote', '-C', 'status'])
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/base.py", line 301, in call_process
    return subprocess.check_output(command, **kwargs, encoding="utf-8")
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['cmus-remote', '-C', 'status']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/base.py", line 550, in on_done
    result = future.result()
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/cmus.py", line 116, in poll
    return self.now_playing()
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/cmus.py", line 83, in now_playing
    info = self.get_info()
  File "/home/bernard/.local/lib/python3.9/site-packages/qtile-0.18.1.dev92+g6f5581eb-py3.9-linux-x86_64.egg/libqtile/widget/cmus.py", line 60, in get_info
    output = err.output.decode()
AttributeError: 'str' object has no attribute 'decode'
2021-08-21 17:26:00,936 WARNING libqtile base.py:on_done():L567 poll() returned None, not rescheduling
```