### PR TITLE
Fix up some bar and widget related code

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -238,13 +238,6 @@ class Bar(Gap, configurable.Configurable):
         width = self.width + (self.border_width[1] + self.border_width[3])
         height = self.height + (self.border_width[0] + self.border_width[2])
 
-        for w in self.widgets:
-            # Executing _test_orientation_compatibility later, for example in
-            # the _configure() method of each widget, would still pass
-            # test/test_bar.py but a segfault would be raised when nosetests is
-            # about to exit
-            w._test_orientation_compatibility(self.horizontal)
-
         if self.window:
             # We get _configure()-ed with an existing window when screens are getting
             # reconfigured but this screen is present both before and after

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -148,10 +148,12 @@ class _Widget(CommandObject, configurable.Configurable):
         if length in (bar.CALCULATED, bar.STRETCH):
             self.length_type = length
             self.length = 0
-        else:
-            assert isinstance(length, int)
+        elif isinstance(length, int):
             self.length_type = bar.STATIC
             self.length = length
+        else:
+            raise confreader.ConfigError("Widget width must be an int")
+
         self.configured = False
         self._futures: List[asyncio.TimerHandle] = []
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -183,8 +183,6 @@ class _Widget(CommandObject, configurable.Configurable):
             return self.offsetx
         return self.offsety
 
-    # Do not start the name with "test", or nosetests will try to test it
-    # directly (prepend an underscore instead)
     def _test_orientation_compatibility(self, horizontal):
         if horizontal:
             if not self.orientations & ORIENTATION_HORIZONTAL:
@@ -204,6 +202,8 @@ class _Widget(CommandObject, configurable.Configurable):
         pass
 
     def _configure(self, qtile, bar):
+        self._test_orientation_compatibility(bar.horizontal)
+
         self.qtile = qtile
         self.bar = bar
         self.drawer = bar.window.create_drawer(self.bar.width, self.bar.height)

--- a/test/widgets/conftest.py
+++ b/test/widgets/conftest.py
@@ -5,19 +5,28 @@ import subprocess
 
 import pytest
 
-import libqtile.bar
 import libqtile.config
 import libqtile.confreader
 import libqtile.layout
+from libqtile.bar import Bar
+from libqtile.widget.base import ORIENTATION_HORIZONTAL
 
 
 @pytest.fixture(scope='function')
 def fake_bar():
-    from libqtile.bar import Bar
-    height = 24
-    b = Bar([], height)
-    b.height = height
-    return b
+    return FakeBar([])
+
+
+class FakeBar(Bar):
+    def __init__(self, widgets, size=24, width=100, window=None, **config):
+        Bar.__init__(self, widgets, size, **config)
+        self.height = size
+        self.width = width
+        self.window = window
+        self.horizontal = ORIENTATION_HORIZONTAL
+
+    def draw(self):
+        pass
 
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -2,7 +2,6 @@ import cairocffi
 import pytest
 
 from libqtile import images
-from libqtile.bar import Bar
 from libqtile.widget import battery
 from libqtile.widget.battery import (
     Battery,
@@ -10,7 +9,7 @@ from libqtile.widget.battery import (
     BatteryState,
     BatteryStatus,
 )
-from test.widgets.conftest import TEST_DIR
+from test.widgets.conftest import TEST_DIR, FakeBar
 
 
 class DummyBattery:
@@ -241,11 +240,7 @@ def test_battery_background(fake_qtile, fake_window, monkeypatch):
             low_percentage=0.2, low_background=low_background, background=background
         )
 
