### PR TITLE
Using decorators to expose commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,23 @@
 Qtile x.xx.x, released XXXX-XX-XX:
+    !!! config breakage/changes !!!
+      - The `cmd_` prefix has been dropped from all commands (this means command names are common when accessed
+        via the command interface or internal python objects).
+      - Custom widgets should now expose command methods with the `@expose_command` decorator (available via
+        `from libqtile.command.base import expose_command`).
+      - Some commands have been renamed (in addition to dropping the 'cmd_' prefix):
+          `hints` -> `get_hints`
+          `groups` -> `get_groups`
+          `screens` -> `get_screens`
+      - Layouts need to rename some methods:
+        - `add` to `add_client`
+        - `cmd_next` to `next`
+        - `cmd_previous` to `previous`
+      - Layouts or widgets that redefine the `commands` property need to update the signature:
+          `@expose_command()`
+          `def commands(self) -> list[str]:`
+      - `Window.getsize` has been renamed `Window.get_size` (i.e. merged with the get_size command).
+      - `Window.getposition` has been renamed `Window.get_position` (i.e. merged with the get_position command).
+      - The `StockTicker` widget `function` option is being deprecated: rename it to `func`.
     * features
         - Add ability to set icon size in `LaunchBar` widget.
     * bugfixes

--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -178,10 +178,11 @@ which will lead to the way the commands are dispatched.
 All of the configured objects setup by Qtile are ``CommandObject`` subclasses.
 These objects are so named because we can issue commands against them using the
 command scripting API.  Looking through the code, the commands that are exposed
-are commands named ``cmd_*``.  When writing custom layouts, widgets, or any
-other object, you can add your own custom ``cmd_`` functions and they will be
-callable using the standard command infrastructure.  An available command can
-be extracted by calling ``.command()`` with the name of the command.
+are commands that are decorated with the ``@expose_command()`` decorator.
+When writing custom layouts, widgets, or any other object, you can add your own
+custom functions and, once you add the decorator, they will be callable using the
+standard command infrastructure. An available command can be extracted by calling
+``.command()`` with the name of the command.
 
 In addition to having a set of associated commands, each command object also
 has a collection of items associated with it.  This is what forms the graph

--- a/docs/manual/faq.rst
+++ b/docs/manual/faq.rst
@@ -88,15 +88,15 @@ of binding keys to ``lazy.group[name].toscreen()``, use this:
     def go_to_group(name: str) -> Callable:
         def _inner(qtile: Qtile) -> None:
             if len(qtile.screens) == 1:
-                qtile.groups_map[name].cmd_toscreen()
+                qtile.groups_map[name].toscreen()
                 return
 
             if name in '123':
                 qtile.focus_screen(0)
-                qtile.groups_map[name].cmd_toscreen()
+                qtile.groups_map[name].toscreen()
             else:
                 qtile.focus_screen(1)
-                qtile.groups_map[name].cmd_toscreen()
+                qtile.groups_map[name].toscreen()
 
         return _inner
 

--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -503,6 +503,39 @@ can do the following:
             self.format = self.short_format
             self.bar.draw()
 
+Exposing commands to the IPC interface
+======================================
+
+If you want to control your widget via ``lazy`` or scripting commands (such as ``qtile cmd-obj``), you
+will need to expose the relevant methods in your widget. Exposing commands is done by adding the
+``@expose_command()`` decorator to your method. For example:
+
+.. code:: python
+
+    from libqtile.command.base import expose_command
+    from libqtile.widget import TextBox
+
+
+    class ExposedWidget(TextBox):
+
+        @expose_command()
+        def uppercase(self):
+            self.update(self.text.upper())
+
+Text in the ``ExposedWidget`` can now be made into upper case by calling ``lazy.widget["exposedwidget"].uppercase()``
+or ``qtile cmd-onj -o widget exposedwidget -f uppercase``.
+
+If you want to expose a method under multiple names, you can pass these additional names to the decorator. For
+example, decorating a method with:
+
+.. code:: python
+
+    @expose_command(["extra", "additional"])
+    def mymethod(self):
+        ...
+
+will make make the method visible under ``mymethod``, ``extra`` and ``additional``.
+
 Debugging
 =========
 

--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -19,8 +19,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import builtins
-import functools
 import importlib
 import inspect
 import json
@@ -28,6 +26,7 @@ import os
 import pprint
 from pathlib import Path
 from subprocess import CalledProcessError, run
+from unittest.mock import MagicMock
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -188,7 +187,10 @@ class QtileClass(SimpleDirectiveMixin, Directive):
         }
         if context['commandable']:
             context['commands'] = [
-                attr for attr in dir(obj) if attr.startswith('cmd_')
+                # Command methods have the "_cmd" attribute so we check for this
+                # However, some modules are Mocked so we need to exclude them
+                attr.__name__ for _, attr in inspect.getmembers(obj)
+                if hasattr(attr, "_cmd") and not isinstance(attr, MagicMock)
             ]
 
         rst = qtile_class_template.render(**context)

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -9,7 +9,7 @@ from abc import ABCMeta, abstractmethod
 import cairocffi
 
 from libqtile import drawer, pangocffi, utils
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, expose_command
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -123,7 +123,8 @@ class Core(CommandObject, metaclass=ABCMeta):
         """Get the keysym for a key from its name"""
         raise NotImplementedError
 
-    def cmd_info(self) -> dict:
+    @expose_command()
+    def info(self) -> dict[str, Any]:
         """Get basic information about the running backend."""
         return {"backend": self.name, "display_name": self.display_name}
 
@@ -143,7 +144,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
         self.reserved_space: tuple[int, int, int, int] | None = None
-        # Window.cmd_static sets this in case it is hooked to client_new to stop the
+        # Window.static sets this in case it is hooked to client_new to stop the
         # Window object from being managed, now that a Static is being used instead
         self.defunct: bool = False
 
@@ -160,11 +161,13 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def unhide(self) -> None:
         """Unhide the window"""
 
-    def cmd_is_visible(self) -> bool:
+    @expose_command()
+    def is_visible(self) -> bool:
         """Is this window visible (i.e. not hidden)?"""
         return False
 
     @abstractmethod
+    @expose_command()
     def kill(self) -> None:
         """Kill the window"""
 
@@ -209,6 +212,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         self._opacity = opacity
 
     @abstractmethod
