### PR TITLE
Reparent systray icons to root window before restart/reload

### DIFF
--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -247,3 +247,11 @@ class Systray(window._Window, base._Widget):
             xcffib.CurrentTime,
         )
         self.hide()
+
+        root = self.qtile.core._root.wid
+        for wid in self.icons:
+            self.conn.conn.core.ReparentWindow(wid, root, 0, 0)
+        self.conn.conn.flush()
+
+        del self.qtile.windows_map[self.wid]
+        self.conn.conn.core.DestroyWindow(self.wid)


### PR DESCRIPTION
This prevents them from being killed when the bar window, which they are
reparented to, is killed during `Bar.finalize()`.

Fixes #2909