### PR TITLE
Floating windows obey wm below

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -341,6 +341,10 @@ class Window(_Window, metaclass=ABCMeta):
     def cmd_bring_to_front(self) -> None:
         """Bring the window to the front"""
 
+    @abstractmethod
+    def cmd_send_to_back(self) -> None:
+        """Send the window to the back"""
+
     def cmd_togroup(
         self, group_name: Optional[str] = None, *, switch_group: bool = False
     ) -> None:

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1820,6 +1820,10 @@ class Window(_Window, base.Window):
         else:
             self._reconfigure_floating()  # atomatically above
 
+    def cmd_send_to_back(self):
+        if self.floating:
+            self.window.configure(stackmode=StackMode.Below)
+
     def cmd_match(self, *args, **kwargs):
         return self.match(*args, **kwargs)
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -253,7 +253,10 @@ class Floating(Layout):
         # alternatively, users may have asked us explicitly to leave the client alone
         elif any(m.compare(client) for m in self.no_reposition_rules):
             client.paint_borders(bc, bw)
-            client.cmd_bring_to_front()
+            if "_NET_WM_STATE_BELOW" in client.window.get_net_wm_state():
+                client.cmd_send_to_back()
+            else:
+                client.cmd_bring_to_front()
 
         else:
             above = False


### PR DESCRIPTION
Some floating windows with widget like behavior have the wm property `_NET_WM_STATE_BELOW`. This PR ensure that those windows stay behind other windows unless focused by the mouse or tasklist widget.

Adds `cmd_send_to_back()` to the window class (X only. IDK how wayland handles this).

I'm not sure how to go about testing window stack order. Does `_NET_CLIENT_STACKING_LIST` have anything to do with it?