### PR TITLE
x11: Include only regular windows in _NET_CLIENT_LIST

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -415,8 +415,9 @@ class Core(base.Core):
         This is needed for third party tasklists and drag and drop of tabs in
         chrome
         """
+        # Regular top-level managed windows, i.e. excluding Static, Internal and Systray Icons
         wids = [
-            wid for wid, c in windows_map.items() if not isinstance(c, window.Internal)
+            wid for wid, c in windows_map.items() if isinstance(c, window.Window)
         ]
         self._root.set_property("_NET_CLIENT_LIST", wids)
         # TODO: check stack order

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1395,6 +1395,7 @@ class Window(_Window, base.Window):
             self.group.remove(self)
         s = Static(self.window, self.qtile, screen, x, y, width, height)
         self.qtile.windows_map[self.window.wid] = s
+        self.qtile.core.update_client_list(self.qtile.windows_map)
         hook.fire("client_managed", s)
 
     def tweak_float(self, x=None, y=None, dx=0, dy=0,


### PR DESCRIPTION
In addition to internal windows, dock-like windows and systray icons
should not be included in the _NET_CLIENT_LIST and
_NET_CLIENT_LIST_STACKING root properties as these windows should not be
visible on pagers. I have included `Static` windows here in general,
though this may include "regular" (non-dock) windows too, because they
do not obey the same rules as regular managed windows (for example you
cannot move them to a different virtual desktop).