### PR TITLE
wttr.py: Fix docstring with a wrong units value

### DIFF
--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -67,7 +67,7 @@ class Wttr(GenPollUrl):
         (
             'units', 'm',
             "``'m'`` - metric, ``'M'`` - show wind speed in m/s, "
-            "``'s'`` - imperial"
+            "``'u'`` - USCS"
         ),
         (
             'update_interval', 600,

--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -67,7 +67,7 @@ class Wttr(GenPollUrl):
         (
             'units', 'm',
             "``'m'`` - metric, ``'M'`` - show wind speed in m/s, "
-            "``'u'`` - USCS"
+            "``'u'`` - United States units"
         ),
         (
             'update_interval', 600,


### PR DESCRIPTION
Change `units='s'` to `units='u'` according to [wttr.in](https://github.com/chubin/wttr.in) docs (issue #2983).