### PR TITLE
x11: Improve UnmapNotify handling to follow spec

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -740,7 +740,8 @@ class _Window:
     def hide(self):
         # We don't want to get the UnmapNotify for this unmap
         with self.disable_mask(EventMask.StructureNotify):
-            self.window.unmap()
+            with self.qtile.core.disable_unmap_events():
+                self.window.unmap()
         self.hidden = True
 
     def unhide(self):


### PR DESCRIPTION
According to
https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm45643490113536,
Qtile should remove the _NET_WM_DESKTOP (and _NET_WM_STATE) property
from windows when they unmap. This lets clients reset this property with
a new value so that when they re-use a window it can be re-managed on a
different desktop.  This only applies to windows unmapped by a client,
and not windows unmapped by Qtile (e.g. when switching groups). Both
actions trigger UnmapNotify events on the root window so currently
cannot be distinguished. This commit disables UnmapNotify events
triggered by internal logic by removing SubstructureNotify events from
the root window's event mask when hiding a window. We can then pass all
windows that emit UnmapNotify events through the current unmanaging
code, and also remove the _NET_WM_DESKTOP property in the process. This
lets clients who re-use windows reset the property and have it respected
when their window gets managed again.

Fixes #1232