### PR TITLE
Fix INCR clipboard transfers.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@ Qtile x.x.x, released xxxx-xx-xx:
           `group_name`. For the time being a log warning is in place and a
           migration is added. In the future `groupName` will fail.
         - Add `min/max_ratio` to Tile layout and fix bug where windows can extend offscreen.
+    * bugfixes
+	    - Fix incremental clipboard transfers
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -359,7 +359,7 @@ class XWindow:
                 'X error in SetProperty (wid=%r, prop=%r), ignoring',
                 self.wid, name)
 
-    def get_property(self, prop, type=None, unpack=None):
+    def get_property(self, prop, type=None, unpack=None, delete=False):
         """Return the contents of a property as a GetPropertyReply
 
         If unpack is specified, a tuple of values is returned.  The type to
@@ -375,7 +375,7 @@ class XWindow:
 
         try:
             r = self.conn.conn.core.GetProperty(
-                False, self.wid,
+                delete, self.wid,
                 self.conn.atoms[prop]
                 if isinstance(prop, str)
                 else prop,
@@ -391,6 +391,9 @@ class XWindow:
             if unpack:
                 return []
             return None
+
+        if unpack is dict:
+            return r.__dict__
 
         if not r.value_len:
             if unpack:


### PR DESCRIPTION
Qtile did not comply with https://tronche.com/gui/x/icccm/sec-2.html#s-2.7.2
When transferring large files, this sometimes caused tools such as xclip
transferring in incremental mode (INCR) to stop responding to transfer
requests from other applications.

For completeness, proper target querying was implemented.

What is more, `XWindow.get_property` mistakenly claims a property does not exist if its value is empty, which seems to be the case for an uninitiated INCR transfer. It also does not support getting a property with deletion. As such, the method was slightly extended.

I believe further testing is needed to determine if no other clipboard managers break. I roughly tested with xclip, xsel and copyq and found no issues.

Obviously standard security considerations are still in place. No work on safe removal of sensitive data was carried out.

This still stands to be extended. for example target selection is very simple. Perhaps adding a hook to let users set a preference for the targets/MIME types. 