### PR TITLE
group.cmd_toscreen - do not toggle by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,8 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Add `aliases` to `lazy.spawncmd()` which takes a dictionary mapping convenient aliases
           to full command lines.
         - Add a new 'prefix' option to the net widget to display speeds with a static unit (e.g. MB).
+        - `lazy.group.toscreen()` now does not toggle groups by default. To get this behaviour back, use
+          `lazy.group.toscreen(toggle=True)`
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -336,7 +336,7 @@ class _Group(CommandObject):
         """Returns a dictionary of info for this group"""
         return self.info()
 
-    def cmd_toscreen(self, screen=None, toggle=True):
+    def cmd_toscreen(self, screen=None, toggle=False):
         """Pull a group to a specified screen.
 
         Parameters

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -33,7 +33,8 @@ from libqtile.confreader import Config
 class GroupConfig(Config):
     auto_fullscreen = True
     groups = [
-        libqtile.config.Group("a")
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
     ]
     layouts = [
         layout.Max()
@@ -57,7 +58,7 @@ def test_window_order(manager):
     for win in windows_name:
         windows[win] = manager.test_window(win)
 
-    # Winmust be sotred in the same order as they were created
+    # Windows must be sorted in the same order as they were created
     assert windows_name == manager.c.group.info()["windows"]
 
     # Randomly remove 5 windows and see if orders remains persistant
@@ -67,3 +68,17 @@ def test_window_order(manager):
         manager.kill_window(windows[win_to_remove])
         del windows[win_to_remove]
         assert windows_name == manager.c.group.info()["windows"]
+
+
+@group_config
+def test_toscreen_toggle(manager):
+    assert manager.c.group.info()["name"] == "a"  # Start on "a"
+    manager.c.group["b"].toscreen()
+    assert manager.c.group.info()["name"] == "b"  # Switch to "b"
+    manager.c.group["b"].toscreen()
+    assert manager.c.group.info()["name"] == "b"  # Does not toggle by default
+    manager.c.group["b"].toscreen(toggle=True)
+    assert manager.c.group.info()["name"] == "a"  # Explicitly toggling moves to "a"
+    manager.c.group["b"].toscreen(toggle=True)
+    manager.c.group["b"].toscreen(toggle=True)
+    assert manager.c.group.info()["name"] == "a"  # Toggling twice roundtrips between the two

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -952,7 +952,7 @@ def test_setgroup(manager):
     assert manager.c.groups()["c"]["screen"] == 0
 
     # Setting the current group once again switches back to the previous group
-    manager.c.group["c"].toscreen()
+    manager.c.group["c"].toscreen(toggle=True)
     manager.groupconsistency()
     assert manager.c.group.info()["name"] == "b"
 


### PR DESCRIPTION
Many, many people complain about this behaviour, so let's return it back
to the old behaviour before then parameter was added. The docs can be
used to find it. Changelog mentions to change in case people come
searching for the behaviour again.