### PR TITLE
[Wayland] Add input inhibitor to enable screen locking

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -34,6 +34,7 @@ from wlroots.wlr_types import (
     DataControlManagerV1,
     DataDeviceManager,
     GammaControlManagerV1,
+    InputInhibitManager,
     OutputLayout,
     PrimarySelectionV1DeviceManager,
     ScreencopyManagerV1,
@@ -156,6 +157,7 @@ class Core(base.Core, wlrq.HasListeners):
         XdgOutputManagerV1(self.display, self.output_layout)
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)
+        self.input_inhibit_manager = InputInhibitManager(self.display)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.14.4
+  pywlroots>=0.14.7
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.14.4
+    pip install pywlroots>=0.14.7
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}


### PR DESCRIPTION
~~**This is a draft PR only!** It is dependent on https://github.com/flacjacket/pywlroots/pull/60 being merged into `pywlroots` and will thus also necessitate the latest version of `pywlroots`.~~ That was fast!

Adds support for the Wayland input inhibitor (`wlr_input_inhibit_manager`), allowing programs such as swaylock or waylock to prevent sneaky input sequences that could get around the screenlocker program.
