### PR TITLE
CryptoTicker migrate format reset (fix #2736)

### DIFF
--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -69,10 +69,32 @@ def pacman_to_checkupdates(query):
     )
 
 
+def reset_format(node, capture, filename):
+    args = capture.get("class_arguments")
+    if args:
+        if args[0].type == 260:  # argument list
+            n_children = len(args[0].children)
+            for i in range(n_children):
+                # we only want to remove the format argument
+                if 'format' in str(args[0].children[i]):
+                    # remove the argument and the trailing or preceeding comma
+                    if i == n_children - 1:  # last argument
+                        args[0].children[i - 1].remove()
+                        args[0].children[i - 1].remove()
+                    else:
+                        args[0].children[i].remove()
+                        args[0].children[i].remove()
+
+                    break
+        else:  # there's only one argument
+            args[0].remove()
+
+
 def bitcoin_to_crypto(query):
     return (
         query
         .select_class("BitcoinTicker")
+        .modify(reset_format)
         .rename("CryptoTicker")
     )
 

--- a/test/test_migrate.py
+++ b/test/test_migrate.py
@@ -174,14 +174,30 @@ def test_crypto():
         from libqtile import bar
         from libqtile.widget import BitcoinTicker
 
-        bar.Bar([BitcoinTicker()], 30)
+        bar.Bar(
+            [
+                BitcoinTicker(crypto='BTC', format='BTC: {avg}'),
+                BitcoinTicker(format='{crypto}: {avg}', font='sans'),
+                BitcoinTicker(),
+                BitcoinTicker(currency='EUR', format='{avg}', foreground='ffffff'),
+            ],
+            30
+        )
     """)
 
     expected = textwrap.dedent("""
         from libqtile import bar
         from libqtile.widget import CryptoTicker
 
-        bar.Bar([CryptoTicker()], 30)
+        bar.Bar(
+            [
+                CryptoTicker(crypto='BTC'),
+                CryptoTicker( font='sans'),
+                CryptoTicker(),
+                CryptoTicker(currency='EUR', foreground='ffffff'),
+            ],
+            30
+        )
     """)
 
     check_migrate(orig, expected)


### PR DESCRIPTION
I haven't used bowler before so hopefully this is the best way to do this...

Fixes #2736 by eliminating the `format` argument from outdated configs using `BitcoinTicker`, which causes the default formatting to be used, thereby preventing breakage.

The tests contain examples of what this can look like.