+    @expose_command()
     def place(
         self,
         x,
@@ -230,6 +234,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         return None
 
     @abstractmethod
+    @expose_command()
     def info(self) -> dict[str, Any]:
         """
         Return information on this window.
@@ -246,10 +251,6 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
         """
         return {}
-
-    def cmd_info(self) -> dict:
-        """Return a dictionary of info."""
-        return self.info()
 
 
 class Window(_Window, metaclass=ABCMeta):
@@ -325,20 +326,9 @@ class Window(_Window, metaclass=ABCMeta):
         return match.compare(self)
 
     @abstractmethod
-    def focus(self, warp: bool) -> None:
+    @expose_command()
+    def focus(self, warp: bool = True) -> None:
         """Focus this window and optional warp the pointer to it."""
-
-    @abstractmethod
-    def togroup(
-        self, group_name: str | None = None, *, switch_group: bool = False, toggle: bool = False
-    ) -> None:
-        """Move window to a specified group
-
-        Also switch to that group if switch_group is True.
-
-        If `toggle` is True and and the specified group is already on the screen,
-        use the last used group as target instead.
-        """
 
     @property
     def has_focus(self):
@@ -360,86 +350,91 @@ class Window(_Window, metaclass=ABCMeta):
         """Paint the window borders with the given color(s) and width"""
 
     @abstractmethod
-    def cmd_focus(self, warp: bool = True) -> None:
-        """Focuses the window."""
-
-    def cmd_match(self, *args, **kwargs) -> bool:
-        return self.match(*args, **kwargs)
-
-    @abstractmethod
-    def cmd_get_position(self) -> tuple[int, int]:
+    @expose_command()
+    def get_position(self) -> tuple[int, int]:
         """Get the (x, y) of the window"""
 
     @abstractmethod
-    def cmd_get_size(self) -> tuple[int, int]:
+    @expose_command()
+    def get_size(self) -> tuple[int, int]:
         """Get the (width, height) of the window"""
 
     @abstractmethod
-    def cmd_move_floating(self, dx: int, dy: int) -> None:
+    @expose_command()
+    def move_floating(self, dx: int, dy: int) -> None:
         """Move window by dx and dy"""
 
     @abstractmethod
-    def cmd_resize_floating(self, dw: int, dh: int) -> None:
+    @expose_command()
+    def resize_floating(self, dw: int, dh: int) -> None:
         """Add dw and dh to size of window"""
 
     @abstractmethod
-    def cmd_set_position_floating(self, x: int, y: int) -> None:
+    @expose_command()
+    def set_position_floating(self, x: int, y: int) -> None:
         """Move window to x and y"""
 
     @abstractmethod
-    def cmd_set_position(self, x: int, y: int) -> None:
+    @expose_command()
+    def set_position(self, x: int, y: int) -> None:
         """
         Move floating window to x and y; swap tiling window with the window under the
         pointer.
         """
 
     @abstractmethod
-    def cmd_set_size_floating(self, w: int, h: int) -> None:
+    @expose_command()
+    def set_size_floating(self, w: int, h: int) -> None:
         """Set window dimensions to w and h"""
 
     @abstractmethod
-    def cmd_place(
-        self, x, y, width, height, borderwidth, bordercolor, above=False, margin=None
-    ) -> None:
-        """Place the window with the given position and geometry."""
-
-    @abstractmethod
-    def cmd_toggle_floating(self) -> None:
+    @expose_command()
+    def toggle_floating(self) -> None:
         """Toggle the floating state of the window."""
 
     @abstractmethod
-    def cmd_enable_floating(self) -> None:
+    @expose_command()
+    def enable_floating(self) -> None:
         """Float the window."""
 
     @abstractmethod
-    def cmd_disable_floating(self) -> None:
+    @expose_command()
+    def disable_floating(self) -> None:
         """Tile the window."""
 
     @abstractmethod
-    def cmd_toggle_maximize(self) -> None:
-        """Toggle the maximize state of the window."""
-
-    @abstractmethod
-    def cmd_toggle_minimize(self) -> None:
-        """Toggle the minimize state of the window."""
-
-    @abstractmethod
-    def cmd_toggle_fullscreen(self) -> None:
+    @expose_command()
+    def toggle_maximize(self) -> None:
         """Toggle the fullscreen state of the window."""
 
     @abstractmethod
-    def cmd_enable_fullscreen(self) -> None:
+    @expose_command()
+    def toggle_minimize(self) -> None:
+        """Toggle the minimized state of the window."""
+
+    @abstractmethod
+    @expose_command()
+    def toggle_fullscreen(self) -> None:
+        """Toggle the fullscreen state of the window."""
+
+    @abstractmethod
+    @expose_command()
+    def enable_fullscreen(self) -> None:
         """Fullscreen the window"""
 
     @abstractmethod
-    def cmd_disable_fullscreen(self) -> None:
+    @expose_command()
+    def disable_fullscreen(self) -> None:
         """Un-fullscreen the window"""
 
     @abstractmethod
-    def cmd_bring_to_front(self) -> None:
+    @expose_command()
+    def bring_to_front(self) -> None:
         """Bring the window to the front"""
 
-    def cmd_togroup(
+    @abstractmethod
+    @expose_command()
+    def togroup(
         self,
         group_name: str | None = None,
         groupName: str | None = None,  # Deprecated  # noqa: N803
@@ -455,13 +450,29 @@ class Window(_Window, metaclass=ABCMeta):
 
         `groupName` is deprecated and will be dropped soon. Please use `group_name`
         instead.
+
+        Examples
+        ========
+
+        Move window to current group::
+
+            togroup()
+
+        Move window to group "a"::
+
+            togroup("a")
+
+        Move window to group "a", and switch to group "a"::
+
+            togroup("a", switch_group=True)
         """
         if groupName is not None:
-            logger.warning("Window.cmd_togroup's groupName is deprecated; use group_name")
+            logger.warning("Window.togroup's groupName is deprecated; use group_name")
             group_name = groupName
         self.togroup(group_name, switch_group=switch_group, toggle=toggle)
 
-    def cmd_toscreen(self, index: int | None = None) -> None:
+    @expose_command()
+    def toscreen(self, index: int | None = None) -> None:
         """Move window to a specified screen.
 
         If index is not specified, we assume the current screen
@@ -486,11 +497,9 @@ class Window(_Window, metaclass=ABCMeta):
                 raise CommandError("No such screen: %d" % index)
         self.togroup(screen.group.name)
 
-    def cmd_opacity(self, opacity: float) -> None:
-        """Set the window's opacity.
-
-        The value must be between 0 and 1 inclusive.
-        """
+    @expose_command()
+    def set_opacity(self, opacity: float) -> None:
+        """Set the window's opacity"""
         if opacity < 0.1:
             self.opacity = 0.1
         elif opacity > 1:
@@ -498,27 +507,19 @@ class Window(_Window, metaclass=ABCMeta):
         else:
             self.opacity = opacity
 
-    def cmd_down_opacity(self) -> None:
+    @expose_command()
+    def down_opacity(self) -> None:
         """Decrease the window's opacity by 10%."""
-        if self.opacity > 0.2:
-            # don't go completely clear
-            self.opacity -= 0.1
-        else:
-            self.opacity = 0.1
+        self.set_opacity(self.opacity - 0.1)
 
-    def cmd_up_opacity(self) -> None:
+    @expose_command()
+    def up_opacity(self) -> None:
         """Increase the window's opacity by 10%."""
-        if self.opacity < 0.9:
-            self.opacity += 0.1
-        else:
-            self.opacity = 1
+        self.set_opacity(self.opacity + 0.1)
 
     @abstractmethod
-    def cmd_kill(self) -> None:
-        """Kill the window. Try to be polite."""
-
-    @abstractmethod
-    def cmd_static(
+    @expose_command()
+    def static(
         self,
         screen: int | None = None,
         x: int | None = None,
@@ -532,7 +533,8 @@ class Window(_Window, metaclass=ABCMeta):
         """
         self.defunct = True
 
-    def cmd_center(self) -> None:
+    @expose_command()
+    def center(self) -> None:
         """Centers a floating window on the screen."""
         if not self.floating:
             return
@@ -542,16 +544,16 @@ class Window(_Window, metaclass=ABCMeta):
 
         screen = self.group.screen
 
-        x = (screen.width - self.width) // 2  # type: ignore
-        y = (screen.height - self.height) // 2  # type: ignore
+        x = (screen.width - self.width) // 2
+        y = (screen.height - self.height) // 2
 
         self.place(
             x,
             y,
-            self.width,  # type: ignore
-            self.height,  # type: ignore
+            self.width,
+            self.height,
             self.borderwidth,
-            self.bordercolor,  # type: ignore
+            self.bordercolor,
             above=True,
             respect_hints=True,
         )
@@ -601,6 +603,7 @@ class Static(_Window, metaclass=ABCMeta):
     def __repr__(self):
         return "%s(name=%r, wid=%i)" % (self.__class__.__name__, self.name, self.wid)
 
+    @expose_command()
     def info(self) -> dict:
         """Return a dictionary of info."""
         return dict(
@@ -614,7 +617,8 @@ class Static(_Window, metaclass=ABCMeta):
         )
 
     @abstractmethod
-    def cmd_bring_to_front(self) -> None:
+    @expose_command()
+    def bring_to_front(self) -> None:
         """Bring the window to the front"""
 
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -78,6 +78,7 @@ from libqtile import hook, log_utils
 from libqtile.backend import base
 from libqtile.backend.wayland import inputs, layer, window, wlrq, xdgwindow, xwindow
 from libqtile.backend.wayland.output import Output
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -501,11 +502,8 @@ class Core(base.Core, wlrq.HasListeners):
         self.exclusive_client = self._input_inhibit_manager.active_client
 
         # If another client has keyboard focus, unfocus it.
-        if (
-            self.qtile.current_window
-            and not self.qtile.current_window.belongs_to_client(  # type: ignore
-                self.exclusive_client
-            )
+        if self.qtile.current_window and not self.qtile.current_window.belongs_to_client(
+            self.exclusive_client
         ):
             self.focus_window(None)
 
@@ -940,12 +938,12 @@ class Core(base.Core, wlrq.HasListeners):
                     return
 
             if self.qtile.config.bring_front_click is True:
-                win.cmd_bring_to_front()
+                win.bring_to_front()
             elif self.qtile.config.bring_front_click == "floating_only":
                 if isinstance(win, base.Window) and win.floating:
-                    win.cmd_bring_to_front()
+                    win.bring_to_front()
                 elif isinstance(win, base.Static):
-                    win.cmd_bring_to_front()
+                    win.bring_to_front()
 
             if isinstance(win, window.Static):
                 if win.screen is not self.qtile.current_screen:
@@ -1110,7 +1108,8 @@ class Core(base.Core, wlrq.HasListeners):
         if self.focused_internal:
             self.focused_internal.process_key_press(keysym)
 
-    def cmd_set_keymap(
+    @expose_command()
+    def set_keymap(
         self,
         layout: str | None = None,
         options: str | None = None,
@@ -1129,20 +1128,23 @@ class Core(base.Core, wlrq.HasListeners):
         else:
             logger.warning("Could not set keymap: no keyboards set up.")
 
-    def cmd_change_vt(self, vt: int) -> bool:
+    @expose_command()
+    def change_vt(self, vt: int) -> bool:
         """Change virtual terminal to that specified"""
         success = self.backend.get_session().change_vt(vt)
         if not success:
             logger.warning("Could not change VT to: %s", vt)
         return success
 
-    def cmd_hide_cursor(self) -> None:
+    @expose_command()
+    def hide_cursor(self) -> None:
         """Hide the cursor."""
         if not self._cursor_state.hidden:
             self.cursor.set_surface(None, self._cursor_state.hotspot)
             self._cursor_state.hidden = True
 
-    def cmd_unhide_cursor(self) -> None:
+    @expose_command()
+    def unhide_cursor(self) -> None:
         """Unhide the cursor."""
         if self._cursor_state.hidden:
             self.cursor.set_surface(
@@ -1151,7 +1153,8 @@ class Core(base.Core, wlrq.HasListeners):
             )
             self._cursor_state.hidden = False
 
-    def cmd_get_inputs(self) -> dict[str, list[dict[str, str]]]:
+    @expose_command()
+    def get_inputs(self) -> dict[str, list[dict[str, str]]]:
         """Get information on all input devices."""
         info = {}
         device_lists: dict[str, list[inputs._Device]] = {

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -41,7 +41,7 @@ class Drawer(base.Drawer):
         width: int | None = None,
         height: int | None = None,
     ) -> None:
-        if offsetx > self._win.width:  # type: ignore
+        if offsetx > self._win.width:
             return
 
         # We need to set the current draw area so we can compare to the previous one
@@ -57,12 +57,12 @@ class Drawer(base.Drawer):
         # Make sure geometry doesn't extend beyond texture
         if width is None:
             width = self.width
-        if width > self._win.width - offsetx:  # type: ignore
-            width = self._win.width - offsetx  # type: ignore
+        if width > self._win.width - offsetx:
+            width = self._win.width - offsetx
         if height is None:
             height = self.height
-        if height > self._win.height - offsety:  # type: ignore
-            height = self._win.height - offsety  # type: ignore
+        if height > self._win.height - offsety:
+            height = self._win.height - offsety
 
         # Paint RecordingSurface operations our window's ImageSurface
         with cairocffi.Context(self._source) as context:
@@ -70,7 +70,7 @@ class Drawer(base.Drawer):
             context.paint()
 
         # Copy drawn ImageSurface data into rendered wlr_texture
-        self._win.texture.write_pixels(  # type: ignore
+        self._win.texture.write_pixels(
             self._stride,
             width,
             height,
@@ -78,7 +78,7 @@ class Drawer(base.Drawer):
             dst_x=offsetx,
             dst_y=offsety,
         )
-        self._win.damage()  # type: ignore
+        self._win.damage()
 
     def clear(self, colour: ColorsType) -> None:
         # Draw background straight to ImageSurface

--- a/libqtile/backend/wayland/layer.py
+++ b/libqtile/backend/wayland/layer.py
@@ -27,6 +27,7 @@ from wlroots.wlr_types.layer_shell_v1 import LayerShellV1Layer, LayerSurfaceV1
 
 from libqtile.backend.wayland.subsurface import SubSurface
 from libqtile.backend.wayland.window import Static
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -156,5 +157,6 @@ class LayerStatic(Static[LayerSurfaceV1]):
         self.surface.configure(self._width, self._height)
         self.damage()
 
-    def cmd_bring_to_front(self) -> None:
+    @expose_command()
+    def bring_to_front(self) -> None:
         pass

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -36,6 +36,7 @@ from libqtile.backend.base import FloatStates
 from libqtile.backend.wayland.subsurface import SubSurface
 from libqtile.backend.wayland.window import Static, Window
 from libqtile.backend.wayland.wlrq import HasListeners
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
@@ -174,9 +175,7 @@ class XdgWindow(Window[XdgSurface]):
         if not self.mapped:
             self.surface.map_event.emit()
 
-    def cmd_is_visible(self) -> bool:
-        return self._mapped
-
+    @expose_command()
     def kill(self) -> None:
         self.surface.send_close()
 
@@ -273,14 +272,15 @@ class XdgWindow(Window[XdgSurface]):
         self.paint_borders(bordercolor, borderwidth)
 
         if above:
-            self.cmd_bring_to_front()
+            self.bring_to_front()
 
         prev_outputs = self._outputs.copy()
         self._find_outputs()
         for output in self._outputs | prev_outputs:
             output.damage()
 
-    def cmd_static(
+    @expose_command()
+    def static(
         self,
         screen: int | None = None,
         x: int | None = None,
@@ -288,7 +288,7 @@ class XdgWindow(Window[XdgSurface]):
         width: int | None = None,
         height: int | None = None,
     ) -> None:
-        Window.cmd_static(self, screen, x, y, width, height)
+        Window.static(self, screen, x, y, width, height)
         win = self.qtile.windows_map[self._wid]
         assert isinstance(win, XdgStatic)
         win.subsurfaces = self.subsurfaces
@@ -338,6 +338,7 @@ class XdgStatic(Static[XdgSurface]):
         for subsurface in self.subsurfaces:
             subsurface.finalize()
 
+    @expose_command()
     def kill(self) -> None:
         self.surface.send_close()
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -265,7 +265,7 @@ class Core(base.Core):
 
                 if item.get_wm_type() == "dock" or win.reserved_space:
                     assert self.qtile.current_screen is not None
-                    win.cmd_static(self.qtile.current_screen.index)
+                    win.static(self.qtile.current_screen.index)
                     continue
 
             self.qtile.manage(win)
@@ -605,7 +605,7 @@ class Core(base.Core):
         if atoms["_NET_CURRENT_DESKTOP"] == opcode:
             index = data.data32[0]
             try:
-                self.qtile.groups[index].cmd_toscreen()
+                self.qtile.groups[index].toscreen()
             except IndexError:
                 logger.debug("Invalid desktop index: %s", index)
 
@@ -691,7 +691,7 @@ class Core(base.Core):
 
             if xwin.get_wm_type() == "dock" or win.reserved_space:
                 assert self.qtile.current_screen is not None
-                win.cmd_static(self.qtile.current_screen.index)
+                win.static(self.qtile.current_screen.index)
                 return
 
             self.qtile.manage(win)
@@ -722,11 +722,11 @@ class Core(base.Core):
                 # since the window is dead.
                 pass
             # Clear these atoms as per spec
-            win.window.conn.conn.core.DeleteProperty(  # type: ignore
-                win.wid, win.window.conn.atoms["_NET_WM_STATE"]  # type: ignore
+            win.window.conn.conn.core.DeleteProperty(
+                win.wid, win.window.conn.atoms["_NET_WM_STATE"]
             )
-            win.window.conn.conn.core.DeleteProperty(  # type: ignore
-                win.wid, win.window.conn.atoms["_NET_WM_DESKTOP"]  # type: ignore
+            win.window.conn.conn.core.DeleteProperty(
+                win.wid, win.window.conn.atoms["_NET_WM_DESKTOP"]
             )
         self.qtile.unmanage(event.window)
         if self.qtile.current_window is None:

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -28,7 +28,9 @@ class Drawer(base.Drawer):
         self._xcb_surface = None
         self._pixmap = None
         self._gc = None
-        self._depth, self._visual = qtile.core.conn.default_screen._get_depth_and_visual(win._depth)  # type: ignore
+        self._depth, self._visual = qtile.core.conn.default_screen._get_depth_and_visual(
+            win._depth
+        )
 
     def finalize(self):
         self._free_xcb_surface()
@@ -153,7 +155,7 @@ class Drawer(base.Drawer):
         self._paint()
 
         # Finally, copy XCBSurface's underlying pixmap to the window.
-        self.qtile.core.conn.conn.core.CopyArea(  # type: ignore
+        self.qtile.core.conn.conn.core.CopyArea(
             self._pixmap,
             self._win.wid,
             self._gc,

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -17,7 +17,7 @@ from libqtile.backend import base
 from libqtile.backend.base import FloatStates
 from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.drawer import Drawer
-from libqtile.command.base import CommandError
+from libqtile.command.base import CommandError, expose_command
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -668,6 +668,7 @@ class _Window:
         if not val:
             self.hints["urgent"] = False
 
+    @expose_command()
     def info(self):
         if self.group:
             group = self.group.name
@@ -723,6 +724,7 @@ class _Window:
             assert hasattr(self, "window")
             self.window.set_property("_NET_WM_WINDOW_OPACITY", real_opacity)
 
+    @expose_command()
     def kill(self):
         if "WM_DELETE_WINDOW" in self.window.get_wm_protocols():
             data = [
@@ -798,6 +800,7 @@ class _Window:
     def get_pid(self):
         return self.window.get_net_wm_pid()
 
+    @expose_command()
     def place(
         self,
         x,
@@ -988,7 +991,9 @@ class _Window:
         # about this.
         return False
 
-    def focus(self, warp: bool) -> None:
+    @expose_command()
+    def focus(self, warp: bool = True) -> None:
+        """Focuses the window."""
         did_focus = self._do_focus()
         if not did_focus:
             return
@@ -1031,15 +1036,13 @@ class _Window:
             self.group.current_window = self
         hook.fire("client_focus", self)
 
-    def cmd_focus(self, warp: bool = True) -> None:
-        """Focuses the window."""
-        self.focus(warp)
-
-    def cmd_hints(self):
+    @expose_command()
+    def get_hints(self):
         """Returns the X11 hints (WM_HINTS and WM_SIZE_HINTS) for this window."""
         return self.hints
 
-    def cmd_inspect(self):
+    @expose_command()
+    def inspect(self):
         """Tells you more than you ever wanted to know about a window"""
         a = self.window.get_attributes()
         attrs = {
@@ -1118,14 +1121,12 @@ class Internal(_Window, base.Internal):
         """Create a Drawer that draws to this window."""
         return Drawer(self.qtile, self, width, height)
 
+    @expose_command()
     def kill(self):
         if self.window.wid in self.qtile.windows_map:
             # It will be present during config reloads; absent during shutdown as this
             # will follow graceful_shutdown
             self.qtile.core.conn.conn.core.DestroyWindow(self.window.wid)
-
-    def cmd_kill(self):
-        self.kill()
 
     def handle_Expose(self, e):  # noqa: N802
         self.process_window_expose()
@@ -1259,7 +1260,8 @@ class Static(_Window, base.Static):
         if name == "_NET_WM_STRUT_PARTIAL":
             self.update_strut()
 
-    def cmd_bring_to_front(self):
+    @expose_command()
+    def bring_to_front(self):
         self.window.configure(stackmode=StackMode.Above)
 
 
@@ -1336,6 +1338,7 @@ class Window(_Window, base.Window):
             pass
         return False
 
+    @expose_command()
     def toggle_floating(self):
         self.floating = not self.floating
 
@@ -1380,9 +1383,6 @@ class Window(_Window, base.Window):
             self.floating = False
             return
 
-    def toggle_fullscreen(self):
-        self.fullscreen = not self.fullscreen
-
     @property
     def maximized(self):
         return self._float_state == FloatStates.MAXIMIZED
@@ -1404,9 +1404,6 @@ class Window(_Window, base.Window):
             if self._float_state == FloatStates.MAXIMIZED:
                 self.floating = False
 
-    def toggle_maximize(self, state=FloatStates.MAXIMIZED):
-        self.maximized = not self.maximized
-
     @property
     def minimized(self):
         return self._float_state == FloatStates.MINIMIZED
@@ -1420,13 +1417,16 @@ class Window(_Window, base.Window):
             if self._float_state == FloatStates.MINIMIZED:
                 self.floating = False
 
+    @expose_command()
     def toggle_minimize(self):
         self.minimized = not self.minimized
 
-    def cmd_is_visible(self) -> bool:
+    @expose_command()
+    def is_visible(self) -> bool:
         return not self.hidden and not self.minimized
 
-    def cmd_static(
+    @expose_command()
+    def static(
         self,
         screen: int | None = None,
         x: int | None = None,
@@ -1485,10 +1485,12 @@ class Window(_Window, base.Window):
 
         self._reconfigure_floating()
 
-    def getsize(self):
+    @expose_command()
+    def get_size(self):
         return (self.width, self.height)
 
-    def getposition(self):
+    @expose_command()
+    def get_position(self):
         return (self.x, self.y)
 
     def _reconfigure_floating(self, new_float_state=FloatStates.FLOATING):
@@ -1527,6 +1529,7 @@ class Window(_Window, base.Window):
         # add to group by position according to _NET_WM_DESKTOP property
         group = None
         index = self.window.get_wm_desktop()
+
         if index is not None and index < len(self.qtile.groups):
             group = self.qtile.groups[index]
         elif index is None:
@@ -1539,6 +1542,7 @@ class Window(_Window, base.Window):
             if group != self.qtile.current_screen.group:
                 self.hide()
 
+    @expose_command()
     def togroup(self, group_name=None, *, switch_group=False, toggle=False):
         """Move window to a specified group
 
@@ -1571,8 +1575,9 @@ class Window(_Window, base.Window):
             self.x += group.screen.x
         group.add(self)
         if switch_group:
-            group.cmd_toscreen(toggle=toggle)
+            group.toscreen(toggle=toggle)
 
+    @expose_command()
     def match(self, match):
         """Match window against given attributes.
 
@@ -1792,64 +1797,52 @@ class Window(_Window, base.Window):
         elif name == "screen":
             return self.group.screen
 
-    def cmd_kill(self):
-        """Kill this window
-
-        Try to do this politely if the client support
-        this, otherwise be brutal.
-        """
-        self.kill()
-
-    def cmd_move_floating(self, dx, dy):
+    @expose_command()
+    def move_floating(self, dx, dy):
         """Move window by dx and dy"""
         self.tweak_float(dx=dx, dy=dy)
 
-    def cmd_resize_floating(self, dw, dh):
+    @expose_command()
+    def resize_floating(self, dw, dh):
         """Add dw and dh to size of window"""
         self.tweak_float(dw=dw, dh=dh)
 
-    def cmd_set_position_floating(self, x, y):
+    @expose_command()
+    def set_position_floating(self, x, y):
         """Move window to x and y"""
         self.tweak_float(x=x, y=y)
 
-    def cmd_set_size_floating(self, w, h):
+    @expose_command()
+    def set_size_floating(self, w, h):
         """Set window dimensions to w and h"""
         self.tweak_float(w=w, h=h)
 
-    def cmd_place(self, x, y, width, height, borderwidth, bordercolor, above=False, margin=None):
-        self.place(x, y, width, height, borderwidth, bordercolor, above, margin)
-
-    def cmd_get_position(self):
-        return self.getposition()
-
-    def cmd_get_size(self):
-        return self.getsize()
-
-    def cmd_toggle_floating(self):
-        self.toggle_floating()
-
-    def cmd_enable_floating(self):
+    @expose_command()
+    def enable_floating(self):
         self.floating = True
 
-    def cmd_disable_floating(self):
+    @expose_command()
+    def disable_floating(self):
         self.floating = False
 
-    def cmd_toggle_maximize(self):
-        self.toggle_maximize()
+    @expose_command()
+    def toggle_maximize(self):
+        self.maximized = not self.maximized
 
-    def cmd_toggle_fullscreen(self):
-        self.toggle_fullscreen()
+    @expose_command()
+    def toggle_fullscreen(self):
+        self.fullscreen = not self.fullscreen
 
-    def cmd_enable_fullscreen(self):
+    @expose_command()
+    def enable_fullscreen(self):
         self.fullscreen = True
 
-    def cmd_disable_fullscreen(self):
+    @expose_command()
+    def disable_fullscreen(self):
         self.fullscreen = False
 
-    def cmd_toggle_minimize(self):
-        self.toggle_minimize()
-
-    def cmd_bring_to_front(self):
+    @expose_command()
+    def bring_to_front(self):
         if self.floating:
             self.window.configure(stackmode=StackMode.Above)
         else:
@@ -1858,7 +1851,8 @@ class Window(_Window, base.Window):
     def _is_in_window(self, x, y, window):
         return window.edges[0] <= x <= window.edges[2] and window.edges[1] <= y <= window.edges[3]
 
-    def cmd_set_position(self, x, y):
+    @expose_command()
+    def set_position(self, x, y):
         if self.floating:
             self.tweak_float(x, y)
             return

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -24,7 +24,7 @@ import typing
 from collections import defaultdict
 
 from libqtile import configurable
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import has_transparency, rgb
 
@@ -113,6 +113,13 @@ class Gap:
         for i in ["top", "bottom", "left", "right"]:
             if getattr(self.screen, i) is self:
                 return i
+
+    @expose_command()
+    def info(self):
+        """
+        Info for this object.
+        """
+        return dict(position=self.position)
 
 
 class Obj:
@@ -622,6 +629,7 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             else:
                 self.drawer.draw(offsety=end, height=self.length - end)
 
+    @expose_command()
     def info(self):
         return dict(
             size=self.size,
@@ -657,7 +665,8 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
         self._add_strut = True
 
-    def cmd_fake_button_press(self, screen, position, x, y, button=1):
+    @expose_command()
+    def fake_button_press(self, screen, position, x, y, button=1):
         """
         Fake a mouse-button-press on the bar. Co-ordinates are relative
         to the top-left corner of the bar.
@@ -666,12 +675,6 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         :position One of "top", "bottom", "left", or "right"
         """
         self.process_button_click(x, y, button)
-
-    def cmd_info(self):
-        """
-        Info for this object.
-        """
-        return self.info()
 
 
 BarType = typing.Union[Bar, Gap]

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -28,8 +28,10 @@ import abc
 import inspect
 import sys
 import traceback
+from functools import partial
 from typing import TYPE_CHECKING
 
+from libqtile.configurable import Configurable
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -38,6 +40,50 @@ if TYPE_CHECKING:
     from libqtile.command.graph import SelectorType
 
     ItemT = Optional[tuple[bool, list[str | int]]]
+
+
+def expose_command(name: Callable | str | list[str] | None = None) -> Callable:
+    """
+    Decorator to expose methods to the command interface.
+
+    The exposed command will have the name of the defined method.
+
+    Methods can also be exposed via multiple names by passing the names to this
+    decorator.
+
+    e.g. if a layout wants "up" and "previous" to call the
+    same method:
+
+    @expose_command("previous")
+    def up(self):
+        ...
+
+    `up` will be exposed as `up` and `previous`.
+
+    Multiple names can be passed as a list.
+    """
+
+    def wrapper(func: Callable):
+        setattr(func, "_cmd", True)
+        if name is not None:
+            if not hasattr(func, "_mapping"):
+                setattr(func, "_mapping", list())
+            if isinstance(name, list):
+                func._mapping += name  # type:ignore
+            elif isinstance(name, str):
+                func._mapping.append(name)  # type:ignore
+            else:
+                logger.error("Unexpected value received in command decorator: %s", name)
+        return func
+
+    # If the decorator is added with no parentheses then we should treat it
+    # as if it had been i.e. expose the decorated method
+    if callable(name):
+        func = name
+        name = None
+        return wrapper(func)
+
+    return wrapper
 
 
 class SelectError(Exception):
@@ -60,10 +106,73 @@ class CommandException(Exception):
 class CommandObject(metaclass=abc.ABCMeta):
     """Base class for objects that expose commands
 
-    Each command should be a method named `cmd_X`, where X is the command name.
+    Any command to be exposed should be decorated with
+    `@expose_command()` (classes that are not explicitly
+    inheriting from CommandObject will need to import the module)
     A CommandObject should also implement `._items()` and `._select()` methods
     (c.f. docstring for `.items()` and `.select()`).
     """
+
+    def __new__(cls, *args, **kwargs):
+
+        # Check which level of command object has been parsed
+        # This test ensures inherited classes don't stop additional
+        # methods from being exposed.
+        # For example, if widget.TextBox has already been parsed, a subsequent
+        # call to initialise a new TextBox will return here. However, if a user
+        # subclasses TextBox for a new widget then that new widget will still
+        # be parsed here to check for new commands.
+        if getattr(cls, "_command_object", "") == cls.__name__:
+            super().__new__(cls)
+
+        commands = {}
+        cmd_s = set()
+
+        # We need to iterate over the class's inherited classes in reverse order
+        # We reverse the order so the exposed command will always be the latest
+        # definition of the method.
+        for c in reversed(list(cls.__mro__)):
+
+            for method_name in list(c.__dict__.keys()):
+                method = getattr(c, method_name, None)
+
+                if method is None:
+                    continue
+
+                # If the command has been exposed, add it to our dictionary
+                # If the method name is already in our dictionary then bind the
+                # latest definition to that command
+                if hasattr(method, "_cmd") or method_name in commands:
+                    commands[method_name] = method
+                # For now, we'll accept the old format `cmd_` naming scheme for
+                # exposing commands.
+                # NOTE: This will be deprecated in the future
+                elif method_name.startswith("cmd_"):
+                    cmd_s.add(method_name)
+                    commands[method_name[4:]] = method
+
+                # Expose additional names
+                for mapping in getattr(method, "_mapping", list()):
+                    setattr(cls, mapping, method)
+                    commands[mapping] = method
+
+        if cmd_s:
+            names = ", ".join(cmd_s)
+            msg = (
+                f"The use of the 'cmd_' prefix to expose commands via IPC "
+                f"is deprecated. Methods should use the "
+                f"@expose_command() decorator instead. "
+                f"Please update: {names}"
+            )
+            logger.warning("Deprecation Warning: %s", msg)
+
+        # Record the object as being parsed.
+        cls._command_object = cls.__name__
+
+        # Store list of exposed commands
+        cls._commands = commands
+
+        return super().__new__(cls)
 
     def select(self, selectors: list[SelectorType]) -> CommandObject:
         """Return a selected object
@@ -92,8 +201,12 @@ class CommandObject(metaclass=abc.ABCMeta):
             obj = maybe_obj
         return obj
 
+    @expose_command()
     def items(self, name: str) -> tuple[bool, list[str | int] | None]:
-        """Build a list of contained items for the given item class
+        """
+        Build a list of contained items for the given item class.
+
+        Exposing this allows __qsh__ to navigate the object graph.
 
         Returns a tuple `(root, items)` for the specified item class, where:
 
@@ -139,39 +252,52 @@ class CommandObject(metaclass=abc.ABCMeta):
         name: str
             The name of the command to fetch.
 
-        Returns
-        -------
-        Callable
-            The command function that can be invoked.
         """
-        return getattr(self, "cmd_" + name, None)
+        return self._commands.get(name)
 
-    @property
+    def __getattr__(self, name):
+        # We can use __getattr_ to handle deprecated calls to
+        # cmd_ but we need to stop this overriding Configurable's
+        # use of this method
+        if isinstance(self, Configurable):
+            try:
+                return Configurable.__getattr__(self, name)
+            except AttributeError:
+                pass
+
+        # It's not a Configurable attribute so let's check if it's
+        # a command call
+        if name.startswith("cmd_"):
+            cmd = name[4:]
+            if cmd in self.commands():
+                logger.warning(
+                    "Deprecation Warning: commands exposed via IPC no "
+                    "longer use the 'cmd_' prefix. "
+                    "Please replace '%s' with '%s' in your code.",
+                    name,
+                    cmd,
+                )
+                # This is not a bound method so we need to pass 'self'
+                return partial(self.command(cmd), self)
+
+        raise AttributeError
+
+    @expose_command()
     def commands(self) -> list[str]:
-        """All of the commands on the given object"""
-        cmds = [i[4:] for i in dir(self) if i.startswith("cmd_")]
-        return cmds
-
-    def cmd_commands(self) -> list[str]:
-        """Returns a list of possible commands for this object
+        """
+        Returns a list of possible commands for this object
 
         Used by __qsh__ for command completion and online help
         """
-        return self.commands
+        return sorted([cmd for cmd in self._commands])
 
-    def cmd_items(self, name) -> tuple[bool, list[str | int] | None]:
-        """Returns a list of contained items for the specified name
-
-        Used by __qsh__ to allow navigation of the object graph.
-        """
-        return self.items(name)
-
-    def cmd_doc(self, name) -> str:
+    @expose_command()
+    def doc(self, name) -> str:
         """Returns the documentation for a specified command name
 
         Used by __qsh__ to provide online help.
         """
-        if name in self.commands:
+        if name in self.commands():
             command = self.command(name)
             assert command
             signature = self._get_command_signature(command)
@@ -189,8 +315,9 @@ class CommandObject(metaclass=abc.ABCMeta):
             signature = signature.replace(parameters=parameters)
         return str(signature)
 
-    def cmd_eval(self, code: str) -> tuple[bool, str | None]:
-        """Evaluates code in the module namespace of the command object
+    @expose_command()
+    def eval(self, code: str) -> tuple[bool, str | None]:
+        """Evaluates code in the same context as this function
 
         Return value is tuple `(success, result)`, success being a boolean and
         result being a string representing the return value of eval, or None if
@@ -207,7 +334,8 @@ class CommandObject(metaclass=abc.ABCMeta):
             error = traceback.format_exc().strip().split("\n")[-1]
             return False, error
 
-    def cmd_function(self, function, *args, **kwargs) -> None:
+    @expose_command()
+    def function(self, function, *args, **kwargs) -> None:
         """Call a function with current object as argument"""
         try:
             function(self, *args, **kwargs)

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -156,7 +156,7 @@ class QtileCommandInterface(CommandInterface):
             return "No such command."
 
         logger.debug("Command: %s(%s, %s)", call.name, args, kwargs)
-        return cmd(*args, **kwargs)
+        return cmd(self._command_object, *args, **kwargs)
 
     def has_command(self, node: CommandGraphNode, command: str) -> bool:
         """Check if the given command exists
@@ -309,7 +309,12 @@ class IPCCommandServer:
 
         logger.debug("Command: %s(%s, %s)", name, args, kwargs)
         try:
-            return SUCCESS, cmd(*args, **kwargs)
+            # Check if method is bound
+            if hasattr(cmd, "__self__"):
+                return SUCCESS, cmd(*args, **kwargs)
+            else:
+                # If not, pass object as first argument
+                return SUCCESS, cmd(obj, *args, **kwargs)
         except CommandError as err:
             return ERROR, err.args[0]
         except Exception:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import configurable, hook, utils
 from libqtile.bar import Bar
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -498,7 +498,7 @@ class Screen(CommandObject):
         hook.fire("focus_change")
         hook.fire("layout_change", self.group.layouts[self.group.current_layout], self.group)
 
-    def toggle_group(self, group: _Group | None = None, warp: bool = True) -> None:
+    def _toggle_group(self, group: _Group | None = None, warp: bool = True) -> None:
         """Switch to the selected group or to the previously active one"""
         if group in (self.group, None) and self.previous_group:
             group = self.previous_group
@@ -552,6 +552,7 @@ class Screen(CommandObject):
                 return self.group if sel == self.group.name else None
         return None
 
+    @expose_command
     def resize(
         self,
         x: int | None = None,
@@ -574,27 +575,20 @@ class Screen(CommandObject):
                 bar.draw()
         self.qtile.call_soon(self.group.layout_all)
 
-    def cmd_info(self) -> dict[str, int]:
+    @expose_command()
+    def info(self) -> dict[str, int]:
         """Returns a dictionary of info for this screen."""
         return dict(index=self.index, width=self.width, height=self.height, x=self.x, y=self.y)
 
-    def cmd_resize(
-        self,
-        x: int | None = None,
-        y: int | None = None,
-        w: int | None = None,
-        h: int | None = None,
-    ) -> None:
-        """Resize the screen"""
-        self.resize(x, y, w, h)
-
-    def cmd_next_group(self, skip_empty: bool = False, skip_managed: bool = False) -> None:
+    @expose_command()
+    def next_group(self, skip_empty: bool = False, skip_managed: bool = False) -> None:
         """Switch to the next group"""
         n = self.group.get_next_group(skip_empty, skip_managed)
         self.set_group(n)
         return n.name
 
-    def cmd_prev_group(
+    @expose_command()
+    def prev_group(
         self, skip_empty: bool = False, skip_managed: bool = False, warp: bool = True
     ) -> None:
         """Switch to the previous group"""
@@ -602,13 +596,15 @@ class Screen(CommandObject):
         self.set_group(n, warp=warp)
         return n.name
 
-    def cmd_toggle_group(self, group_name: str | None = None, warp: bool = True) -> None:
+    @expose_command()
+    def toggle_group(self, group_name: str | None = None, warp: bool = True) -> None:
         """Switch to the selected group or to the previously active one"""
         assert self.qtile is not None
         group = self.qtile.groups_map.get(group_name if group_name else "")
-        self.toggle_group(group, warp=warp)
+        self._toggle_group(group, warp=warp)
 
-    def cmd_set_wallpaper(self, path: str, mode: str | None = None) -> None:
+    @expose_command()
+    def set_wallpaper(self, path: str, mode: str | None = None) -> None:
         """Set the wallpaper to the given file."""
         self.paint(path, mode)
 

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -127,7 +127,7 @@ class DGroups:
                 else:
                     spawns = group.spawn
                 for spawn in spawns:
-                    pid = self.qtile.cmd_spawn(spawn)
+                    pid = self.qtile.spawn(spawn)
                     self.add_rule(Rule(Match(net_wm_pid=pid), group.name))
 
     def _setup_hooks(self):
@@ -189,7 +189,7 @@ class DGroups:
                             self.qtile.screens[affinity].set_group(group_obj)
 
                 if rule.float:
-                    client.cmd_enable_floating()
+                    client.enable_floating()
 
                 if rule.intrusive:
                     intrusive = rule.intrusive

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -59,7 +59,7 @@ class CommandSet(Dmenu):
 
         if self.pre_commands:
             for cmd in self.pre_commands:
-                self.qtile.cmd_spawn(cmd)
+                self.qtile.spawn(cmd)
 
         out = super(CommandSet, self).run(items=self.commands.keys())
 
@@ -74,4 +74,4 @@ class CommandSet(Dmenu):
         if sout not in self.commands:
             return
 
-        self.qtile.cmd_spawn(self.commands[sout])
+        self.qtile.spawn(self.commands[sout])

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import hook, utils
 from libqtile.backend.base import FloatStates
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -231,7 +231,9 @@ class _Group(CommandObject):
             hook.fire("focus_change")
             self.layout_all(warp)
 
+    @expose_command()
     def info(self):
+        """Returns a dictionary of info for this group"""
         return dict(
             name=self.name,
             label=self.label,
@@ -255,11 +257,11 @@ class _Group(CommandObject):
         elif self.floating_layout.match(win) and not win.fullscreen:
             win._float_state = FloatStates.FLOATING
         if win.floating and not win.fullscreen:
-            self.floating_layout.add(win)
+            self.floating_layout.add_client(win)
         if not win.floating or win.fullscreen:
             self.tiled_windows.add(win)
             for i in self.layouts:
-                i.add(win)
+                i.add_client(win)
         if focus:
             self.focus(win, warp=True, force=force)
 
@@ -318,7 +320,7 @@ class _Group(CommandObject):
                         i.remove(win)
                         if win is self.current_window:
                             i.blur()
-                    self.floating_layout.add(win)
+                    self.floating_layout.add_client(win)
                     if win is self.current_window:
                         self.floating_layout.focus(win)
         else:
@@ -327,7 +329,7 @@ class _Group(CommandObject):
             # A window that was fullscreen should only be added if it was not a tiled window
             if win not in self.tiled_windows:
                 for i in self.layouts:
-                    i.add(win)
+                    i.add_client(win)
                 self.tiled_windows.add(win)
             if win is self.current_window:
                 for i in self.layouts:
@@ -358,14 +360,12 @@ class _Group(CommandObject):
                     return i
         raise RuntimeError("Invalid selection: {}".format(name))
 
-    def cmd_setlayout(self, layout):
+    @expose_command()
+    def setlayout(self, layout):
         self.layout = layout
 
-    def cmd_info(self):
-        """Returns a dictionary of info for this group"""
-        return self.info()
-
-    def cmd_toscreen(self, screen=None, toggle=False):
+    @expose_command()
+    def toscreen(self, screen=None, toggle=False):
         """Pull a group to a specified screen.
 
         Parameters
@@ -431,13 +431,15 @@ class _Group(CommandObject):
     def get_next_group(self, skip_empty=False, skip_managed=False):
         return self._get_group(1, skip_empty, skip_managed)
 
-    def cmd_unminimize_all(self):
+    @expose_command()
+    def unminimize_all(self):
         """Unminimise all windows in this group"""
         for win in self.windows:
             win.minimized = False
         self.layout_all()
 
-    def cmd_next_window(self):
+    @expose_command()
+    def next_window(self):
         """
         Focus the next window in group.
 
@@ -461,7 +463,8 @@ class _Group(CommandObject):
             )
         self.focus(nxt, True)
 
-    def cmd_prev_window(self):
+    @expose_command()
+    def prev_window(self):
         """
         Focus the previous window in group.
 
@@ -485,7 +488,8 @@ class _Group(CommandObject):
             )
         self.focus(nxt, True)
 
-    def cmd_focus_back(self):
+    @expose_command()
+    def focus_back(self):
         """
         Focus the window that had focus before the current one got it.
 
@@ -500,7 +504,8 @@ class _Group(CommandObject):
         else:
             self.focus(win)
 
-    def cmd_focus_by_name(self, name):
+    @expose_command()
+    def focus_by_name(self, name):
         """
         Focus the first window with the given name. Do nothing if the name is
         not found.
@@ -510,7 +515,8 @@ class _Group(CommandObject):
                 self.focus(win)
                 break
 
-    def cmd_info_by_name(self, name):
+    @expose_command()
+    def info_by_name(self, name):
         """
         Get the info for the first window with the given name without giving it
         focus. Do nothing if the name is not found.
@@ -519,11 +525,13 @@ class _Group(CommandObject):
             if win.name == name:
                 return win.info()
 
-    def cmd_switch_groups(self, name):
+    @expose_command()
+    def switch_groups(self, name):
         """Switch position of current group with name"""
-        self.qtile.cmd_switch_groups(self.name, name)
+        self.qtile.switch_groups(self.name, name)
 
-    def cmd_set_label(self, label):
+    @expose_command()
+    def set_label(self, label):
         """
         Set the display name of current group to be used in GroupBox widget.
         If label is None, the name of the group is used as display name.

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -191,7 +191,7 @@ class Subscribe:
                 if c.name == "xterm":
                     c.togroup("a")
                 elif c.name == "dzen":
-                    c.cmd_static(0)
+                    c.static(0)
         """
         return self._subscribe("client_new", func)
 
@@ -304,7 +304,7 @@ class Subscribe:
         return self._subscribe("screen_change", func)
 
     def screens_reconfigured(self, func):
-        """Called once ``qtile.cmd_reconfigure_screens`` has completed (e.g. if
+        """Called once ``qtile.reconfigure_screens`` has completed (e.g. if
         ``reconfigure_screens`` is set to ``True`` in your config).
 
         **Arguments**

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -15,6 +15,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from libqtile.command.base import expose_command
 from libqtile.layout.base import Layout
 
 
@@ -187,6 +188,7 @@ class Bsp(Layout):
     def get_windows(self):
         return list(self.root.clients())
 
+    @expose_command()
     def info(self):
         return dict(name=self.name, clients=[c.name for c in self.root.clients()])
 
@@ -198,7 +200,7 @@ class Bsp(Layout):
     def focus(self, client):
         self.current = self.get_node(client)
 
-    def add(self, client):
+    def add_client(self, client):
         node = self.root.get_shortest() if self.fair else self.current
         self.current = node.insert(client, int(self.lower_right), self.ratio)
 
@@ -235,7 +237,8 @@ class Bsp(Layout):
             )
         client.unhide()
 
-    def cmd_toggle_split(self):
+    @expose_command()
+    def toggle_split(self):
         if self.current.parent:
             self.current.parent.split_horizontal = not self.current.parent.split_horizontal
         self.group.layout_all()
@@ -265,12 +268,14 @@ class Bsp(Layout):
             elif wrap:
                 return clients[(idx - 1) % len(clients)]
 
-    def cmd_next(self):
+    @expose_command()
+    def next(self):
         client = self.focus_next(self.current.client, wrap=self.wrap_clients)
         if client:
             self.group.focus(client, True)
 
-    def cmd_previous(self):
+    @expose_command()
+    def previous(self):
         client = self.focus_previous(self.current.client, wrap=self.wrap_clients)
         if client:
             self.group.focus(client, True)
@@ -339,27 +344,32 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_left(self):
+    @expose_command()
+    def left(self):
         node = self.find_left()
         if node:
             self.group.focus(node.client, True)
 
-    def cmd_right(self):
+    @expose_command()
+    def right(self):
         node = self.find_right()
         if node:
             self.group.focus(node.client, True)
 
-    def cmd_up(self):
+    @expose_command()
+    def up(self):
         node = self.find_up()
         if node:
             self.group.focus(node.client, True)
 
-    def cmd_down(self):
+    @expose_command()
+    def down(self):
         node = self.find_down()
         if node:
             self.group.focus(node.client, True)
 
-    def cmd_shuffle_left(self):
+    @expose_command()
+    def shuffle_left(self):
         node = self.find_left()
         if node:
             node.client, self.current.client = self.current.client, node.client
@@ -377,7 +387,8 @@ class Bsp(Layout):
             self.current = node
             self.group.layout_all()
 
-    def cmd_shuffle_right(self):
+    @expose_command()
+    def shuffle_right(self):
         node = self.find_right()
         if node:
             node.client, self.current.client = self.current.client, node.client
@@ -395,7 +406,8 @@ class Bsp(Layout):
             self.current = node
             self.group.layout_all()
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         node = self.find_up()
         if node:
             node.client, self.current.client = self.current.client, node.client
@@ -413,7 +425,8 @@ class Bsp(Layout):
             self.current = node
             self.group.layout_all()
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         node = self.find_down()
         if node:
             node.client, self.current.client = self.current.client, node.client
@@ -431,7 +444,8 @@ class Bsp(Layout):
             self.current = node
             self.group.layout_all()
 
-    def cmd_grow_left(self):
+    @expose_command()
+    def grow_left(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -442,7 +456,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_grow_right(self):
+    @expose_command()
+    def grow_right(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -453,7 +468,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_grow_up(self):
+    @expose_command()
+    def grow_up(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -464,7 +480,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_grow_down(self):
+    @expose_command()
+    def grow_down(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -475,7 +492,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_flip_left(self):
+    @expose_command()
+    def flip_left(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -486,7 +504,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_flip_right(self):
+    @expose_command()
+    def flip_right(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -497,7 +516,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_flip_up(self):
+    @expose_command()
+    def flip_up(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -508,7 +528,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_flip_down(self):
+    @expose_command()
+    def flip_down(self):
         child = self.current
         parent = child.parent
         while parent:
@@ -519,7 +540,8 @@ class Bsp(Layout):
             child = parent
             parent = child.parent
 
-    def cmd_normalize(self):
+    @expose_command()
+    def normalize(self):
         distribute = True
         for node in self.root:
             if node.split_ratio != 50:

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -15,6 +15,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from libqtile.command.base import expose_command
 from libqtile.layout.base import Layout, _ClientList
 from libqtile.log_utils import logger
 
@@ -32,6 +33,7 @@ class _Column(_ClientList):
         self.insert_position = insert_position
         self.heights = {}
 
+    @expose_command()
     def info(self):
         info = _ClientList.info(self)
         info.update(
@@ -45,8 +47,8 @@ class _Column(_ClientList):
     def toggle_split(self):
         self.split = not self.split
 
-    def add(self, client, height=100):
-        _ClientList.add(self, client, self.insert_position)
+    def add_client(self, client, height=100):
+        _ClientList.add_client(self, client, self.insert_position)
         self.heights[client] = height
         delta = 100 - height
         if delta != 0:
@@ -168,6 +170,7 @@ class Columns(Layout):
             clients.extend(c.clients)
         return clients
 
+    @expose_command()
     def info(self):
         d = Layout.info(self)
         d["clients"] = []
@@ -215,7 +218,7 @@ class Columns(Layout):
             for c, g in zip(self.columns, growth):
                 c.width += g
 
-    def add(self, client):
+    def add_client(self, client):
         c = self.cc
         if len(c) > 0 and len(self.columns) < self.num_columns:
             c = self.add_column()
@@ -224,7 +227,7 @@ class Columns(Layout):
             if len(least) < len(c):
                 c = least
         self.current = self.columns.index(c)
-        c.add(client)
+        c.add_client(client)
 
     def remove(self, client):
         remove = None
@@ -328,11 +331,13 @@ class Columns(Layout):
         if idx > 0:
             return self.columns[idx - 1].focus_last()
 
-    def cmd_toggle_split(self):
+    @expose_command()
+    def toggle_split(self):
         self.cc.toggle_split()
         self.group.layout_all()
 
-    def cmd_left(self):
+    @expose_command()
+    def left(self):
         if self.wrap_focus_columns:
             if len(self.columns) > 1:
                 self.current = (self.current - 1) % len(self.columns)
@@ -341,7 +346,8 @@ class Columns(Layout):
                 self.current = self.current - 1
         self.group.focus(self.cc.cw, True)
 
-    def cmd_right(self):
+    @expose_command()
+    def right(self):
         if self.wrap_focus_columns:
             if len(self.columns) > 1:
                 self.current = (self.current + 1) % len(self.columns)
@@ -355,7 +361,8 @@ class Columns(Layout):
             return self.wrap_focus_rows
         return self.wrap_focus_stacks
 
-    def cmd_up(self):
+    @expose_command()
+    def up(self):
         col = self.cc
         if self.want_wrap(col):
             if len(col) > 1:
@@ -365,7 +372,8 @@ class Columns(Layout):
                 col.current_index -= 1
         self.group.focus(col.cw, True)
 
-    def cmd_down(self):
+    @expose_command()
+    def down(self):
         col = self.cc
         if self.want_wrap(col):
             if len(col) > 1:
@@ -375,7 +383,8 @@ class Columns(Layout):
                 col.current_index += 1
         self.group.focus(col.cw, True)
 
-    def cmd_next(self):
+    @expose_command()
+    def next(self):
         if self.cc.split and self.cc.current < len(self.cc) - 1:
             self.cc.current += 1
         elif self.columns:
@@ -384,7 +393,8 @@ class Columns(Layout):
                 self.cc.current = 0
         self.group.focus(self.cc.cw, True)
 
-    def cmd_previous(self):
+    @expose_command()
+    def previous(self):
         if self.cc.split and self.cc.current > 0:
             self.cc.current -= 1
         elif self.columns:
@@ -393,7 +403,8 @@ class Columns(Layout):
                 self.cc.current = len(self.cc) - 1
         self.group.focus(self.cc.cw, True)
 
-    def cmd_shuffle_left(self):
+    @expose_command()
+    def shuffle_left(self):
         cur = self.cc
         client = cur.cw
         if client is None:
@@ -401,20 +412,21 @@ class Columns(Layout):
         if self.current > 0:
             self.current -= 1
             new = self.cc
-            new.add(client, cur.heights[client])
+            new.add_client(client, cur.heights[client])
             cur.remove(client)
             if len(cur) == 0:
                 self.remove_column(cur)
         elif len(cur) > 1:
             new = self.add_column(True)
-            new.add(client, cur.heights[client])
+            new.add_client(client, cur.heights[client])
             cur.remove(client)
             self.current = 0
         else:
             return
         self.group.layout_all()
 
-    def cmd_shuffle_right(self):
+    @expose_command()
+    def shuffle_right(self):
         cur = self.cc
         client = cur.cw
         if client is None:
@@ -422,30 +434,33 @@ class Columns(Layout):
         if self.current + 1 < len(self.columns):
             self.current += 1
             new = self.cc
-            new.add(client, cur.heights[client])
+            new.add_client(client, cur.heights[client])
             cur.remove(client)
             if len(cur) == 0:
                 self.remove_column(cur)
         elif len(cur) > 1:
             new = self.add_column()
-            new.add(client, cur.heights[client])
+            new.add_client(client, cur.heights[client])
             cur.remove(client)
             self.current = len(self.columns) - 1
         else:
             return
         self.group.layout_all()
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         if self.cc.current_index > 0:
             self.cc.shuffle_up()
             self.group.layout_all()
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         if self.cc.current_index + 1 < len(self.cc):
             self.cc.shuffle_down()
             self.group.layout_all()
 
-    def cmd_grow_left(self):
+    @expose_command()
+    def grow_left(self):
         if self.current > 0:
             if self.columns[self.current - 1].width > self.grow_amount:
                 self.columns[self.current - 1].width -= self.grow_amount
@@ -457,7 +472,8 @@ class Columns(Layout):
                 self.cc.width -= self.grow_amount
                 self.group.layout_all()
 
-    def cmd_grow_right(self):
+    @expose_command()
+    def grow_right(self):
         if self.current + 1 < len(self.columns):
             if self.columns[self.current + 1].width > self.grow_amount:
                 self.columns[self.current + 1].width -= self.grow_amount
@@ -469,7 +485,8 @@ class Columns(Layout):
                 self.columns[self.current - 1].width += self.grow_amount
                 self.group.layout_all()
 
-    def cmd_grow_up(self):
+    @expose_command()
+    def grow_up(self):
         col = self.cc
         if col.current > 0:
             if col.heights[col[col.current - 1]] > self.grow_amount:
@@ -482,7 +499,8 @@ class Columns(Layout):
                 col.heights[col.cw] -= self.grow_amount
                 self.group.layout_all()
 
-    def cmd_grow_down(self):
+    @expose_command()
+    def grow_down(self):
         col = self.cc
         if col.current + 1 < len(col):
             if col.heights[col[col.current + 1]] > self.grow_amount:
@@ -495,7 +513,8 @@ class Columns(Layout):
                 col.heights[col.cw] -= self.grow_amount
                 self.group.layout_all()
 
-    def cmd_normalize(self):
+    @expose_command()
+    def normalize(self):
         for col in self.columns:
             for client in col:
                 col.heights[client] = 100
@@ -507,12 +526,14 @@ class Columns(Layout):
         self.current = dst
         self.group.layout_all()
 
-    def cmd_swap_column_left(self):
+    @expose_command()
+    def swap_column_left(self):
         src = self.current
         dst = src - 1 if src > 0 else len(self.columns) - 1
         self.swap_column(src, dst)
 
-    def cmd_swap_column_right(self):
+    @expose_command()
+    def swap_column_right(self):
         src = self.current
         dst = src + 1 if src < len(self.columns) - 1 else 0
         self.swap_column(src, dst)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -31,6 +31,7 @@
 from __future__ import annotations
 
 from libqtile.backend.base import Window
+from libqtile.command.base import expose_command
 from libqtile.config import Match
 from libqtile.layout.base import Layout
 
@@ -251,12 +252,12 @@ class Floating(Layout):
         is_java_dropdown = "sun-awt-X11-XWindowPeer" in cls
         if is_java_dropdown:
             client.paint_borders(bc, bw)
-            client.cmd_bring_to_front()
+            client.bring_to_front()
 
         # alternatively, users may have asked us explicitly to leave the client alone
         elif any(m.compare(client) for m in self.no_reposition_rules):
             client.paint_borders(bc, bw)
-            client.cmd_bring_to_front()
+            client.bring_to_front()
 
         else:
             above = False
@@ -278,7 +279,7 @@ class Floating(Layout):
             )
         client.unhide()
 
-    def add(self, client):
+    def add_client(self, client):
         self.clients.append(client)
         self.focused = client
 
@@ -295,15 +296,18 @@ class Floating(Layout):
     def get_windows(self):
         return self.clients
 
+    @expose_command()
     def info(self):
         d = Layout.info(self)
         d["clients"] = [c.name for c in self.clients]
         return d
 
-    def cmd_next(self):
+    @expose_command()
+    def next(self):
         # This can't ever be called, but implement the abstract method
         pass
 
-    def cmd_previous(self):
+    @expose_command()
+    def previous(self):
         # This can't ever be called, but implement the abstract method
         pass

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import math
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 from libqtile.log_utils import logger
 
@@ -72,6 +73,7 @@ class Matrix(_SimpleLayoutBase):
         """Calc column index of current client"""
         return self.clients.current_index % self.columns
 
+    @expose_command()
     def info(self):
         d = _SimpleLayoutBase.info(self)
         d["rows"] = [[win.name for win in self.get_row(i)] for i in range(self.rows)]
@@ -93,7 +95,7 @@ class Matrix(_SimpleLayoutBase):
         assert column < self.columns
         return [self.clients[i] for i in range(column, len(self.clients), self.columns)]
 
-    def add(self, client):
+    def add_client(self, client):
         """Add client to Layout.
         Note that for Matrix the clients are appended at end of list.
         If needed a new row in matrix is created"""
@@ -129,8 +131,13 @@ class Matrix(_SimpleLayoutBase):
         )
         client.unhide()
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command()
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
+
+    @expose_command()
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
     def horizontal_traversal(self, direction):
         """
@@ -152,28 +159,34 @@ class Matrix(_SimpleLayoutBase):
         self.clients.current_index = row * self.columns + column
         self.group.focus(self.clients.current_client)
 
-    def cmd_left(self):
+    @expose_command()
+    def left(self):
         """Switch to the next window on current row"""
         self.horizontal_traversal(-1)
 
-    def cmd_right(self):
+    @expose_command()
+    def right(self):
         """Switch to the next window on current row"""
         self.horizontal_traversal(+1)
 
-    def cmd_up(self):
+    @expose_command()
+    def up(self):
         """Switch to the previous window in current column"""
         self.vertical_traversal(-1)
 
-    def cmd_down(self):
+    @expose_command()
+    def down(self):
         """Switch to the next window in current column"""
         self.vertical_traversal(+1)
 
-    def cmd_delete(self):
+    @expose_command()
+    def delete(self):
         """Decrease number of columns"""
         self.columns -= 1
         self.group.layout_all()
 
-    def cmd_add(self):
+    @expose_command()
+    def add(self):
         """Increase number of columns"""
         self.columns += 1
         self.group.layout_all()

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 
 
@@ -42,8 +43,8 @@ class Max(_SimpleLayoutBase):
         _SimpleLayoutBase.__init__(self, **config)
         self.add_defaults(Max.defaults)
 
-    def add(self, client):
-        return super().add(client, 1)
+    def add_client(self, client):
+        return super().add_client(client, 1)
 
     def configure(self, client, screen_rect):
         if self.clients and client is self.clients.current_client:
@@ -60,8 +61,10 @@ class Max(_SimpleLayoutBase):
         else:
             client.hide()
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command("previous")
+    def up(self):
+        _SimpleLayoutBase.previous(self)
 
-    cmd_up = cmd_previous
-    cmd_down = cmd_next
+    @expose_command("next")
+    def down(self):
+        _SimpleLayoutBase.next(self)

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -29,6 +29,7 @@
 
 import math
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 
 ROWCOL = 1  # do rows at a time left to right top down
@@ -221,7 +222,7 @@ class RatioTile(_SimpleLayoutBase):
     def clone(self, group):
         return _SimpleLayoutBase.clone(self, group)
 
-    def add(self, w):
+    def add_client(self, w):
         self.dirty = True
         self.clients.append_head(w)
 
@@ -269,6 +270,7 @@ class RatioTile(_SimpleLayoutBase):
         )
         win.unhide()
 
+    @expose_command()
     def info(self):
         d = _SimpleLayoutBase.info(self)
         focused = self.clients.current_client
@@ -277,29 +279,35 @@ class RatioTile(_SimpleLayoutBase):
         d["layout_info"] = self.layout_info
         return d
 
-    cmd_down = _SimpleLayoutBase.previous
-    cmd_up = _SimpleLayoutBase.next
+    @expose_command("down")
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command("up")
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         if self.clients:
             self.clients.rotate_up()
             self.group.layout_all()
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         if self.clients:
             self.clients.rotate_down()
             self.group.layout_all()
 
-    def cmd_decrease_ratio(self):
+    @expose_command()
+    def decrease_ratio(self):
         new_ratio = self.ratio - self.ratio_increment
         if new_ratio < 0:
             return
         self.ratio = new_ratio
         self.group.layout_all()
 
-    def cmd_increase_ratio(self):
+    @expose_command()
+    def increase_ratio(self):
         self.ratio += self.ratio_increment
         self.group.layout_all()

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 from libqtile.log_utils import logger
 
@@ -142,9 +143,9 @@ class Spiral(_SimpleLayoutBase):
     def clone(self, group):
         return _SimpleLayoutBase.clone(self, group)
 
-    def add(self, client):
+    def add_client(self, client):
         self.dirty = True
-        self.clients.add(client, client_position=self.new_client_position)
+        self.clients.add_client(client, client_position=self.new_client_position)
 
     def remove(self, w):
         self.dirty = True
@@ -339,11 +340,13 @@ class Spiral(_SimpleLayoutBase):
         d["clockwise"] = self.clockwise
         return d
 
-    cmd_down = _SimpleLayoutBase.previous
-    cmd_up = _SimpleLayoutBase.next
+    @expose_command("up")
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command("down")
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
     def _set_ratio(self, prop: str, value: float | str):
         # We allow a str for 'value' as a string may be issued via IPC.
@@ -363,47 +366,56 @@ class Spiral(_SimpleLayoutBase):
         setattr(self, prop, value)
         self.group.layout_all()
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         if self.clients:
             self.clients.rotate_down()
             self.group.layout_all()
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         if self.clients:
             self.clients.rotate_up()
             self.group.layout_all()
 
-    def cmd_decrease_ratio(self):
+    @expose_command()
+    def decrease_ratio(self):
         """Decrease spiral ratio."""
         self._set_ratio("ratio", self.ratio - self.ratio_increment)
 
-    def cmd_increase_ratio(self):
+    @expose_command()
+    def increase_ratio(self):
         """Increase spiral ratio."""
         self._set_ratio("ratio", self.ratio + self.ratio_increment)
 
-    def cmd_shrink_main(self):
+    @expose_command()
+    def shrink_main(self):
         """Shrink the main window."""
         if self.main_pane_ratio is None:
             self.main_pane_ratio = self.ratio
 
         self._set_ratio("main_pane_ratio", self.main_pane_ratio - self.ratio_increment)
 
-    def cmd_grow_main(self):
+    @expose_command()
+    def grow_main(self):
         """Grow the main window."""
         if self.main_pane_ratio is None:
             self.main_pane_ratio = self.ratio
 
         self._set_ratio("main_pane_ratio", self.main_pane_ratio + self.ratio_increment)
 
-    def cmd_set_ratio(self, ratio: float | str):
+    @expose_command()
+    def set_ratio(self, ratio: float | str):
         """Set the ratio for all windows."""
         self._set_ratio("ratio", ratio)
 
-    def cmd_set_master_ratio(self, ratio: float | str):
+    @expose_command()
+    def set_master_ratio(self, ratio: float | str):
         """Set the ratio for the main window."""
         self._set_ratio("main_pane_ratio", ratio)
 
-    def cmd_reset(self):
+    @expose_command()
+    def reset(self):
         """Reset ratios to values set in config."""
         self.ratio = self.initial_ratio
         self.main_pane_ratio = self.initial_main_pane_ratio

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from libqtile.command.base import expose_command
 from libqtile.layout.base import Layout, _ClientList
 
 
@@ -35,6 +36,7 @@ class _WinStack(_ClientList):
     def __str__(self):
         return "_WinStack: %s, %s" % (self.cw, str([client.name for client in self.clients]))
 
+    @expose_command()
     def info(self):
         info = _ClientList.info(self)
         info["split"] = self.split
@@ -169,16 +171,16 @@ class Stack(Layout):
             if i:
                 return i.focus_last()
 
-    def add(self, client):
+    def add_client(self, client):
         for i in self.stacks:
             if not i:
-                i.add(client)
+                i.add_client(client)
                 return
         if self.fair:
             target = min(self.stacks, key=len)
-            target.add(client)
+            target.add_client(client)
         else:
-            self.current_stack.add(client)
+            self.current_stack.add_client(client)
 
     def remove(self, client):
         current_offset = self.current_stack_offset
@@ -246,6 +248,7 @@ class Stack(Layout):
     def get_windows(self):
         return self.clients
 
+    @expose_command()
     def info(self):
         d = Layout.info(self)
         d["stacks"] = [i.info() for i in self.stacks]
@@ -253,36 +256,43 @@ class Stack(Layout):
         d["clients"] = [c.name for c in self.clients]
         return d
 
-    def cmd_toggle_split(self):
+    @expose_command()
+    def toggle_split(self):
         """Toggle vertical split on the current stack"""
         self.current_stack.toggle_split()
         self.group.layout_all()
 
-    def cmd_down(self):
+    @expose_command()
+    def down(self):
         """Switch to the next window in this stack"""
         self.current_stack.current_index += 1
         self.group.focus(self.current_stack.cw, False)
 
-    def cmd_up(self):
+    @expose_command()
+    def up(self):
         """Switch to the previous window in this stack"""
         self.current_stack.current_index -= 1
         self.group.focus(self.current_stack.cw, False)
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         """Shuffle the order of this stack up"""
         self.current_stack.shuffle_up()
         self.group.layout_all()
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         """Shuffle the order of this stack down"""
         self.current_stack.shuffle_down()
         self.group.layout_all()
 
-    def cmd_delete(self):
+    @expose_command()
+    def delete(self):
         """Delete the current stack from the layout"""
         self.delete_current_stack()
 
-    def cmd_add(self):
+    @expose_command()
+    def add(self):
         """Add another stack to the layout"""
         newstack = _WinStack(autosplit=self.autosplit)
         if self.autosplit:
@@ -290,29 +300,35 @@ class Stack(Layout):
         self.stacks.append(newstack)
         self.group.layout_all()
 
-    def cmd_rotate(self):
+    @expose_command()
+    def rotate(self):
         """Rotate order of the stacks"""
         if self.stacks:
             self.stacks.insert(0, self.stacks.pop())
         self.group.layout_all()
 
-    def cmd_next(self):
+    @expose_command()
+    def next(self):
         """Focus next stack"""
         return self.next_stack()
 
-    def cmd_previous(self):
+    @expose_command()
+    def previous(self):
         """Focus previous stack"""
         return self.previous_stack()
 
-    def cmd_client_to_next(self):
+    @expose_command()
+    def client_to_next(self):
         """Send the current client to the next stack"""
-        return self.cmd_client_to_stack(self.current_stack_offset + 1)
+        return self.client_to_stack(self.current_stack_offset + 1)
 
-    def cmd_client_to_previous(self):
+    @expose_command()
+    def client_to_previous(self):
         """Send the current client to the previous stack"""
-        return self.cmd_client_to_stack(self.current_stack_offset - 1)
+        return self.client_to_stack(self.current_stack_offset - 1)
 
-    def cmd_client_to_stack(self, n):
+    @expose_command()
+    def client_to_stack(self, n):
         """
         Send the current client to stack n, where n is an integer offset.  If
         is too large or less than 0, it is wrapped modulo the number of stacks.
@@ -322,9 +338,6 @@ class Stack(Layout):
         next = n % len(self.stacks)
         win = self.current_stack.cw
         self.current_stack.remove(win)
-        self.stacks[next].add(win)
+        self.stacks[next].add_client(win)
         self.stacks[next].focus(win)
         self.group.layout_all()
-
-    def cmd_info(self):
-        return self.info()

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -29,7 +29,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+from libqtile.command.base import expose_command
 from libqtile.config import Match
 from libqtile.layout.base import _SimpleLayoutBase
 
@@ -69,8 +69,8 @@ class Tile(_SimpleLayoutBase):
         (
             "ratio_increment",
             0.05,
-            "By which amount to change ratio when cmd_decrease_ratio or "
-            "cmd_increase_ratio are called.",
+            "By which amount to change ratio when decrease_ratio or "
+            "increase_ratio are called.",
         ),
         (
             "add_on_top",
@@ -118,14 +118,16 @@ class Tile(_SimpleLayoutBase):
     def slave_windows(self):
         return self.clients[self.master_length :]
 
-    def up(self):
+    @expose_command("shuffle_left")
+    def shuffle_up(self):
         if self.shift_windows:
             self.clients.shuffle_up()
         else:
             self.clients.rotate_down()
         self.group.layout_all()
 
-    def down(self):
+    @expose_command("shuffle_right")
+    def shuffle_down(self):
         if self.shift_windows:
             self.clients.shuffle_down()
         else:
@@ -152,13 +154,13 @@ class Tile(_SimpleLayoutBase):
         c = _SimpleLayoutBase.clone(self, group)
         return c
 
-    def add(self, client, offset_to_current=1):
+    def add_client(self, client, offset_to_current=1):
         if self.add_after_last:
             self.clients.append(client)
         elif self.add_on_top:
             self.clients.append_head(client)
         else:
-            super().add(client, offset_to_current)
+            super().add_client(client, offset_to_current)
         self.reset_master()
 
     def configure(self, client, screen_rect):
@@ -204,6 +206,7 @@ class Tile(_SimpleLayoutBase):
         else:
             client.hide()
 
+    @expose_command()
     def info(self):
         d = _SimpleLayoutBase.info(self)
         d.update(
@@ -214,42 +217,37 @@ class Tile(_SimpleLayoutBase):
         )
         return d
 
-    def cmd_shuffle_down(self):
-        self.down()
+    @expose_command(["left", "up"])
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
 
-    def cmd_shuffle_up(self):
-        self.up()
+    @expose_command(["right", "down"])
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
-    def cmd_reset(self):
+    @expose_command("normalize")
+    def reset(self):
         self.ratio_size = self._initial_ratio
         self.group.layout_all()
 
-    cmd_normalize = cmd_reset
-
-    cmd_shuffle_left = cmd_shuffle_up
-    cmd_shuffle_right = cmd_shuffle_down
-
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
-    cmd_up = cmd_previous
-    cmd_down = cmd_next
-    cmd_left = cmd_previous
-    cmd_right = cmd_next
-
-    def cmd_decrease_ratio(self):
+    @expose_command()
+    def decrease_ratio(self):
         self.ratio_size -= self.ratio_increment
         self.group.layout_all()
 
-    def cmd_increase_ratio(self):
+    @expose_command()
+    def increase_ratio(self):
         self.ratio_size += self.ratio_increment
         self.group.layout_all()
 
-    def cmd_decrease_nmaster(self):
+    @expose_command()
+    def decrease_nmaster(self):
         self.master_length -= 1
         if self.master_length <= 0:
             self.master_length = 1
         self.group.layout_all()
 
-    def cmd_increase_nmaster(self):
+    @expose_command()
+    def increase_nmaster(self):
         self.master_length += 1
         self.group.layout_all()

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -19,6 +19,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 
 
@@ -98,8 +99,8 @@ class VerticalTile(_SimpleLayoutBase):
         self.add_defaults(VerticalTile.defaults)
         self.maximized = None
 
-    def add(self, window):
-        return self.clients.add(window, 1)
+    def add_client(self, window):
+        return self.clients.add_client(window, 1)
 
     def remove(self, window):
         if self.maximized is window:
@@ -172,51 +173,59 @@ class VerticalTile(_SimpleLayoutBase):
         else:
             window.hide()
 
-    def grow(self):
+    def _grow(self):
         if self.ratio + self.steps < 1:
             self.ratio += self.steps
             self.group.layout_all()
 
-    def shrink(self):
+    def _shrink(self):
         if self.ratio - self.steps > 0:
             self.ratio -= self.steps
             self.group.layout_all()
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command("up")
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
 
-    cmd_up = cmd_previous
-    cmd_down = cmd_next
+    @expose_command("down")
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         self.clients.shuffle_up()
         self.group.layout_all()
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         self.clients.shuffle_down()
         self.group.layout_all()
 
-    def cmd_maximize(self):
+    @expose_command()
+    def maximize(self):
         if self.clients:
             self.maximized = self.clients.current_client
             self.group.layout_all()
 
-    def cmd_normalize(self):
+    @expose_command()
+    def normalize(self):
         self.maximized = None
         self.group.layout_all()
 
-    def cmd_grow(self):
+    @expose_command()
+    def grow(self):
         if not self.maximized:
             return
         if self.clients.current_client is self.maximized:
-            self.grow()
+            self._grow()
         else:
-            self.shrink()
+            self._shrink()
 
-    def cmd_shrink(self):
+    @expose_command()
+    def shrink(self):
         if not self.maximized:
             return
         if self.clients.current_client is self.maximized:
-            self.shrink()
+            self._shrink()
         else:
-            self.grow()
+            self._grow()

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -36,6 +36,7 @@
 import math
 from collections import namedtuple
 
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 
 
@@ -46,9 +47,9 @@ class MonadTall(_SimpleLayoutBase):
 
     A main pane that contains a single window takes up a vertical portion of
     the screen_rect based on the ratio setting. This ratio can be adjusted with
-    the ``cmd_grow_main`` and ``cmd_shrink_main`` or, while the main pane is in
-    focus, ``cmd_grow`` and ``cmd_shrink``. You may also set the ratio directly
-    with ``cmd_set_ratio``.
+    the ``grow_main`` and ``shrink_main`` or, while the main pane is in
+    focus, ``grow`` and ``shrink``. You may also set the ratio directly
+    with ``set_ratio``.
 
     ::
 
@@ -61,7 +62,7 @@ class MonadTall(_SimpleLayoutBase):
         |            |      |
         ---------------------
 
-    Using the ``cmd_flip`` method will switch which horizontal side the main
+    Using the ``flip`` method will switch which horizontal side the main
     pane will occupy. The main pane is considered the "top" of the stack.
 
     ::
@@ -79,7 +80,7 @@ class MonadTall(_SimpleLayoutBase):
 
     Occupying the rest of the screen_rect are one or more secondary panes.  The
     secondary panes will share the vertical space of the screen_rect however
-    they can be resized at will with the ``cmd_grow`` and ``cmd_shrink``
+    they can be resized at will with the ``grow`` and ``shrink``
     methods.  The other secondary panes will adjust their sizes to smoothly fill
     all of the space.
 
@@ -94,7 +95,7 @@ class MonadTall(_SimpleLayoutBase):
         |            |      |          |            |      |
         ---------------------          ---------------------
 
-    Panes can be moved with the ``cmd_shuffle_up`` and ``cmd_shuffle_down``
+    Panes can be moved with the ``shuffle_up`` and ``shuffle_down``
     methods. As mentioned the main pane is considered the top of the stack;
     moving up is counter-clockwise and moving down is clockwise.
 
@@ -115,15 +116,15 @@ class MonadTall(_SimpleLayoutBase):
     Normalizing/Resetting:
 
     To restore all secondary client windows to their default size ratios
-    use the ``cmd_normalize`` method.
+    use the ``normalize`` method.
 
     To reset all client windows to their default sizes, including the primary
-    window, use the ``cmd_reset`` method.
+    window, use the ``reset`` method.
 
     Maximizing:
 
     To toggle a client window between its minimum and maximum sizes
-    simply use the ``cmd_maximize`` on a focused client.
+    simply use the ``maximize`` on a focused client.
 
     Suggested Bindings::
 
@@ -218,9 +219,9 @@ class MonadTall(_SimpleLayoutBase):
         c.align = self.align
         return c
 
-    def add(self, client):
+    def add_client(self, client):
         "Add client to layout"
-        self.clients.add(client, client_position=self.new_client_position)
+        self.clients.add_client(client, client_position=self.new_client_position)
         self.do_normalize = True
 
     def remove(self, client):
@@ -228,13 +229,15 @@ class MonadTall(_SimpleLayoutBase):
         self.do_normalize = True
         return self.clients.remove(client)
 
-    def cmd_set_ratio(self, ratio):
+    @expose_command()
+    def set_ratio(self, ratio):
         "Directly set the main pane ratio"
         ratio = min(self.max_ratio, ratio)
         self.ratio = max(self.min_ratio, ratio)
         self.group.layout_all()
 
-    def cmd_normalize(self, redraw=True):
+    @expose_command()
+    def normalize(self, redraw=True):
         "Evenly distribute screen-space among secondary clients"
         n = len(self.clients) - 1  # exclude main client, 0
         # if secondary clients exist
@@ -245,12 +248,13 @@ class MonadTall(_SimpleLayoutBase):
             self.group.layout_all()
         self.do_normalize = False
 
-    def cmd_reset(self, ratio=None, redraw=True):
+    @expose_command()
+    def reset(self, ratio=None, redraw=True):
         "Reset Layout."
         self.ratio = ratio or self.default_ratio
         if self.align == self._right:
             self.align = self._left
-        self.cmd_normalize(redraw)
+        self.normalize(redraw)
 
     def _maximize_main(self):
         "Toggle the main pane between min and max size"
@@ -282,7 +286,8 @@ class MonadTall(_SimpleLayoutBase):
         else:
             self._grow_secondary(maxed_size)
 
-    def cmd_maximize(self):
+    @expose_command()
+    def maximize(self):
         "Grow the currently focused client to the max size"
         # if we have 1 or 2 panes or main pane is focused
         if len(self.clients) < 3 or self.focused == 0:
@@ -298,7 +303,7 @@ class MonadTall(_SimpleLayoutBase):
 
         # if no sizes or normalize flag is set, normalize
         if not self.relative_sizes or self.do_normalize:
-            self.cmd_normalize(False)
+            self.normalize(False)
 
         # if client not in this layout
         if not self.clients or client not in self.clients:
@@ -393,6 +398,7 @@ class MonadTall(_SimpleLayoutBase):
                 ],
             )
 
+    @expose_command()
     def info(self):
         d = _SimpleLayoutBase.info(self)
         d.update(
@@ -411,7 +417,7 @@ class MonadTall(_SimpleLayoutBase):
             - self.min_secondary_size,
         )
 
-    def shrink(self, cidx, amt):
+    def _shrink(self, cidx, amt):
         """Reduce the size of a client
 
         Will only shrink the client until it reaches the configured minimum
@@ -439,7 +445,7 @@ class MonadTall(_SimpleLayoutBase):
         # for each client before specified index
         for idx in range(0, cidx):
             # shrink by whatever is left-over of original amount
-            left -= left - self.shrink(idx, left)
+            left -= left - self._shrink(idx, left)
         # return unused shrink amount
         return left
 
@@ -459,10 +465,10 @@ class MonadTall(_SimpleLayoutBase):
         # for each client before specified index
         for idx in range(0, cidx):
             # shrink by equal amount and track left-over
-            left -= per_amt - self.shrink(idx, per_amt)
+            left -= per_amt - self._shrink(idx, per_amt)
         # apply non-equal shrinkage secondary pass
         # in order to use up any left over shrink amounts
-        left = self.shrink_up(cidx, left)
+        left = self._shrink_up(cidx, left)
         # return whatever could not be applied
         return left
 
@@ -479,7 +485,7 @@ class MonadTall(_SimpleLayoutBase):
         # for each client after specified index
         for idx in range(cidx + 1, len(self.relative_sizes)):
             # shrink by current total left-over amount
-            left -= left - self.shrink(idx, left)
+            left -= left - self._shrink(idx, left)
         # return unused shrink amount
         return left
 
@@ -499,7 +505,7 @@ class MonadTall(_SimpleLayoutBase):
         # for each client after specified index
         for idx in range(cidx + 1, len(self.relative_sizes)):
             # shrink by equal amount and track left-over
-            left -= per_amt - self.shrink(idx, per_amt)
+            left -= per_amt - self._shrink(idx, per_amt)
         # apply non-equal shrinkage secondary pass
         # in order to use up any left over shrink amounts
         left = self.shrink_down(cidx, left)
@@ -543,7 +549,8 @@ class MonadTall(_SimpleLayoutBase):
         # grow client by diff amount
         self.relative_sizes[self.focused - 1] += self._get_relative_size_from_absolute(diff)
 
-    def cmd_grow(self):
+    @expose_command()
+    def grow(self):
         """Grow current window
 
         Will grow the currently focused client reducing the size of those
@@ -558,7 +565,8 @@ class MonadTall(_SimpleLayoutBase):
             self._grow_secondary(self.change_size)
         self.group.layout_all()
 
-    def cmd_grow_main(self):
+    @expose_command()
+    def grow_main(self):
         """Grow main pane
 
         Will grow the main pane, reducing the size of clients in the secondary
@@ -567,7 +575,8 @@ class MonadTall(_SimpleLayoutBase):
         self._grow_main(self.change_ratio)
         self.group.layout_all()
 
-    def cmd_shrink_main(self):
+    @expose_command()
+    def shrink_main(self):
         """Shrink main pane
 
         Will shrink the main pane, increasing the size of clients in the
@@ -576,7 +585,7 @@ class MonadTall(_SimpleLayoutBase):
         self._shrink_main(self.change_ratio)
         self.group.layout_all()
 
-    def grow(self, cidx, amt):
+    def _grow(self, cidx, amt):
         "Grow secondary client by specified amount"
         self.relative_sizes[cidx] += self._get_relative_size_from_absolute(amt)
 
@@ -589,7 +598,7 @@ class MonadTall(_SimpleLayoutBase):
         # split grow amount among number of clients
         per_amt = amt / cidx
         for idx in range(0, cidx):
-            self.grow(idx, per_amt)
+            self._grow(idx, per_amt)
 
     def grow_down_shared(self, cidx, amt):
         """Grow lower secondary clients
@@ -600,7 +609,7 @@ class MonadTall(_SimpleLayoutBase):
         # split grow amount among number of clients
         per_amt = amt / (len(self.relative_sizes) - 1 - cidx)
         for idx in range(cidx + 1, len(self.relative_sizes)):
-            self.grow(idx, per_amt)
+            self._grow(idx, per_amt)
 
     def _shrink_main(self, amt):
         """Will shrink the client that currently in the main pane"""
@@ -647,10 +656,16 @@ class MonadTall(_SimpleLayoutBase):
         # shrink client by total change
         self.relative_sizes[self.focused - 1] -= self._get_relative_size_from_absolute(change)
 
-    cmd_next = _SimpleLayoutBase.next
-    cmd_previous = _SimpleLayoutBase.previous
+    @expose_command("down")
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
-    def cmd_shrink(self):
+    @expose_command("up")
+    def previous(self):
+        _SimpleLayoutBase.previous(self)
+
+    @expose_command()
+    def shrink(self):
         """Shrink current window
 
         Will shrink the currently focused client reducing the size of those
@@ -665,22 +680,22 @@ class MonadTall(_SimpleLayoutBase):
             self._shrink_secondary(self.change_size)
         self.group.layout_all()
 
-    cmd_up = cmd_previous
-    cmd_down = cmd_next
-
-    def cmd_shuffle_up(self):
+    @expose_command()
+    def shuffle_up(self):
         """Shuffle the client up the stack"""
         self.clients.shuffle_up()
         self.group.layout_all()
         self.group.focus(self.clients.current_client)
 
-    def cmd_shuffle_down(self):
+    @expose_command()
+    def shuffle_down(self):
         """Shuffle the client down the stack"""
         self.clients.shuffle_down()
         self.group.layout_all()
         self.group.focus(self.clients[self.focused])
 
-    def cmd_flip(self):
+    @expose_command()
+    def flip(self):
         """Flip the layout horizontally"""
         self.align = self._left if self.align == self._right else self._right
         self.group.layout_all()
@@ -694,36 +709,41 @@ class MonadTall(_SimpleLayoutBase):
         )
         return target
 
-    def cmd_swap(self, window1, window2):
+    @expose_command()
+    def swap(self, window1, window2):
         """Swap two windows"""
         self.clients.swap(window1, window2, 1)
         self.group.layout_all()
         self.group.focus(window1)
 
-    def cmd_swap_left(self):
+    @expose_command("shuffle_left")
+    def swap_left(self):
         """Swap current window with closest window to the left"""
         win = self.clients.current_client
         x, y = win.x, win.y
         candidates = [c for c in self.clients if c.info()["x"] < x]
         target = self._get_closest(x, y, candidates)
-        self.cmd_swap(win, target)
+        self.swap(win, target)
 
-    def cmd_swap_right(self):
+    @expose_command("shuffle_right")
+    def swap_right(self):
         """Swap current window with closest window to the right"""
         win = self.clients.current_client
         x, y = win.x, win.y
         candidates = [c for c in self.clients if c.info()["x"] > x]
         target = self._get_closest(x, y, candidates)
-        self.cmd_swap(win, target)
+        self.swap(win, target)
 
-    def cmd_swap_main(self):
+    @expose_command()
+    def swap_main(self):
         """Swap current window to main pane"""
         if self.align == self._left:
-            self.cmd_swap_left()
+            self.swap_left()
         elif self.align == self._right:
-            self.cmd_swap_right()
+            self.swap_right()
 
-    def cmd_left(self):
+    @expose_command()
+    def left(self):
         """Focus on the closest window to the left of the current window"""
         win = self.clients.current_client
         x, y = win.x, win.y
@@ -731,16 +751,14 @@ class MonadTall(_SimpleLayoutBase):
         self.clients.current_client = self._get_closest(x, y, candidates)
         self.group.focus(self.clients.current_client)
 
-    def cmd_right(self):
+    @expose_command()
+    def right(self):
         """Focus on the closest window to the right of the current window"""
         win = self.clients.current_client
         x, y = win.x, win.y
         candidates = [c for c in self.clients if c.info()["x"] > x]
         self.clients.current_client = self._get_closest(x, y, candidates)
         self.group.focus(self.clients.current_client)
-
-    cmd_shuffle_left = cmd_swap_left
-    cmd_shuffle_right = cmd_swap_right
 
 
 class MonadWide(MonadTall):
@@ -753,8 +771,8 @@ class MonadWide(MonadTall):
 
     A main pane that contains a single window takes up a horizontal
     portion of the screen_rect based on the ratio setting. This ratio can be
-    adjusted with the ``cmd_grow_main`` and ``cmd_shrink_main`` or,
-    while the main pane is in focus, ``cmd_grow`` and ``cmd_shrink``.
+    adjusted with the ``grow_main`` and ``shrink_main`` or,
+    while the main pane is in focus, ``grow`` and ``shrink``.
 
     ::
 
@@ -767,7 +785,7 @@ class MonadWide(MonadTall):
         |                   |
         ---------------------
 
-    Using the ``cmd_flip`` method will switch which vertical side the
+    Using the ``flip`` method will switch which vertical side the
     main pane will occupy. The main pane is considered the "top" of
     the stack.
 
@@ -786,8 +804,8 @@ class MonadWide(MonadTall):
 
     Occupying the rest of the screen_rect are one or more secondary panes.
     The secondary panes will share the horizontal space of the screen_rect
-    however they can be resized at will with the ``cmd_grow`` and
-    ``cmd_shrink`` methods. The other secondary panes will adjust their
+    however they can be resized at will with the ``grow`` and
+    ``shrink`` methods. The other secondary panes will adjust their
     sizes to smoothly fill all of the space.
 
     ::
@@ -801,7 +819,7 @@ class MonadWide(MonadTall):
         |     |       |     |          |   |           |   |
         ---------------------          ---------------------
 
-    Panes can be moved with the ``cmd_shuffle_up`` and ``cmd_shuffle_down``
+    Panes can be moved with the ``shuffle_up`` and ``shuffle_down``
     methods. As mentioned the main pane is considered the top of the
     stack; moving up is counter-clockwise and moving down is clockwise.
 
@@ -821,16 +839,16 @@ class MonadWide(MonadTall):
     Normalizing/Resetting:
 
     To restore all secondary client windows to their default size ratios
-    use the ``cmd_normalize`` method.
+    use the ``normalize`` method.
 
     To reset all client windows to their default sizes, including the primary
-    window, use the ``cmd_reset`` method.
+    window, use the ``reset`` method.
 
 
     Maximizing:
 
     To toggle a client window between its minimum and maximum sizes
-    simply use the ``cmd_maximize`` on a focused client.
+    simply use the ``maximize`` on a focused client.
 
     Suggested Bindings::
 
@@ -980,28 +998,31 @@ class MonadWide(MonadTall):
         # shrink client by total change
         self.relative_sizes[self.focused - 1] -= self._get_relative_size_from_absolute(change)
 
-    def cmd_swap_left(self):
+    @expose_command()
+    def swap_left(self):
         """Swap current window with closest window to the down"""
         win = self.clients.current_client
         x, y = win.x, win.y
         candidates = [c for c in self.clients.clients if c.info()["y"] > y]
         target = self._get_closest(x, y, candidates)
-        self.cmd_swap(win, target)
+        self.swap(win, target)
 
-    def cmd_swap_right(self):
+    @expose_command()
+    def swap_right(self):
         """Swap current window with closest window to the up"""
         win = self.clients.current_client
         x, y = win.x, win.y
         candidates = [c for c in self.clients if c.info()["y"] < y]
         target = self._get_closest(x, y, candidates)
-        self.cmd_swap(win, target)
+        self.swap(win, target)
 
-    def cmd_swap_main(self):
+    @expose_command()
+    def swap_main(self):
         """Swap current window to main pane"""
         if self.align == self._up:
-            self.cmd_swap_right()
+            self.swap_right()
         elif self.align == self._down:
-            self.cmd_swap_left()
+            self.swap_left()
 
 
 class MonadThreeCol(MonadTall):
@@ -1015,8 +1036,8 @@ class MonadThreeCol(MonadTall):
 
     A main pane that contains a single window takes up a vertical portion of
     the screen_rect based on the ratio setting. This ratio can be adjusted with
-    the ``cmd_grow_main`` and ``cmd_shrink_main`` or, while the main pane is in
-    focus, ``cmd_grow`` and ``cmd_shrink``. The main pane can also be centered.
+    the ``grow_main`` and ``shrink_main`` or, while the main pane is in
+    focus, ``grow`` and ``shrink``. The main pane can also be centered.
 
     ::
 
@@ -1033,8 +1054,8 @@ class MonadThreeCol(MonadTall):
 
     Occupying the rest of the screen_rect are one or more secondary panes.  The
     secondary panes will be divided into two columns and share the vertical space
-    of each column. However they can be resized at will with the ``cmd_grow`` and
-    ``cmd_shrink`` methods. The other secondary panes will adjust their sizes to
+    of each column. However they can be resized at will with the ``grow`` and
+    ``shrink`` methods. The other secondary panes will adjust their sizes to
     smoothly fill all of the space.
 
     ::
@@ -1048,23 +1069,23 @@ class MonadThreeCol(MonadTall):
         |           |      |      |    |           |      |      |
         ---------------------------    ---------------------------
 
-    Panes can be moved with the ``cmd_shuffle_up`` and ``cmd_shuffle_down``
+    Panes can be moved with the ``shuffle_up`` and ``shuffle_down``
     methods. As mentioned the main pane is considered the top of the stack;
     moving up is counter-clockwise and moving down is clockwise. A secondary
-    pane can also be promoted to the main pane with the ``cmd_swap_main``
+    pane can also be promoted to the main pane with the ``swap_main``
     method.
 
     Normalizing/Resetting:
 
     To restore all secondary client windows to their default size ratios
-    use the ``cmd_normalize`` method.
+    use the ``normalize`` method.
 
     To reset all client windows to their default sizes, including the primary
-    window, use the ``cmd_reset`` method.
+    window, use the ``reset`` method.
 
     Maximizing:
 
-    To maximized a client window simply use the ``cmd_maximize`` on a focused
+    To maximized a client window simply use the ``maximize`` on a focused
     client.
     """
 
@@ -1174,7 +1195,8 @@ class MonadThreeCol(MonadTall):
             margin=margin,
         )
 
-    def cmd_normalize(self, redraw=True):
+    @expose_command()
+    def normalize(self, redraw=True):
         """Evenly distribute screen-space among secondary clients"""
         if self.screen_rect is not None:
             self.relative_sizes = []
@@ -1191,9 +1213,10 @@ class MonadThreeCol(MonadTall):
             self.group.layout_all()
         self.do_normalize = False
 
-    def cmd_swap_main(self):
+    @expose_command()
+    def swap_main(self):
         """Swap current window to main pane"""
-        self.cmd_swap(self.clients.current_client, self.clients[0])
+        self.swap(self.clients.current_client, self.clients[0])
 
     def _maximize_secondary(self):
         """Maximize the focused secondary pane"""

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -28,6 +28,7 @@
 # SOFTWARE.
 
 import libqtile
+from libqtile.command.base import expose_command
 from libqtile.layout.base import _SimpleLayoutBase
 
 
@@ -46,7 +47,7 @@ class Zoomy(_SimpleLayoutBase):
         _SimpleLayoutBase.__init__(self, **config)
         self.add_defaults(Zoomy.defaults)
 
-    def add(self, client):
+    def add_client(self, client):
         self.clients.append_head(client)
 
     def configure(self, client, screen_rect):
@@ -111,8 +112,10 @@ class Zoomy(_SimpleLayoutBase):
                 self.property_name, self.property_big, "UTF8_STRING", format=8
             )
 
-    cmd_next = _SimpleLayoutBase.next
-    cmd_down = _SimpleLayoutBase.next
+    @expose_command("down")
+    def next(self):
+        _SimpleLayoutBase.next(self)
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_up = _SimpleLayoutBase.previous
+    @expose_command("up")
+    def previous(self):
+        _SimpleLayoutBase.previous(self)

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import config, group, hook
 from libqtile.backend.base import FloatStates
+from libqtile.command.base import expose_command
 from libqtile.config import Match
 
 if TYPE_CHECKING:
@@ -114,7 +115,7 @@ class WindowVisibilityToggler:
             win._float_state = FloatStates.TOP
             # add to group and bring it to front.
             win.togroup()
-            win.cmd_bring_to_front()
+            win.bring_to_front()
             # toggle internal flag of visibility
             self.shown = True
 
@@ -251,8 +252,7 @@ class ScratchPad(group._Group):
         if name not in self._spawned:
             if not self._spawned:
                 hook.subscribe.client_new(self.on_client_new)
-
-            pid = self.qtile.cmd_spawn(ddconfig.command)
+            pid = self.qtile.spawn(ddconfig.command)
             self._spawned[name] = ddconfig.match or Match(net_wm_pid=pid)
 
     def on_client_new(self, client, *args, **kwargs):
@@ -312,7 +312,8 @@ class ScratchPad(group._Group):
                     break
         self._check_unsubscribe()
 
-    def cmd_dropdown_toggle(self, name):
+    @expose_command()
+    def dropdown_toggle(self, name):
         """
         Toggle visibility of named DropDown.
         """
@@ -326,14 +327,16 @@ class ScratchPad(group._Group):
             if name in self._dropdownconfig:
                 self._spawn(self._dropdownconfig[name])
 
-    def cmd_hide_all(self):
+    @expose_command()
+    def hide_all(self):
         """
         Hide all scratchpads.
         """
         for d in self.dropdowns.values():
             d.hide()
 
-    def cmd_dropdown_reconfigure(self, name, **kwargs):
+    @expose_command()
+    def dropdown_reconfigure(self, name, **kwargs):
         """
         reconfigure the named DropDown configuration.
         Note that changed attributes only have an effect on spawning the window.
@@ -345,7 +348,8 @@ class ScratchPad(group._Group):
             if hasattr(dd, attr):
                 setattr(dd, attr, value)
 
-    def cmd_dropdown_info(self, name=None):
+    @expose_command()
+    def dropdown_info(self, name=None):
         """
         Get information on configured or currently active DropDowns.
         If name is None, a list of all dropdown names is returned.

--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -125,6 +125,59 @@ def windowtogroup_groupName_argument(funcname, query):  # noqa: N802
     return query.select_method(funcname).modify_argument("groupName", "group_name")
 
 
+def command_decorators_changes(query):
+    """
+    Some commands were renamed when moving from `cmd_` to decorator syntax for
+    exposed commands.
+
+    While most code should continue to work, with required changes indicated in log files,
+    some changes may cause breakages.
+
+    This migration function attempts to address the key changes.
+    """
+    return (
+        query.select_method("cmd_groups")  # noqa: BLK100
+        .rename("get_groups")
+        .select_method("cmd_screens")
+        .rename("get_screens")
+        .select_method("opacity")
+        .rename("set_opacity")
+        .select_method("cmd_opacity")
+        .rename("set_opacity")
+        .select_method("hints")
+        .rename("get_hints")
+        .select_method("cmd_hints")
+        .rename("get_hints")
+    )
+
+
+def rename_cmd_methods(query):
+    """
+    Renames any method call that starts with "cmd_" to remove
+    the prefix.
+    """
+
+    select = """power< name=any* trailer< "(" any* ")" > any* >"""
+
+    def modify(node, capture, filename):
+        def search_method(item):
+            """
+            Result will be a nested list of Node and Leaf objects so
+            we need to be able to recursively check each object.
+            """
+            for obj in item:
+                if hasattr(obj, "value"):
+                    if obj.value.startswith("cmd_"):
+                        obj.value = obj.value[4:]
+                else:
+                    search_method(obj.leaves())
+
+        cmd_name = capture.get("name")
+        search_method(cmd_name)
+
+    return query.select(select).modify(modify)
+
+
 MIGRATIONS = [
     client_name_updated,
     tile_master_windows_rename,
@@ -135,6 +188,8 @@ MIGRATIONS = [
     new_at_current_to_new_client_position,
     partial(windowtogroup_groupName_argument, "togroup"),
     partial(windowtogroup_groupName_argument, "cmd_togroup"),
+    command_decorators_changes,
+    rename_cmd_methods,
 ]
 
 

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -26,6 +26,7 @@ import os
 import shlex
 from functools import partial
 
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -104,8 +105,8 @@ class Backlight(base.InLoopPollText):
 
         self.add_callbacks(
             {
-                "Button4": partial(self.cmd_change_backlight, ChangeDirection.UP),
-                "Button5": partial(self.cmd_change_backlight, ChangeDirection.DOWN),
+                "Button4": partial(self.change_backlight, ChangeDirection.UP),
+                "Button5": partial(self.change_backlight, ChangeDirection.DOWN),
             }
         )
 
@@ -148,7 +149,8 @@ class Backlight(base.InLoopPollText):
         else:
             self.call_process(shlex.split(self.change_command.format(value)))
 
-    def cmd_change_backlight(self, direction, step=None):
+    @expose_command()
+    def change_backlight(self, direction, step=None):
         if not step:
             step = self.step
         if self._future and not self._future.done():

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import bar, configurable, confreader
 from libqtile.command import interface
-from libqtile.command.base import CommandError, CommandObject
+from libqtile.command.base import CommandError, CommandObject, expose_command
 from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
 
@@ -117,7 +117,7 @@ class _Widget(CommandObject, configurable.Configurable):
         from libqtile import qtile
 
         def open_calendar():
-            qtile.cmd_spawn('gsimplecal next_month')
+            qtile.spawn('gsimplecal next_month')
 
         clock = widget.Clock(
             mouse_callbacks={
@@ -249,7 +249,9 @@ class _Widget(CommandObject, configurable.Configurable):
         self.drawer.set_source_rgb(self.bar.background)
         self.drawer.fillrect(self.offsetx, self.offsety, self.width, self.height)
 
+    @expose_command()
     def info(self):
+        """Info for this object."""
         return dict(
             name=self.name,
             offset=self.offset,
@@ -301,12 +303,6 @@ class _Widget(CommandObject, configurable.Configurable):
             return self.bar
         elif name == "screen":
             return self.bar.screen
-
-    def cmd_info(self):
-        """
-        Info for this object.
-        """
-        return self.info()
 
     def draw(self):
         """
@@ -669,7 +665,8 @@ class _TextBox(_Widget):
     def hide_scroll(self):
         self.update("")
 
-    def cmd_set_font(self, font=UNSPECIFIED, fontsize=UNSPECIFIED, fontshadow=UNSPECIFIED):
+    @expose_command()
+    def set_font(self, font=UNSPECIFIED, fontsize=UNSPECIFIED, fontshadow=UNSPECIFIED):
         """
         Change the font used by this widget. If font is None, the current
         font is used.
@@ -682,6 +679,7 @@ class _TextBox(_Widget):
             self.fontshadow = fontshadow
         self.bar.draw()
 
+    @expose_command()
     def info(self):
         d = _Widget.info(self)
         d["foreground"] = self.foreground
@@ -689,6 +687,7 @@ class _TextBox(_Widget):
         return d
 
     def update(self, text):
+        """Update the widget text."""
         if self.text == text:
             return
         if text is None:
@@ -809,7 +808,8 @@ class ThreadPoolText(_TextBox):
     def poll(self):
         pass
 
-    def cmd_force_update(self):
+    @expose_command()
+    def force_update(self):
         """Immediately poll the widget. Existing timers are unaffected."""
         self.update(self.poll())
 

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -47,7 +47,7 @@ CMD_DOC_COMMANDS = "\n".join(f"    * ``'{k}'`` runs ``{v}``" for k, v in CMD_DIC
 class CheckUpdates(base.ThreadPoolText):
     # The docstring includes some dynamic content so we need to compile that content
     # first and then set the docstring to that content.
-    doc = f"""
+    _doc = f"""
     Shows number of pending updates in different unix systems.
 
     The following built-in options are available via the ``distro`` parameter:
@@ -67,7 +67,7 @@ class CheckUpdates(base.ThreadPoolText):
 
     """
 
-    __doc__ = doc
+    __doc__ = _doc
 
     defaults = [
         ("distro", "Arch", "Name of your distribution"),

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -51,8 +51,8 @@ class CurrentLayout(base._TextBox):
 
         self.add_callbacks(
             {
-                "Button1": qtile.cmd_next_layout,
-                "Button2": qtile.cmd_prev_layout,
+                "Button1": qtile.next_layout,
+                "Button2": qtile.prev_layout,
             }
         )
 
@@ -128,8 +128,8 @@ class CurrentLayoutIcon(base._TextBox):
 
         self.add_callbacks(
             {
-                "Button1": qtile.cmd_next_layout,
-                "Button2": qtile.cmd_prev_layout,
+                "Button1": qtile.next_layout,
+                "Button2": qtile.prev_layout,
             }
         )
 

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -157,7 +157,7 @@ class AGroupBox(_GroupBase):
 
     def _configure(self, qtile, bar):
         _GroupBase._configure(self, qtile, bar)
-        self.add_callbacks({"Button1": partial(self.bar.screen.cmd_next_group, warp=False)})
+        self.add_callbacks({"Button1": partial(self.bar.screen.next_group, warp=False)})
 
     def calculate_length(self):
         return self.box_width(self.qtile.groups) + self.margin_x * 2
@@ -335,7 +335,7 @@ class GroupBox(_GroupBase):
         if button not in (5, 4):
             group = self.get_clicked_group()
             if group and self.clicked:
-                group.cmd_switch_groups(self.clicked.name)
+                group.switch_groups(self.clicked.name)
                 self.clicked = None
 
     def calculate_length(self):

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -22,6 +22,7 @@
 import os
 
 from libqtile import bar
+from libqtile.command.base import expose_command
 from libqtile.images import Img
 from libqtile.log_utils import logger
 from libqtile.widget import base
@@ -99,7 +100,8 @@ class Image(base._Widget, base.MarginMixin):
         else:
             return self.img.height + (self.margin_y * 2)
 
-    def cmd_update(self, filename):
+    @expose_command()
+    def update(self, filename):
         old_length = self.calculate_length()
         self.filename = filename
         self._update_image()

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -29,6 +29,7 @@ from abc import ABCMeta, abstractmethod
 from subprocess import CalledProcessError, check_output
 from typing import TYPE_CHECKING
 
+from libqtile.command.base import expose_command
 from libqtile.confreader import ConfigError
 from libqtile.log_utils import logger
 from libqtile.widget import base
@@ -98,7 +99,7 @@ class _X11LayoutBackend(_BaseLayoutBackend):
 
 class _WaylandLayoutBackend(_BaseLayoutBackend):
     def __init__(self, qtile: Qtile) -> None:
-        self.set_keymap = qtile.core.cmd_set_keymap  # type: ignore
+        self.set_keymap = qtile.core.set_keymap
         self._layout: str = ""
 
     def get_keyboard(self) -> str:
@@ -167,6 +168,7 @@ class KeyboardLayout(base.InLoopPollText):
         self.backend = layout_backends[qtile.core.name](qtile)
         self.backend.set_keyboard(self.configured_keyboards[0], self.option)
 
+    @expose_command()
     def next_keyboard(self):
         """set the next layout in the list of configured keyboard layouts as
         new current layout in use
@@ -194,7 +196,3 @@ class KeyboardLayout(base.InLoopPollText):
         if keyboard in self.display_map.keys():
             return self.display_map[keyboard]
         return keyboard.upper()
-
-    def cmd_next_keyboard(self):
-        """Select next keyboard layout"""
-        self.next_keyboard()

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -36,7 +36,7 @@ displayed instead.
 To execute a software:
  - ('thunderbird', 'thunderbird -safe-mode', 'launch thunderbird in safe mode')
 To execute a python command in qtile, begin with by 'qshell:'
- - ('logout', 'qshell:self.qtile.cmd_shutdown()', 'logout from qtile')
+ - ('logout', 'qshell:self.qtile.shutdown()', 'logout from qtile')
 
 
 """
@@ -79,7 +79,7 @@ class LaunchBar(base._Widget):
             [],
             "A list of tuples (software_name, command_to_execute, comment), for example:"
             " [('thunderbird', 'thunderbird -safe-mode', 'launch thunderbird in safe mode'), "
-            " ('logout', 'qshell:self.qtile.cmd_shutdown()', 'logout from qtile')]",
+            " ('logout', 'qshell:self.qtile.shutdown()', 'logout from qtile')]",
         ),
         ("text_only", False, "Don't use any icons."),
         ("icon_size", None, "Size of icons. ``None`` to fit to bar."),
@@ -231,7 +231,7 @@ class LaunchBar(base._Widget):
                 if cmd.startswith("qshell:"):
                     exec(cmd[7:].lstrip())
                 else:
-                    self.qtile.cmd_spawn(cmd)
+                    self.qtile.spawn(cmd)
             self.draw()
 
     def draw(self):

--- a/libqtile/widget/load.py
+++ b/libqtile/widget/load.py
@@ -19,6 +19,7 @@ from itertools import cycle
 
 from psutil import getloadavg
 
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
@@ -44,7 +45,8 @@ class Load(base.ThreadPoolText):
     def set_time(self):
         self.time = next(self.cycled_times)
 
-    def cmd_next_load(self):
+    @expose_command()
+    def next_load(self):
         self.set_time()
         self.update(self.poll())
 

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 from dbus_next import Message, Variant
 from dbus_next.constants import MessageType
 
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import _send_dbus_message, add_signal_receiver
 from libqtile.widget import base
@@ -101,9 +102,9 @@ class Mpris2(base._TextBox):
         self.status = "{track}"
         self.add_callbacks(
             {
-                "Button1": self.cmd_play_pause,
-                "Button4": self.cmd_next,
-                "Button5": self.cmd_previous,
+                "Button1": self.play_pause,
+                "Button4": self.next,
+                "Button5": self.previous,
             }
         )
         paused = ""
@@ -233,13 +234,6 @@ class Mpris2(base._TextBox):
 
         return text
 
-    def cmd_info(self) -> dict[str, Any]:
-        info = base._TextBox.info(self)
-        info["isplaying"] = self.is_playing
-        info["player"] = self.player
-
-        return info
-
     def _player_cmd(self, cmd: str) -> None:
         if self._current_player is None:
             return
@@ -275,18 +269,29 @@ class Mpris2(base._TextBox):
         if message.message_type != MessageType.METHOD_RETURN:
             logger.warning("Unable to send command to player.")
 
-    def cmd_play_pause(self) -> None:
+    @expose_command()
+    def play_pause(self) -> None:
         """Toggle the playback status."""
         self._player_cmd("PlayPause")
 
-    def cmd_next(self) -> None:
+    @expose_command()
+    def next(self) -> None:
         """Play the next track."""
         self._player_cmd("Next")
 
-    def cmd_previous(self) -> None:
+    @expose_command()
+    def previous(self) -> None:
         """Play the previous track."""
         self._player_cmd("Previous")
 
-    def cmd_stop(self) -> None:
+    @expose_command()
+    def stop(self) -> None:
         """Stop playback."""
         self._player_cmd("Stop")
+
+    @expose_command()
+    def info(self):
+        """What's the current state of the widget?"""
+        d = base._TextBox.info(self)
+        d.update(dict(isplaying=self.is_playing, player=self.player))
+        return d

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -29,6 +29,7 @@
 from os import path
 
 from libqtile import bar, pangocffi, utils
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.notify import ClosedReason, notifier
 from libqtile.widget import base
@@ -76,7 +77,7 @@ class Notify(base._TextBox):
             "Button5": self.next,
         }
         if self.action:
-            default_callbacks["Button3"] = self.invoke
+            default_callbacks["Button3"] = self._invoke
         else:
             self.capabilities = Notify.capabilities.difference({"actions"})
         self.add_callbacks(default_callbacks)
@@ -114,7 +115,7 @@ class Notify(base._TextBox):
             except:  # noqa: E722
                 logger.exception("parse_text function failed:")
         if self.audiofile and path.exists(self.audiofile):
-            self.qtile.cmd_spawn("aplay -q '%s'" % self.audiofile)
+            self.qtile.spawn("aplay -q '%s'" % self.audiofile)
 
     def update(self, notif):
         self.qtile.call_soon_threadsafe(self.real_update, notif)
@@ -124,15 +125,16 @@ class Notify(base._TextBox):
         self.current_id = notif.id - 1
         if notif.timeout and notif.timeout > 0:
             self.timeout_add(
-                notif.timeout / 1000, self.clear, method_args=(ClosedReason.expired,)
+                notif.timeout / 1000, self._clear, method_args=(ClosedReason.expired,)
             )
         elif self.default_timeout:
             self.timeout_add(
-                self.default_timeout, self.clear, method_args=(ClosedReason.expired,)
+                self.default_timeout, self._clear, method_args=(ClosedReason.expired,)
             )
         self.bar.draw()
         return True
 
+    @expose_command()
     def display(self):
         if notifier is None:
             return
@@ -140,7 +142,7 @@ class Notify(base._TextBox):
         self.set_notif_text(notifier.notifications[self.current_id])
         self.bar.draw()
 
-    def clear(self, reason=ClosedReason.dismissed):
+    def _clear(self, reason=ClosedReason.dismissed):
         if notifier is None:
             return
 
@@ -153,55 +155,50 @@ class Notify(base._TextBox):
         if self.current_id < len(notifier.notifications):
             notif = notifier.notifications[self.current_id]
             if notif.id == nid:
-                self.clear(ClosedReason.method)
+                self._clear(ClosedReason.method)
 
+    @expose_command()
     def prev(self):
+        """Show previous notification."""
         if self.current_id > 0:
             self.current_id -= 1
         self.display()
 
+    @expose_command()
     def next(self):
         if notifier is None:
             return
 
+        """Show next notification."""
         if self.current_id < len(notifier.notifications) - 1:
             self.current_id += 1
             self.display()
 
-    def invoke(self):
+    def _invoke(self):
         if self.current_id < len(notifier.notifications):
             notif = notifier.notifications[self.current_id]
             if notif.actions:
                 notifier._service.ActionInvoked(notif.id, notif.actions[0])
-            self.clear()
+            self._clear()
 
-    def cmd_display(self):
-        """Display the notifcication"""
-        self.display()
-
-    def cmd_clear(self):
+    @expose_command()
+    def clear(self):
         """Clear the notification"""
-        self.clear()
+        self._clear()
 
-    def cmd_toggle(self):
+    @expose_command()
+    def toggle(self):
         """Toggle showing/clearing the notification"""
         if self.text == "":
             self.display()
         else:
-            self.clear()
+            self._clear()
 
-    def cmd_prev(self):
-        """Show previous notification"""
-        self.prev()
-
-    def cmd_next(self):
-        """Show next notification"""
-        self.next()
-
-    def cmd_invoke(self):
+    @expose_command()
+    def invoke(self):
         """Invoke the notification's default action"""
         if self.action:
-            self.invoke()
+            self._invoke()
 
     def finalize(self):
         # We may need some async calls as part of the finalize call

--- a/libqtile/widget/pomodoro.py
+++ b/libqtile/widget/pomodoro.py
@@ -21,6 +21,7 @@
 from datetime import datetime, timedelta
 from time import time
 
+from libqtile.command.base import expose_command
 from libqtile.utils import send_notification
 from libqtile.widget import base
 
@@ -76,8 +77,8 @@ class Pomodoro(base.ThreadPoolText):
 
         self.add_callbacks(
             {
-                "Button1": self.cmd_toggle_break,
-                "Button3": self.cmd_toggle_active,
+                "Button1": self.toggle_break,
+                "Button3": self.toggle_active,
             }
         )
 
@@ -146,7 +147,8 @@ class Pomodoro(base.ThreadPoolText):
         )
         return self.prefix[self.status] + time_string
 
-    def cmd_toggle_break(self):
+    @expose_command()
+    def toggle_break(self):
         if self.status == self.STATUS_INACTIVE:
             self.status = self.STATUS_START
             return
@@ -173,7 +175,8 @@ class Pomodoro(base.ThreadPoolText):
                     + self.end_time.strftime("%H:%M"),
                 )
 
-    def cmd_toggle_active(self):
+    @expose_command()
+    def toggle_active(self):
         if self.status != self.STATUS_INACTIVE:
             self.status = self.STATUS_INACTIVE
             if self.notification_on:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -41,7 +41,7 @@ import string
 from collections import deque
 
 from libqtile import hook, pangocffi, utils
-from libqtile.command.base import CommandObject, SelectError
+from libqtile.command.base import CommandObject, SelectError, expose_command
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import CommandError, QtileCommandInterface
 from libqtile.log_utils import logger
@@ -199,7 +199,7 @@ class GroupCompleter(AbstractCompleter):
         txt = txt.lower()
         if not self.lookup:
             self.lookup = []
-            for group in self.qtile.groups_map.keys():  # type: ignore
+            for group in self.qtile.groups_map.keys():
                 if group.lower().startswith(txt):
                     self.lookup.append((group, group))
 
@@ -234,7 +234,7 @@ class WindowCompleter(AbstractCompleter):
         """Returns the next completion for txt, or None if there is no completion"""
         if self.lookup is None:
             self.lookup = []
-            for wid, window in self.qtile.windows_map.items():  # type: ignore
+            for wid, window in self.qtile.windows_map.items():
                 if window.group and window.name.lower().startswith(txt):
                     self.lookup.append((window.name, wid))
 
@@ -674,10 +674,12 @@ class Prompt(base._TextBox):
             del self.key
         self._update()
 
-    def cmd_fake_keypress(self, key: str) -> None:
+    @expose_command()
+    def fake_keypress(self, key: str) -> None:
         self.process_key_press(self.qtile.core.keysym_from_name(key))
 
-    def cmd_info(self):
+    @expose_command()
+    def info(self):
         """Returns a dictionary of info for this object"""
         return dict(
             name=self.name,
@@ -686,7 +688,8 @@ class Prompt(base._TextBox):
             active=self.active,
         )
 
-    def cmd_exec_general(self, prompt, object_name, cmd_name, selector=None, completer=None):
+    @expose_command()
+    def exec_general(self, prompt, object_name, cmd_name, selector=None, completer=None):
         """
         Execute a cmd of any object. For example layout, group, window, widget
         , etc with a string that is obtained from start_input.

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from libqtile.command.base import expose_command
 from libqtile.widget._pulse_audio import ffi, lib
 from libqtile.widget.volume import Volume
 
@@ -161,7 +162,8 @@ class PulseVolume(Volume):
         if op:
             self.wait_for_operation(op)
 
-    def cmd_mute(self):
+    @expose_command()
+    def mute(self):
         op = lib.pa_context_set_sink_mute_by_index(
             self.context,
             self.default_sink["index"],
@@ -172,7 +174,8 @@ class PulseVolume(Volume):
         if op:
             self.wait_for_operation(op)
 
-    def cmd_increase_vol(self, value=None):
+    @expose_command()
+    def increase_vol(self, value=None):
         if value is None:
             value = self.step
         base = self.default_sink["base_volume"]
@@ -192,7 +195,8 @@ class PulseVolume(Volume):
             volume.values = [(i if i <= base else base) for i in volume.values]
         self.change_volume(volume)
 
-    def cmd_decrease_vol(self, value=None):
+    @expose_command()
+    def decrease_vol(self, value=None):
         if value is None:
             value = self.step
         volume_level = int(value * self.default_sink["base_volume"] / 100)

--- a/libqtile/widget/quick_exit.py
+++ b/libqtile/widget/quick_exit.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
@@ -41,7 +42,7 @@ class QuickExit(base._TextBox):
         self.text = self.default_text
         self.countdown = self.countdown_start
 
-        self.add_callbacks({"Button1": self.cmd_trigger})
+        self.add_callbacks({"Button1": self.trigger})
 
     def __reset(self):
         self.is_counting = False
@@ -62,7 +63,8 @@ class QuickExit(base._TextBox):
             self.qtile.stop()
             return
 
-    def cmd_trigger(self):
+    @expose_command()
+    def trigger(self):
         if not self.is_counting:
             self.is_counting = True
             self.update()

--- a/libqtile/widget/stock_ticker.py
+++ b/libqtile/widget/stock_ticker.py
@@ -21,6 +21,7 @@
 import locale
 from urllib.parse import urlencode
 
+from libqtile.log_utils import logger
 from libqtile.widget.generic_poll_text import GenPollUrl
 
 
@@ -46,18 +47,18 @@ class StockTicker(GenPollUrl):
 
     defaults = [
         ("interval", "1min", "The default latency to query"),
-        ("function", "TIME_SERIES_INTRADAY", "The default API function to query"),
+        ("func", "TIME_SERIES_INTRADAY", "The default API function to query"),
+        ("function", "TIME_SERIES_INTRADAY", "DEPRECATED: Use `func`."),
     ]
 
     def __init__(self, **config):
+        if "function" in config:
+            logger.warning("`function` parameter is deprecated. Please rename to `func`")
+            config["func"] = config.pop("function")
         GenPollUrl.__init__(self, **config)
         self.add_defaults(StockTicker.defaults)
         self.sign = locale.localeconv()["currency_symbol"]
-        self.query = {
-            "interval": self.interval,
-            "outputsize": "compact",
-            "function": self.function,
-        }
+        self.query = {"interval": self.interval, "outputsize": "compact", "function": self.func}
         for k, v in config.items():
             self.query[k] = v
 

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -426,9 +426,9 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             if window is not current_win:
                 window.group.focus(window, False)
                 if window.floating:
-                    window.cmd_bring_to_front()
+                    window.bring_to_front()
             else:
-                window.cmd_toggle_minimize()
+                window.toggle_minimize()
 
     def _get_class_icon(self, window):
         if not getattr(window, "icons", False):

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -26,6 +26,7 @@
 from typing import Any
 
 from libqtile import bar
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
@@ -43,10 +44,11 @@ class TextBox(base._TextBox):
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, text=text, width=width, **config)
 
-    def cmd_update(self, text):
-        """Update the text in a TextBox widget"""
-        self.update(text)
-
-    def cmd_get(self):
+    @expose_command()
+    def get(self):
         """Retrieve the text in a TextBox widget"""
         return self.text
+
+    @expose_command()
+    def update(self, text):
+        base._TextBox.update(self, text)

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -34,6 +34,7 @@ import re
 import subprocess
 
 from libqtile import bar
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 __all__ = [
@@ -88,10 +89,10 @@ class Volume(base._TextBox):
 
         self.add_callbacks(
             {
-                "Button1": self.cmd_mute,
-                "Button3": self.cmd_run_app,
-                "Button4": self.cmd_increase_vol,
-                "Button5": self.cmd_decrease_vol,
+                "Button1": self.mute,
+                "Button3": self.run_app,
+                "Button4": self.increase_vol,
+                "Button5": self.decrease_vol,
             }
         )
 
@@ -205,7 +206,8 @@ class Volume(base._TextBox):
         else:
             base._TextBox.draw(self)
 
-    def cmd_increase_vol(self):
+    @expose_command()
+    def increase_vol(self):
         if self.volume_up_command is not None:
             subprocess.call(self.volume_up_command, shell=True)
         else:
@@ -213,7 +215,8 @@ class Volume(base._TextBox):
                 self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
             )
 
-    def cmd_decrease_vol(self):
+    @expose_command()
+    def decrease_vol(self):
         if self.volume_down_command is not None:
             subprocess.call(self.volume_down_command, shell=True)
         else:
@@ -221,12 +224,14 @@ class Volume(base._TextBox):
                 self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
             )
 
-    def cmd_mute(self):
+    @expose_command()
+    def mute(self):
         if self.mute_command is not None:
             subprocess.call(self.mute_command, shell=True)
         else:
             subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
 
-    def cmd_run_app(self):
+    @expose_command()
+    def run_app(self):
         if self.volume_app is not None:
             subprocess.Popen(self.volume_app, shell=True)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from libqtile import bar
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
 
@@ -73,7 +74,7 @@ class WidgetBox(base._Widget):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
         self.box_is_open = False
-        self.add_callbacks({"Button1": self.cmd_toggle})
+        self.add_callbacks({"Button1": self.toggle})
 
         if _widgets:
             logger.warning(
@@ -167,7 +168,8 @@ class WidgetBox(base._Widget):
 
         self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.width)
 
-    def cmd_toggle(self):
+    @expose_command()
+    def toggle(self):
         """Toggle box state"""
         self.box_is_open = not self.box_is_open
         self.toggle_widgets()

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from libqtile import bar, hook
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
@@ -82,6 +83,7 @@ class WindowCount(base._TextBox):
         else:
             return 0
 
-    def cmd_get(self):
+    @expose_command()
+    def get(self):
         """Retrieve the current text."""
         return self.text

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -63,7 +63,7 @@ class WindowTabs(base._TextBox):
         hook.subscribe.client_name_updated(self.update)
         hook.subscribe.focus_change(self.update)
         hook.subscribe.float_change(self.update)
-        self.add_callbacks({"Button1": self.bar.screen.group.cmd_next_window})
+        self.add_callbacks({"Button1": self.bar.screen.group.next_window})
 
     def update(self, *args):
         names = []

--- a/test/backend/x11/test_window.py
+++ b/test/backend/x11/test_window.py
@@ -317,7 +317,7 @@ def test_hints_setting_unsetting(xmanager, conn):
         # We default the input hint to true since some non-trivial number of
         # windows don't set it, and most of them want focus. The spec allows
         # WMs to assume "convenient" values.
-        assert xmanager.c.window.hints()["input"]
+        assert xmanager.c.window.get_hints()["input"]
 
         # now try to "update" it, but don't really set an update (i.e. the
         # InputHint bit is 0, so the WM should not derive a new hint from the
@@ -327,21 +327,21 @@ def test_hints_setting_unsetting(xmanager, conn):
         conn.flush()
 
         # should still have the hint
-        assert xmanager.c.window.hints()["input"]
+        assert xmanager.c.window.get_hints()["input"]
 
         # now do an update: turn it off
         hints[0] = xcbq.HintsFlags["InputHint"]
         hints[1] = 0
         w.set_property("WM_HINTS", hints, type="WM_HINTS", format=32)
         conn.flush()
-        assert not xmanager.c.window.hints()["input"]
+        assert not xmanager.c.window.get_hints()["input"]
 
         # turn it back on
         hints[0] = xcbq.HintsFlags["InputHint"]
         hints[1] = 1
         w.set_property("WM_HINTS", hints, type="WM_HINTS", format=32)
         conn.flush()
-        assert xmanager.c.window.hints()["input"]
+        assert xmanager.c.window.get_hints()["input"]
 
     finally:
         w.kill_client()

--- a/test/configs/reloading.py
+++ b/test/configs/reloading.py
@@ -1,4 +1,4 @@
-# This is used for test_manager.py::test_cmd_reload_config
+# This is used for test_manager.py::test_reload_config
 #
 # The exported configuration variables have a different value depending on whether
 # libqtile has a 'test_data' attribute (see below)

--- a/test/extension/test_command_set.py
+++ b/test/extension/test_command_set.py
@@ -28,7 +28,7 @@ from libqtile.log_utils import init_log, logger
 @pytest.fixture
 def fake_qtile():
     class FakeQtile:
-        def cmd_spawn(self, value):
+        def spawn(self, value):
             logger.warning(value)
 
     yield FakeQtile()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -342,8 +342,8 @@ class TestManager:
         return self.test_window(name, wm_type="notification")
 
     def groupconsistency(self):
-        groups = self.c.groups()
-        screens = self.c.screens()
+        groups = self.c.get_groups()
+        screens = self.c.get_screens()
         seen = set()
         for g in groups.values():
             scrn = g["screen"]

--- a/test/layouts/test_base.py
+++ b/test/layouts/test_base.py
@@ -21,6 +21,7 @@
 import pytest
 
 import libqtile
+from libqtile.command.base import expose_command
 from libqtile.confreader import Config
 from libqtile.layout.base import _SimpleLayoutBase
 
@@ -35,19 +36,21 @@ class DummyLayout(_SimpleLayoutBase):
         _SimpleLayoutBase.__init__(self, **config)
         self.add_defaults(DummyLayout.defaults)
 
-    def add(self, client):
-        return super().add(
+    def add_client(self, client):
+        return super().add_client(
             client, offset_to_current=self.current_offset, client_position=self.current_position
         )
 
     def configure(self, client, screen_rect):
         pass
 
-    cmd_previous = _SimpleLayoutBase.previous
-    cmd_next = _SimpleLayoutBase.next
+    @expose_command("up")
+    def previous(self):
+        _SimpleLayoutBase.previous()
 
-    cmd_up = cmd_previous
-    cmd_down = cmd_next
+    @expose_command("down")
+    def next(self):
+        _SimpleLayoutBase.next()
 
 
 class BaseLayoutConfigBottom(Config):

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -71,9 +71,9 @@ def test_max_updown(manager):
     manager.test_window("three")
     assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
     manager.c.layout.up()
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.layout.down()
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
 
 
 @max_config

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -150,3 +150,15 @@ def test_command_propagation(manager):
     org_height = manager.c.window.info()["height"]
     manager.c.layout.toggle_split()
     assert manager.c.window.info()["height"] != org_height
+
+
+@slice_config
+def test_command_propagation_direct_call(manager):
+    manager.test_window("slice")
+    manager.test_window("one")
+    manager.test_window("two")
+    info = manager.c.layout.info()
+    assert info["name"] == "slice"
+    org_height = manager.c.window.info()["height"]
+    manager.c.layout.eval("self.toggle_split()")
+    assert manager.c.window.info()["height"] != org_height

--- a/test/layouts/test_stack.py
+++ b/test/layouts/test_stack.py
@@ -79,7 +79,7 @@ def test_stack_commands(manager):
 
     manager.c.layout.delete()
     assert _stacks(manager) == [["one", "three", "two"]]
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert info["focus"] == "one"
     manager.c.layout.delete()
     assert len(_stacks(manager)) == 1
@@ -92,7 +92,7 @@ def test_stack_commands(manager):
 
 
 @stack_config
-def test_stack_cmd_down(manager):
+def test_stack_down(manager):
     manager.c.layout.down()
 
 
@@ -139,35 +139,35 @@ def test_stack_nextprev(manager):
     two = manager.test_window("two")
     three = manager.test_window("three")
 
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
     manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
     manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
 
     manager.c.layout.next()
     manager.c.layout.next()
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
 
     manager.kill_window(three)
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.layout.next()
     manager.kill_window(two)
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
     manager.kill_window(one)
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["a"]["focus"] is None
     manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["a"]["focus"] is None
 
 
 @stack_config

--- a/test/layouts/test_tile.py
+++ b/test/layouts/test_tile.py
@@ -75,21 +75,21 @@ def test_tile_nextprev(manager):
     manager.test_window("three")
 
     assert manager.c.layout.info()["clients"] == ["three", "two", "one"]
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
 
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "two"
-
-    manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
 
     manager.c.layout.previous()
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
+
+    manager.c.layout.previous()
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
     manager.c.layout.next()
     manager.c.layout.next()
     manager.c.layout.next()
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
 
 @tile_config

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -185,9 +185,9 @@ def test_textbox_errors(manager):
 @gb_config
 def test_groupbox_button_press(manager):
     manager.c.group["ccc"].toscreen()
-    assert manager.c.groups()["a"]["screen"] is None
+    assert manager.c.get_groups()["a"]["screen"] is None
     manager.c.bar["bottom"].fake_button_press(0, "bottom", 10, 10, 1)
-    assert manager.c.groups()["a"]["screen"] == 0
+    assert manager.c.get_groups()["a"]["screen"] == 0
 
 
 class GeomConf(libqtile.confreader.Config):
@@ -235,7 +235,7 @@ class DWidget:
 @geom_config
 def test_geometry(manager):
     manager.test_window("one")
-    g = manager.c.screens()[0]["gaps"]
+    g = manager.c.get_screens()[0]["gaps"]
     assert g["top"] == (0, 0, 800, 10)
     assert g["bottom"] == (0, 590, 800, 10)
     assert g["left"] == (0, 10, 10, 580)

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2012, 2014 Tycho Andersen
 # Copyright (c) 2013 Craig Barnes
 # Copyright (c) 2014 Sean Vig
+# Copyright (c) 2021 elParaguayo
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +31,7 @@ import libqtile.confreader
 import libqtile.layout
 import libqtile.log_utils
 import libqtile.widget
-from libqtile.command.base import CommandObject
+from libqtile.command.base import CommandObject, expose_command
 from libqtile.command.interface import CommandError
 from libqtile.confreader import Config
 from libqtile.lazy import lazy
@@ -80,25 +81,29 @@ call_config = pytest.mark.parametrize("manager", [CallConfig], indirect=True)
 def test_layout_filter(manager):
     manager.test_window("one")
     manager.test_window("two")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress(["control"], "j")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.simulate_keypress(["control"], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
 
 
-class TestCommands(CommandObject):
+class FakeCommandObject(CommandObject):
     @staticmethod
-    def cmd_one():
+    @expose_command()
+    def one():
         pass
 
-    def cmd_one_self(self):
+    @expose_command()
+    def one_self(self):
         pass
 
-    def cmd_two(self, a):
+    @expose_command()
+    def two(self, a):
         pass
 
-    def cmd_three(self, a, b=99):
+    @expose_command()
+    def three(self, a, b=99):
         pass
 
     def _items(self, name):
@@ -109,22 +114,28 @@ class TestCommands(CommandObject):
 
 
 def test_doc():
-    c = TestCommands()
-    assert "one()" in c.cmd_doc("one")
-    assert "one_self()" in c.cmd_doc("one_self")
-    assert "two(a)" in c.cmd_doc("two")
-    assert "three(a, b=99)" in c.cmd_doc("three")
+    c = FakeCommandObject()
+    assert "one()" in c.doc("one")
+    assert "one_self()" in c.doc("one_self")
+    assert "two(a)" in c.doc("two")
+    assert "three(a, b=99)" in c.doc("three")
 
 
 def test_commands():
-    c = TestCommands()
-    assert len(c.cmd_commands()) == 9
+    c = FakeCommandObject()
+    assert len(c.commands()) == 9
 
 
 def test_command():
-    c = TestCommands()
+    c = FakeCommandObject()
     assert c.command("one")
     assert not c.command("nonexistent")
+
+
+class DecoratedTextBox(libqtile.widget.TextBox):
+    @expose_command("mapped")
+    def exposed(self):
+        return "OK"
 
 
 class ServerConfig(Config):
@@ -154,7 +165,7 @@ class ServerConfig(Config):
         libqtile.config.Screen(
             bottom=libqtile.bar.Bar(
                 [
-                    libqtile.widget.TextBox(name="two"),
+                    DecoratedTextBox(name="two"),
                 ],
                 20,
             ),
@@ -468,3 +479,40 @@ def test_deprecated_modules(caplog):
             "libqtile.command_object is deprecated. It has been moved to libqtile.command.base.",
         )
     ]
+
+
+def test_decorators_direct_call():
+    widget = DecoratedTextBox()
+    undecorated = libqtile.widget.TextBox()
+
+    cmds = ["exposed", "mapped"]
+
+    for cmd in cmds:
+        # Check new command is exposed
+        assert cmd in widget.commands()
+        # Check commands are not in widget with same parent class
+        assert cmd not in undecorated.commands()
+
+    assert widget.exposed() == "OK"
+    assert widget.mapped() == "OK"
+
+
+def test_decorators_deprecated_direct_call():
+    widget = DecoratedTextBox()
+    assert widget.cmd_exposed() == "OK"
+
+
+def test_decorators_deprecated_method():
+    class CmdWidget(libqtile.widget.TextBox):
+        def cmd_exposed(self):
+            pass
+
+    assert "exposed" in CmdWidget().commands()
+
+
+@dualmonitor
+@server_config
+def test_decorators_manager_call(manager):
+    widget = manager.c.widget["two"]
+    assert widget.exposed() == "OK"
+    assert widget.mapped() == "OK"

--- a/test/test_fakescreen.py
+++ b/test/test_fakescreen.py
@@ -172,19 +172,19 @@ def test_basic(manager):
 
 @fakescreen_config
 def test_gaps(manager):
-    g = manager.c.screens()[0]["gaps"]
+    g = manager.c.get_screens()[0]["gaps"]
     assert g["bottom"] == (0, 316, 500, 24)
     assert g["left"] == (0, 0, 16, 316)
     assert g["right"] == (480, 0, 20, 316)
-    g = manager.c.screens()[1]["gaps"]
+    g = manager.c.get_screens()[1]["gaps"]
     assert g["top"] == (500, 0, 300, 30)
     assert g["bottom"] == (500, 356, 300, 24)
     assert g["left"] == (500, 30, 12, 326)
-    g = manager.c.screens()[2]["gaps"]
+    g = manager.c.get_screens()[2]["gaps"]
     assert g["top"] == (0, 340, 450, 30)
     assert g["bottom"] == (0, 544, 450, 16)
     assert g["right"] == (410, 370, 40, 174)
-    g = manager.c.screens()[3]["gaps"]
+    g = manager.c.get_screens()[3]["gaps"]
     assert g["top"] == (450, 380, 350, 30)
     assert g["left"] == (450, 410, 20, 190)
     assert g["right"] == (776, 410, 24, 190)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -138,7 +138,7 @@ def test_clone_dim(manager):
     assert manager.c.group.info()["name"] == "a"
     assert manager.c.group.info()["focus"] == "one"
 
-    assert len(manager.c.screens()) == 1
+    assert len(manager.c.get_screens()) == 1
 
 
 @dualmonitor
@@ -151,10 +151,10 @@ def test_to_screen(manager):
     manager.c.to_screen(0)
     manager.test_window("two")
 
-    ga = manager.c.groups()["a"]
+    ga = manager.c.get_groups()["a"]
     assert ga["windows"] == ["two"]
 
-    gb = manager.c.groups()["b"]
+    gb = manager.c.get_groups()["b"]
     assert gb["windows"] == ["one"]
 
     assert manager.c.window.info()["name"] == "two"
@@ -172,23 +172,23 @@ def test_togroup(manager):
     manager.test_window("one")
     with pytest.raises(CommandError):
         manager.c.window.togroup("nonexistent")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
     manager.c.window.togroup("a")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
     manager.c.window.togroup("b", switch_group=True)
-    assert manager.c.groups()["b"]["focus"] == "one"
-    assert manager.c.groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["b"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] is None
     assert manager.c.group.info()["name"] == "b"
 
     manager.c.window.togroup("a")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     assert manager.c.group.info()["name"] == "b"
 
     manager.c.to_screen(1)
     manager.c.window.togroup("c")
-    assert manager.c.groups()["c"]["focus"] == "one"
+    assert manager.c.get_groups()["c"]["focus"] == "one"
 
 
 @manager_config
@@ -223,9 +223,9 @@ def test_keypress(manager):
     manager.test_window("two")
     with pytest.raises(CommandError):
         manager.c.simulate_keypress(["unknown"], "j")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress(["control"], "j")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
 
 class TooFewGroupsConfig(ManagerConfig):
@@ -235,8 +235,8 @@ class TooFewGroupsConfig(ManagerConfig):
 @pytest.mark.parametrize("manager", [TooFewGroupsConfig], indirect=True)
 @multimonitor
 def test_too_few_groups(manager):
-    assert manager.c.groups()
-    assert len(manager.c.groups()) == len(manager.c.screens())
+    assert manager.c.get_groups()
+    assert len(manager.c.get_groups()) == len(manager.c.get_screens())
 
 
 class _ChordsConfig(Config):
@@ -319,26 +319,26 @@ def test_immediate_chord(manager):
     manager.test_window("three")
     manager.test_window("two")
     manager.test_window("one")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # use normal bind to shift focus up
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # enter into key chord and "k" binding no longer working
     manager.c.simulate_keypress(["control"], "a")
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # leave chord using "Escape", "k" bind work again
     manager.c.simulate_keypress([], "Escape")
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
     # enter key chord and use it's "j" binding to shift focus down
     manager.c.simulate_keypress(["control"], "a")
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # in immediate chord we leave it after use any
     # bind from it, "j" bind no longer working
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
 
 
 @chords_config
@@ -346,61 +346,61 @@ def test_mode_chord(manager):
     manager.test_window("three")
     manager.test_window("two")
     manager.test_window("one")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # use normal bind to shift focus up
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # enter into key chord and "k" binding no longer working
     manager.c.simulate_keypress(["control"], "b")
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # leave chord using "Escape", "k" bind work again
     manager.c.simulate_keypress([], "Escape")
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "three"
+    assert manager.c.get_groups()["a"]["focus"] == "three"
     # enter key chord and use it's "j" binding to shift focus down
     manager.c.simulate_keypress(["control"], "b")
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     # in mode chord we __not__ leave it after use any
     # bind from it, "j" bind still working
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # only way to exit mode chord is by hit "Escape"
     manager.c.simulate_keypress([], "Escape")
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
 
 @chords_config
 def test_chord_stack(manager):
     manager.test_window("two")
     manager.test_window("one")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.simulate_keypress(["control"], "d")  # ["nesting_test"]
     # "z" should work, "k" shouldn't:
     manager.c.simulate_keypress([], "z")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress([], "z")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # enter ["nesting_test", "", "inner_named"]:
     manager.c.simulate_keypress([], "a")
     manager.c.simulate_keypress([], "1")
     # "j" should work:
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress([], "j")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # leave "inner_named" ~> ["nesting_test"]:
     manager.c.simulate_keypress([], "u")
     manager.c.simulate_keypress([], "z")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress([], "z")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     # enter ["nesting_test", "", "inner_named"]:
     manager.c.simulate_keypress([], "a")
     manager.c.simulate_keypress([], "1")
@@ -408,11 +408,11 @@ def test_chord_stack(manager):
     manager.c.simulate_keypress([], "v")
     # "k" should work, "z" shouldn't:
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "two"
+    assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.simulate_keypress([], "k")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
     manager.c.simulate_keypress([], "z")
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
 
 @manager_config
@@ -461,7 +461,7 @@ def test_kill_other(manager):
 def test_regression_groupswitch(manager):
     manager.c.group["c"].toscreen()
     manager.c.group["d"].toscreen()
-    assert manager.c.groups()["c"]["screen"] is None
+    assert manager.c.get_groups()["c"]["screen"] is None
 
 
 @manager_config
@@ -501,22 +501,22 @@ def test_adddelgroup(manager):
     manager.test_window("one")
     manager.c.addgroup("dummygroup")
     manager.c.addgroup("testgroup")
-    assert "testgroup" in manager.c.groups().keys()
+    assert "testgroup" in manager.c.get_groups().keys()
 
     manager.c.window.togroup("testgroup")
     manager.c.delgroup("testgroup")
-    assert "testgroup" not in manager.c.groups().keys()
+    assert "testgroup" not in manager.c.get_groups().keys()
     # Assert that the test window is still a member of some group.
-    assert sum(len(i["windows"]) for i in manager.c.groups().values())
+    assert sum(len(i["windows"]) for i in manager.c.get_groups().values())
 
-    for i in list(manager.c.groups().keys())[:-1]:
+    for i in list(manager.c.get_groups().keys())[:-1]:
         manager.c.delgroup(i)
     with pytest.raises(CommandException):
-        manager.c.delgroup(list(manager.c.groups().keys())[0])
+        manager.c.delgroup(list(manager.c.get_groups().keys())[0])
 
-    # Assert that setting layout via cmd_addgroup works
+    # Assert that setting layout via addgroup works
     manager.c.addgroup("testgroup2", layout="max")
-    assert manager.c.groups()["testgroup2"]["layout"] == "max"
+    assert manager.c.get_groups()["testgroup2"]["layout"] == "max"
 
 
 @manager_config
@@ -910,13 +910,13 @@ def test_move_floating(manager):
 
 @manager_config
 def test_one_screen(manager):
-    assert len(manager.c.screens()) == 1
+    assert len(manager.c.get_screens()) == 1
 
 
 @dualmonitor
 @manager_config
 def test_two_screens(manager):
-    assert len(manager.c.screens()) == 2
+    assert len(manager.c.get_screens()) == 2
 
 
 @manager_config
@@ -940,12 +940,12 @@ def test_focus_stays_on_layout_switch(manager):
 @pytest.mark.parametrize("manager", [BareConfig, ManagerConfig], indirect=True)
 def test_map_request(manager):
     manager.test_window("one")
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert "one" in info["windows"]
     assert info["focus"] == "one"
 
     manager.test_window("two")
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert "two" in info["windows"]
     assert info["focus"] == "two"
 
@@ -955,24 +955,24 @@ def test_unmap(manager):
     one = manager.test_window("one")
     two = manager.test_window("two")
     three = manager.test_window("three")
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert info["focus"] == "three"
 
     assert len(manager.c.windows()) == 3
     manager.kill_window(three)
 
     assert len(manager.c.windows()) == 2
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert info["focus"] == "two"
 
     manager.kill_window(two)
     assert len(manager.c.windows()) == 1
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert info["focus"] == "one"
 
     manager.kill_window(one)
     assert len(manager.c.windows()) == 0
-    info = manager.c.groups()["a"]
+    info = manager.c.get_groups()["a"]
     assert info["focus"] is None
 
 
@@ -982,15 +982,15 @@ def test_setgroup(manager):
     manager.test_window("one")
     manager.c.group["b"].toscreen()
     manager.groupconsistency()
-    if len(manager.c.screens()) == 1:
-        assert manager.c.groups()["a"]["screen"] is None
+    if len(manager.c.get_screens()) == 1:
+        assert manager.c.get_groups()["a"]["screen"] is None
     else:
-        assert manager.c.groups()["a"]["screen"] == 1
-    assert manager.c.groups()["b"]["screen"] == 0
+        assert manager.c.get_groups()["a"]["screen"] == 1
+    assert manager.c.get_groups()["b"]["screen"] == 0
 
     manager.c.group["c"].toscreen()
     manager.groupconsistency()
-    assert manager.c.groups()["c"]["screen"] == 0
+    assert manager.c.get_groups()["c"]["screen"] == 0
 
     # Setting the current group once again switches back to the previous group
     manager.c.group["c"].toscreen(toggle=True)
@@ -1010,7 +1010,7 @@ def test_unmap_noscreen(manager):
     assert len(manager.c.windows()) == 2
     manager.kill_window(pid)
     assert len(manager.c.windows()) == 1
-    assert manager.c.groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] == "one"
 
 
 class TScreen(libqtile.config.Screen):
@@ -1126,7 +1126,7 @@ def test_switch_groups_cursor_warp(manager_nospawn):
     assert manager_nospawn.c.layout.info()["name"] == "max"
 
 
-def test_cmd_reload_config(manager_nospawn):
+def test_reload_config(manager_nospawn):
     # The test config uses presence of Qtile.test_data to change config values
     # Here we just want to check configurables are being updated within the live Qtile
     manager_nospawn.start(lambda: BareConfig(file_path=configs_dir / "reloading.py"))
@@ -1138,10 +1138,10 @@ def test_cmd_reload_config(manager_nospawn):
     # Original config
     assert manager_nospawn.c.eval("len(self.keys_map)") == (True, "1")
     assert manager_nospawn.c.eval("len(self.mouse_map)") == (True, "1")
-    assert "".join(manager_nospawn.c.groups().keys()) == "12345S"
+    assert "".join(manager_nospawn.c.get_groups().keys()) == "12345S"
     assert len(manager_nospawn.c.group.info()["layouts"]) == 1
     assert manager_nospawn.c.widget["clock"].eval("self.background") == (True, "None")
-    screens = manager_nospawn.c.screens()[0]
+    screens = manager_nospawn.c.get_screens()[0]
     assert screens["gaps"]["bottom"][3] == 24 and not screens["gaps"]["top"]
     assert len(manager_nospawn.c.internal_windows()) == 1
     assert manager_nospawn.c.eval("self.dgroups.key_binder") == (True, "None")
@@ -1160,10 +1160,10 @@ def test_cmd_reload_config(manager_nospawn):
     manager_nospawn.c.reload_config()
     assert manager_nospawn.c.eval("len(self.keys_map)") == (True, "2")
     assert manager_nospawn.c.eval("len(self.mouse_map)") == (True, "2")
-    assert "".join(manager_nospawn.c.groups().keys()) == "123456789S"
+    assert "".join(manager_nospawn.c.get_groups().keys()) == "123456789S"
     assert len(manager_nospawn.c.group.info()["layouts"]) == 2
     assert manager_nospawn.c.widget["currentlayout"].eval("self.background") == (True, "#ff0000")
-    screens = manager_nospawn.c.screens()[0]
+    screens = manager_nospawn.c.get_screens()[0]
     assert screens["gaps"]["top"][3] == 32 and not screens["gaps"]["bottom"]
     assert len(manager_nospawn.c.internal_windows()) == 1
     _, binder = manager_nospawn.c.eval("self.dgroups.key_binder")
@@ -1177,8 +1177,8 @@ def test_cmd_reload_config(manager_nospawn):
     manager_nospawn.c.group["S"].dropdown_toggle("dropdown2")  # Spawn second dropdown
     assert_dd_appeared()
     manager_nospawn.c.group["S"].dropdown_toggle("dropdown1")  # Send it to ScratchPad
-    assert "dd" in manager_nospawn.c.groups()["S"]["windows"]
-    assert "dd" in manager_nospawn.c.groups()["S"]["windows"]
+    assert "dd" in manager_nospawn.c.get_groups()["S"]["windows"]
+    assert "dd" in manager_nospawn.c.get_groups()["S"]["windows"]
 
     # Reload #2 - back to without libqtile.qtile.test_data
     manager_nospawn.c.eval("del self.test_data")
@@ -1186,10 +1186,10 @@ def test_cmd_reload_config(manager_nospawn):
     assert manager_nospawn.c.eval("len(self.keys_map)") == (True, "1")
     assert manager_nospawn.c.eval("len(self.mouse_map)") == (True, "1")
     # The last four groups persist within QtileState
-    assert "".join(manager_nospawn.c.groups().keys()) == "12345S"
+    assert "".join(manager_nospawn.c.get_groups().keys()) == "12345S"
     assert len(manager_nospawn.c.group.info()["layouts"]) == 1
     assert manager_nospawn.c.widget["clock"].eval("self.background") == (True, "None")
-    screens = manager_nospawn.c.screens()[0]
+    screens = manager_nospawn.c.get_screens()[0]
     assert screens["gaps"]["bottom"][3] == 24 and not screens["gaps"]["top"]
     assert len(manager_nospawn.c.internal_windows()) == 1
     assert manager_nospawn.c.eval("self.dgroups.key_binder") == (True, "None")
@@ -1199,8 +1199,8 @@ def test_cmd_reload_config(manager_nospawn):
     manager_nospawn.c.window.kill()
     if manager_nospawn.backend.name == "x11":
         assert manager_nospawn.c.eval("self.core.wmname") == (True, "LG3D")
-    assert "dd" in manager_nospawn.c.groups()["S"]["windows"]  # First dropdown persists
-    assert "dd" in manager_nospawn.c.groups()["1"]["windows"]  # Second orphans to group
+    assert "dd" in manager_nospawn.c.get_groups()["S"]["windows"]  # First dropdown persists
+    assert "dd" in manager_nospawn.c.get_groups()["1"]["windows"]  # Second orphans to group
 
 
 class CommandsConfig(Config):

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -293,7 +293,7 @@ def test_windowtogroup_groupName_argument():  # noqa: N802
         from libqtile.lazy import lazy
 
         k = Key([], 's', lazy.window.togroup(groupName="g"))
-        c = lambda win: win.cmd_togroup(groupName="g")
+        c = lambda win: win.togroup(groupName="g")
     """
     )
 
@@ -303,7 +303,93 @@ def test_windowtogroup_groupName_argument():  # noqa: N802
         from libqtile.lazy import lazy
 
         k = Key([], 's', lazy.window.togroup(group_name="g"))
-        c = lambda win: win.cmd_togroup(group_name="g")
+        c = lambda win: win.togroup(group_name="g")
+    """
+    )
+
+    check_migrate(orig, expected)
+
+
+def test_command_decorators_opacity():
+    orig = textwrap.dedent(
+        """
+        from libqtile.config import Key
+        from libqtile.lazy import lazy
+
+        def my_func(qtile, opacity):
+            qtile.current_window.cmd_opacity(opacity)
+
+        Key([], 's', lazy.window.opacity(0.8))
+    """
+    )
+
+    expected = textwrap.dedent(
+        """
+        from libqtile.config import Key
+        from libqtile.lazy import lazy
+
+        def my_func(qtile, opacity):
+            qtile.current_window.set_opacity(opacity)
+
+        Key([], 's', lazy.window.set_opacity(0.8))
+    """
+    )
+
+    check_migrate(orig, expected)
+
+
+def test_command_decorators_hints():
+    orig = textwrap.dedent(
+        """
+        def my_func(qtile):
+            hints = qtile.current_window.cmd_hints(opacity)
+    """
+    )
+
+    expected = textwrap.dedent(
+        """
+        def my_func(qtile):
+            hints = qtile.current_window.get_hints(opacity)
+    """
+    )
+
+    check_migrate(orig, expected)
+
+
+def test_command_decorators_screens_and_groups():
+    orig = textwrap.dedent(
+        """
+        def my_func(qtile):
+            screens = qtile.cmd_screens()
+            groups = qtile.cmd_groups()
+    """
+    )
+
+    expected = textwrap.dedent(
+        """
+        def my_func(qtile):
+            screens = qtile.get_screens()
+            groups = qtile.get_groups()
+    """
+    )
+
+    check_migrate(orig, expected)
+
+
+def test_rename_cmd_method_calls():
+    orig = textwrap.dedent(
+        """
+        def my_func(qtile):
+            qtile.cmd_spawn("xterm")
+            qtile.window.cmd_togroup(groupname="1", switch_group=True)
+    """
+    )
+
+    expected = textwrap.dedent(
+        """
+        def my_func(qtile):
+            qtile.spawn("xterm")
+            qtile.window.togroup(groupname="1", switch_group=True)
     """
     )
 

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -108,33 +108,33 @@ def test_no_size_hint(manager):
 def test_togroup_toggle(manager):
     manager.test_window("one")
     assert manager.c.group.info()["name"] == "a"  # Start on "a"
-    assert manager.c.groups()["a"]["focus"] == "one"
-    assert manager.c.groups()["b"]["focus"] is None
+    assert manager.c.get_groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["b"]["focus"] is None
     manager.c.window.togroup("b", switch_group=True)
     assert manager.c.group.info()["name"] == "b"  # Move the window and switch to "b"
-    assert manager.c.groups()["a"]["focus"] is None
-    assert manager.c.groups()["b"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["b"]["focus"] == "one"
     manager.c.window.togroup("b", switch_group=True)
     assert manager.c.group.info()["name"] == "b"  # Does not toggle by default
-    assert manager.c.groups()["a"]["focus"] is None
-    assert manager.c.groups()["b"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["b"]["focus"] == "one"
     manager.c.window.togroup("b", switch_group=True, toggle=True)
     assert (
         manager.c.group.info()["name"] == "a"
     )  # Explicitly toggling moves the window and switches to "a"
-    assert manager.c.groups()["a"]["focus"] == "one"
-    assert manager.c.groups()["b"]["focus"] is None
+    assert manager.c.get_groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["b"]["focus"] is None
     manager.c.window.togroup("b", switch_group=True, toggle=True)
     manager.c.window.togroup("b", switch_group=True, toggle=True)
     assert manager.c.group.info()["name"] == "a"  # Toggling twice roundtrips between the two
-    assert manager.c.groups()["a"]["focus"] == "one"
-    assert manager.c.groups()["b"]["focus"] is None
+    assert manager.c.get_groups()["a"]["focus"] == "one"
+    assert manager.c.get_groups()["b"]["focus"] is None
     manager.c.window.togroup("b", toggle=True)
     assert (
         manager.c.group.info()["name"] == "a"
     )  # Toggling without switching only moves the window
-    assert manager.c.groups()["a"]["focus"] is None
-    assert manager.c.groups()["b"]["focus"] == "one"
+    assert manager.c.get_groups()["a"]["focus"] is None
+    assert manager.c.get_groups()["b"]["focus"] == "one"
 
 
 class BringFrontClickConfig(ManagerConfig):

--- a/test/widgets/docs_screenshots/conftest.py
+++ b/test/widgets/docs_screenshots/conftest.py
@@ -27,6 +27,7 @@ import cairocffi
 import pytest
 
 from libqtile.bar import Bar
+from libqtile.command.base import expose_command
 from libqtile.config import Group, Screen
 
 
@@ -119,7 +120,8 @@ def screenshot_manager(widget, request, manager_nospawn, minimal_conf_noscreen, 
             # We need the widget's name to be the name of the inherited class
             self.name = widget_class.__name__.lower()
 
-        def cmd_take_screenshot(self, target):
+        @expose_command()
+        def take_screenshot(self, target):
             if not self.configured:
                 return
 
@@ -134,7 +136,8 @@ def screenshot_manager(widget, request, manager_nospawn, minimal_conf_noscreen, 
             dest.write_to_png(target)
 
     class ScreenshotBar(Bar):
-        def cmd_take_screenshot(self, target, x=0, y=0, width=None, height=None):
+        @expose_command()
+        def take_screenshot(self, target, x=0, y=0, width=None, height=None):
             """Takes a screenshot of the bar. The area can be selected."""
             if not self._configured:
                 return

--- a/test/widgets/test_base.py
+++ b/test/widgets/test_base.py
@@ -21,25 +21,31 @@ import pytest
 
 import libqtile.bar
 import libqtile.config
+from libqtile.command.base import expose_command
 from libqtile.widget import TextBox
 from libqtile.widget.base import ThreadPoolText, _Widget
 from test.helpers import BareConfig, Retry
 
 
 class TimerWidget(_Widget):
-    def cmd_set_timer1(self):
-        self.timer1 = self.timeout_add(10, self.cmd_set_timer1)
+    @expose_command()
+    def set_timer1(self):
+        self.timer1 = self.timeout_add(10, self.set_timer1)
 
-    def cmd_cancel_timer1(self):
+    @expose_command()
+    def cancel_timer1(self):
         self.timer1.cancel()
 
-    def cmd_set_timer2(self):
-        self.timer2 = self.timeout_add(10, self.cmd_set_timer2)
+    @expose_command()
+    def set_timer2(self):
+        self.timer2 = self.timeout_add(10, self.set_timer2)
 
-    def cmd_cancel_timer2(self):
+    @expose_command()
+    def cancel_timer2(self):
         self.timer2.cancel()
 
-    def cmd_get_active_timers(self):
+    @expose_command()
+    def get_active_timers(self):
         active = [x for x in self._futures if x._scheduled]
         return len(active)
 

--- a/test/widgets/test_misc.py
+++ b/test/widgets/test_misc.py
@@ -24,6 +24,7 @@
 import pytest
 
 from libqtile.bar import Bar
+from libqtile.command.base import expose_command
 from libqtile.config import Screen
 from libqtile.widget import TextBox
 from test.conftest import BareConfig
@@ -32,6 +33,7 @@ from test.conftest import BareConfig
 class ColorChanger(TextBox):
     count = 0
 
+    @expose_command()
     def update(self, text):
         self.count += 1
         if self.count % 2 == 0:

--- a/test/widgets/test_mpris2widget.py
+++ b/test/widgets/test_mpris2widget.py
@@ -152,7 +152,7 @@ def test_mpris2_signal_handling(fake_qtile, patched_module, fake_window):
     mp.parse_message(*STATUS_PLAYING.body)
     assert mp.text == "Never Gonna Give You Up - Whenever You Need Somebody - Rick Astley"
 
-    info = mp.cmd_info()
+    info = mp.info()
     assert info["text"] == "Never Gonna Give You Up - Whenever You Need Somebody - Rick Astley"
     assert info["isplaying"]
 

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -45,7 +45,7 @@ def test_widgetbox_widget(fake_qtile, fake_window):
     assert fakebar.widgets == [widget_box]
 
     # Open box
-    widget_box.cmd_toggle()
+    widget_box.toggle()
 
     # Check it's open
     assert widget_box.box_is_open
@@ -54,7 +54,7 @@ def test_widgetbox_widget(fake_qtile, fake_window):
     assert fakebar.widgets == [widget_box, tb_one, tb_two]
 
     # Close box
-    widget_box.cmd_toggle()
+    widget_box.toggle()
 
     # Check it's closed
     assert not widget_box.box_is_open
@@ -66,7 +66,7 @@ def test_widgetbox_widget(fake_qtile, fake_window):
     widget_box.close_button_location = "right"
 
     # Re-open box with new layout
-    widget_box.cmd_toggle()
+    widget_box.toggle()
 
     # Now widgetbox is on the right
     assert fakebar.widgets == [tb_one, tb_two, widget_box]


### PR DESCRIPTION
Currently, commands that wish to be exposed via IPC need to be prefixed with `cmd_` but this prefix is then removed when calling commands. This can cause confusion for users.

This PR replaces the prefix mechanism with a new decorator: `@CommandObject.expose`. Methods decorated with this will be exposed via IPC but the method name is consistent.


This is draft for now as I'm interested in opinions here and there's a lot more work to do to completely convert it. 

Personally, I've never particularly liked the `cmd_` prefix approach and I think decorators are a clearer solution but I appreciate there may be some differing views.

Pros:

- Consistent naming of methods
- Removes some unnecessary code (e.g. `cmd_info()` calling `info()`. We can remove `cmd_info` and just decorate `info`)

Cons:

- Might be a breaking change for users (e.g. configs may have scripts making references to `cmd_` methods). May be able to mitigate with `migrate` scripts.
- Underlying decorator code is slightly harder to follow than the code used to process `cmd_` methods. I've added fairly detailed comments to explain how it works.


As this PR is not complete, I've not touched the tests yet so it will be interesting to see how many I've broken at this stage!!

EDIT:
```
2021-08-29T17:38:38.2216360Z ====== 225 failed, 189 passed, 1 skipped, 610 errors in 416.32s (0:06:56) ======
```
:thumbsup: