### PR TITLE
Make eventloop accessible to threads

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -48,7 +48,7 @@ from libqtile.config import Click, Drag, Key, KeyChord, Match, Rule
 from libqtile.config import ScratchPad as ScratchPadConfig
 from libqtile.config import Screen
 from libqtile.core.lifecycle import lifecycle
-from libqtile.core.loop import LoopContext
+from libqtile.core.loop import LoopContext, QtileEventLoopPolicy
 from libqtile.core.state import QtileState
 from libqtile.dgroups import DGroups
 from libqtile.extension.base import _Extension
@@ -215,6 +215,8 @@ class Qtile(CommandObject):
         Finalizes the Qtile instance on exit.
         """
         self._eventloop = asyncio.get_running_loop()
+        # Set the event loop policy to facilitate access to main event loop
+        asyncio.set_event_loop_policy(QtileEventLoopPolicy(self))
         self._stopped_event = asyncio.Event()
         self.core.setup_listener(self)
         try:

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -243,7 +243,7 @@ def send_notification(title, message, urgent=False, timeout=10000, id=None):
     urgency = 2 if urgent else 1
 
     try:
-        loop = asyncio.get_running_loop()
+        loop = asyncio.get_event_loop()
     except RuntimeError:
         logger.warning("Eventloop has not started. Cannot send notification.")
     else:


### PR DESCRIPTION
Issue #2620 identified a problem where calls to `asyncio.get_running_loop()` would fail if the call is not made from the parent thread.

This PR implements an asyncio event loop policy which will return `qtile._eventloop` whenever `asyncio.get_event_loop()` is called.

Fixes #2620