### PR TITLE
widget: groupbox: add support for show_screen_only flag

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -230,6 +230,11 @@ class GroupBox(_GroupBase):
             "Hide groups that have no windows and that are not displayed on any screen."
         ),
         (
+            "show_screen_only",
+            False,
+            "Show groups that are currenly only available to the attached screen"
+        ),
+        (
             "spacing",
             None,
             "Spacing between groups"
@@ -347,6 +352,10 @@ class GroupBox(_GroupBase):
 
         offset = self.margin_x
         for i, g in enumerate(self.groups):
+
+            if self.show_screen_only and self.qtile.current_screen != self.bar.screen:
+                continue
+
             to_highlight = False
             is_block = (self.highlight_method == 'block')
             is_line = (self.highlight_method == 'line')


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This PR enables support for `show_screen_only` flag that allows you to filter groups per screen.