### PR TITLE
Add aliases feature to lazy.spawncmd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ Qtile x.x.x, released xxxx-xx-xx:
           migration is added. In the future `groupName` will fail.
         - Add `min/max_ratio` to Tile layout and fix bug where windows can extend offscreen.
         - Add ability for widget `mouse_callbacks` to take `lazy` calls (similar to keybindings)
+        - Add `aliases` to `lazy.spawncmd()` which takes a dictionary mapping convenient aliases
+          to full command lines.
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1357,6 +1357,7 @@ class Qtile(CommandObject):
         command: str = "%s",
         complete: str = "cmd",
         shell: bool = True,
+        aliases: Optional[Dict[str, str]] = None,
     ) -> None:
         """Spawn a command using a prompt widget, with tab-completion.
 
@@ -1370,9 +1371,16 @@ class Qtile(CommandObject):
             command template (default: "%s").
         complete :
             Tab completion function (default: "cmd")
+        shell :
+            Execute the command with /bin/sh (default: True)
+        aliases :
+            Dictionary mapping aliases to commands. If the entered command is a key in
+            this dict, the command it maps to will be executed instead.
         """
         def f(args):
             if args:
+                if aliases and args in aliases:
+                    args = aliases[args]
                 self.cmd_spawn(command % args, shell=shell)
         try:
             mb = self.widgets_map[widget]


### PR DESCRIPTION
This lets the user pass 'aliases' to `lazy.spawncmd()` which can be used
to let the command accept shortened strings and map those into larger
command lines before passing those into `Qtile.cmd_spawn()`.

Closes #2966