### PR TITLE
Add support for on-release key bindings.

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -176,8 +176,12 @@ class Core(base.Core):
         modmap_keycodes = modmap_reply.keycodes.raw
         keycodes_per_modifier = modmap_reply.keycodes_per_modifier
         n_modifiers = modmap_reply.length
-        assert len(modmap_keycodes) >= n_modifiers * keycodes_per_modifier
-        ks_to_mask: Dict[int, int] = {}
+        ks_to_mask: dict[int, int] = {}
+
+        if not len(modmap_keycodes) >= n_modifiers * keycodes_per_modifier:
+            logger.error("Couldn't create keysym->modmask mapping dict. Please report.")
+            return ks_to_mask
+
         for mod_num in range(n_modifiers):  # usually 8
             for i_keycode in range(keycodes_per_modifier):  # usually 4
                 kc = modmap_keycodes[keycodes_per_modifier * mod_num + i_keycode]

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -66,16 +66,24 @@ class Key:
         commands should be separated by commas.
     desc:
         Description to be added to the key binding. (Optional)
+    on_release:
+        Whether this binding should apply to key releases rather than presses. (Optional)
 
     """
 
     def __init__(
-        self, modifiers: list[str], key: str, *commands: LazyCall, desc: str = ""
+        self,
+        modifiers: list[str],
+        key: str,
+        *commands: LazyCall,
+        desc: str = "",
+        on_release: bool = False,
     ) -> None:
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
         self.desc = desc
+        self.on_release = on_release
 
     def __repr__(self) -> str:
         return "<Key (%s, %s)>" % (self.modifiers, self.key)

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -273,9 +273,7 @@ class ScratchPad(group._Group):
                 hook.unsubscribe.client_new(self.on_client_new)
             self.dropdowns[name] = DropDownToggler(client, self.name, self._dropdownconfig[name])
             if self._single:
-                for n, d in self.dropdowns.items():
-                    if n != name:
-                        d.hide()
+                self._hide_all_except(name)
             if name in self._to_hide:
                 self.dropdowns[name].hide()
                 self._to_hide.remove(name)
@@ -312,20 +310,47 @@ class ScratchPad(group._Group):
                     break
         self._check_unsubscribe()
 
+    def _hide_all_except(self, name: str) -> None:
+        """
+        Hide all dropdowns except the one with the given name.
+        """
+        for n, d in self.dropdowns.items():
+            if n != name:
+                d.hide()
+
     @expose_command()
     def dropdown_toggle(self, name):
         """
         Toggle visibility of named DropDown.
         """
         if self._single:
-            for n, d in self.dropdowns.items():
-                if n != name:
-                    d.hide()
+            self._hide_all_except(name)
         if name in self.dropdowns:
             self.dropdowns[name].toggle()
         else:
             if name in self._dropdownconfig:
                 self._spawn(self._dropdownconfig[name])
+
+    @expose_command()
+    def dropdown_show(self, name):
+        """
+        Show named DropDown if it is hidden.
+        """
+        if self._single:
+            self._hide_all_except(name)
+        if name in self.dropdowns:
+            self.dropdowns[name].show()
+        else:
+            if name in self._dropdownconfig:
+                self._spawn(self._dropdownconfig[name])
+
+    @expose_command()
+    def dropdown_hide(self, name):
+        """
+        Hide named DropDown if it is visible.
+        """
+        if name in self.dropdowns:
+            self.dropdowns[name].hide()
 
     @expose_command()
     def hide_all(self):

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -123,8 +123,6 @@ def test_toggling_single(manager):
     # adjust command for current display
     manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-e")
     manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-f")
-    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-g")
-    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-h")
 
     manager.test_window("one")
     assert manager.c.group["a"].info()["windows"] == ["one"]
@@ -320,3 +318,64 @@ def test_stepping_between_groups_should_skip_scratchpads(manager):
     manager.c.screen.prev_group()
     # we should be on b group
     assert manager.c.group.info()["name"] == "b"
+
+
+@scratchpad_config
+def test_show_hide_single(manager):
+    # adjust command for current display
+    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-e")
+    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_reconfigure("dd-f")
+
+    manager.test_window("one")
+    assert manager.c.group["a"].info()["windows"] == ["one"]
+
+    # First show: wait for window
+    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_show("dd-e")
+    is_spawned(manager, "dd-e", "SINGLE_SCRATCHPAD")
+
+    # assert window in current group "a"
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["dd-e", "one"]
+    assert_focused(manager, "dd-e")
+
+    # show another window, this should hide the previous one.
+    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_show("dd-f")
+    is_spawned(manager, "dd-f", "SINGLE_SCRATCHPAD")
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["dd-f", "one"]
+    assert_focused(manager, "dd-f")
+    assert manager.c.group["SINGLE_SCRATCHPAD"].info()["windows"] == ["dd-e"]
+
+    # hide the scratchpad that is now visible.
+    manager.c.group["SINGLE_SCRATCHPAD"].dropdown_hide("dd-f")
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["one"]
+    assert_focused(manager, "one")
+    assert sorted(manager.c.group["SINGLE_SCRATCHPAD"].info()["windows"]) == ["dd-e", "dd-f"]
+
+
+@scratchpad_config
+def test_show_hide(manager):
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure("dd-a")
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure("dd-b")
+
+    manager.test_window("one")
+    assert manager.c.group["a"].info()["windows"] == ["one"]
+
+    # First show: wait for window
+    manager.c.group["SCRATCHPAD"].dropdown_show("dd-a")
+    is_spawned(manager, "dd-a", "SCRATCHPAD")
+
+    # assert window in current group "a"
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["dd-a", "one"]
+    assert_focused(manager, "dd-a")
+
+    # show another window
+    manager.c.group["SCRATCHPAD"].dropdown_show("dd-b")
+    is_spawned(manager, "dd-b", "SCRATCHPAD")
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["dd-a", "dd-b", "one"]
+    assert_focused(manager, "dd-b")
+    assert manager.c.group["SCRATCHPAD"].info()["windows"] == []
+
+    # hide the first scratchpad that is visible
+    manager.c.group["SCRATCHPAD"].dropdown_hide("dd-a")
+    assert sorted(manager.c.group["a"].info()["windows"]) == ["dd-b", "one"]
+    assert_focused(manager, "dd-b")
+    assert sorted(manager.c.group["SCRATCHPAD"].info()["windows"]) == ["dd-a"]


### PR DESCRIPTION
See #2778: When using keys like alt/meta, control, super etc. both as
modifiers for bindings and as bindings, the on-key-down policy
interferes, resulting in unwanted behaviour.

This commit adds the possibility to only trigger actions on release.

+ Configuration is simple: `Key([], "Super_L", ..., on_release=True)`.
+ The backend has to call `Qtile.process_key_event` with two additional
  arguments:
  1. `is_release: bool`: if the event corresponds to the release of a
     key.
  2. `key_as_modifier: int`: a mask representing the key, e.g. control
     would be 0b00000100 = 0x04, shift would be 0b00000001 = 0x01 and so
     on. For most (normal) keys this should be 0x00 and have no effect (XOR).
+ The mapping from key (syms) to masks (in the case of backend.x11) is
  calculated in `x11.core.Core._make_keysym_to_modmask_dict`, hacked
  together and heavily inspired by `xmodmap -pm` and its source code:
    https://github.com/freedesktop/xmodmap/blob/6d5aa481669cdbf2f0cb83bb0b8f142ba94307ae/exec.c#L216
  Remark:  This could also be achieved by chaining
  `keysym_to_keycode | get_modifier | ModMasks | maskname2mask`
  where get_modifier might return None. A cached dictionary is more
  efficient in the long run.

-------------------

Progress:

+ [x] Configuration option is implemented
+ [x] X11 backend changes implemented
+ [ ] wayland implementation (@m-col?)