### PR TITLE
New Net widget option to display the current speed with a static prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Add ability for widget `mouse_callbacks` to take `lazy` calls (similar to keybindings)
         - Add `aliases` to `lazy.spawncmd()` which takes a dictionary mapping convenient aliases
           to full command lines.
+        - Add a new 'prefix' option to the net widget to display speeds with a static unit (e.g. MB).
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/test/widgets/test_net.py
+++ b/test/widgets/test_net.py
@@ -120,4 +120,10 @@ def test_net_convert_zero_b(patch_net):
     assert net5.convert_b(0.0) == (0.0, "B")
 
 
+def test_net_use_prefix(patch_net):
+    '''Tests `prefix` configurable option'''
+    net6 = patch_net(prefix="M")
+    assert net6.poll() == "all: U  0.04MB D  1.20MB T  1.24MB"
+
+
 # Untested: 128-129 - generic exception catching


### PR DESCRIPTION
Within the net widget it would be nice to have the option to always show the same unit (prefix) of the current traffic speed. I never liked the fact, that the prefix jumps between "kB" and "MB" and so on. It makes it much harder for me to read the output of the widget with a fast look.

With this change the user can set the widget option "prefix" to one of the
`allowed_prefixes = ["", "k", "M", "G", "T", "P", "E", "Z", "Y"]`
The default setting is "None" which keeps the unit switching depending to the actual traffic (old behaviour).

**This is my first contribution to any project. So please double-check and tell me if i did something wrong in the process.**

One last question: Should the documentation be updated after such a change? If yes, how?