### PR TITLE
Add core/backend to object graph

### DIFF
--- a/docs/_static/diagrams/object-graph-orig.dot
+++ b/docs/_static/diagrams/object-graph-orig.dot
@@ -24,12 +24,16 @@ digraph G {
     node [style="filled", color=Purple, fillcolor=Violet, label="window"];
     window;
 
+    node [style="filled", color=SlateBlue, fillcolor=SlateBlue1, label="core"];
+    core;
+
     root -> bar;
     root -> group;
     root -> layout;
     root -> screen;
     root -> widget;
     root -> window;
+    root -> core;
 
     bar -> screen [dir=both];
     bar -> widget [dir=both];

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -21,7 +21,7 @@ if typing.TYPE_CHECKING:
     from libqtile.utils import ColorType
 
 
-class Core(metaclass=ABCMeta):
+class Core(CommandObject, metaclass=ABCMeta):
     painter: Any
 
     @property
@@ -29,6 +29,12 @@ class Core(metaclass=ABCMeta):
     def name(self) -> str:
         """The name of the backend"""
         pass
+
+    def _items(self, name: str) -> ItemT:
+        return None
+
+    def _select(self, name, sel):
+        return None
 
     @abstractmethod
     def finalize(self):
@@ -116,6 +122,12 @@ class Core(metaclass=ABCMeta):
     def change_vt(self, vt: int) -> bool:
         """Change virtual terminal, returning success."""
         return False
+
+    def cmd_info(self):
+        return {
+            "backend": self.name,
+            "display_name": self.display_name
+        }
 
 
 @enum.unique

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -129,7 +129,7 @@ class CommandGraphRoot(CommandGraphNode):
     @property
     def children(self) -> List[str]:
         """All of the child elements in the root of the command graph"""
-        return ["bar", "group", "layout", "screen", "widget", "window"]
+        return ["bar", "group", "layout", "screen", "widget", "window", "core"]
 
 
 class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
@@ -201,6 +201,11 @@ class _WindowGraphNode(CommandGraphObject):
     children = ["group", "screen", "layout"]
 
 
+class _CoreGraphNode(CommandGraphObject):
+    object_type = "core"
+    children: List[str] = []
+
+
 _COMMAND_GRAPH_MAP: Dict[str, Type[CommandGraphObject]] = {
     "bar": _BarGraphNode,
     "group": _GroupGraphNode,
@@ -208,4 +213,5 @@ _COMMAND_GRAPH_MAP: Dict[str, Type[CommandGraphObject]] = {
     "widget": _WidgetGraphNode,
     "window": _WindowGraphNode,
     "screen": _ScreenGraphNode,
+    "core": _CoreGraphNode
 }

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -756,6 +756,8 @@ class Qtile(CommandObject):
             return True, list(self.windows_map.keys())
         elif name == "screen":
             return True, list(range(len(self.screens)))
+        elif name == "core":
+            return True, []
         return None
 
     def _select(self, name: str, sel: Optional[Union[str, int]]) -> Optional[CommandObject]:
@@ -783,6 +785,8 @@ class Qtile(CommandObject):
                 return self.current_screen
             else:
                 return utils.lget(self.screens, sel)
+        elif name == "core":
+            return self.core
         return None
 
     def call_soon(self, func: Callable, *args) -> asyncio.Handle:

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -377,3 +377,7 @@ def test_select_widget(manager):
     assert widget.bar.info()["position"] == "bottom"
     with pytest.raises(libqtile.command.client.SelectError, match="Item not available in object"):
         widget.bar["bottom"]
+
+
+def test_core_node(manager, backend_name):
+    assert manager.c.core.info()["backend"] == backend_name

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -68,8 +68,8 @@ def test_ls(manager):
     client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
-    assert sh.do_ls(None) == "bar/     group/   layout/  screen/  widget/  window/"
-    assert sh.do_ls("") == "bar/     group/   layout/  screen/  widget/  window/"
+    assert sh.do_ls(None) == "bar/     group/   layout/  screen/  widget/  window/  core/  "
+    assert sh.do_ls("") == "bar/     group/   layout/  screen/  widget/  window/  core/  "
     assert sh.do_ls("layout") == "layout/group/   layout/window/  layout/screen/  layout[0]/    "
 
     assert sh.do_cd("layout") == "layout"


### PR DESCRIPTION
As per #2552, this adds `core` to the object graph which will allow us to expose backend commands to shell commands etc.

Currently, the node is called `core` but happy to rename to `backend` if that's better.

Also, I've only linked the node to root but, in theory, it could probably be linked to all the other nodes. However, I don't really see a reason to do that. Again, happy to listen to differing opinions.
