### PR TITLE
WL: Fix no Internal clicks when bring_front_click is floating_only

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -671,11 +671,10 @@ class Core(base.Core, wlrq.HasListeners):
         if found:
             win, surface, _, _ = found
 
-            if self.qtile.config.bring_front_click:
-                if (
-                    self.qtile.config.bring_front_click != "floating_only"
-                    or win.floating
-                ):
+            if self.qtile.config.bring_front_click is True:
+                win.cmd_bring_to_front()
+            elif self.qtile.config.bring_front_click == "floating_only":
+                if not isinstance(win, base.Internal) and win.floating:
                     win.cmd_bring_to_front()
 
             if not isinstance(win, base.Internal):


### PR DESCRIPTION
This error is caused by `win.floating` raising an exception because
`Internal` doesn't have a float state. This commit re-writes the
bring-to-fron conditions to be more easy to read and explicitly check
that the window is not internal. It now passes this exception just fine
for all 3 window classes. As a result, the code continues and forwards
clicks to internal windows.

Closes #2793