### PR TITLE
Fix scratchpad focus issue in X11 - take 2

### DIFF
--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -112,7 +112,7 @@ class WindowVisibilityToggler:
             # add hooks to determine if focus get lost
             if self.on_focus_lost_hide:
                 if self.warp_pointer:
-                    win.qtile.core.warp_pointer(win.x + win.width // 2, win.y + win.height // 2)
+                    win.focus(warp=True)
                 hook.subscribe.client_focus(self.on_focus_change)
                 hook.subscribe.setgroup(self.on_focus_change)
 


### PR DESCRIPTION
There is an issue with some scratchpads where the window will alternate opening with and without focus which can cause issues
for certain keybindings.

The issue seems to be that `set_input_focus` tries to focus the root window rather than the scratchpad window.

Fixes #2588


@m-col - different approach, the `warp_pointer` call seems to involve the root window but, if we just call `window.focus` with `warp=True` then the scratchpad keeps focus each time.