### PR TITLE
Add ability to pass parameters to lazy calls

### DIFF
--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -139,3 +139,67 @@ User-defined functions
     * - ``lazy.function(func, *args, **kwargs)``
       - Calls ``func(qtile, *args, **kwargs)``. NB. the ``qtile`` object is
         automatically passed as the first argument.
+
+Examples
+--------
+
+``lazy.function`` can also be used as a decorator for functions.
+
+::
+
+    from libqtile.config import Key
+    from libqtile.command import lazy
+
+    @lazy.function
+    def my_function(qtile):
+        ...
+
+    keys = [
+        Key(
+            ["mod1"], "k",
+            my_function
+        )
+    ]
+
+Additionally, you can pass arguments to user-defined function in one of two ways:
+
+1) In-line definition
+
+Arguments can be added to the ``lazy.function`` call.
+
+::
+
+    from libqtile.config import Key
+    from libqtile.command import lazy
+    from libqtile.log_utils import logger
+
+    def multiply(qtile, value, multiplier=10):
+        logger.warning(f"Multiplication results: {value * multiplier}")
+
+    keys = [
+        Key(
+            ["mod1"], "k",
+            lazy.function(multiply, 10, multiplier=2)
+        )
+    ]
+
+2) Decorator
+
+Arguments can also be passed to the decorated function.
+
+::
+
+    from libqtile.config import Key
+    from libqtile.command import lazy
+    from libqtile.log_utils import logger
+
+    @lazy.function
+    def multiply(qtile, value, multiplier=10):
+        logger.warning(f"Multiplication results: {value * multiplier}")
+
+    keys = [
+        Key(
+            ["mod1"], "k",
+            multiply(10, multiplier=2)
+        )
+    ]

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -49,6 +49,27 @@ class LazyCall:
         self._layouts: Set[str] = set()
         self._when_floating = True
 
+    def __call__(self, *args, **kwargs):
+        """Convenience method to allow users to pass arguments to
+        functions decorated with `@lazy.function`.
+
+            @lazy.function
+            def my_function(qtile, pos_arg, keyword_arg=False):
+                pass
+
+            ...
+
+            Key(... my_function("Positional argument", keyword_arg=True))
+
+        """
+        # We need to return a new object so the arguments are not shared between
+        # a single instance of the LazyCall object.
+        return LazyCall(
+            self._call,
+            (*self._args, *args),
+            {**self._kwargs, **kwargs}
+        )
+
     @property
     def selectors(self) -> List[SelectorType]:
         """The selectors for the given call"""

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -35,6 +35,9 @@ mod = "mod4"
 terminal = guess_terminal()
 
 keys = [
+    # A list of available commands that can be bound to keys can be found
+    # at https://docs.qtile.org/en/latest/manual/config/lazy.html
+
     # Switch between windows
     Key([mod], "h", lazy.layout.left(), desc="Move focus to left"),
     Key([mod], "l", lazy.layout.right(), desc="Move focus to right"),

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -381,3 +381,33 @@ def test_select_widget(manager):
 
 def test_core_node(manager, backend_name):
     assert manager.c.core.info()["backend"] == backend_name
+
+
+def test_lazy_arguments(manager_nospawn):
+
+    # Decorated function to be bound to key presses
+    @lazy.function
+    def test_func(qtile, value, multiplier=1):
+        qtile.test_func_output = value * multiplier
+
+    config = ServerConfig
+    config.keys = [
+        libqtile.config.Key(
+            ["control"], "j",
+            test_func(10),
+        ),
+        libqtile.config.Key(
+            ["control"], "k",
+            test_func(5, multiplier=100)
+        ),
+    ]
+
+    manager_nospawn.start(config)
+
+    manager_nospawn.c.simulate_keypress(["control"], "j")
+    _, val = manager_nospawn.c.eval("self.test_func_output")
+    assert val == "10"
+
+    manager_nospawn.c.simulate_keypress(["control"], "k")
+    _, val = manager_nospawn.c.eval("self.test_func_output")
+    assert val == "500"


### PR DESCRIPTION
Where users create functions in their config which are decorated with `@lazy.function`, there is no easy way to allow arguments to be passed to the decorated function when attaching to a keybinding.

One alternative is to use a closure to wrap the decorated function but this is more complicated for users.

The alternative, which is presented by this PR, is to create a `__call__` method in the `LazyCall` class so that, when a user binds
a key in their config by doing `Key(..., decorated_function(args))` those arguments are added to the `LazyCall` object and passed to the decorated function when the key is pressed.

See https://github.com/qtile/qtile/issues/2848#issuecomment-934093883 for more detail on this.