### PR TITLE
Update Import collections as of Python3.10

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -30,7 +30,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import collections
+import collections.abc as collections
 
 from libqtile import pangocffi, utils
 


### PR DESCRIPTION
Due to an update for Python3.10, Iterables and isinstance() has moved to collection.abc. Here is the doc refering to this change: https://docs.python.org/3/library/collections.abc.html