### PR TITLE
Using window list form the layout in tasklist widget

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -496,7 +496,7 @@ class _SimpleLayoutBase(Layout):
     def remove(self, client):
         return self.clients.remove(client)
 
-    def clients_window(self):
+    def get_windows(self):
         return self.clients.clients
 
     def info(self):

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -171,7 +171,7 @@ class Bsp(Layout):
         c.current = c.root
         return c
 
-    def clients_window(self):
+    def get_windows(self):
         return list(self.root.clients())
 
     def info(self):

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -147,7 +147,7 @@ class Columns(Layout):
         c.columns = [_Column(self.split, self.insert_position)]
         return c
 
-    def clients_window(self):
+    def get_windows(self):
         clients = []
         for c in self.columns:
             clients.extend(c.clients)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -289,7 +289,7 @@ class Floating(Layout):
         self.clients.remove(client)
         return next_focus
 
-    def clients_window(self):
+    def get_windows(self):
         return self.clients
 
     def info(self):

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -30,6 +30,7 @@ Slice layout. Serves as example of delegating layouts (or sublayouts)
 from libqtile.layout.base import Layout
 from libqtile.layout.max import Max
 
+
 class Single(Layout):
     """Layout with single window
 
@@ -94,7 +95,7 @@ class Single(Layout):
     def cmd_previous(self):
         pass
 
-    def clients_window(self):
+    def get_windows(self):
         return self.window
 
 
@@ -267,11 +268,11 @@ class Slice(Layout):
     def commands(self):
         return self._get_active_layout().commands
 
-    def clients_window(self):
+    def get_windows(self):
         clients = list()
         for layout in self._get_layouts():
-            if layout.clients_window() is not None:
-                clients.extend(layout.clients_window())
+            if layout.get_windows() is not None:
+                clients.extend(layout.get_windows())
         return clients
         
     def info(self):

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -254,7 +254,7 @@ class Stack(Layout):
             else:
                 client.hide()
 
-    def clients_window(self):
+    def get_windows(self):
         return self.clients
 
     def info(self):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -498,7 +498,7 @@ class TreeTab(Layout):
         if self._drawer is not None:
             self._drawer.finalize()
 
-    def clients_window(self):
+    def get_windows(self):
         clients = []
         for section in self._tree.children:
             for window in section.children:

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -239,7 +239,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
     @property
     def windows(self):
         current_layout = self.bar.screen.group.current_layout
-        return self.bar.screen.group.layouts[current_layout].clients_window()
+        return self.bar.screen.group.layouts[current_layout].get_windows()
 
     def calc_box_widths(self):
         """


### PR DESCRIPTION
This uses the list of client's window returned from selected layout's info in the output of tasklist widget. When we go to next or previous windows, it uses a window list stored in layout, so it would be nice and easy to have tasklist show the window in the same order.