### PR TITLE
Fix scratchpad focus issue in X11

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -125,11 +125,12 @@ class XWindow:
         self.conn.conn.core.KillClient(self.wid)
 
     def set_input_focus(self):
-        self.conn.conn.core.SetInputFocus(
-            xcffib.xproto.InputFocus.PointerRoot,
-            self.wid,
-            xcffib.xproto.Time.CurrentTime
-        )
+        if self.wid != self.conn.default_screen.root.wid:
+            self.conn.conn.core.SetInputFocus(
+                xcffib.xproto.InputFocus.PointerRoot,
+                self.wid,
+                xcffib.xproto.Time.CurrentTime
+            )
 
     def warp_pointer(self, x, y):
         """Warps the pointer to the location `x`, `y` on the window"""


### PR DESCRIPTION
There is an issue with some scratchpads where the window will alternate opening with and without focus which can cause issues
for certain keybindings.

The issue seems to be that `set_input_focus` tries to focus the root window rather than the scratchpad window.

This PR prevents focussing of the root window. This may or may not cause other issues so needs testing!

Fixes #2588


@m-col - I'm a bit concerned about preventing focus of the root window so this may be more of a plaster than finding the root cause.

@jwijenbergh - can you have a test and see if this works (and if you notice any other bugs)