### PR TITLE
Fix build errors in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,6 @@ MOCK_MODULES = [
     'pywayland',
     'pywayland.protocol.wayland',
     'pywayland.server',
-    'trollius',
     'wlroots',
     'wlroots.helper',
     'wlroots.util',


### PR DESCRIPTION
Adding Wayland compositor page which references backend class object introduced build errors as pywayland and wlroots are not
in the readthedocs environment. We therefore need to add the modules to the list of classes to be mocked.

Fixes #2923


I think we also need to look at how we test docs buillding as the readthedocs environment is not the same as the `tox` environment.