### PR TITLE
x11: toggle window button grabbing with focussing

### DIFF
--- a/test/test_window.py
+++ b/test/test_window.py
@@ -92,6 +92,7 @@ def test_bring_front_click(manager, bring_front_click):
 
     # Click on window two
     manager.backend.fake_click(55, 55)
+    assert manager.c.window.info()["name"] == "two"
     wins = manager.backend.get_all_windows()
     if bring_front_click:
         assert wins.index(wids[0]) < wins.index(wids[2]) < wins.index(wids[1])
@@ -100,6 +101,7 @@ def test_bring_front_click(manager, bring_front_click):
 
     # Click on window one
     manager.backend.fake_click(10, 10)
+    assert manager.c.window.info()["name"] == "one"
     wins = manager.backend.get_all_windows()
     if bring_front_click == "floating_only":
         assert wins.index(wids[0]) < wins.index(wids[2]) < wins.index(wids[1])


### PR DESCRIPTION
This changes how the x11 backend handles grabbing of button events on
windows. Currently, button events are grabbed for button 1 when new
windows are created so that we can listen to these and focus an
unfocussed window upon click. This works for focussing, but the grabbing
of buttons even on the focussed window can cause some problems, such as
that seen in #2744. This new approach changes this so that the button
events are grabbed only when a window is unfocussed, and ungrabs them
when the window gains focus. This follows the approach used by i3, and
also reduces some unnecessary button event processing as we no longer
respond to button events on the focussed window, whose button events we
do not care about.

Fixes #2744

--

I'd like some x11 uses to test this out during daily use for a bit just to make sure it's working just fine, particularly anyone who uses any chromium-based software. I did some general testing and so far it seems to work pretty well without issues.