### PR TITLE
docs: fix rendering of types

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -737,7 +737,7 @@ class Core(base.Core):
 
         Parameters
         ==========
-        e : xcb event
+        e: xcb event
             Click event used to determine window to focus
         """
         qtile = self.qtile

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -312,9 +312,9 @@ class XWindow:
         """
         Parameters
         ==========
-        name : String Atom name
-        type : String Atom name
-        format : 8, 16, 32
+        name: String Atom name
+        type: String Atom name
+        format: 8, 16, 32
         """
         if name in xcbq.PropertyMap:
             if type or format:
@@ -774,16 +774,16 @@ class _Window:
 
         Parameters
         ==========
-        x : int
-        y : int
-        width : int
-        height : int
-        borderwidth : int
-        bordercolor : string
-        above : bool, optional
-        margin : int or list, optional
+        x: int
+        y: int
+        width: int
+        height: int
+        borderwidth: int
+        bordercolor: string
+        above: bool, optional
+        margin: int or list, optional
             space around window as int or list of ints [N E S W]
-        above : bool, optional
+        above: bool, optional
             If True, the geometry will be adjusted to respect hints provided by the
             client.
         """

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -133,7 +133,7 @@ class CommandObject(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        name : str
+        name: str
             The name of the command to fetch.
 
         Returns

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -77,9 +77,9 @@ class CommandClient:
 
         Parameters
         ----------
-        name : str
+        name: str
             The name of the command graph object to resolve.
-        selector : Optional[str]
+        selector: Optional[str]
             If given, the selector to use to select the next object, and if
             None, then selects the default object.
 
@@ -104,11 +104,11 @@ class CommandClient:
 
         Parameters
         ----------
-        name : str
+        name: str
             The name of the command to resolve in the command graph.
-        args :
+        args:
             The arguments to pass into the call invocation.
-        kwargs :
+        kwargs:
             The keyword arguments to pass into the call invocation.
 
         Returns
@@ -196,7 +196,7 @@ class InteractiveCommandClient:
 
         Parameters
         ----------
-        name : str
+        name: str
             The name of the element to resolve
 
         Return
@@ -236,7 +236,7 @@ class InteractiveCommandClient:
 
         Parameters
         ----------
-        name : str
+        name: str
             The name, or index if it's of int type, of the item to resolve
 
         Return

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -87,9 +87,9 @@ class CommandInterface(metaclass=ABCMeta):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for commands
-        command : str
+        command: str
             The name of the command to check for
 
         Returns
@@ -104,11 +104,11 @@ class CommandInterface(metaclass=ABCMeta):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for items
-        object_type : str
+        object_type: str
             The type of object to check for items.
-        command : str
+        command: str
             The name of the item to check for
 
         Returns
@@ -126,7 +126,7 @@ class QtileCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        command_object : CommandObject
+        command_object: CommandObject
             The command object to use for resolving the commands and items
             against.
         """
@@ -162,9 +162,9 @@ class QtileCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for commands
-        command : str
+        command: str
             The name of the command to check for
 
         Returns
@@ -181,11 +181,11 @@ class QtileCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for items
-        object_type : str
+        object_type: str
             The type of object to check for items.
-        item : str
+        item: str
             The name or index of the item to check for
 
         Returns
@@ -208,7 +208,7 @@ class IPCCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        ipc_client : ipc.Client
+        ipc_client: ipc.Client
             The client that is to be used to resolve the calls.
         """
         self._client = ipc_client
@@ -245,9 +245,9 @@ class IPCCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for commands
-        command : str
+        command: str
             The name of the command to check for
 
         Returns
@@ -268,11 +268,11 @@ class IPCCommandInterface(CommandInterface):
 
         Parameters
         ----------
-        node : CommandGraphNode
+        node: CommandGraphNode
             The node to check for items
-        object_type : str
+        object_type: str
             The type of object to check for items.
-        command : str
+        command: str
             The name of the item to check for
 
         Returns

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -542,13 +542,13 @@ class ScratchPad(Group):
 
     Parameters
     ==========
-    name : string
+    name: string
         the name of this group
-    dropdowns : default ``None``
+    dropdowns: default ``None``
         list of DropDown objects
-    position : int
+    position: int
         group position
-    label : string
+    label: string
         The display name of the ScratchPad group. Defaults to the empty string
         such that the group is hidden in ``GroupList`` widget.
     """
@@ -771,9 +771,9 @@ class DropDown(configurable.Configurable):
 
         Parameters
         ==========
-        name : string
+        name: string
             The name of the DropDown configuration.
-        cmd : string
+        cmd: string
             Command to spawn a process.
         """
         configurable.Configurable.__init__(self, **config)

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -94,9 +94,9 @@ class _IPC:
 
         Parameters
         ----------
-        data : bytes
+        data: bytes
             The incoming message to unpack
-        is_json : Optional[bool]
+        is_json: Optional[bool]
             If the message should be unpacked as json.  By default, try to
             unpack json and fallback gracefully to marshalled bytes.
 
@@ -142,10 +142,10 @@ class Client:
 
         Parameters
         ----------
-        socket_path : str
+        socket_path: str
             The file path to the file that is used to open the connection to
             the running IPC server.
-        is_json : bool
+        is_json: bool
             Pack and unpack messages as json
         """
         self.socket_path = socket_path

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -294,7 +294,7 @@ class _ClientList:
         Positive values are after the client.
 
         Use parameter 'client_position' to insert the given client at 4 specific
-        positions : top, bottom, after_current, before_current.
+        positions: top, bottom, after_current, before_current.
         """
         if client_position is not None:
             if client_position == "after_current":

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -654,9 +654,9 @@ class TreeTab(Layout):
 
         Parameters
         ==========
-        sorter : function with single arg returning string
+        sorter: function with single arg returning string
             returns name of the section where window should be
-        create_sections :
+        create_sections:
             if this parameter is True (default), if sorter returns unknown
             section name it will be created dynamically
         """

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -167,7 +167,7 @@ class MonadTall(_SimpleLayoutBase):
         ("change_ratio", .05, "Resize ratio"),
         ("change_size", 20, "Resize change in pixels"),
         ("new_client_position", "after_current",
-            "Place new windows : "
+            "Place new windows: "
             " after_current - after the active window."
             " before_current - before the active window,"
             " top - at the top of the stack,"

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -35,11 +35,11 @@ class LazyCall:
 
         Parameters
         ----------
-        call : CommandGraphCall
+        call: CommandGraphCall
             The call that is made
-        args : Tuple
+        args: Tuple
             The args passed to the call when it is evaluated.
-        kwargs : Dict
+        kwargs: Dict
             The kwargs passed to the call when it is evaluated.
         """
         self._call = call
@@ -75,10 +75,10 @@ class LazyCall:
 
         Parameters
         ----------
-        layout : str, Iterable[str], or None
+        layout: str, Iterable[str], or None
             Restrict call to one or more layouts.
             If None, enable the call for all layouts.
-        when_floating : bool
+        when_floating: bool
             Enable call when the current window is floating.
         """
         if layout is not None:

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -41,13 +41,13 @@ class WindowVisibilityToggler:
 
         Parameters:
         ===========
-        scratchpad_name : string
+        scratchpad_name: string
             The name (not label) of the ScratchPad group used to hide the window
-        window : window
+        window: window
             The window to toggle
-        on_focus_lost_hide : bool
+        on_focus_lost_hide: bool
             if True the associated window is hidden if it loses focus
-        warp_pointer : bool
+        warp_pointer: bool
             if True the mouse pointer is warped to center of associated window
             if shown. Only used if on_focus_lost_hide is True
         """

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -91,7 +91,7 @@ class Mpd2(base.ThreadPoolText):
 
     Parameters
     ==========
-    status_format :
+    status_format:
         format string to display status
 
         For a full list of values, see:
@@ -110,7 +110,7 @@ class Mpd2(base.ThreadPoolText):
             Note that the ``time`` property of the song renamed to ``fulltime``
             to prevent conflicts with status information during formating.
 
-    idle_format :
+    idle_format:
         format string to display status when no song is in queue.
 
         Default::
@@ -118,13 +118,13 @@ class Mpd2(base.ThreadPoolText):
             '{play_status} {idle_message} \
                 [{repeat}{random}{single}{consume}{updating_db}]'
 
-    idle_message :
+    idle_message:
         text to display instead of song information when MPD is idle.
         (i.e. no song in queue)
 
         Default:: "MPD IDLE"
 
-    prepare_status :
+    prepare_status:
         dict of functions to replace values in status with custom characters.
 
         ``f(status, key, space_element) => str``
@@ -141,17 +141,17 @@ class Mpd2(base.ThreadPoolText):
                 'updating_db': 'U'
             }
 
-    format_fns :
+    format_fns:
         A dict of functions to format the various elements.
 
-        'Tag' : f(str) => str
+        'Tag': f(str) => str
 
         Default:: { 'all': lambda s: cgi.escape(s) }
 
         N.B. if 'all' is present, it is processed on every element of song_info
             before any other formatting is done.
 
-    mouse_buttons :
+    mouse_buttons:
         A dict of mouse button numbers to actions
 
     Widget requirements: python-mpd2_.


### PR DESCRIPTION
Deleting the space before a colon in type annotations fixes
an issue when parameter name and type are joined after
building docs by sphinx.

Fixes #2390.
