### PR TITLE
Add option to draw border/margin in Tile layout if there is only one window

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Add a new 'prefix' option to the net widget to display speeds with a static unit (e.g. MB).
         - `lazy.group.toscreen()` now does not toggle groups by default. To get this behaviour back, use
           `lazy.group.toscreen(toggle=True)`
+        - Tile layout has new `margin_on_single` and `border_on_single` option to specify
+          whether to draw margin and border when there is only one window.
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -50,7 +50,7 @@ class Tile(_SimpleLayoutBase):
         ("border_on_single", 1, "Draw border if there is only one window."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
-        ("margin_on_single", 1, "Draw margin if there is only one window."),
+        ("margin_on_single", True, "Whether to draw margin if there is only one window."),
         ("ratio", 0.618,
             "Width-percentage of screen size reserved for master windows."),
         ("max_ratio", 0.85, "Maximum width of master windows"),

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -47,7 +47,7 @@ class Tile(_SimpleLayoutBase):
     defaults = [
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
-        ("border_on_single", 1, "Draw border if there is only one window."),
+        ("border_on_single", True, "Whether to draw border if there is only one window."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("margin_on_single", True, "Whether to draw margin if there is only one window."),

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -50,6 +50,7 @@ class Tile(_SimpleLayoutBase):
         ("border_on_single", 1, "Draw border if there is only one window."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
+        ("margin_on_single", 1, "Draw margin if there is only one window."),
         ("ratio", 0.618,
             "Width-percentage of screen size reserved for master windows."),
         ("max_ratio", 0.85, "Maximum width of master windows"),
@@ -167,7 +168,7 @@ class Tile(_SimpleLayoutBase):
                 h - border_width * 2,
                 border_width,
                 bc,
-                margin=self.margin,
+                margin = 0 if (not self.margin_on_single and len(self.clients)==1) else self.margin,
             )
             client.unhide()
         else:

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -47,6 +47,7 @@ class Tile(_SimpleLayoutBase):
     defaults = [
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
+        ("border_on_single", 1, "Draw border if there is only one window."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
         ("ratio", 0.618,
@@ -155,6 +156,10 @@ class Tile(_SimpleLayoutBase):
                 bc = self.border_focus
             else:
                 bc = self.border_normal
+            if not self.border_on_single and len(self.clients)==1:
+                border_width = 0
+            else:
+                border_width = self.border_width
             client.place(
                 x,
                 y,

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -157,7 +157,7 @@ class Tile(_SimpleLayoutBase):
                 bc = self.border_focus
             else:
                 bc = self.border_normal
-            if not self.border_on_single and len(self.clients)==1:
+            if not self.border_on_single and len(self.clients) == 1:
                 border_width = 0
             else:
                 border_width = self.border_width
@@ -168,7 +168,7 @@ class Tile(_SimpleLayoutBase):
                 h - border_width * 2,
                 border_width,
                 bc,
-                margin = 0 if (not self.margin_on_single and len(self.clients)==1) else self.margin,
+                margin = 0 if (not self.margin_on_single and len(self.clients) == 1) else self.margin,
             )
             client.unhide()
         else:

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -168,7 +168,7 @@ class Tile(_SimpleLayoutBase):
                 h - border_width * 2,
                 border_width,
                 bc,
-                margin = 0 if (not self.margin_on_single and len(self.clients) == 1) else self.margin,
+                margin=0 if (not self.margin_on_single and len(self.clients) == 1) else self.margin,
             )
             client.unhide()
         else:


### PR DESCRIPTION
Dear developer, this patch adds two options which could determine whether to draw border and margin when there is only one window in Tile layout