### PR TITLE
WindowCount widget per screen

### DIFF
--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -25,7 +25,10 @@ from libqtile.widget import base
 
 
 class WindowCount(base._TextBox):
-    """A simple widget to show the number of windows in the current group."""
+    """
+    A simple widget to display the number of windows in the
+    current group of the screen on which the widget is.
+    """
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("font", "sans", "Text font"),
@@ -55,7 +58,7 @@ class WindowCount(base._TextBox):
 
     def _wincount(self, *args):
         try:
-            self._count = len(self.qtile.current_group.windows)
+            self._count = len(self.bar.screen.group.windows)
         except AttributeError:
             self._count = 0
 
@@ -63,12 +66,11 @@ class WindowCount(base._TextBox):
 
     def _win_killed(self, window):
         try:
-            self._count = len(self.qtile.current_group.windows)
+            self._count = len(self.bar.screen.group.windows)
+            if window.group == self.bar.screen.group:
+                self._count -= 1
         except AttributeError:
             self._count = 0
-
-        if self._count and getattr(window, "group", None):
-            self._count -= 1
 
         self.update(self.text_format.format(num=self._count))
 

--- a/test/widgets/test_window_count.py
+++ b/test/widgets/test_window_count.py
@@ -1,5 +1,58 @@
+import pytest
+
 import libqtile
+from libqtile.confreader import Config
 from libqtile.widget import WindowCount
+
+
+class DifferentScreens(Config):
+    groups = [
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
+    ]
+    layouts = [
+        libqtile.layout.Stack(num_stacks=1),
+    ]
+    floating_layout = libqtile.resources.default_config.floating_layout
+    fake_screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [
+                    WindowCount(),
+                ],
+                20
+            ),
+            x=0, y=0, width=300, height=300
+        ),
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [
+                    WindowCount(),
+                ],
+                20
+            ),
+            x=0, y=300, width=300, height=300
+        )
+    ]
+    auto_fullscreen = True
+
+
+different_screens = pytest.mark.parametrize("manager", [DifferentScreens], indirect=True)
+
+
+@different_screens
+def test_different_screens(manager):
+    # Put one window on screen 0
+    manager.c.to_screen(0)
+    manager.test_window("one")
+
+    # Put two windows on screen 1
+    manager.c.to_screen(1)
+    manager.test_window("two")
+    manager.test_window("three")
+
+    assert manager.c.screen[0].widget["windowcount"].get() == "1"
+    assert manager.c.screen[1].widget["windowcount"].get() == "2"
 
 
 def test_window_count(manager_nospawn, minimal_conf_noscreen):


### PR DESCRIPTION
I've got an issue with the WindowCount widget in multi monitor setups. I think it's easiest to show my problem with some screenshots.

In both Screenshots I have one window in group 2 on screen 1 and 3 windows on group 3 on screen 2. The Number in square brackets right of CurrentLayoutIcon widget is the number of of the WindowCount widget.

The first Screenshot is the way it currently works. It displays the number of windows on the currently focused screen on all screens. So all the WindowCount widgets always display the same number. This is not the way, that I at least expected it to work.
![Issue](https://user-images.githubusercontent.com/23218558/134772718-acfeee46-e75d-4424-b947-ad0db9b31bf3.png)

So I've created a small fix:
![Issue_fix](https://user-images.githubusercontent.com/23218558/134772808-91c75b12-98f0-4a53-9dd9-8a7feaf22163.png)
Now the windowCount shows the number of windows of the screen the widget lives on.

~~Because some people may want the widget to behave the way it does currently I introduced a new optional flag, which when left out behaves the same way as before. But I think most people would expect it to work as I did.~~

If this is a feature that could be added, I of course could also edit the docs on this branch to reflect the introduction of the new optional parameter.

~~Also suggestions for a better name for the `this_screen` parameter are welcome ;)~~

EDIT:
Removed option, the behaviour from second screenshot is now how it works.