### PR TITLE
Try to get version from importlib.metadata

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -6,10 +6,16 @@ from libqtile.log_utils import init_log
 from libqtile.scripts import check, cmd_obj, migrate, run_cmd, shell, start, top
 
 try:
-    import pkg_resources
-    VERSION = pkg_resources.require("qtile")[0].version
-except (pkg_resources.DistributionNotFound, ImportError):
-    VERSION = 'dev'
+    # Python>3.7 can get the version from importlib
+    from importlib.metadata import distribution
+    VERSION = distribution("qtile").version
+except ModuleNotFoundError:
+    try:
+        # pkg_resources is required for 3.7
+        import pkg_resources
+        VERSION = pkg_resources.require("qtile")[0].version
+    except (pkg_resources.DistributionNotFound, ModuleNotFoundError):
+        VERSION = 'dev'
 
 
 def main():


### PR DESCRIPTION
This makes the `main` script try to find the installed `qtile` version
from `importlib.metadata`, which is available from Python 3.8 onwards.
This removes the `pkg_resources` dependency. `pkg_resources` is still
used as a fallback when used with Python 3.7.

Also, the try block that does this falling-back should be catching
`ModuleNotFoundError` which was not being caught in the case that
`pkg_resources` was not installed.

Fixes #2809