### PR TITLE
Rename issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
-name: "Bug report"
-description: Report a bug in Qtile
+name: "Issue template"
+description: Required
 labels: ["unconfirmed"]
 body:
   - type: markdown


### PR DESCRIPTION
This should make it more clear the there is one issue template and all
issues should use it.