### PR TITLE
Some Wayland input fixes

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -423,32 +423,28 @@ class Core(base.Core, wlrq.HasListeners):
                     self._hovered_internal = win
                 return
 
-            focus_changed = self.seat.pointer_state.focused_surface != surface
             if surface is not None:
                 self.seat.pointer_notify_enter(surface, sx, sy)
-            if focus_changed:
-                if surface is None:
-                    self.seat.pointer_clear_focus()
-                if win is not self.qtile.current_window:
-                    hook.fire("client_mouse_enter", win)
-
-                    if self.qtile.config.follow_mouse_focus:
-                        if isinstance(win, window.Static):
-                            self.qtile.focus_screen(win.screen.index, False)
-                        else:
-                            if win.group.current_window != win:
-                                win.group.focus(win, False)
-                            if (
-                                win.group.screen
-                                and self.qtile.current_screen != win.group.screen
-                            ):
-                                self.qtile.focus_screen(win.group.screen.index, False)
-                        self.focus_window(win, surface)
-
+                if self.seat.pointer_state.focused_surface == surface:
+                    self.seat.pointer_notify_motion(time, sx, sy)
             else:
-                # The enter event contains coordinates, so we only need to
-                # notify on motion if the focus did not change
-                self.seat.pointer_notify_motion(time, sx, sy)
+                self.seat.pointer_clear_focus()
+
+            if win is not self.qtile.current_window:
+                hook.fire("client_mouse_enter", win)
+
+                if self.qtile.config.follow_mouse_focus:
+                    if isinstance(win, window.Static):
+                        self.qtile.focus_screen(win.screen.index, False)
+                    else:
+                        if win.group.current_window != win:
+                            win.group.focus(win, False)
+                        if (
+                            win.group.screen
+                            and self.qtile.current_screen != win.group.screen
+                        ):
+                            self.qtile.focus_screen(win.group.screen.index, False)
+                    self.focus_window(win, surface)
 
             if self._hovered_internal:
                 self._hovered_internal = None

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -90,6 +90,7 @@ class Keyboard(HasListeners):
         self.finalize()
 
     def _on_modifier(self, _listener, _data):
+        self.seat.set_keyboard(self.device)
         self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)
 
     def _on_key(self, _listener, event: KeyboardKeyEvent):


### PR DESCRIPTION
3 misc commits that fix some input-handling for the Wayland backend:

1.  Consider window under pointer when over its border:  This restores the behaviour where moving the pointer over a window border considers that window under the pointer (rather than needing to enter the main content rectangle).
2. Set seat keyboard upon modifier press: this is needed so that multiple keyboards can be used without issues 
3. Don't send clicks used for mouse bindings to focussed window: currently the keys for keybindings are still send into the window but they should be swallowed.