### PR TITLE
Fix broken building of docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 setuptools_scm
 sphinx
 sphinx_rtd_theme
+funcparserlib==1.0.0a0
 sphinxcontrib-seqdiag
 numpydoc
 


### PR DESCRIPTION
One of the libraries required for building our command node graph, funcparserlib, is broken (last updated in 2013). There's a
pre-release version on PyPi now that fixes the bug but we need to tell requirements.txt to explicitly install this version.