### PR TITLE
Add new hook: screens_reconfigured

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -395,6 +395,7 @@ class Core(base.Core, wlrq.HasListeners):
             config.send_failed()
         config.destroy()
         hook.fire("screen_change", None)
+        hook.fire("screens_reconfigured")
 
     def _process_cursor_motion(self, time):
         self.qtile.process_button_motion(self.cursor.x, self.cursor.y)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -717,6 +717,7 @@ class Core(base.Core):
 
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
         hook.fire("screen_change", event)
+        hook.fire("screens_reconfigured")
 
     @contextlib.contextmanager
     def disable_unmap_events(self):

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -304,6 +304,19 @@ class Subscribe:
         """
         return self._subscribe("screen_change", func)
 
+    def screens_reconfigured(self, func):
+        """Called when all ``screen_change`` hooks have fired.
+
+        This is primarily useful where you want a callback to be triggered once
+        ``qtile.cmd_reconfigure_screens`` has completed (e.g. if
+        ``reconfigure_screens`` is set to ``True`` in your config).
+
+        **Arguments**
+
+        None
+        """
+        return self._subscribe("screens_reconfigured", func)
+
     def current_screen_change(self, func):
         """Called when the current screen (i.e. the screen with focus) changes
 


### PR DESCRIPTION
Users trying to use the `screen_change` hook will have their callback called _before_ `qtile.cmd_reconfigure_screens` is run.
This new hook is called when that process is complete.

Background:
My [WordClock widget](https://qtile-extras.readthedocs.io/en/latest/manual/ref/widgets.html#wordclock) works by painting the clock to root window every 5 minutes. If a new screen is plugged in then `cmd_reconfigure_screens` is run and the screen is refreshed, restoring the original wallpaper. The clock won't repaint the clock until the next 5 minute change.

I tried using the `screen_change` hook but my callback is run before the `cmd_reconfigure_screens` one, presumably because it is added to the list first. I could add a timer but that's hacky.

My solution was to add a new hook that is run once `cmd_reconfigure_screens` is complete. I've tested it with the clock and it works perfectly.

I've not passed any arguments with the hook as `qtile.screens` is already accessible.