### PR TITLE
WL: support foreign toplevel management protocol

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ MOCK_MODULES = [
     'wlroots.util.region',
     'wlroots.wlr_types',
     'wlroots.wlr_types.cursor',
+    'wlroots.wlr_types.foreign_toplevel_management_v1',
     'wlroots.wlr_types.keyboard',
     'wlroots.wlr_types.layer_shell_v1',
     'wlroots.wlr_types.output_management_v1',

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.14.8
+  pywlroots>=0.14.10
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.14.8
+    pip install pywlroots>=0.14.10
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
@@ -89,7 +89,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.14.8
+    pip install pywlroots>=0.14.10
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install


### PR DESCRIPTION
This adds supports for the wlr_foreign_toplevel_management_v1 protocol.
This provides an interface through which clients such as status bars and
other WM utilities can control windows belonging to regular clients.
This provides similar functionality as seen in X via e.g. xdotool,
wmctrl to manipulate windows in some ways.

Requires pywlroots 0.14.10