### PR TITLE
WL: let wlroots internal signals destroy resources

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -183,17 +183,7 @@ class Core(base.Core, wlrq.HasListeners):
         return "wayland"
 
     def finalize(self):
-        for kb in self.keyboards:
-            kb.finalize()
-        for out in self.outputs:
-            out.finalize()
-
         self.finalize_listeners()
-        self.cursor_manager.destroy()
-        self.cursor.destroy()
-        self.output_layout.destroy()
-        self.seat.destroy()
-        self.backend.destroy()
         self.display.destroy()
         self.qtile = None
 

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -62,12 +62,6 @@ class Keyboard(HasListeners):
         self.add_listener(self.keyboard.key_event, self._on_key)
         self.add_listener(self.keyboard.destroy_event, self._on_destroy)
 
-    def finalize(self):
-        self.finalize_listeners()
-        self.core.keyboards.remove(self)
-        if self.core.keyboards and self.core.seat.keyboard.destroyed:
-            self.seat.set_keyboard(self.core.keyboards[-1].device)
-
     def set_keymap(
         self, layout: Optional[str], options: Optional[str], variant: Optional[str]
     ) -> None:
@@ -87,7 +81,10 @@ class Keyboard(HasListeners):
 
     def _on_destroy(self, _listener, _data):
         logger.debug("Signal: keyboard destroy")
-        self.finalize()
+        self.finalize_listeners()
+        self.core.keyboards.remove(self)
+        if self.core.keyboards and self.core.seat.keyboard.destroyed:
+            self.seat.set_keyboard(self.core.keyboards[-1].device)
 
     def _on_modifier(self, _listener, _data):
         self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -77,10 +77,6 @@ class Output(HasListeners):
                 wlr_output.set_custom_mode(640, 480, 0)
             wlr_output.commit()
 
-    def finalize(self):
-        self.core.outputs.remove(self)
-        self.finalize_listeners()
-
     @property
     def screen(self) -> Screen:
         assert self.core.qtile is not None
@@ -93,7 +89,8 @@ class Output(HasListeners):
 
     def _on_destroy(self, _listener, _data):
         logger.debug("Signal: output destroy")
-        self.finalize()
+        self.core.outputs.remove(self)
+        self.finalize_listeners()
 
     def _on_frame(self, _listener, _data):
         wlr_output = self.wlr_output


### PR DESCRIPTION
Many wlroots managers used by the wayland `Core` respond to destruction
of the display so let's let them handle destruction themselves. This
results in a cleaner shutdown.

Seems we're still getting a segfault right at the end of shutdown though.