### PR TITLE
resources: add wayland session desktop entry

### DIFF
--- a/resources/qtile-wayland.desktop
+++ b/resources/qtile-wayland.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Qtile (Wayland)
+Comment=Qtile Session
+Exec=qtile start -b wayland
+Type=Application
+Keywords=wm;tiling


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This is needed in order to distributions install the correct session to `/usr/share/wayland-sessions/` to provide Wayland support.