### PR TITLE
Floating windows snap to windows/screens borders option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@ Qtile xxxxxx, released xxxxxxxxxx:
     * features
         - All layouts will accept a list of colors for border_* options with which
           they will draw multiple borders on the appropriate windows.
+        - lazy.window.set_position_floating() now has the options
+          `border_snapping=bool`(False by default) and `snap_dist=int`(in pixels)
+          which allows floating window's borders to snap/stick to screen and other window's borders
+          similar to features seen in KDE and Gnome.
 
 Qtile 0.18.0, released 2021-07-04:
     !!! Config breakage !!!

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -107,6 +107,9 @@ Window functions
       - Put the focused window to/from floating mode
     * - ``lazy.window.toggle_fullscreen()``
       - Put the focused window to/from fullscreen mode
+    * - ``lazy.window.set_position_floating(x, y, border_snapping=False, snap_dist=10)``
+      - Move the focused floating window to x,y with optional border snapping for
+        for easy alignment with other windows and screen edges
 
 ScratchPad DropDown functions
 -----------------------------

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1790,7 +1790,8 @@ class Window(_Window, base.Window):
         for s in self.qtile.screens:
             borders.append((s.x, s.y, s.x+s.width, s.y+s.height))
             for w in s.group.windows:
-                borders.append(w.edges)
+                if not w.hidden:
+                    borders.append(w.edges)
         borders.remove(self.edges)
         return borders
 


### PR DESCRIPTION
Similar to the KDE and Gnome (and other WM/DEs I assume) feature.
Intended to be enable in the config via:
```
mouse = [
    Drag([mod], "Button1", lazy.window.set_position_floating(border_snapping=True, snap_dist=10),
         start=lazy.window.get_position()),
]
```
disabled by default.

Notice how the mouse keeps moving while the window pauses on the border.
![border_snapping](https://user-images.githubusercontent.com/21085003/132133669-2b7580c8-4827-4200-bfbf-b26aa789314c.gif)



some squashed commit stuff:
Add test for window border snapping
Add changes to docs and changelog
Fix pep8 issues