### PR TITLE
Take borders into account when placing fullscreened/maximized windows

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -348,11 +348,12 @@ class Window(base.Window, HasListeners):
         if do_full:
             screen = self.group.screen or \
                 self.qtile.find_closest_screen(self.x, self.y)
+            bw = self.group.floating_layout.fullscreen_border_width
             self._enablefloating(
                 screen.x,
                 screen.y,
-                screen.width,
-                screen.height,
+                screen.width - 2 * bw,
+                screen.height - 2 * bw,
                 new_float_state=FloatStates.FULLSCREEN
             )
             return
@@ -370,11 +371,12 @@ class Window(base.Window, HasListeners):
             screen = self.group.screen or \
                 self.qtile.find_closest_screen(self.x, self.y)
 
+            bw = self.group.floating_layout.max_border_width
             self._enablefloating(
                 screen.dx,
                 screen.dy,
-                screen.dwidth,
-                screen.dheight,
+                screen.dwidth - 2 * bw,
+                screen.dheight - 2 * bw,
                 new_float_state=FloatStates.MAXIMIZED
             )
         else:

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1323,11 +1323,12 @@ class Window(_Window, base.Window):
             screen = self.group.screen or \
                 self.qtile.find_closest_screen(self.x, self.y)
 
+            bw = self.group.floating_layout.fullscreen_border_width
             self._enablefloating(
                 screen.x,
                 screen.y,
-                screen.width,
-                screen.height,
+                screen.width - 2 * bw,
+                screen.height - 2 * bw,
                 new_float_state=FloatStates.FULLSCREEN
             )
             set_state(prev_state, prev_state | atom)
@@ -1353,11 +1354,12 @@ class Window(_Window, base.Window):
             screen = self.group.screen or \
                 self.qtile.find_closest_screen(self.x, self.y)
 
+            bw = self.group.floating_layout.max_border_width
             self._enablefloating(
                 screen.dx,
                 screen.dy,
-                screen.dwidth,
-                screen.dheight,
+                screen.dwidth - 2 * bw,
+                screen.dheight - 2 * bw,
                 new_float_state=FloatStates.MAXIMIZED
             )
         else:

--- a/test/layouts/test_floating.py
+++ b/test/layouts/test_floating.py
@@ -34,7 +34,10 @@ class FloatingConfig(Config):
     layouts = [
         layout.Floating()
     ]
-    floating_layout = libqtile.resources.default_config.floating_layout
+    floating_layout = layout.Floating(
+        fullscreen_border_width=15,
+        max_border_width=10,
+    )
     keys = []
     mouse = []
     screens = []
@@ -69,3 +72,32 @@ def test_float_next_prev_window(manager):
     assert_focused(manager, "two")
     manager.c.group.next_window()
     assert_focused(manager, "three")
+
+
+@floating_config
+def test_border_widths(manager):
+    manager.test_window("one")
+
+    # Default geometry
+    info = manager.c.window.info()
+    assert info["x"] == 350
+    assert info["y"] == 250
+    assert info["width"] == 100
+    assert info["height"] == 100
+
+    # Fullscreen
+    manager.c.window.enable_fullscreen()
+    info = manager.c.window.info()
+    assert info["x"] == 0
+    assert info["y"] == 0
+    assert info["width"] == 770
+    assert info["height"] == 570
+    manager.c.window.disable_fullscreen()
+
+    # Maximized
+    manager.c.window.toggle_maximize()
+    info = manager.c.window.info()
+    assert info["x"] == 0
+    assert info["y"] == 0
+    assert info["width"] == 780
+    assert info["height"] == 580


### PR DESCRIPTION
When enabling the fullscreen or maximized state on windows, they should
subtract border widths from the floating layout from the dimensions so
as to not be shifted off to the right and down.

Fixes #2704.