-    fakebar = Bar([batt], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = lambda *a, **k: None
+    fakebar = FakeBar([batt], window=fake_window)
     batt._configure(fake_qtile, fakebar)
 
     assert batt.background == background

--- a/test/widgets/test_caps_num_lock_indicator.py
+++ b/test/widgets/test_caps_num_lock_indicator.py
@@ -23,8 +23,8 @@ from typing import List
 
 import pytest
 
-from libqtile.bar import Bar
 from libqtile.widget import caps_num_lock_indicator
+from test.widgets.conftest import FakeBar
 
 
 class MockCapsNumLockIndicator:
@@ -88,11 +88,7 @@ def patched_cnli(monkeypatch):
 
 def test_cnli(fake_qtile, patched_cnli, fake_window):
     widget = patched_cnli.CapsNumLockIndicator()
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 
@@ -105,11 +101,7 @@ def test_cnli_caps_on(fake_qtile, patched_cnli, fake_window):
     # Simulate Caps on
     MockCapsNumLockIndicator.index = 1
 
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 
@@ -122,11 +114,7 @@ def test_cnli_error_handling(fake_qtile, patched_cnli, fake_window):
     # Simulate a CalledProcessError exception
     MockCapsNumLockIndicator.is_error = True
 
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 

--- a/test/widgets/test_check_updates.py
+++ b/test/widgets/test_check_updates.py
@@ -1,11 +1,6 @@
 import libqtile.config
-from libqtile.bar import Bar
 from libqtile.widget.check_updates import CheckUpdates, Popen  # noqa: F401
-
-
-def no_op(*args, **kwargs):
-    pass
-
+from test.widgets.conftest import FakeBar
 
 wrong_distro = "Barch"
 good_distro = "Arch"
@@ -28,11 +23,7 @@ def test_update_available(fake_qtile, fake_window):
                        custom_command=cmd_1_line,
                        colour_have_updates="#123456"
                        )
-    fakebar = Bar([cu2], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu2], window=fake_window)
     cu2._configure(fake_qtile, fakebar)
     text = cu2.poll()
     assert text == "Updates: 1"
@@ -42,11 +33,7 @@ def test_update_available(fake_qtile, fake_window):
 def test_no_update_available_without_no_update_string(fake_qtile, fake_window):
     """ test output with no update (without dedicated string nor color) """
     cu3 = CheckUpdates(distro=good_distro, custom_command=cmd_0_line)
-    fakebar = Bar([cu3], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu3], window=fake_window)
     cu3._configure(fake_qtile, fakebar)
     text = cu3.poll()
     assert text == ""
@@ -61,11 +48,7 @@ def test_no_update_available_with_no_update_string_and_color_no_updates(
                        no_update_string=nus,
                        colour_no_updates="#654321"
                        )
-    fakebar = Bar([cu4], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu4], window=fake_window)
     cu4._configure(fake_qtile, fakebar)
     text = cu4.poll()
     assert text == nus
@@ -79,11 +62,7 @@ def test_update_available_with_restart_indicator(monkeypatch, fake_qtile, fake_w
                        restart_indicator="*",
                        )
     monkeypatch.setattr("os.path.exists", lambda x: True)
-    fakebar = Bar([cu5], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu5], window=fake_window)
     cu5._configure(fake_qtile, fakebar)
     text = cu5.poll()
     assert text == "Updates: 1*"
@@ -155,11 +134,7 @@ def test_update_process_error(fake_qtile, fake_window):
                        custom_command=cmd_error,
                        no_update_string="ERROR",
                        )
-    fakebar = Bar([cu7], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu7], window=fake_window)
     cu7._configure(fake_qtile, fakebar)
     text = cu7.poll()
     assert text == "ERROR"
@@ -176,11 +151,7 @@ def test_line_truncations(fake_qtile, monkeypatch, fake_window):
     cu8 = CheckUpdates(distro="Fedora")
 
     monkeypatch.setattr(cu8, "call_process", mock_process)
