### PR TITLE
x11: fix up focus when focus goes to None

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
 _IGNORED_EVENTS = {
     xcffib.xproto.CreateNotifyEvent,
     xcffib.xproto.FocusInEvent,
-    xcffib.xproto.FocusOutEvent,
     xcffib.xproto.KeyReleaseEvent,
     # DWM handles this to help "broken focusing windows".
     xcffib.xproto.MapNotifyEvent,
@@ -546,6 +545,10 @@ class Core(base.Core):
         internal.place(x, y, width, height, 0, None)
         self.qtile.manage(internal)
         return internal
+
+    def handle_FocusOut(self, event) -> None:
+        if event.detail == xcffib.xproto.NotifyDetail._None:
+            self.conn.fixup_focus()
 
     def handle_SelectionNotify(self, event) -> None:  # noqa: N802
         if not getattr(event, "owner", None):


### PR DESCRIPTION
We have a bug where sometimes we lose track of focus all together, and
hotkeys don't work, etc.

I haven't been able to track down where this bug comes from, but it is
*always* a bug to focus None, since it breaks our hotkeys. See 7b43c9f8af83
("manager: focus root if nothing is focused") for a more detailed
explanation.

Since it is always a bug, let's listen for focus None events and fix up the
focus in this case.

Per: https://tronche.com/gui/x/xlib/events/input-focus/normal-and-grabbed.html

we'll get a FocusOut event with detail set to NotifyDetail#None. Let's test
for this and fixup the focus as we do in other cases.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>