### PR TITLE
Fix memory leak with widgetbox

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -487,6 +487,7 @@ class Drawer:
 
         self.current_rect = (0, 0, 0, 0)
         self.previous_rect = (-1, -1, -1, -1)
+        self._enabled = True
 
     def finalize(self):
         """Destructor/Clean up resources"""
@@ -529,6 +530,14 @@ class Drawer:
             None,
         )
         self.ctx = self.new_ctx()
+
+    def _check_surface_reset(self):
+        """
+        Checks to see if the widget is not being reflected and
+        then clears RecordingSurface of operations.
+        """
+        if not self.mirrors:
+            self._reset_surface()
 
     @property
     def needs_update(self) -> bool:
@@ -591,7 +600,48 @@ class Drawer:
         self.ctx.fill()
         self.ctx.stroke()
 
+    def enable(self):
+        """Enable drawing of surface to Internal window."""
+        self._enabled = True
+
+    def disable(self):
+        """Disable drawing of surface to Internal window."""
+        self._enabled = False
+
     def draw(
+        self,
+        offsetx: int = 0,
+        offsety: int = 0,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ):
+        """
+        A wrapper for the draw operation.
+
+        This draws our cached operations to the Internal window.
+
+        If Drawer has been disabled then the RecordingSurface will
+        be cleared if no mirrors are waiting to copy its contents.
+
+        Parameters
+        ==========
+
+        offsetx :
+            the X offset to start drawing at.
+        offsety :
+            the Y offset to start drawing at.
+        width :
+            the X portion of the canvas to draw at the starting point.
+        height :
+            the Y portion of the canvas to draw at the starting point.
+        """
+        if self._enabled:
+            self._draw(offsetx, offsety, width, height)
+
+        # Check to see if RecordingSurface can be cleared.
+        self._check_surface_reset()
+
+    def _draw(
         self,
         offsetx: int = 0,
         offsety: int = 0,

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -36,7 +36,7 @@ class Drawer(base.Drawer):
             context.set_source_rgba(*utils.rgb("#000000"))
             context.paint()
 
-    def draw(
+    def _draw(
         self,
         offsetx: int = 0,
         offsety: int = 0,
@@ -81,12 +81,6 @@ class Drawer(base.Drawer):
             dst_y=offsety,
         )
         self._win.damage()  # type: ignore
-
-        # If the widget is not being reflected then clear RecordingSurface of operations
-        # If it is, we need to keep the RecordingSurface contents until the mirrors have
-        # been drawn
-        if not self.mirrors:
-            self._reset_surface()
 
     def clear(self, colour):
         # Draw background straight to ImageSurface

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -130,15 +130,9 @@ class Drawer(base.Drawer):
             ctx.set_source_surface(self.surface, 0, 0)
             ctx.paint()
 
-            # If the widget is not being reflected then clear RecordingSurface of operations
-            # If it is, we need to keep the RecordingSurface contents until the mirrors have
-            # been drawn
-            if not self.mirrors:
-                self._reset_surface()
-
             self.previous_rect = self.current_rect
 
-    def draw(
+    def _draw(
         self,
         offsetx: int = 0,
         offsety: int = 0,

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -17,18 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from collections import namedtuple
-
 from libqtile import bar
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
-
-BoxedWidget = namedtuple("BoxedWidget", ["widget", "draw"])
-
-
-def _no_draw(*args, **kwargs):
-    pass
 
 
 class WidgetBox(base._Widget):
@@ -97,7 +88,7 @@ class WidgetBox(base._Widget):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
         self.box_is_open = False
-        self._widgets = widgets if widgets is not None else []
+        self.widgets = widgets if widgets is not None else []
         self.add_callbacks({"Button1": self.cmd_toggle})
 
         self.close_button_location: str
@@ -119,10 +110,10 @@ class WidgetBox(base._Widget):
             markup=False,
         )
 
-        for idx, w in enumerate(self._widgets):
+        for idx, w in enumerate(self.widgets):
             if w.configured:
                 w = w.create_mirror()
-                self._widgets[idx] = w
+                self.widgets[idx] = w
             self.qtile.register_widget(w)
             w._configure(self.qtile, self.bar)
 
@@ -131,14 +122,9 @@ class WidgetBox(base._Widget):
             w.offsetx = self.bar.width
             self.qtile.call_soon(w.draw)
 
-        # We need to stop hidden widgets from drawing while hidden
-        # (e.g. draw could be triggered by a timer) so we take a reference to
-        # the widget's drawer.draw method
-        self.widgets = [BoxedWidget(w, w.drawer.draw) for w in self._widgets]
-
-        # # Overwrite the current drawer.draw method with a no-op
+        # Disable drawing of the widget's contents
         for w in self.widgets:
-            w.widget.drawer.draw = _no_draw
+            w.drawer.disable()
 
     def calculate_length(self):
         return self.layout.width
@@ -148,17 +134,17 @@ class WidgetBox(base._Widget):
                             else self.text_closed)
 
     def toggle_widgets(self):
-        for item in self.widgets:
+        for widget in self.widgets:
             try:
-                self.bar.widgets.remove(item.widget)
+                self.bar.widgets.remove(widget)
                 # Override drawer.drawer with a no-op
-                item.widget.drawer.draw = _no_draw
+                widget.drawer.disable()
 
                 # Systray widget needs some additional steps to hide as the icons
                 # are separate _Window instances.
                 # Systray unhides icons when it draws so we only need to hide them.
-                if isinstance(item.widget, Systray):
-                    for icon in item.widget.icons.values():
+                if isinstance(widget, Systray):
+                    for icon in widget.icons.values():
                         icon.hide()
 
             except ValueError:
@@ -172,10 +158,10 @@ class WidgetBox(base._Widget):
         if self.box_is_open:
 
             # Need to reverse list as widgets get added in front of eachother.
-            for item in self.widgets[::-1]:
-                # Restore the original drawer.draw method
-                item.widget.drawer.draw = item.draw
-                self.bar.widgets.insert(index, item.widget)
+            for widget in self.widgets[::-1]:
+                # enable drawing again
+                widget.drawer.enable()
+                self.bar.widgets.insert(index, widget)
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)


### PR DESCRIPTION
See: https://github.com/qtile/qtile/issues/2622#issuecomment-912946655

b2b1ed8 changed the way that surfaces are drawn. When the widgetbox hides widgets, it replaces `self.drawer.draw` with a no-op. However, this prevents the drawer from clearing its `RecordingSurface` object. As a result, the `RecordingSurface` will continue to accumulate details of all draws made by the widget while it is hidden.

This PR clears the RecordingSurface while widgets are hidden.