### PR TITLE
x11: Do not set straight-to-Static window geometry to 0

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1108,10 +1108,11 @@ class Static(_Window, base.Static):
         y = y or 0
         self.x = x + screen.x
         self.y = y + screen.y
-        self.width = width or 0
-        self.height = height or 0
+        self.width = width or 200
+        self.height = height or 200
         self.screen = screen
         self.place(self.x, self.y, self.width, self.height, 0, 0)
+        self.unhide()
         self.update_strut()
 
         # Grab button 1 to focus upon click


### PR DESCRIPTION
If a newly created window gets `cmd_static`-ed right away (due to having
the dock window type), it might not have its width and height set yet,
and so we configure it with placeholder values of 0. This results in an
X protocol value error. Instead we should fall back to non-zero values.
I've put 200 for width and height which seems reasonable. The window
should then set its own geometry after mapping in that case.

Also - static windows created in this way need to unhide themselves, so
that's added too.