### PR TITLE
WL: wlroots.wlr_types.box -> wlroots.util.box

### DIFF
--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -23,9 +23,10 @@ from __future__ import annotations
 import os
 import typing
 
+from wlroots.util.box import Box
 from wlroots.util.clock import Timespec
 from wlroots.util.region import PixmanRegion32
-from wlroots.wlr_types import Box, Matrix
+from wlroots.wlr_types import Matrix
 from wlroots.wlr_types import Output as wlrOutput
 from wlroots.wlr_types import OutputDamage
 from wlroots.wlr_types.layer_shell_v1 import (

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -26,8 +26,9 @@ import typing
 import cairocffi
 import pywayland
 from wlroots import ffi
+from wlroots.util.box import Box
 from wlroots.util.edges import Edges
-from wlroots.wlr_types import Box, Texture
+from wlroots.wlr_types import Texture
 from wlroots.wlr_types.layer_shell_v1 import LayerSurfaceV1
 from wlroots.wlr_types.xdg_shell import (
     XdgPopup,

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.13.4
+  pywlroots>=0.14.4
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.13.4
+    pip install pywlroots>=0.14.4
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
@@ -93,7 +93,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.13.4
+    pip install pywlroots>=0.14.4
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
This moves the import for pywlroots' `Box`, which has moved with a
deprecation warning.