### PR TITLE
Centre align logo and buttons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,33 @@
-|logo|
+.. raw:: html
 
-**A full-featured, hackable tiling window manager written and configured in Python**
-
-|website| |pypi| |ci| |rtd| |license|
+   <p align="center">
+     <a href="https://www.qtile.org">
+       <img
+         src="https://raw.githubusercontent.com/qtile/qtile/master/logo.png"
+         alt="Logo"
+       >
+     </a>
+   </p>
+   <p align="center">
+     <b>A full-featured, hackable tiling window manager written and configured in Python</b>
+   </p>
+   <p align="center">
+     <a href="https://www.qtile.org">
+       <img src="https://img.shields.io/badge/website-qtile.org-blue.svg" alt="Website">
+     </a>
+     <a href="https://pypi.org/project/qtile/">
+       <img src="https://img.shields.io/pypi/v/qtile.svg" alt="PyPI">
+     </a>
+     <a href="https://github.com/qtile/qtile/actions">
+       <img src="https://github.com/qtile/qtile/workflows/ci/badge.svg?branch=master" alt="CI Status">
+     </a>
+     <a href="https://docs.qtile.org/en/latest/">
+       <img src="https://readthedocs.org/projects/qtile/badge/?version=latest" alt="Read the Docs">
+     </a>
+     <a href="https://github.com/qtile/qtile/blob/master/LICENSE">
+       <img src="https://img.shields.io/github/license/qtile/qtile.svg" alt="License">
+     </a>
+   </p>
 
 Features
 ========
@@ -37,26 +62,6 @@ and `guidelines`_ for contributing in the documentation.
 .. _`issue tracker`: https://github.com/qtile/qtile/issues
 .. _`tips & tricks`: https://docs.qtile.org/en/latest/manual/hacking.html
 .. _`guidelines`: https://docs.qtile.org/en/latest/manual/contributing.html
-
-.. |logo| image:: https://raw.githubusercontent.com/qtile/qtile/master/logo.png
-    :alt: Logo
-    :target: https://www.qtile.org
-.. |website| image:: https://img.shields.io/badge/website-qtile.org-blue.svg
-    :alt: Website
-    :target: https://www.qtile.org
-.. |pypi| image:: https://img.shields.io/pypi/v/qtile.svg
-    :alt: PyPI
-    :target: https://pypi.org/project/qtile/
-.. |ci| image:: https://github.com/qtile/qtile/workflows/ci/badge.svg?branch=master
-    :alt: CI status
-    :target: https://github.com/qtile/qtile/actions
-.. |rtd| image:: https://readthedocs.org/projects/qtile/badge/?version=latest
-    :alt: Read the Docs
-    :target: https://docs.qtile.org/en/latest/
-.. |license| image:: https://img.shields.io/github/license/qtile/qtile.svg
-    :alt: License
-    :target: https://github.com/qtile/qtile/blob/master/LICENSE
-
 
 Maintainers
 ===========


### PR DESCRIPTION
A subjective improvement in making the readme look nice. Only if others
agree of course :)

GitHub rst doesn't seem to like rst's actual ways of centreing things so
it seems putting stuff in html is the way to do this.

--

Thoughts? See https://github.com/m-col/qtile/tree/readmecentre for it rendered.