### PR TITLE
treewide: remove usage of deprecated ABCs from 'collections'

### DIFF
--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -186,7 +186,7 @@ class DGroups:
                     group = self.groups_map.get(rule.group)
                     if group and group_added:
                         for k, v in list(group.layout_opts.items()):
-                            if isinstance(v, collections.Callable):
+                            if isinstance(v, collections.abc.Callable):
                                 v(group_obj.layout)
                             else:
                                 setattr(group_obj.layout, k, v)

--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -141,13 +141,13 @@ class TextFrame:
         self.drawer = self.layout.drawer
         self.highlight_color = highlight_color
 
-        if isinstance(pad_x, collections.Iterable):
+        if isinstance(pad_x, collections.abc.Iterable):
             self.pad_left = pad_x[0]
             self.pad_right = pad_x[1]
         else:
             self.pad_left = self.pad_right = pad_x
 
-        if isinstance(pad_y, collections.Iterable):
+        if isinstance(pad_y, collections.abc.Iterable):
             self.pad_top = pad_y[0]
             self.pad_bottom = pad_y[1]
         else:


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```