### PR TITLE
Persist ScratchPad groups across config reloads

### DIFF
--- a/libqtile/core/state.py
+++ b/libqtile/core/state.py
@@ -90,7 +90,7 @@ class QtileState:
         """
         Remove any windows from now non-existent scratchpad groups.
         """
-        client_wid = client.window.wid
+        client_wid = client.wid
         if client_wid in self.orphans:
             self.orphans.remove(client_wid)
             client.group = None

--- a/libqtile/core/state.py
+++ b/libqtile/core/state.py
@@ -30,6 +30,7 @@ class QtileState:
 
     If `restart` is True, the current set of groups will be saved in the state. This is
     useful when restarting for Qtile version updates rather than reloading the config.
+    ScratchPad groups are saved for both reloading and restarting.
     """
     def __init__(self, qtile, restart=True):
         self.groups = []
@@ -39,12 +40,11 @@ class QtileState:
         self.orphans = []
         self.restart = restart  # True when restarting, False when config reloading
 
-        if restart:
-            for group in qtile.groups:
-                if isinstance(group, ScratchPad):
-                    self.scratchpads[group.name] = group.get_state(restart)
-                else:
-                    self.groups.append((group.name, group.layout.name, group.label))
+        for group in qtile.groups:
+            if isinstance(group, ScratchPad):
+                self.scratchpads[group.name] = group.get_state()
+            elif restart:
+                self.groups.append((group.name, group.layout.name, group.label))
 
         for index, screen in enumerate(qtile.screens):
             self.screens[index] = screen.group.name

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -346,7 +346,7 @@ class ScratchPad(group._Group):
         else:
             raise ValueError('No DropDown named "%s".' % name)
 
-    def get_state(self, restart):
+    def get_state(self):
         """
         Get the state of existing dropdown windows. Used for restoring state across
         Qtile restarts (`restart` == True) or config reloads (`restart` == False).

--- a/test/configs/reloading.py
+++ b/test/configs/reloading.py
@@ -3,8 +3,20 @@
 # The exported configuration variables have a different value depending on whether
 # libqtile has a 'test_data' attribute (see below)
 
+import sys
+from pathlib import Path
+
 from libqtile import bar, layout, qtile, widget
-from libqtile.config import Drag, Group, Key, Match, Rule, Screen
+from libqtile.config import (
+    Drag,
+    DropDown,
+    Group,
+    Key,
+    Match,
+    Rule,
+    ScratchPad,
+    Screen,
+)
 from libqtile.dgroups import simple_key_binder
 from libqtile.lazy import lazy
 
@@ -15,7 +27,7 @@ keys = [
 groups = [Group(i) for i in "12345"]
 
 layouts = [
-    layout.Columns(border_focus_stack=['#d75f5f', '#8f3d3d'], border_width=4),
+    layout.Columns(border_focus_stack=["#d75f5f", "#8f3d3d"], border_width=4),
 ]
 
 screens = [
@@ -24,7 +36,7 @@ screens = [
             [
                 widget.CurrentLayout(),
                 widget.GroupBox(),
-                widget.Clock(format='%Y-%m-%d %a %I:%M %p'),
+                widget.Clock(format="%Y-%m-%d %a %I:%M %p"),
                 widget.QuickExit(),
             ],
             24,
@@ -35,13 +47,21 @@ screens = [
 widget_defaults = dict()
 
 mouse = [
-    Drag(["mod4"], "Button1", lazy.window.set_position_floating(),
-         start=lazy.window.get_position()),
+    Drag(
+        ["mod4"],
+        "Button1",
+        lazy.window.set_position_floating(),
+        start=lazy.window.get_position(),
+    ),
 ]
+
+windowpy = Path(__file__).parent.parent / "scripts" / "window.py"
+script = " ".join([sys.executable, windowpy.as_posix(), "--name", "dd", "dd", "normal"])
+dropdowns = [DropDown("dropdown1", script)]
 
 dgroups_key_binder = None
 dgroups_app_rules = []
-floating_layout = layout.Floating(float_rules=[Match(title='one')])
+floating_layout = layout.Floating(float_rules=[Match(title="one")])
 wmname = "LG3D"
 
 
@@ -59,14 +79,22 @@ if hasattr(qtile, "test_data"):
         Screen(top=bar.Bar([widget.CurrentLayout()], 32)),
     ]
 
-    widget_defaults['background'] = '#ff0000'
+    widget_defaults["background"] = "#ff0000"
 
     mouse.append(
-        Drag(["mod4"], "Button3", lazy.window.set_size_floating(),
-             start=lazy.window.get_size()),
+        Drag(
+            ["mod4"],
+            "Button3",
+            lazy.window.set_size_floating(),
+            start=lazy.window.get_size(),
+        ),
     )
 
+    dropdowns.append(DropDown("dropdown2", script))
+
     dgroups_key_binder = simple_key_binder
-    dgroups_app_rules = [Rule(Match(wm_class='test'), float=True)]
+    dgroups_app_rules = [Rule(Match(wm_class="test"), float=True)]
     floating_layout = layout.Floating()
     wmname = "TEST"
+
+groups.append(ScratchPad("S", dropdowns))


### PR DESCRIPTION
As part of the config reload functionality, we decided to not persist
groups across reloads as they do across restarts. This was because it
becomes difficult to consolidate existing groups that may or may not be
reflected in the config with new groups added to the config and groups
removed from the config.

However, this also applied to scratchpads, which can not be dynamically
changed during normal runtime and so do not pose the same issues. The
effect of doing this is that following a config reload each
scratchpad groups is fresh and old scratchpad windows get orphaned to
the current group. Instead, let's persist scratchpad groups across
reloads to prevent this and prevent this unexpected behaviour.

--

I have also added a scratchpad with one or two dropdowns to the config-reload test, however I couldn't get dropdowns to be toggled correctly. I'm not exactly sure what's going on there, so perhaps some fresh eyes will provide some insight. Basically the idea is it'd be good to also spawn a test dropdown, reload, check the window persists in the scratchpad, toggle the second dropdown, reload again, check the first window persists in the scratchpad, and check the second window (from a now defunct dropdown) has successfully been orphaned to the current group.