### PR TITLE
widget: net: add support for 'total' bandwidth value

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Qtile x.x.x, released xxxx-xx-xx:
+    * features
+        - Add `total` bandwidth format value to the Net widget.
+
 Qtile 0.18.1, released 2021-09-16:
     * features
         - All layouts will accept a list of colors for border_* options with which

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -38,7 +38,7 @@ class Net(base.ThreadPoolText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ('format', '{interface}: {down} \u2193\u2191 {up}',
-         'Display format of down-/upload speed of given interfaces'),
+         'Display format of down/upload/total speed of given interfaces'),
         ('interface', None, 'List of interfaces or single NIC as string to monitor, \
             None to displays all active NICs combined'),
         ('update_interval', 1, 'The update interval.'),
@@ -82,22 +82,32 @@ class Net(base.ThreadPoolText):
         interfaces = {}
         if self.interface == ["all"]:
             net = psutil.net_io_counters(pernic=False)
-            interfaces["all"] = {'down': net.bytes_recv, 'up': net.bytes_sent}
+            interfaces["all"] = {
+                    'down': net.bytes_recv,
+                    'up': net.bytes_sent,
+                    'total': net.bytes_recv + net.bytes_sent,
+                }
             return interfaces
         else:
             net = psutil.net_io_counters(pernic=True)
             for iface in net:
                 down = net[iface].bytes_recv
                 up = net[iface].bytes_sent
-                interfaces[iface] = {'down': down, 'up': up}
+                interfaces[iface] = {
+                        'down': down,
+                        'up': up,
+                        'total': down + up,
+                    }
             return interfaces
 
-    def _format(self, down, down_letter, up, up_letter):
+    def _format(self, down, down_letter, up, up_letter, total, total_letter):
         max_len_down = 7 - len(down_letter)
         max_len_up = 7 - len(up_letter)
+        max_len_total = 7 - len(total_letter)
         down = '{val:{max_len}.2f}'.format(val=down, max_len=max_len_down)
         up = '{val:{max_len}.2f}'.format(val=up, max_len=max_len_up)
-        return down[:max_len_down], up[:max_len_up]
+        total = '{val:{max_len}.2f}'.format(val=total, max_len=max_len_total)
+        return down[:max_len_down], up[:max_len_up], total[:max_len_total]
 
     def poll(self):
         ret_stat = []
@@ -108,19 +118,28 @@ class Net(base.ThreadPoolText):
                     self.stats[intf]['down']
                 up = new_stats[intf]['up'] - \
                     self.stats[intf]['up']
+                total = new_stats[intf]['total'] - \
+                    self.stats[intf]['total']
 
                 down = down / self.update_interval
                 up = up / self.update_interval
+                total = total / self.update_interval
                 down, down_letter = self.convert_b(down)
                 up, up_letter = self.convert_b(up)
-                down, up = self._format(down, down_letter, up, up_letter)
+                total, total_letter = self.convert_b(total)
+                down, up, total = self._format(
+                        down, down_letter,
+                        up, up_letter,
+                        total, total_letter
+                    )
                 self.stats[intf] = new_stats[intf]
                 ret_stat.append(
                     self.format.format(
                         **{
                             'interface': intf,
                             'down': down + down_letter,
-                            'up': up + up_letter
+                            'up': up + up_letter,
+                            'total': total + total_letter,
                         }))
 
             return " ".join(ret_stat)

--- a/test/widgets/test_net.py
+++ b/test/widgets/test_net.py
@@ -69,7 +69,10 @@ def patch_net(fake_qtile, monkeypatch, fake_window):
 
         # Reload fixes cases where psutil may have been imported previously
         reload(net)
-        widget = net.Net(**kwargs)
+        widget = net.Net(
+                format='{interface}: U {up} D {down} T {total}',
+                **kwargs
+            )
         fakebar = Bar([widget], 24)
         fakebar.window = fake_window
         fakebar.width = 10
@@ -84,19 +87,19 @@ def patch_net(fake_qtile, monkeypatch, fake_window):
 def test_net_defaults(patch_net):
     '''Default: widget shows `all` interfaces'''
     net1 = patch_net()
-    assert net1.poll() == "all:  1.20MB ↓↑ 40.00kB"
+    assert net1.poll() == "all: U 40.00kB D  1.20MB T  1.24MB"
 
 
 def test_net_single_interface(patch_net):
     '''Display single named interface'''
     net2 = patch_net(interface="wlp58s0")
-    assert net2.poll() == "wlp58s0:  1.20MB ↓↑ 40.00kB"
+    assert net2.poll() == "wlp58s0: U 40.00kB D  1.20MB T  1.24MB"
 
 
 def test_net_list_interface(patch_net):
     '''Display multiple named interfaces'''
     net2 = patch_net(interface=["wlp58s0", "lo"])
-    assert net2.poll() == "wlp58s0:  1.20MB ↓↑ 40.00kB lo:  1.20MB ↓↑ 40.00kB"
+    assert net2.poll() == "wlp58s0: U 40.00kB D  1.20MB T  1.24MB lo: U 40.00kB D  1.20MB T  1.24MB"
 
 
 def test_net_invalid_interface(patch_net):
@@ -108,7 +111,7 @@ def test_net_invalid_interface(patch_net):
 def test_net_use_bits(patch_net):
     '''Display all interfaces in bits rather than bytes'''
     net4 = patch_net(use_bits=True)
-    assert net4.poll() == "all:  9.60Mb ↓↑ 320.0kb"
+    assert net4.poll() == "all: U 320.0kb D  9.60Mb T  9.92Mb"
 
 
 def test_net_convert_zero_b(patch_net):


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

Some users (like me) would like to have, instead of up and down values separately, sum it up altogether. This PR adds 'total' value for that purpose.