### PR TITLE
Make keybinding swallow configurable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,11 @@ Qtile x.x.x, released xxxx-xx-xx:
           `lazy.group.toscreen(toggle=True)`
         - Tile layout has new `margin_on_single` and `border_on_single` option to specify
           whether to draw margin and border when there is only one window.
+        - `Key`, `KeyChord`, `Click` and `Drag` bindings now have another argument `swallow`.
+          It indicates whether or not the pressed keys should be passed on to the focused client.
+          By default the keys are not passed (swallowed), so this argument is set to `True`.
+          When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
+          function is not executed, e.g. due to failing the `.when()` check.
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -114,8 +114,8 @@ class Keyboard(HasListeners):
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    self.qtile.process_key_event(keysym, mods)
-                    return
+                    if self.qtile.process_key_event(keysym, mods):
+                        return
 
             if self.core.focused_internal:
                 self.core.focused_internal.process_key_press(keysym)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
 _IGNORED_EVENTS = {
     xcffib.xproto.CreateNotifyEvent,
     xcffib.xproto.FocusInEvent,
-    xcffib.xproto.KeyReleaseEvent,
     # DWM handles this to help "broken focusing windows".
     xcffib.xproto.MapNotifyEvent,
     xcffib.xproto.NoExposureEvent,
@@ -358,6 +357,7 @@ class Core(base.Core):
             "ButtonPress",
             "ButtonRelease",
             "KeyPress",
+            "KeyRelease",
         ]
         if hasattr(event, "window"):
             window = self.qtile.windows_map.get(event.window)
@@ -465,7 +465,7 @@ class Core(base.Core):
                     modmask | amask,
                     code,
                     xcffib.xproto.GrabMode.Async,
-                    xcffib.xproto.GrabMode.Async,
+                    xcffib.xproto.GrabMode.Sync,
                 )
         return keysym, modmask & self._valid_mask
 
@@ -514,7 +514,7 @@ class Core(base.Core):
                 True,
                 self._root.wid,
                 eventmask,
-                xcffib.xproto.GrabMode.Async,
+                xcffib.xproto.GrabMode.Sync,
                 xcffib.xproto.GrabMode.Async,
                 xcffib.xproto.Atom._None,
                 xcffib.xproto.Atom._None,
@@ -600,25 +600,54 @@ class Core(base.Core):
             except IndexError:
                 logger.debug("Invalid desktop index: %s" % index)
 
-    def handle_KeyPress(self, event) -> None:  # noqa: N802
+    def handle_KeyPress(self, event, *, simulated=False) -> None:  # noqa: N802
         assert self.qtile is not None
 
         keysym = self.conn.code_to_syms[event.detail][0]
