### PR TITLE
Add low_background option to Battery widget

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -318,6 +318,7 @@ class Battery(base.ThreadPoolText):
         ('show_short_text', True, 'Show "Full" or "Empty" rather than formated text'),
         ('low_percentage', 0.10, "Indicates when to use the low_foreground color 0 < x < 1"),
         ('low_foreground', 'FF0000', 'Font color on low battery'),
+        ('low_background', None, 'Background color on low battery'),
         ('update_interval', 60, 'Seconds between status updates'),
         ('battery', 0, 'Which battery should be monitored (battery number or name)'),
         ('notify_below', None, 'Send a notification below this battery level.'),
@@ -334,6 +335,10 @@ class Battery(base.ThreadPoolText):
 
         self._battery = self._load_battery(**config)
         self._has_notified = False
+
+        if not self.low_background:
+            self.low_background = self.background
+        self.normal_background = self.background
 
     @staticmethod
     def _load_battery(**config):
@@ -386,8 +391,10 @@ class Battery(base.ThreadPoolText):
         if self.layout is not None:
             if status.state == BatteryState.DISCHARGING and status.percent < self.low_percentage:
                 self.layout.colour = self.low_foreground
+                self.background = self.low_background
             else:
                 self.layout.colour = self.foreground
+                self.background = self.normal_background
 
         if status.state == BatteryState.CHARGING:
             char = self.charge_char

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -2,6 +2,7 @@ import cairocffi
 import pytest
 
 from libqtile import images
+from libqtile.bar import Bar
 from libqtile.widget import battery
 from libqtile.widget.battery import (
     Battery,
@@ -215,3 +216,42 @@ def test_images_default(fake_bar):
     assert len(batt.surfaces) == len(BatteryIcon.icon_names)
     for name, surfpat in batt.surfaces.items():
         assert isinstance(surfpat, cairocffi.SurfacePattern)
+
+
+def test_battery_background(fake_qtile, fake_window, monkeypatch):
+    ok = BatteryStatus(
+        state=BatteryState.DISCHARGING,
+        percent=0.5,
+        power=15.,
+        time=1729,
+    )
+    low = BatteryStatus(
+        state=BatteryState.DISCHARGING,
+        percent=0.1,
+        power=15.,
+        time=1729,
+    )
+
+    low_background = "ff0000"
+    background = "000000"
+
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(ok))
+        batt = Battery(
+            low_percentage=0.2, low_background=low_background, background=background
+        )
+
+    fakebar = Bar([batt], 24)
+    fakebar.window = fake_window
+    fakebar.width = 10
+    fakebar.height = 10
+    fakebar.draw = lambda *a, **k: None
+    batt._configure(fake_qtile, fakebar)
+
+    assert batt.background == background
+    batt._battery._status = low
+    batt.poll()
+    assert batt.background == low_background
+    batt._battery._status = ok
+    batt.poll()
+    assert batt.background == background


### PR DESCRIPTION
This lets us change the background of widget when on low battery, in
addition to the foreground colour.

Closes #2683