### PR TITLE
Rename widgets with duplicate names by appending numeric suffixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix a bug where a .when() check for lazy functions errors out when matching
           on focused windows when none is focused. By default we do not match on focused windows,
           to change this set `if_no_focused` to True.
+        - Widget with duplicate names will be automatically renamed by appending numeric suffixes
 
 Qtile 0.20.0, released 2022-01-24:
     * features


### PR DESCRIPTION
Widgets with duplicate names are mostly "forgotten" by Qtile, i.e. they do not appear in the list of widgets. The widgets can continue to work normally, but there is one caveat: qtile.finalize() only calls finalize on named widgets, so some widgets can be left un-finalized.

This patch makes sure every widget, registered in qtile.widgets_map or not, is finalized on shutdown.