### PR TITLE
Fix quotes in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -207,6 +207,10 @@ html_static_path = ['_static']
 # typographically correct entities.
 #html_use_smartypants = True
 
+# smartypants was deprecated in favour of smartquotes
+# We want to disable this so users can copy an paste text into their configs
+smartquotes = False
+
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -562,7 +562,7 @@ class ThreadPoolText(_TextBox):
     """
     defaults = [
         ("update_interval", 600, "Update interval in seconds, if none, the "
-            "widget updates whenever it's done'."),
+            "widget updates whenever it's done."),
     ]  # type: List[Tuple[str, Any, str]]
 
     def __init__(self, text, **config):

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -142,7 +142,7 @@ class KeyboardLayout(base.InLoopPollText):
             "['us', 'us colemak', 'es', 'fr']."),
         ("display_map", {}, "Custom display of layout. Key should be in format "
             "'layout variant'. For example: "
-            "{'us': 'us ', 'lt sgs': 'sgs', 'ru phonetic': 'ru '}"),
+            "{'us': 'us', 'lt sgs': 'sgs', 'ru phonetic': 'ru'}"),
         ("option", None, "string of setxkbmap option. Ex., 'compose:menu,grp_led:scroll'"),
     ]
 


### PR DESCRIPTION
Docs use "smartquotes" which convert single and double quotations into more aesthetically pleasing versions. Unfortunately, this
makes the text invalid as python code resulting in errors for anyone who tries to copy and paste from the docs.

Closes #3005