### PR TITLE
Allow widgets to accept LazyCalls as callbacks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           `group_name`. For the time being a log warning is in place and a
           migration is added. In the future `groupName` will fail.
         - Add `min/max_ratio` to Tile layout and fix bug where windows can extend offscreen.
+        - Add ability for widget `mouse_callbacks` to take `lazy` calls (similar to keybindings)
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/test/widgets/test_mouse_callback.py
+++ b/test/widgets/test_mouse_callback.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import libqtile.bar
+import libqtile.config
+import libqtile.confreader
+import libqtile.layout
+from libqtile import widget
+from libqtile.lazy import lazy
+
+
+def test_lazy_callback(manager_nospawn, minimal_conf_noscreen):
+    """Test widgets accept lazy calls"""
+    textbox = widget.TextBox(
+        text="Testing",
+        mouse_callbacks={
+            "Button1": lazy.widget["textbox"].update("LazyCall"),
+        }
+    )
+
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar([textbox], 10)
+        )
+    ]
+
+    manager_nospawn.start(config)
+
+    topbar = manager_nospawn.c.bar["top"]
+    assert topbar.widget["textbox"].info()["text"] == "Testing"
+
+    topbar.fake_button_press(0, "top", 0, 0, button=1)
+    assert topbar.widget["textbox"].info()["text"] == "LazyCall"


### PR DESCRIPTION
Users are already familiar with `lazy` calls from their keybindings. This PR allows the `lazy` calls to be bound to mouse callbacks for widgets.