### PR TITLE
x11: Don't re-set static window geometry if not passed to cmd_static

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1104,14 +1104,12 @@ class Static(_Window, base.Static):
         self.conf_y = y
         self.conf_width = width
         self.conf_height = height
-        x = x or 0
-        y = y or 0
+        x = x or self.x
+        y = y or self.y
         self.x = x + screen.x
         self.y = y + screen.y
-        self.width = width or 200
-        self.height = height or 200
         self.screen = screen
-        self.place(self.x, self.y, self.width, self.height, 0, 0)
+        self.place(self.x, self.y, width or self.width, height or self.height, 0, 0)
         self.unhide()
         self.update_strut()
 


### PR DESCRIPTION
Currently `Static.__init__` sets, again, `self.width` and
`self.height`. These are set initially by `_Window.__init__` so lets
keep those original values if the values passed to `Static.__init__`
from `cmd_static` are `None`.

Fixes #2642