### PR TITLE
Fix path to window class in Clipboard widget.

### DIFF
--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -66,7 +66,7 @@ class Clipboard(base._TextBox):
         if owner_id in self.qtile.windows_map:
             owner = self.qtile.windows_map[owner_id].window
         else:
-            owner = xcbq.Window(self.qtile.core.conn, owner_id)
+            owner = xcbq.window.XWindow(self.qtile.core.conn, owner_id)
 
         owner_class = owner.get_wm_class()
         if owner_class:


### PR DESCRIPTION
Since bdd73d08, the window class has moved and the XWindow class has
been created. This commit allows the use of Clipboard widget on x11 backend
by adapting the path to the class accordingly.

Fix #2696.