### PR TITLE
Add coveralls to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,22 @@ jobs:
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]
                 tox
+            - name: Upload coverage data to coveralls.io
+              run: |
+                pip -q install coveralls
+                coveralls --service=github
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                COVERALLS_PARALLEL: true
 
+    coverage:
+        name: Finalize Coverage
+        needs: build
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Coveralls Finished
+              uses: coverallsapp/github-action@master
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                parallel-finished: true


### PR DESCRIPTION
This PR submits test results to coveralls.io. 

The job will only run on python 3.9 and only if the previous tasks (`pep8`, `docs` etc.) have all completed successfuly.

Fixes #2054


Pinging @ramnes and @m-col as I suspect we want to discuss this a bit.

This is just the basic uploading of test results but doesn't have any conditions set for when the test should report as failed.

FYI - the job ran successfully on my fork so you can see the results here: https://coveralls.io/builds/43991594

EDIT:
The result of this build is here: https://coveralls.io/jobs/89478238

Some points to note:
- The commit message is messed up
- It doesn't compare the coverage to the `master` branch