### PR TITLE
Update scratchpad documentation to include match parameter

### DIFF
--- a/docs/manual/commands/index.rst
+++ b/docs/manual/commands/index.rst
@@ -10,9 +10,9 @@ different places:
 
 * Commands can be :ref:`bound to keys <config-keys>` in the Qtile
   configuration file.
-* Commands can be :ref:`called through qtile shell <qshell>`, the
+* Commands can be :ref:`called through qtile shell <qtile-shell>`, the
   Qtile shell.
-* The qsh can also be hooked into a Jupyter kernel :ref:`called iqshell
+* The shell can also be hooked into a Jupyter kernel :ref:`called iqshell
   <iqshell>`.
 * Commands can be :ref:`called from a script <scripting>` to
   interact with Qtile from Python.

--- a/docs/manual/commands/scripting.rst
+++ b/docs/manual/commands/scripting.rst
@@ -18,7 +18,7 @@ commands to the running instance.  Commands then appear as methods with the
 appropriate signature on the ``InteractiveCommandClient`` object.  The object hierarchy is
 described in the :ref:`commands-api` section of this manual. Full
 command documentation is available through the :ref:`Qtile Shell
-<qshell>`.
+<qtile-shell>`.
 
 
 Example

--- a/docs/manual/commands/shell/index.rst
+++ b/docs/manual/commands/shell/index.rst
@@ -10,7 +10,7 @@ repository are also documented below.
     :maxdepth: 1
 
     qtile start <qtile-start>
-    qtile shell <qshell>
+    qtile shell <qtile-shell>
     qtile cmd-obj <qtile-cmd>
     qtile run-cmd <qtile-run>
     qtile top <qtile-top>

--- a/docs/manual/commands/shell/qtile-shell.rst
+++ b/docs/manual/commands/shell/qtile-shell.rst
@@ -1,4 +1,4 @@
-.. _qshell:
+.. _qtile-shell:
 
 ===========
 qtile shell

--- a/docs/manual/config/groups.rst
+++ b/docs/manual/config/groups.rst
@@ -77,8 +77,8 @@ Example
           # it is placed in the upper third of screen by default.
           DropDown("term", "urxvt", opacity=0.8),
 
-          # define another terminal exclusively for qshell at different position
-          DropDown("qshell", "urxvt -hold -e qshell",
+          # define another terminal exclusively for ``qtile shell` at different position
+          DropDown("qtile shell", "urxvt -hold -e 'qtile shell'",
                    x=0.05, y=0.4, width=0.9, height=0.6, opacity=0.9,
                    on_focus_lost_hide=True) ]),
       Group("a"),
@@ -87,7 +87,7 @@ Example
   keys = [
     # toggle visibiliy of above defined DropDown named "term"
     Key([], 'F11', lazy.group['scratchpad'].dropdown_toggle('term')),
-    Key([], 'F12', lazy.group['scratchpad'].dropdown_toggle('qshell')),
+    Key([], 'F12', lazy.group['scratchpad'].dropdown_toggle('qtile shell')),
   ]
 
 Note that if the window is set to not floating, it is detached from DropDown

--- a/docs/manual/config/groups.rst
+++ b/docs/manual/config/groups.rst
@@ -58,7 +58,7 @@ bind thats process' window to it. The associated window can then be shown and
 hidden by the lazy command ``dropdown_toggle()``
 (see :ref:`lazy`) from the ScratchPad group.
 Thus - for example - your favorite terminal emulator turns into a quake-like
-terminal by the control of qtile.
+terminal by the control of Qtile.
 
 If the DropDown window turns visible it is placed as a floating window on top
 of the current group.
@@ -90,18 +90,19 @@ Example
     Key([], 'F12', lazy.group['scratchpad'].dropdown_toggle('qshell')),
   ]
 
-There is only one DropDown visible in current group at a time.
-If a further DropDown is set visible the currently shown DropDown turns
-invisble immediately.
-
 Note that if the window is set to not floating, it is detached from DropDown
-and ScratchPad, and a new pocess is spawned next time the DropDown is set visible.
+and ScratchPad, and a new process is spawned next time the DropDown is set
+visible.
+
+Some programs run in a server-like mode where the spawned process does not
+directly own the window that is created, which is instead created by a
+background process. In this case, the window may not be correctly caught in the
+scratchpad group. To work around this, you can pass a ``config.Match`` object
+to the corresponding ``Dropdown``. See below.
 
 Reference
 ---------
 
 .. qtile_class:: libqtile.config.ScratchPad
-    :no-commands:
 
 .. qtile_class:: libqtile.config.DropDown
-     :no-commands:

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -7,7 +7,7 @@ Lazy objects
 The ``lazy.lazy`` object is a special helper object to specify a command for
 later execution. This object acts like the root of the object graph, which
 means that we can specify a key binding command with the same syntax used to
-call the command through a script or through :ref:`qshell`.
+call the command through a script or through :ref:`qtile-shell`.
 
 Example
 -------

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -122,6 +122,10 @@ ScratchPad DropDown functions
     * - ``lazy.group["group_name"].dropdown_toggle("name")``
       - Toggles the visibility of the specified DropDown window.
         On first use, the configured process is spawned.
+    * - ``lazy.group["group_name"].hide_all()``
+      - Hides all DropDown windows.
+    * - ``lazy.group["group_name"].dropdown_reconfigure("name", **configuration)``
+      - Update the configuration of the named DropDown.
 
 User-defined functions
 ----------------------

--- a/docs/manual/ref/commands.rst
+++ b/docs/manual/ref/commands.rst
@@ -5,10 +5,10 @@ Scripting Commands
 ==================
 
 Here is documented some of the commands available on objects in the command
-tree when running qshell or scripting commands to qtile.  Note that this is an
-incomplete list, some objects, such as :ref:`layouts <ref-layouts>` and
-:ref:`widgets <ref-widgets>`, may implement their own set of commands beyond
-those given here.
+tree when running ``qtile shell`` or scripting commands to qtile. Note that
+this is an incomplete list, some objects, such as :ref:`layouts <ref-layouts>`
+and :ref:`widgets <ref-widgets>`, may implement their own set of commands
+beyond those given here.
 
 .. _qtile_commands:
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -769,9 +769,17 @@ class DropDown(configurable.Configurable):
             'This has only effect if any of the on_focus_lost_xxx '
             'configurations is True'
         ),
+        (
+            'match',
+            None,
+            "Use a ``config.Match`` to identify the spawned window and move it to the "
+            "scratchpad, instead of relying on the window's PID. This works around "
+            "some programs that may not be caught by the window's PID if it does "
+            "not match the PID of the spawned process."
+        ),
     )
 
-    def __init__(self, name, cmd, match=None, **config):
+    def __init__(self, name, cmd, **config):
         """
         Initialize DropDown window wrapper.
         Define a command to spawn a process for the first time the DropDown
@@ -789,7 +797,6 @@ class DropDown(configurable.Configurable):
         configurable.Configurable.__init__(self, **config)
         self.name = name
         self.command = cmd
-        self.match = match
         self.add_defaults(self.defaults)
 
     def info(self):


### PR DESCRIPTION
This follows 314eceba637443eef3dc72cf79bcaa525ebcbe17 to add the new
`match` parameter for `DropDown` to the docs.