-    fakebar = Bar([cu8], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([cu8], window=fake_window)
     cu8._configure(fake_qtile, fakebar)
     text = cu8.poll()
 

--- a/test/widgets/test_clock.py
+++ b/test/widgets/test_clock.py
@@ -27,8 +27,8 @@ from importlib import reload
 import pytest
 
 import libqtile.config
-from libqtile.bar import Bar
 from libqtile.widget import clock
+from test.widgets.conftest import FakeBar
 
 
 def no_op(*args, **kwargs):
@@ -69,11 +69,7 @@ def test_clock(fake_qtile, monkeypatch, fake_window):
     """ test clock output with default settings """
     monkeypatch.setattr("libqtile.widget.clock.datetime", MockDatetime)
     clk1 = clock.Clock()
-    fakebar = Bar([clk1], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([clk1], window=fake_window)
     clk1._configure(fake_qtile, fakebar)
     text = clk1.poll()
     assert text == "10:20"
@@ -104,11 +100,7 @@ def test_clock_invalid_timezone(fake_qtile, monkeypatch, fake_window):
     # Fake datetime module just adds the timezone value to the time
     clk2 = clock.Clock(timezone="1")
 
-    fakebar = Bar([clk2], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([clk2], window=fake_window)
     clk2._configure(fake_qtile, fakebar)
 
     # An invalid timezone current causes a TypeError
@@ -136,11 +128,7 @@ def test_clock_datetime_timezone(fake_qtile, monkeypatch, fake_window):
     # Fake datetime module just adds the timezone value to the time
     clk3 = clock.Clock(timezone=1)
 
-    fakebar = Bar([clk3], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([clk3], window=fake_window)
     clk3._configure(fake_qtile, fakebar)
     text = clk3.poll()
 
@@ -178,11 +166,7 @@ def test_clock_pytz_timezone(fake_qtile, monkeypatch, fake_window):
     # Pytz timezone must be a string
     clk4 = clock.Clock(timezone="1")
 
-    fakebar = Bar([clk4], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([clk4], window=fake_window)
     clk4._configure(fake_qtile, fakebar)
     text = clk4.poll()
 
@@ -217,11 +201,7 @@ def test_clock_dateutil_timezone(fake_qtile, monkeypatch, fake_window):
     # Pytz timezone must be a string
     clk5 = clock.Clock(timezone="1")
 
-    fakebar = Bar([clk5], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([clk5], window=fake_window)
     clk5._configure(fake_qtile, fakebar)
     text = clk5.poll()
 

--- a/test/widgets/test_cmus.py
+++ b/test/widgets/test_cmus.py
@@ -25,8 +25,8 @@ import subprocess
 import pytest
 
 import libqtile.config
-from libqtile.bar import Bar
 from libqtile.widget import cmus
+from test.widgets.conftest import FakeBar
 
 
 class MockCmusRemoteProcess:
@@ -144,11 +144,7 @@ def patched_cmus(monkeypatch):
 
 def test_cmus(fake_qtile, patched_cmus, fake_window):
     widget = patched_cmus.Cmus()
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
     assert text == "♫ Rick Astley - Never Gonna Give You Up"
@@ -165,11 +161,7 @@ def test_cmus_play_stopped(fake_qtile, patched_cmus, fake_window):
 
     # Set track to a stopped item
     MockCmusRemoteProcess.index = 2
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 
@@ -219,11 +211,7 @@ def test_cmus_buttons(minimal_conf_noscreen, manager_nospawn, patched_cmus):
 def test_cmus_error_handling(fake_qtile, patched_cmus, fake_window):
     widget = patched_cmus.Cmus()
     MockCmusRemoteProcess.is_error = True
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 
@@ -237,11 +225,7 @@ def test_escape_text(fake_qtile, patched_cmus, fake_window):
 
     # Set track to a stopped item
     MockCmusRemoteProcess.index = 3
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     text = widget.poll()
 

--- a/test/widgets/test_df.py
+++ b/test/widgets/test_df.py
@@ -26,12 +26,8 @@ from types import ModuleType
 
 import pytest
 
-from libqtile.bar import Bar
 from libqtile.widget import df
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 class FakeOS(ModuleType):
@@ -72,12 +68,7 @@ def patched_df(monkeypatch):
 def test_df_no_warning(fake_qtile, fake_window):
     ''' Test no text when free space over threshold '''
     df1 = df.DF()
-    fakebar = Bar([df1], 24)
-    fakebar.horizontal = True
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([df1], window=fake_window)
     df1._configure(fake_qtile, fakebar)
     text = df1.poll()
     assert text == ""
@@ -90,12 +81,7 @@ def test_df_no_warning(fake_qtile, fake_window):
 def test_df_always_visible(fake_qtile, fake_window):
     ''' Test text is always displayed '''
     df2 = df.DF(visible_on_warn=False)
-    fakebar = Bar([df2], 24)
-    fakebar.horizontal = True
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([df2], window=fake_window)
     df2._configure(fake_qtile, fakebar)
     text = df2.poll()
 
@@ -113,12 +99,7 @@ def test_df_warn_space(fake_qtile, fake_window):
         below threshold
     '''
     df3 = df.DF(warn_space=40)
-    fakebar = Bar([df3], 24)
-    fakebar.horizontal = True
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([df3], window=fake_window)
     df3._configure(fake_qtile, fakebar)
     text = df3.poll()
 

--- a/test/widgets/test_gmail_checker.py
+++ b/test/widgets/test_gmail_checker.py
@@ -24,12 +24,8 @@ import sys
 from importlib import reload
 from types import ModuleType
 
-from libqtile.bar import Bar
 from libqtile.widget import gmail_checker
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 class FakeIMAP(ModuleType):
@@ -56,11 +52,7 @@ def test_gmail_checker_valid_response(fake_qtile, monkeypatch, fake_window):
     reload(gmail_checker)
 
     gmc = gmail_checker.GmailChecker(username="qtile", password="test")
-    fakebar = Bar([gmc], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([gmc], window=fake_window)
     gmc._configure(fake_qtile, fakebar)
     text = gmc.poll()
     assert text == "inbox[10],unseen[2]"
@@ -71,11 +63,7 @@ def test_gmail_checker_invalid_response(fake_qtile, monkeypatch, fake_window):
     reload(gmail_checker)
 
     gmc = gmail_checker.GmailChecker()
-    fakebar = Bar([gmc], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([gmc], window=fake_window)
     gmc._configure(fake_qtile, fakebar)
     text = gmc.poll()
     assert text == "UNKNOWN ERROR"
@@ -93,11 +81,7 @@ def test_gmail_checker_only_unseen(fake_qtile, monkeypatch, fake_window):
         username="qtile",
         password="test"
     )
-    fakebar = Bar([gmc], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([gmc], window=fake_window)
     gmc._configure(fake_qtile, fakebar)
     text = gmc.poll()
     assert text == "unseen[2]"

--- a/test/widgets/test_imapwidget.py
+++ b/test/widgets/test_imapwidget.py
@@ -26,11 +26,7 @@ from types import ModuleType
 
 import pytest
 
-from libqtile.bar import Bar
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 class FakeIMAP(ModuleType):
@@ -82,11 +78,7 @@ def patched_imap(monkeypatch):
 
 def test_imapwidget(fake_qtile, monkeypatch, fake_window, patched_imap):
     imap = patched_imap.ImapWidget(user="qtile")
-    fakebar = Bar([imap], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([imap], window=fake_window)
     imap._configure(fake_qtile, fakebar)
     text = imap.poll()
     assert text == "INBOX: 2"
@@ -95,11 +87,7 @@ def test_imapwidget(fake_qtile, monkeypatch, fake_window, patched_imap):
 def test_imapwidget_keyring_error(fake_qtile, monkeypatch, fake_window, patched_imap):
     patched_imap.keyring.valid = False
     imap = patched_imap.ImapWidget(user="qtile")
-    fakebar = Bar([imap], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([imap], window=fake_window)
     imap._configure(fake_qtile, fakebar)
     text = imap.poll()
     assert text == "Gnome Keyring Error"
@@ -115,11 +103,7 @@ def test_imapwidget_password_none(fake_qtile, monkeypatch, fake_window, patched_
     patched_imap.keyring.error = False
 
     imap = patched_imap.ImapWidget(user="qtile")
-    fakebar = Bar([imap], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([imap], window=fake_window)
     imap._configure(fake_qtile, fakebar)
     with pytest.raises(AttributeError):
         with pytest.raises(UnboundLocalError):

--- a/test/widgets/test_keyboardkbdd.py
+++ b/test/widgets/test_keyboardkbdd.py
@@ -31,11 +31,7 @@ from types import ModuleType
 
 import pytest
 
-from libqtile.bar import Bar
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 async def mock_signal_receiver(*args, **kwargs):
@@ -80,11 +76,7 @@ def patched_widget(monkeypatch):
 def test_keyboardkbdd_process_running(fake_qtile, patched_widget, fake_window):
     MockSpawn.call_count = 1
     kbd = patched_widget.KeyboardKbdd(configured_keyboards=["gb", "us"])
-    fakebar = Bar([kbd], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([kbd], window=fake_window)
     kbd._configure(fake_qtile, fakebar)
     assert kbd.is_kbdd_running
     assert kbd.keyboard == "gb"
@@ -103,11 +95,7 @@ def test_keyboardkbdd_process_running(fake_qtile, patched_widget, fake_window):
 def test_keyboardkbdd_process_not_running(fake_qtile, patched_widget, fake_window):
     MockSpawn.call_count = 0
     kbd = patched_widget.KeyboardKbdd(configured_keyboards=["gb", "us"])
-    fakebar = Bar([kbd], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([kbd], window=fake_window)
     kbd._configure(fake_qtile, fakebar)
     assert not kbd.is_kbdd_running
     assert kbd.keyboard == "N/A"
@@ -126,11 +114,7 @@ def test_keyboard_kbdd_colours(fake_qtile, patched_widget, fake_window):
         configured_keyboards=["gb", "us"],
         colours=["#ff0000", "#00ff00"]
     )
-    fakebar = Bar([kbd], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([kbd], window=fake_window)
     kbd._configure(fake_qtile, fakebar)
 
     # Create a message with the index of the active keyboard

--- a/test/widgets/test_moc.py
+++ b/test/widgets/test_moc.py
@@ -25,8 +25,8 @@ import subprocess
 import pytest
 
 import libqtile.config
-from libqtile.bar import Bar
 from libqtile.widget import moc
+from test.widgets.conftest import FakeBar
 
 
 class MockMocpProcess:
@@ -103,11 +103,7 @@ def patched_moc(fake_qtile, monkeypatch, fake_window):
     MockMocpProcess.reset()
     monkeypatch.setattr(widget, "call_process", MockMocpProcess.run)
     monkeypatch.setattr("libqtile.widget.moc.subprocess.Popen", MockMocpProcess.run)
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
     return widget
 

--- a/test/widgets/test_mpris2widget.py
+++ b/test/widgets/test_mpris2widget.py
@@ -26,7 +26,7 @@ from types import ModuleType
 
 import pytest
 
-from libqtile.bar import Bar
+from test.widgets.conftest import FakeBar
 
 
 def no_op(*args, **kwargs):
@@ -124,11 +124,7 @@ def patched_module(monkeypatch):
 
 def test_mpris2_signal_handling(fake_qtile, patched_module, fake_window):
     mp = patched_module.Mpris2(scroll_chars=20, scroll_wait_intervals=5)
-    fakebar = Bar([mp], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([mp], window=fake_window)
     mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
 
@@ -187,11 +183,7 @@ def test_mpris2_signal_handling(fake_qtile, patched_module, fake_window):
 
 def test_mpris2_custom_stop_text(fake_qtile, patched_module, fake_window):
     mp = patched_module.Mpris2(stop_pause_text="Test Paused")
-    fakebar = Bar([mp], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([mp], window=fake_window)
     mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
@@ -208,11 +200,7 @@ def test_mpris2_custom_stop_text(fake_qtile, patched_module, fake_window):
 
 def test_mpris2_no_metadata(fake_qtile, patched_module, fake_window):
     mp = patched_module.Mpris2(stop_pause_text="Test Paused")
-    fakebar = Bar([mp], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([mp], window=fake_window)
     mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
@@ -225,11 +213,7 @@ def test_mpris2_no_scroll(fake_qtile, patched_module, fake_window):
     # If no scrolling, then the update function creates the text to display
     # and draws the bar.
     mp = patched_module.Mpris2(scroll_chars=None)
-    fakebar = Bar([mp], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([mp], window=fake_window)
     mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
@@ -243,11 +227,7 @@ def test_mpris2_no_scroll(fake_qtile, patched_module, fake_window):
 
 def test_mpris2_clear_after_scroll(fake_qtile, patched_module, fake_window):
     mp = patched_module.Mpris2(scroll_chars=60, scroll_wait_intervals=2)
-    fakebar = Bar([mp], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([mp], window=fake_window)
     mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True

--- a/test/widgets/test_net.py
+++ b/test/widgets/test_net.py
@@ -26,11 +26,7 @@ from types import ModuleType
 
 import pytest
 
-from libqtile.bar import Bar
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 # Net widget only needs bytes_recv/sent attributes
@@ -73,11 +69,7 @@ def patch_net(fake_qtile, monkeypatch, fake_window):
                 format='{interface}: U {up} D {down} T {total}',
                 **kwargs
             )
-        fakebar = Bar([widget], 24)
-        fakebar.window = fake_window
-        fakebar.width = 10
-        fakebar.height = 10
-        fakebar.draw = no_op
+        fakebar = FakeBar([widget], window=fake_window)
         widget._configure(fake_qtile, fakebar)
 
         return widget

--- a/test/widgets/test_nvidia_sensors.py
+++ b/test/widgets/test_nvidia_sensors.py
@@ -1,10 +1,10 @@
 import pytest
 
-from libqtile import bar
 from libqtile.widget.nvidia_sensors import (
     NvidiaSensors,
     _all_sensors_names_correct,
 )
+from test.widgets.conftest import FakeBar
 
 
 def test_nvidia_sensors_input_regex():
@@ -34,11 +34,7 @@ def fake_nvidia(fake_qtile, monkeypatch, fake_window):
     # on the test computer having the required hardware.
     monkeypatch.setattr(n, "call_process", MockNvidiaSMI.get_temperature)
     monkeypatch.setattr("libqtile.widget.moc.subprocess.Popen", MockNvidiaSMI.get_temperature)
-    fakebar = bar.Bar([n], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = None
+    fakebar = FakeBar([n], window=fake_window)
     n._configure(fake_qtile, fakebar)
     return n
 

--- a/test/widgets/test_pomodoro.py
+++ b/test/widgets/test_pomodoro.py
@@ -22,8 +22,8 @@ from importlib import reload
 
 import pytest
 
-from libqtile.bar import Bar
 from libqtile.widget import pomodoro
+from test.widgets.conftest import FakeBar
 
 COLOR_INACTIVE = "123456"
 COLOR_ACTIVE = "654321"
@@ -33,10 +33,6 @@ PREFIX_ACTIVE = "ACTIVE"
 PREFIX_BREAK = "BREAK"
 PREFIX_LONG_BREAK = "LONG BREAK"
 PREFIX_PAUSED = "PAUSING"
-
-
-def no_op(*args, **kwargs):
-    pass
 
 
 # Mock Datetime object that returns a set datetime but can
@@ -75,11 +71,7 @@ def test_pomodoro(fake_qtile, fake_window):
         prefix_paused=PREFIX_PAUSED
     )
 
-    fakebar = Bar([widget], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget], window=fake_window)
     widget._configure(fake_qtile, fakebar)
 
     # When we start, widget is inactive

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -27,7 +27,11 @@ import libqtile.config
 import libqtile.confreader
 import libqtile.layout
 import libqtile.widget as widgets
+from libqtile.widget.base import ORIENTATION_VERTICAL
+from libqtile.widget.clock import Clock
 from libqtile.widget.crashme import _CrashMe
+
+from .conftest import FakeBar
 
 # This file runs a very simple test to check that widgets can be initialised
 # and that keyword arguments are added to default values.
@@ -117,3 +121,11 @@ def test_widget_init_config(manager_nospawn, minimal_conf_noscreen, widget_class
 
     # Check widget is registered by checking names of widgets in bar
     assert i["widgets"][0]["name"] == widget.name
+
+
+def test_incompatible_orientation(fake_qtile, fake_window):
+    clk1 = Clock()
+    clk1.orientations = ORIENTATION_VERTICAL
+    fakebar = FakeBar([clk1], window=fake_window)
+    with pytest.raises(libqtile.confreader.ConfigError):
+        clk1._configure(fake_qtile, fakebar)

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -30,8 +30,7 @@ import libqtile.widget as widgets
 from libqtile.widget.base import ORIENTATION_VERTICAL
 from libqtile.widget.clock import Clock
 from libqtile.widget.crashme import _CrashMe
-
-from .conftest import FakeBar
+from test.widgets.conftest import FakeBar
 
 # This file runs a very simple test to check that widgets can be initialised
 # and that keyword arguments are added to default values.

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -1,10 +1,6 @@
 import libqtile.config
-from libqtile.bar import Bar
 from libqtile.widget import TextBox, WidgetBox
-
-
-def no_op(*args, **kwargs):
-    pass
+from test.widgets.conftest import FakeBar
 
 
 def test_widgetbox_widget(fake_qtile, fake_window):
@@ -18,11 +14,7 @@ def test_widgetbox_widget(fake_qtile, fake_window):
                            fontsize=10)
 
     # Create a bar and set attributes needed to run widget
-    fakebar = Bar([widget_box], 24)
-    fakebar.window = fake_window
-    fakebar.width = 10
-    fakebar.height = 10
-    fakebar.draw = no_op
+    fakebar = FakeBar([widget_box], window=fake_window)
 
     # Configure the widget box
     widget_box._configure(fake_qtile, fakebar)


### PR DESCRIPTION
These are just some smallish fixes for the bar and widget code:

1. Move the widget orientation check into `_configure` so that failures do not fail config loading, only widget setup, so the rest of the config continues to work.
2. Give a more useful exception when a widget is not given an `int` for its size.
3. Handle consecutivete `STRETCH` widgets a bit differently, where instead they are grouped together and each group of consecutive stretch widgets is given the same amount of space. Lots of info on this, the issue, the solution etc in the commit message.
4. Add a `FakeBar` test class for the widget tests to reduce lots of code duplication that was collecting there.