### PR TITLE
Allow KeyChord mode names without staying in mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
           (which were ignored previously), remove them.
         - If you have a custom startup Python script that you use instead of `qtile start` and run init_log
           manually, the signature has changed. Please check the source for the updated arguments.
+        - `KeyChord`'s signature has changed. ``mode`` is now a boolean to indicate whether the mode should persist.
+          The ``name`` parameter should be used to name the chord (e.g. for the ``Chord`` widget).
     * features
         - Add ability to draw borders and add margins to the `Max` layout.
         - The default XWayland cursor is now set at startup to left_ptr, so an xsetroot call is not needed to

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -98,8 +98,8 @@ The above code will launch xterm when the user presses Mod + z, followed by x.
 Modes
 -----
 
-Chords can optionally specify a "mode". When this is done, the mode will remain
-active until the user presses <escape>. This can be useful for configuring a
+Chords can optionally persist until a user presses <escape>. This can be done
+by setting ``mode=True``. This can be useful for configuring a
 subset of commands for a particular situations (i.e. similar to vim modes).
 
 ::
@@ -112,7 +112,8 @@ subset of commands for a particular situations (i.e. similar to vim modes).
             Key([], "s", lazy.layout.shrink()),
             Key([], "n", lazy.layout.normalize()),
             Key([], "m", lazy.layout.maximize())],
-            mode="Windows"
+            mode=True,
+            name="Windows"
         )
     ]
 
@@ -121,9 +122,10 @@ then resize windows by just pressing g (to grow the window), s to
 shrink it etc. as many times as needed. To exit the mode, press <escape>.
 
 .. note::
-    If using modes, users may also wish to use the Chord widget
-    (:class:`~libqtile.widget.Chord`) as this will display the name of the
-    currently active mode on the bar.
+    The Chord widget (:class:`~libqtile.widget.Chord`) will display the name
+    of the active chord (as set by the ``name`` parameter). This is particularly
+    useful where the chord is a persistent mode as this will indicate when the
+    chord's mode is still active.
 
 Chains
 ------
@@ -154,9 +156,9 @@ demonstrates the behaviour when using the ``mode`` argument in chains:
             KeyChord([], "y", [
                 KeyChord([], "x", [
                     Key([], "c", lazy.spawn("xterm"))
-                ], mode="inner")
+                ], mode=True, name="inner")
             ])
-        ], mode="outer")
+        ], mode=True, name="outer")
     ]
 
 After pressing Mod+z y x c, the "inner" mode will remain active. When pressing

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from libqtile import configurable, hook, utils
 from libqtile.bar import Bar
 from libqtile.command.base import CommandObject
+from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
     from typing import Any, Callable, ContextManager, Iterable
@@ -93,10 +94,12 @@ class KeyChord:
     submappings:
         A list of :class:`Key` or :class:`KeyChord` declarations to bind in this chord.
     mode:
