### PR TITLE
Store windows in list instead of set

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -44,7 +44,7 @@ class _Group(CommandObject):
         self.name = name
         self.label = name if label is None else label
         self.custom_layout = layout  # will be set on _configure
-        self.windows = set()
+        self.windows = []
         self.qtile = None
         self.layouts = []
         self.floating_layout = None
@@ -61,7 +61,7 @@ class _Group(CommandObject):
         self.screen = None
         self.current_layout = 0
         self.focus_history = []
-        self.windows = set()
+        self.windows = []
         self.qtile = qtile
         self.layouts = [i.clone(self) for i in layouts]
         self.floating_layout = floating_layout
@@ -235,7 +235,8 @@ class _Group(CommandObject):
 
     def add(self, win, focus=True, force=False):
         hook.fire("group_window_add", self, win)
-        self.windows.add(win)
+        if win not in self.windows:
+            self.windows.append(win)
         win.group = self
         if self.qtile.config.auto_fullscreen and win.wants_to_fullscreen:
             win._float_state = FloatStates.FULLSCREEN

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2011 Florian Mounier
+# Copyright (c) 2012, 2014 Tycho Andersen
+# Copyright (c) 2013 Craig Barnes
+# Copyright (c) 2014 Sean Vig
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import random
+import pytest
+import libqtile.config
+from libqtile import layout
+from libqtile.confreader import Config
+
+class GroupConfig(Config):
+    auto_fullscreen = True
+    groups = [
+        libqtile.config.Group("a")
+    ]
+    layouts = [
+        layout.Max()
+    ]
+    floating_layout = libqtile.resources.default_config.floating_layout
+    keys = []
+    mouse = []
+    screens = []
+
+
+group_config = pytest.mark.parametrize("manager", [GroupConfig], indirect=True)
+
+
+@group_config
+def test_window_order(manager):
+    # windows to add
+    windows_name = ["one","two","three","four","five","six","seven","eight","nine","ten"]
+    windows = {}
+
+    # Add windows one by one
+    for win in windows_name:
+        windows[win] = manager.test_window(win)
+
+    # Winmust be sotred in the same order as they were created
+    assert windows_name == manager.c.group.info()["windows"]
+
+    # Randomly remove 5 windows and see if orders remains persistant
+    for i in range(5):
+        win_to_remove = random.choice(windows_name)
+        windows_name.remove(win_to_remove)
+        manager.kill_window(windows[win_to_remove])
+        del windows[win_to_remove]
+        assert windows_name == manager.c.group.info()["windows"]


### PR DESCRIPTION
Since set is unordered, output of TaskList like widget was unpredictable.
So, keeping windows in list keeps them in order by which they are created.

Output of TaskList Before the fix:
window 4 | window 1 | window 3|  window 2 |
After the fix:
window 1 | window 2 | window 3 | window 4 |

Fixes #1541