### PR TITLE
Move cmd_change_vt to Wayland Core

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -119,10 +119,6 @@ class Core(CommandObject, metaclass=ABCMeta):
         """Get the keysym for a key from its name"""
         raise NotImplementedError
 
-    def change_vt(self, vt: int) -> bool:
-        """Change virtual terminal, returning success."""
-        return False
-
     def cmd_info(self):
         return {
             "backend": self.name,

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -710,13 +710,6 @@ class Core(base.Core, wlrq.HasListeners):
             if not self.qtile.windows_map:
                 break
 
-    def change_vt(self, vt: int) -> bool:
-        """Change virtual terminal to that specified"""
-        success = self.backend.get_session().change_vt(vt)
-        if not success:
-            logger.warning(f"Could not change VT to: {vt}")
-        return success
-
     @property
     def painter(self):
         return wlrq.Painter(self)
@@ -757,3 +750,10 @@ class Core(base.Core, wlrq.HasListeners):
 
         if self.focused_internal:
             self.focused_internal.process_key_press(keysym)
+
+    def cmd_change_vt(self, vt: int) -> bool:
+        """Change virtual terminal to that specified"""
+        success = self.backend.get_session().change_vt(vt)
+        if not success:
+            logger.warning(f"Could not change VT to: {vt}")
+        return success

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -723,17 +723,6 @@ class Core(base.Core, wlrq.HasListeners):
         assert len(matched) == 1
         return matched[0]
 
-    def set_keymap(
-        self, layout: Optional[str], options: Optional[str], variant: Optional[str]
-    ) -> None:
-        """
-        Set the keymap for the current keyboard.
-        """
-        if self.keyboards:
-            self.keyboards[-1].set_keymap(layout, options, variant)
-        else:
-            logger.warning("Could not set keymap: no keyboards set up.")
-
     def keysym_from_name(self, name: str) -> int:
         """Get the keysym for a key from its name"""
         return xkb.keysym_from_name(name, case_insensitive=True)
@@ -750,6 +739,20 @@ class Core(base.Core, wlrq.HasListeners):
 
         if self.focused_internal:
             self.focused_internal.process_key_press(keysym)
+
+    def cmd_set_keymap(
+        self,
+        layout: Optional[str] = None,
+        options: Optional[str] = None,
+        variant: Optional[str] = None,
+    ) -> None:
+        """
+        Set the keymap for the current keyboard.
+        """
+        if self.keyboards:
+            self.keyboards[-1].set_keymap(layout, options, variant)
+        else:
+            logger.warning("Could not set keymap: no keyboards set up.")
 
     def cmd_change_vt(self, vt: int) -> bool:
         """Change virtual terminal to that specified"""

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1523,7 +1523,3 @@ class Qtile(CommandObject):
     def cmd_run_extension(self, extension: _Extension) -> None:
         """Run extensions"""
         extension.run()
-
-    def cmd_change_vt(self, vt: int) -> bool:
-        """Change virtual terminal, returning success."""
-        return self.core.change_vt(vt)

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -100,7 +100,7 @@ class _X11LayoutBackend(_BaseLayoutBackend):
 
 class _WaylandLayoutBackend(_BaseLayoutBackend):
     def __init__(self, qtile: Qtile) -> None:
-        self.set_keymap = qtile.core.set_keymap  # type: ignore
+        self.set_keymap = qtile.core.cmd_set_keymap  # type: ignore
         self._layout: str = ""
 
     def get_keyboard(self) -> str:

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -114,7 +114,6 @@ def test_complete(manager):
     sh = QSh(command)
     assert sh._complete("c", "c") == [
         "cd",
-        "change_vt",
         "commands",
         "critical",
     ]


### PR DESCRIPTION
This is currently at `Qtile.cmd_change_vt` but really only applies to
the wayland `Core`. Now that the core can expose commands itself let's
move it there and remove it from the base `Core` class.