-        A string with Vim-like mode name. If set, the chord mode will not be left after
-        a keystroke (except for Esc which always leaves the current chord/mode).
-        (Optional)
-
+        Boolean. Setting to ``True`` will result in the chord persisting until
+        Escape is pressed. Setting to ``False`` (default) will exit the chord once
+        the sequence has ended.
+    name:
+        A string to name the chord. The name will be displayed in the Chord
+        widget.
     """
 
     def __init__(
@@ -104,14 +107,26 @@ class KeyChord:
         modifiers: list[str],
         key: str,
         submappings: list[Key | KeyChord],
-        mode: str = "",
-    ) -> None:
+        mode: bool | str = False,
+        name: str = "",
+    ):
         self.modifiers = modifiers
         self.key = key
 
         submappings.append(Key([], "Escape"))
         self.submappings = submappings
         self.mode = mode
+        self.name = name
+
+        if isinstance(mode, str):
+            logger.warning(
+                "The use of `mode` to set the KeyChord name is deprecated. "
+                "Please use `name='%s'` instead. "
+                "'mode' should be a boolean value to set whether the chord is persistent (True) or not.",
+                mode,
+            )
+            self.name = mode
+            self.mode = True
 
     def __repr__(self) -> str:
         return "<KeyChord (%s, %s)>" % (self.modifiers, self.key)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -394,7 +394,7 @@ class Qtile(CommandObject):
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("KB command error %s: %s", cmd.name, val)
-            if self.chord_stack and (self.chord_stack[-1].mode == "" or key.key == "Escape"):
+            if self.chord_stack and (not self.chord_stack[-1].mode or key.key == "Escape"):
                 self.cmd_ungrab_chord()
             return
 
@@ -425,7 +425,7 @@ class Qtile(CommandObject):
     def grab_chord(self, chord: KeyChord) -> None:
         self.chord_stack.append(chord)
         if self.chord_stack:
-            hook.fire("enter_chord", chord.mode)
+            hook.fire("enter_chord", chord.name)
 
         self.ungrab_keys()
         for key in chord.submappings:
@@ -990,11 +990,11 @@ class Qtile(CommandObject):
                 )
                 return
             if isinstance(k, KeyChord):
-                new_mode_s = k.mode if k.mode else "<unnamed>"
+                new_mode_s = k.name if k.name else "<unnamed>"
                 new_mode = (
-                    k.mode
+                    k.name
                     if mode == "<root>"
-                    else "{}>{}".format(mode, k.mode if k.mode else "_")
+                    else "{}>{}".format(mode, k.name if k.name else "_")
                 )
                 rows.append([mode, name, modifiers, "", "Enter {:s} mode".format(new_mode_s)])
                 for s in k.submappings:

--- a/test/widgets/test_chord.py
+++ b/test/widgets/test_chord.py
@@ -1,4 +1,29 @@
+# Copyright (c) 2020 Tycho Andersen
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.confreader
 from libqtile import hook
+from libqtile.config import Key, KeyChord
+from libqtile.lazy import lazy
 from libqtile.widget import Chord, base
 from test.widgets.conftest import FakeBar
 
@@ -8,6 +33,42 @@ BLUE = "#00FF00"
 textbox = base._TextBox("")
 BASE_BACKGROUND = textbox.background
 BASE_FOREGROUND = textbox.foreground
+
+
+def no_op(*args):
+    pass
+
+
+class ChordConf(libqtile.confreader.Config):
+    auto_fullscreen = False
+    keys = [
+        KeyChord([], "a", [Key([], "b", lazy.function(no_op))], mode="persistent_chord"),
+        KeyChord(
+            [],
+            "z",
+            [
+                Key([], "b", lazy.function(no_op)),
+            ],
+            name="temporary_name",
+        ),
+        KeyChord(
+            [],
+            "y",
+            [
+                Key([], "b", lazy.function(no_op)),
+            ],
+            name="mode_true",
+            mode=True,
+        ),
+    ]
+    mouse = []
+    groups = [libqtile.config.Group("a"), libqtile.config.Group("b")]
+    layouts = [libqtile.layout.stack.Stack(num_stacks=1)]
+    floating_layout = libqtile.resources.default_config.floating_layout
+    screens = [libqtile.config.Screen(top=libqtile.bar.Bar([Chord()], 10))]
+
+
+chord_config = pytest.mark.parametrize("manager", [ChordConf], indirect=True)
 
 
 def test_chord_widget(fake_window, fake_qtile):
@@ -33,7 +94,7 @@ def test_chord_widget(fake_window, fake_qtile):
     assert chord.foreground == BASE_FOREGROUND
 
     # Unnamed chord so no text
-    hook.fire("enter_chord", True)
+    hook.fire("enter_chord", "")
     assert chord.text == ""
     assert chord.background == BASE_BACKGROUND
     assert chord.foreground == BASE_FOREGROUND
@@ -52,3 +113,69 @@ def test_chord_widget(fake_window, fake_qtile):
 
     # Finalize the widget to prevent segfault
     chord.finalize()
+
+
+@chord_config
+def test_chord_persistence(manager):
+    widget = manager.c.widget["chord"]
+
+    assert widget.info()["text"] == ""
+
+    # Test 1: Test persistent chord mode name
+    # Old style where mode contains text.
+    # Enter the chord
+    manager.c.simulate_keypress([], "a")
+    assert widget.info()["text"] == "persistent_chord"
+
+    # Chord has finished but mode should still be in place
+    manager.c.simulate_keypress([], "b")
+    assert widget.info()["text"] == "persistent_chord"
+
+    # Escape to leave chord
+    manager.c.simulate_keypress([], "Escape")
+    assert widget.info()["text"] == ""
+
+    # Test 2: Test persistent chord mode name
+    # New style - mode = True
+    # Enter the chord
+    manager.c.simulate_keypress([], "y")
+    assert widget.info()["text"] == "mode_true"
+
+    # Chord has finished but mode should still be in place
+    manager.c.simulate_keypress([], "b")
+    assert widget.info()["text"] == "mode_true"
+
+    # Escape to leave chord
+    manager.c.simulate_keypress([], "Escape")
+    assert widget.info()["text"] == ""
+
+    # Test 3: Test temporary chord name
+    # Enter the chord
+    manager.c.simulate_keypress([], "z")
+    assert widget.info()["text"] == "temporary_name"
+
+    # Chord has finished and should exit
+    manager.c.simulate_keypress([], "b")
+    assert widget.info()["text"] == ""
+
+    # Enter the chord
+    manager.c.simulate_keypress([], "z")
+    assert widget.info()["text"] == "temporary_name"
+
+    # Escape to cancel chord
+    manager.c.simulate_keypress([], "Escape")
+    assert widget.info()["text"] == ""
+
+
+def test_chord_mode_name_deprecation(caplog):
+    chord = KeyChord([], "a", [Key([], "b", lazy.function(no_op))], mode="persistent_chord")
+
+    assert caplog.records
+
+    log = caplog.records[0]
+    assert log.levelname == "WARNING"
+    assert "name='persistent_chord'" in log.message
+
+    # Mode should be set to True and name set to the mode name
+    assert chord.mode is True
+    assert chord.name == "persistent_chord"


### PR DESCRIPTION
This PR allows all KeyChords to be named (via `mode`) but gives the user the option to switch off the mode persistence then the key sequence is complete.

The benefit of this is that the mode name can be displayed in the Chord widget for all KeyChords, not just those with persistent modes.

Closes #2647