### PR TITLE
Notify using asyncio.run() if event loop is not running, fixes #2620

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -245,7 +245,11 @@ def send_notification(title, message, urgent=False, timeout=10000, id=None):
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        logger.warning("Eventloop has not started. Cannot send notification.")
+        """
+        If event loop is not already running,
+        let asyncio.run() handle the task instead of just throwing warning
+        """
+        asyncio.run(_notify(title, message, urgency, timeout, id))
     else:
         loop.create_task(_notify(title, message, urgency, timeout, id))
 


### PR DESCRIPTION
In send notification function, instead of just throwing warning that event loop is not running, use asyncio.run() to send the notification.