### PR TITLE
Make `setup.py install` less verbose

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install pywlroots>=0.14.8
-    python3 setup.py install
+    python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
 
@@ -96,7 +96,7 @@ commands =
     pip install pywlroots>=0.14.8
     mypy -p libqtile
     # also run the tests that require mypy
-    python3 setup.py install
+    python3 setup.py -q install
     python3 -m pytest -W error -- test/test_check.py test/test_migrate.py
 
 [testenv:docs]


### PR DESCRIPTION
This reduces the vast amount of scolling required when trying to see why
the tests failed in github CI.