### PR TITLE
(Idea) Use Typer for CLI to generate command completions

### DIFF
--- a/bin/qtile
+++ b/bin/qtile
@@ -30,7 +30,7 @@ sys.path.insert(0, base_dir)
 
 # import lifecycle early so no atexit handlers are lost on restart
 import libqtile.core.lifecycle  # noqa: F401, E402
-from libqtile.scripts.main import main  # noqa: E402
+from libqtile.scripts.main import app  # noqa: E402
 
 if __name__ == '__main__':
-    main()
+    app()

--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -1,15 +1,16 @@
 import importlib
+from enum import Enum
 
 from libqtile.utils import QtileError
 
-CORES = [
-    'wayland',
-    'x11',
-]
+
+class Backends(str, Enum):
+    x11 = "x11"
+    wayland = "wayland"
 
 
 def get_core(backend, *args):
-    if backend not in CORES:
+    if not hasattr(Backends, backend):
         raise QtileError(f"Backend {backend} does not exist")
 
     return importlib.import_module(f"libqtile.backend.{backend}.core").Core(*args)

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+from os import getenv
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -37,6 +38,9 @@ if TYPE_CHECKING:
 
     from libqtile.config import Group, Key, Mouse, Rule, Screen
     from libqtile.layout.base import Layout
+
+
+path = Path(getenv('XDG_CONFIG_HOME', '~/.config')).expanduser() / 'qtile' / 'config.py'
 
 
 class ConfigError(Exception):

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -24,8 +24,13 @@
 import os
 import sys
 import warnings
+from enum import Enum
 from logging import (
+    DEBUG,
+    INFO,
     WARNING,
+    ERROR,
+    CRITICAL,
     Formatter,
     StreamHandler,
     captureWarnings,
@@ -34,6 +39,14 @@ from logging import (
 from logging.handlers import RotatingFileHandler
 
 logger = getLogger(__package__)
+
+
+class LogLevels(str, Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
 
 
 class ColorFormatter(Formatter):


### PR DESCRIPTION
This replaces `argparse` with `typer` for handling the CLI. The main
benefit of using typer is that it can automatically generate command
completions for a number of common shells.

--

This is just an idea I'm throwing out there to see if there is interest. I wanted to play around with [typer](https://typer.tiangolo.com/) so figured I'd give it a go with qtile. This primarily just replaces argparse with typer, keeping most of the behaviour unchanged. A few things outside of `libqtile/scripts/` were changed to fit with how typer works. Below are the other changes:

I removed `--log-level` from all but `qtile start`. This was left applied to
all subcommands intentionally with the explanation that all commands used
logging but, unless I am mistaken, they do not.

I also removed `qtile help` which was broken and displays this:
```
usage: qtile [-h] [-v] {start,shell,top,run-cmd,cmd-obj,check,migrate,help} ...

Did you mean:
./bin/qtile help start
```

Instead it will now display:
```
Usage: qtile [OPTIONS] COMMAND [ARGS]...
Try 'qtile --help' for help.

Error: No such command 'help'.
```

Which is the default message for any `qtile X` where `X` is not a defined subcommand.

Nicely, `no_args_is_help=True` passed to `Typer` will make it display the help
message if there is no command i.e. with just `qtile`.

Typer makes light formatting changes to help messages that make things less
messy (IMO). I'll only show `qtile shell` to illustrate but generally the
formatting change is similar to this:

Old `qtile shell --help`:
```
usage: qtile shell [-h] [-l {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [-s SOCKET] [-c COMMAND] [-j]

optional arguments:
  -h, --help            show this help message and exit
  -l {DEBUG,INFO,WARNING,ERROR,CRITICAL}, --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Set qtile log level
  -s SOCKET, --socket SOCKET
                        Use specified socket to connect to qtile.
  -c COMMAND, --command COMMAND
                        Run the specified qshell command and exit.
  -j, --json            Use json in order to communicate with qtile server.
```

New `qtile shell --help`:
```
Usage: qtile shell [OPTIONS]

  A shell-like interface to Qtile.

Options:
  -s, --socket PATH   Path of the Qtile IPC socket.
  -c, --command TEXT  Run the specified shell command.
  -j, --json          Don't spawn apps (Used for restart).
  --help              Show this message and exit.
```

Note that options have their types displayed, and subcommands have their
docstrings displayed at the top the help message. 

And ultimately the main reason I started playing with Typer was because I
wanted shell completion. This is the output for `qtile --help`:

```
Usage: qtile [OPTIONS] COMMAND [ARGS]...

  A full-featured, pure-Python tiling window manager.

Options:
  --version
  --install-completion [bash|zsh|fish|powershell|pwsh]
                                  Install completion for the specified shell.
  --show-completion [bash|zsh|fish|powershell|pwsh]
                                  Show completion for the specified shell, to
                                  copy it or customize the installation.
  --help                          Show this message and exit.

Commands:
  check    Check a configuration file for errors.
  cmd-obj  qtile.command functionality exposed to the shell.
  migrate  Migrate a configuration file to the current API.
  run-cmd  A wrapper around the command graph.
  shell    A shell-like interface to Qtile.
  start    Start Qtile.
  top      Display Qtile's resource usage.
```

I'd like to figure out how to move the commands above the options, and also to
stop typer from sorting the commands alphabetically and instead keep them in
the order they are configured. The two completion commands are added by typer. What would be nice for packaging would be to generate completions for the supported shells, package those with the build, and then disable those CLI options. Installing completion via typer gives us
completion like this (zsh):

```
$ qtile [Tab]
check    -- Check a configuration file for errors.
cmd-obj  -- qtile.command functionality exposed to the...
migrate  -- Migrate a configuration file to the...
run-cmd  -- A wrapper around the command graph.
shell    -- A shell-like interface to Qtile.
start    -- Start Qtile.
top      -- Display Qtiles resource usage.
```
```
 $ qtile cmd-obj -[Tab]
--args      -a  -- Set arguments supplied to function.                                                              
--function  -f  -- Select function to execute.                                                                      
--help      -h  -- Show this message and exit.                                                                      
--info      -i  -- With both --object and --function args prints documentation.                                     
--object    -o  -- Specify path to object (space separated). If no --function flag display available commands. Use `
--socket    -s  -- Path of the Qtile IPC socket.                                                                    
```
I imagine this could become incredibly useful specifically for `qtile cmd-obj`, and it would even be possible for the completion engine (at least in zsh; not sure about others) to execute code in the client and therefore fetch completions from the server. An example usage would be `qtile cmd-obj -o group [Tab]` to display the names of the current groups.

Another change I made which I was unsure about was removing the `epilog` showing examples of `qtile cmd-obj`. I removed this because I haven't figured out to keep it in, so I can put it back, though I wonder if the completions kinda make it redundant as it becomes easier to tab through the options.

I also checked out [python-fire](https://github.com/google/python-fire) which looks like it has a nicer way to describe the commands in the Python code, but its completion support is pretty weak and I think that's the main thing we'd be getting.

Anyway, just thought it might be cool as a 'show and tell' so no worries at all if people aren't a fan! The code itself is not proof-read - consider it a WIP if people do like it.