### PR TITLE
Add default config to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,18 @@ Getting started
     manual/troubleshooting
     As a Wayland Compositor <manual/wayland>
     manual/commands/shell/index
+
+Reference
+=========
+
+.. toctree::
+    :maxdepth: 1
+
     manual/ref/extensions
     manual/ref/hooks
     manual/ref/layouts
     manual/ref/widgets
+    manual/config/default
 
 Advanced scripting
 ==================

--- a/docs/manual/config/default.rst
+++ b/docs/manual/config/default.rst
@@ -1,0 +1,7 @@
+.. _default_config:
+
+===================
+Default Config File
+===================
+
+.. literalinclude:: ../../../libqtile/resources/default_config.py

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -23,8 +23,7 @@ config, if it doesn't exist yet.
 Default Configuration
 =====================
 
-The `default configuration
-<https://github.com/qtile/qtile/blob/master/libqtile/resources/default_config.py>`_
+The :ref:`default configuration<default_config>`
 is invoked when qtile cannot find a configuration file. In addition, if qtile
 is restarted or the config is reloaded, qtile will load the default
 configuration if the config file it finds has some kind of error in it. The


### PR DESCRIPTION
Adds the `default_config.py` source to our docs so it _should_ display the right version depending on the version of the docs being browsed.

Haven't been able to confirm that though as building locally doesn't give me the option to select versions!