-        self.qtile.process_key_event(keysym, event.state & self._valid_mask)
+        handled = self.qtile.process_key_event(keysym, event.state & self._valid_mask)
+
+        if simulated:
+            # Simulated key press are currently for internal use only
+            return
+
+        if handled:
+            # Swallow the event
+            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.SyncKeyboard, event.time)
+        else:
+            # Forward the event to any focused client
+            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayKeyboard, event.time)
+
+    def handle_KeyRelease(self, event) -> None:  # noqa: N802
+        assert self.qtile is not None
+
+        # We just forward the event to any focused client as we do not handle on release key bindings yet
+        self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayKeyboard, event.time)
 
     def handle_ButtonPress(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 
         button_code = event.detail
         state = event.state & self._valid_mask
+        root = False
 
         if not event.child:  # The client's handle_ButtonPress will focus it
+            root = True
             self.focus_by_click(event)
 
-        self.qtile.process_button_click(
+        handled = self.qtile.process_button_click(
             button_code, state, event.event_x, event.event_y
         )
-        self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
+
+        # Prevent double clicks on the root window if handled was False
+        if root:
+            handled = True
+
+        if handled:
+            # Swallow the event
+            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.SyncPointer, event.time)
+        else:
+            # Forward the event to any focused client
+            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
 
     def handle_ButtonRelease(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
@@ -755,7 +784,7 @@ class Core(base.Core):
         d = DummyEv()
         d.detail = self.conn.keysym_to_keycode(keysym)[0]
         d.state = modmasks
-        self.handle_KeyPress(d)
+        self.handle_KeyPress(d, simulated=True)
 
     def focus_by_click(self, e, window=None):
         """Bring a window to the front

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -59,12 +59,16 @@ class Key:
         If multiple Call objects are specified, they are run in sequence.
     desc:
         description to be added to the key binding
+    swallow:
+        Configures when we swallow the key binding.
+        Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
-    def __init__(self, modifiers: List[str], key: str, *commands, desc: str = ""):
+    def __init__(self, modifiers: List[str], key: str, *commands, desc: str = "", swallow: bool = True):
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
         self.desc = desc
+        self.swallow = swallow
 
     def __repr__(self):
         return "<Key (%s, %s)>" % (self.modifiers, self.key)
@@ -86,22 +90,26 @@ class KeyChord:
         A string with vim like mode name. If it's set, the chord mode will
         not be left after a keystroke (except for Esc which always leaves the
         current chord/mode).
+    swallow:
+        Configures when we swallow the key binding of the chord.
+        Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
     def __init__(self, modifiers: List[str], key: str,
-                 submappings: List[Union[Key, KeyChord]], mode: str = ""):
+                 submappings: List[Union[Key, KeyChord]], mode: str = "", swallow: bool = True):
         self.modifiers = modifiers
         self.key = key
 
         submappings.append(Key([], "Escape"))
         self.submappings = submappings
         self.mode = mode
+        self.swallow = swallow
 
     def __repr__(self):
         return "<KeyChord (%s, %s)>" % (self.modifiers, self.key)
 
 
 class Mouse:
-    def __init__(self, modifiers: List[str], button: str, *commands, **kwargs):
+    def __init__(self, modifiers: List[str], button: str, *commands, swallow: bool = True, **kwargs):
         self.modifiers = modifiers
         self.button = button
         self.commands = commands
@@ -109,6 +117,7 @@ class Mouse:
         for k, v in kwargs.items():
             setattr(self, k, v)
         self.modmask: int = 0
+        self.swallow = swallow
 
 
 class Drag(Mouse):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -371,15 +371,17 @@ class Qtile(CommandObject):
     ) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(self, keysym: int, mask: int) -> None:
+    def process_key_event(self, keysym: int, mask: int) -> bool:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.debug("Ignoring unknown keysym: {keysym}, mask: {mask}".format(keysym=keysym, mask=mask))
-            return
+            return False
 
         if isinstance(key, KeyChord):
             self.grab_chord(key)
         else:
+            # Keep track if we have executed a command
+            executed = False
             for cmd in key.commands:
                 if cmd.check(self):
                     status, val = self.server.call(
@@ -387,9 +389,15 @@ class Qtile(CommandObject):
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("KB command error %s: %s" % (cmd.name, val))
+                    executed = True
             if self.chord_stack and (self.chord_stack[-1].mode == "" or key.key == "Escape"):
                 self.cmd_ungrab_chord()
-            return
+            # We never swallow when no commands have been executed,
+            # even when key.swallow is set to True
+            elif not executed:
+                return False
+        # Return whether we have handled the key based on the key's swallow parameter
+        return key.swallow
 
     def grab_keys(self) -> None:
         """Re-grab all of the keys configured in the key map
@@ -706,7 +714,7 @@ class Qtile(CommandObject):
                             logger.error(
                                 "Mouse command error %s: %s" % (i.name, val)
                             )
-                        handled = True
+                        handled = m.swallow
             elif isinstance(m, Drag):
                 if m.start:
                     i = m.start
@@ -721,7 +729,7 @@ class Qtile(CommandObject):
                     val = (0, 0)
                 self._drag = (x, y, val[0], val[1], m.commands)
                 self.core.grab_pointer()
-                handled = True
+                handled = m.swallow
 
         return handled
 

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2021 Jeroen Wijenbergh
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from libqtile import config
+from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11.core import Core
+from libqtile.confreader import Config
+from libqtile.lazy import lazy
+
+
+# Function that does nothing
+def swallow_nop(qtile):
+    pass
+
+
+# Config with multiple keys and swallow parameters
+class SwallowConfig(Config):
+    keys = [
+        config.Key(
+            ["control"],
+            "k",
+            lazy.function(swallow_nop),
+        ),
+        config.Key(
+            ["control"],
+            "j",
+            lazy.function(swallow_nop),
+            swallow=False
+        ),
+        config.Key(
+            ["control"],
+            "i",
+            lazy.function(swallow_nop).when(layout='idonotexist')
+        ),
+        config.Key(
+            ["control"],
+            "o",
+            lazy.function(swallow_nop).when(layout='idonotexist'),
+            lazy.function(swallow_nop)
+        ),
+    ]
+
+    mouse = [
+        config.Click(
+            [],
+            "Button1",
+            lazy.function(swallow_nop),
+        ),
+        config.Click(
+            ["control"],
+            "Button3",
+            lazy.function(swallow_nop),
+            swallow=False
+        ),
+        config.Click(
+            ["mod4"],
+            "Button3",
+            lazy.function(swallow_nop).when(layout='idonotexist')
+        ),
+        config.Click(
+            [],
+            "Button3",
+            lazy.function(swallow_nop).when(layout='idonotexist'),
+            lazy.function(swallow_nop)
+        ),
+    ]
+
+
+# Helper to send process_key_event to the core manager
+# It also looks up the keysym and mask to pass to it
+def send_process_key_event(manager, key):
+    keysym, mask = Core.lookup_key(None, key)
+    output = manager.c.eval(f"self.process_key_event({keysym}, {mask})")
+    # Assert if eval successful
+    assert output[0]
+    # Convert the string to a bool
+    return output[1] == 'True'
+
+
+# Helper to send process_button_click to the core manager
+# It also looks up the button code and mask to pass to it
+def send_process_button_click(manager, mouse):
+    modmask = xcbq.translate_masks(mouse.modifiers)
+    output = manager.c.eval(f"self.process_button_click({mouse.button_code}, {modmask}, {0}, {0})")
+    # Assert if eval successful
+    assert output[0]
+    # Convert the string to a bool
+    return output[1] == 'True'
+
+
+def test_swallow(manager_nospawn):
+    manager = manager_nospawn
+    manager.start(SwallowConfig)
+
+    # The first key needs to be True as swallowing is not set here
+    # We expect the second key to not be handled, as swallow is set to False
+    # The third needs to not be swallowed as the layout .when(...) check does not succeed
+    # The fourth needs to be True as one of the functions is executed due to passing the .when(...) check
+    expectedswallow = [True, False, False, True]
+
+    # Loop over all the keys in the config and assert
+    for index, key in enumerate(SwallowConfig.keys):
+        assert send_process_key_event(manager, key) == expectedswallow[index]
+
+    # Loop over all the mouse bindings in the config and assert
+    for index, binding in enumerate(SwallowConfig.mouse):
+        assert send_process_button_click(manager, binding) == expectedswallow[index]
+
+    not_used_key = config.Key(
+        ["control"],
+        "h",
+        lazy.function(swallow_nop),
+    )
+
+    not_used_mouse = config.Click(
+        [],
+        "Button2",
+        lazy.function(swallow_nop),
+    )
+
+    # This key is not defined in the config so it should not be handled
+    assert not send_process_key_event(manager, not_used_key)
+
+    # This mouse binding is not defined in the config so it should not be handled
+    assert not send_process_button_click(manager, not_used_mouse)


### PR DESCRIPTION
Key and KeyChord now get another argument: A swallow boolean

With "swallow", I mean whether or not the focused client still gets the keybinding passed to it. When it is set to False, the focused window will get the keybinding passed after the command has been executed. True is the default. Key bindings that are not executed (so also keybindings that fail the `when(...)` check) are never swallowed

Fixes #324 (needs to be re-opened as it was reverted) and implements the feature request in #2587 (as of now partially, but I plan to do the same for mouse keybindings).

This seems to properly handle all cases I tested. The problem we had before (https://github.com/qtile/qtile/pull/2625) is that we did not set handled to `False` when the keybinding is an instance of `KeyChord`. This needs a ton of testing though to confirm everything works correctly. You can test with something like 

```python

# Make sure it's imported
def keychordfunc(qtile):
    print("EXECUTED KEYCHORD")

keys = [
    KeyChord([mod], "y", [
        KeyChord([], "z", [
            KeyChord([], "x", [
                Key([], "c", lazy.function(keychordfunc).when(layout='max'))
            ], mode="inner")
        ])
    ], mode="outer", swallow=False),
...
```

 Added @m-col to co-authors as most of it is based on the previous pr (https://github.com/qtile/qtile/pull/2561).