### PR TITLE
fixed _get_closest function in xmonad, added default value to handle empty candidates list

### DIFF
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -687,7 +687,8 @@ class MonadTall(_SimpleLayoutBase):
         """Get closest window to a point x,y"""
         target = min(
             clients,
-            key=lambda c: math.hypot(c.info()["x"] - x, c.info()["y"] - y)
+            key=lambda c: math.hypot(c.x - x, c.y - y),
+            default=self.clients.current_client
         )
         return target
 

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -677,6 +677,25 @@ def test_tall_swap(manager):
     assert manager.c.layout.info()['main'] == 'focused'
     assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
 
+    # Since the focused window is already to the right this swap shouldn't
+    # change the position of the windows
+    # The swap function will try to get all windows to the right of the
+    # focused window, which will result in a empty list that could cause
+    # an error if not handled
+
+    # Swap againts right edge
+    manager.c.layout.swap_right()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
+
+    # Same as above but for the swap_left function
+
+    # Swap againts left edge
+    manager.c.layout.swap_left()
+    manager.c.layout.swap_left()
+    assert manager.c.layout.info()['main'] == 'three'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'two', 'one']
+
 
 @monadwide_config
 def test_wide_swap(manager):
@@ -718,6 +737,26 @@ def test_wide_swap(manager):
     manager.c.layout.swap_main()
     assert manager.c.layout.info()['main'] == 'focused'
     assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
+
+    # Since the focused window is already to the left this swap shouldn't
+    # change the position of the windows
+    # The swap function will try to get all windows to the left of the
+    # focused window, which will result in a empty list that could cause
+    # an error if not handled
+
+    # Swap againts left edge
+    manager.c.layout.swap_left()
+    assert manager.c.layout.info()['main'] == 'focused'
+    assert manager.c.layout.info()['secondary'] == ['three', 'two', 'one']
+
+    # Same as above but for the swap_right function
+
+    # Swap againts right edge
+    manager.c.layout.swap_right()
+    manager.c.layout.swap_right()
+    assert manager.c.layout.info()['main'] == 'three'
+    assert manager.c.layout.info()['secondary'] == ['focused', 'two', 'one']
+
 
 
 @monadtall_config


### PR DESCRIPTION
Without this fix `min()` would throw an error every time you would call `cmd_swap_right`, `cmd_swap_left,`  `cmd_right` and `cmd_left` with no available client to move.
```
2021-09-05 08:38:14,313 ERROR libqtile manager.py:process_key_event():L359 KB command error right: Traceback (most recent call last):
  File "/home/matteo/.local/lib/python3.9/site-packages/libqtile/command/interface.py", line 313, in call
    return SUCCESS, cmd(*args, **kwargs)
  File "/home/matteo/.local/lib/python3.9/site-packages/libqtile/layout/xmonad.py", line 736, in cmd_right
    self.clients.current_client = self._get_closest(x, y, candidates)
  File "/home/matteo/.local/lib/python3.9/site-packages/libqtile/layout/xmonad.py", line 688, in _get_closest
    target = min(
ValueError: min() arg is an empty sequence
```