### PR TITLE
WL: implement drag and drop functionality

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.14.6
+  pywlroots>=0.14.8
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.14.6
+    pip install pywlroots>=0.14.8
     python3 setup.py install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
@@ -93,7 +93,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.14.6
+    pip install pywlroots>=0.14.8
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py install


### PR DESCRIPTION
This uses wlroots' API for getting drag-and-drop to work in the Wayland
backend. wlroots does most of the work here; we just need to implement
responding to the appropriate events (client requests) to render a
client-provided icon while dragging, and then wlroots handles data
transfer between clients at the drop.

This is used for dragging within clients (for example re-ordering browser
tabs in firefox; moving files into folders in a file manager) and
between clients (e.g. dragging files from a file manager into firefox).

Requires pywlroots 0.14.8.

Closes #2531