### PR TITLE
X11: set _NET_FRAME_EXTENTS window property

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -432,6 +432,8 @@ class XWindow:
         """
         This method is used only by the managing Window class.
         """
+        self.set_property('_NET_FRAME_EXTENTS', [borderwidth] * 4)
+
         if not colors or not borderwidth:
             return
 

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -171,6 +171,7 @@ PropertyMap = {
     "_NET_WM_STRUT_PARTIAL": ("CARDINAL", 32),
     "_NET_WM_WINDOW_OPACITY": ("CARDINAL", 32),
     "_NET_WM_WINDOW_TYPE": ("ATOM", 32),
+    "_NET_FRAME_EXTENTS": ("CARDINAL", 32),
     # Net State
     "_NET_WM_STATE": ("ATOM", 32),
     # Xembed


### PR DESCRIPTION
This sets the _NET_FRAME_EXTENTS window property as per
https://specifications.freedesktop.org/wm-spec/latest/ar01s05.html#idm45623293938880.

Fixes #3011