### PR TITLE
Add ability for multiple timers in widgets

### DIFF
--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -58,6 +58,7 @@ class PulseVolume(Volume):
         lib.pa_mainloop_quit(self.loop, 1)
         lib.pa_context_unref(self.context)
         lib.pa_mainloop_free(self.loop)
+        Volume.finalize(self)
 
     def connect(self):
         """

--- a/libqtile/widget/quick_exit.py
+++ b/libqtile/widget/quick_exit.py
@@ -42,7 +42,6 @@ class QuickExit(base._TextBox):
         self.is_counting = False
         self.text = self.default_text
         self.countdown = self.countdown_start
-        self.__call_later_funcs = []
 
         self.add_callbacks({'Button1': self.cmd_trigger})
 
@@ -50,8 +49,7 @@ class QuickExit(base._TextBox):
         self.is_counting = False
         self.countdown = self.countdown_start
         self.text = self.default_text
-        for f in self.__call_later_funcs:
-            f.cancel()
+        self.timer.cancel()
 
     def update(self):
         if not self.is_counting:
@@ -59,8 +57,7 @@ class QuickExit(base._TextBox):
 
         self.countdown -= 1
         self.text = self.countdown_format.format(self.countdown)
-        self.timeout_add(self.timer_interval, self.update)
-        self.__call_later_funcs.append(self.future)
+        self.timer = self.timeout_add(self.timer_interval, self.update)
         self.draw()
 
         if self.countdown == 0:

--- a/test/widgets/test_base.py
+++ b/test/widgets/test_base.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2021 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import libqtile.config
+from libqtile.widget.base import _Widget
+
+
+class TimerWidget(_Widget):
+
+    def cmd_set_timer1(self):
+        self.timer1 = self.timeout_add(10, self.cmd_set_timer1)
+
+    def cmd_cancel_timer1(self):
+        self.timer1.cancel()
+
+    def cmd_set_timer2(self):
+        self.timer2 = self.timeout_add(10, self.cmd_set_timer2)
+
+    def cmd_cancel_timer2(self):
+        self.timer2.cancel()
+
+    def cmd_get_active_timers(self):
+        active = [x for x in self._futures if x._scheduled]
+        return len(active)
+
+
+def test_multiple_timers(minimal_conf_noscreen, manager_nospawn):
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar([TimerWidget(10)], 10)
+        )
+    ]
+
+    # Start manager and check no active timers
+    manager_nospawn.start(config)
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 0
+
+    # Start both timers and confirm both are active
+    manager_nospawn.c.widget["timerwidget"].set_timer1()
+    manager_nospawn.c.widget["timerwidget"].set_timer2()
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 2
+
+    # Cancel timer1
+    manager_nospawn.c.widget["timerwidget"].cancel_timer1()
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 1
+
+    # Cancel timer2
+    manager_nospawn.c.widget["timerwidget"].cancel_timer2()
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 0
+
+    # Restart both timers
+    manager_nospawn.c.widget["timerwidget"].set_timer1()
+    manager_nospawn.c.widget["timerwidget"].set_timer2()
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 2
+
+    # Verify that `finalize()` cancels all timers.
+    manager_nospawn.c.widget["timerwidget"].eval("self.finalize()")
+    assert manager_nospawn.c.widget["timerwidget"].get_active_timers() == 0

--- a/test/widgets/test_mpris2widget.py
+++ b/test/widgets/test_mpris2widget.py
@@ -42,6 +42,10 @@ def fake_timer(interval, func, *args, **kwargs):
         def cancel(self):
             pass
 
+        @property
+        def _scheduled(self):
+            return False
+
     return TimerObj()
 
 
@@ -125,7 +129,7 @@ def test_mpris2_signal_handling(fake_qtile, patched_module, fake_window):
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    fake_qtile.call_later = fake_timer
+    mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
 
     assert mp.displaytext == ""
@@ -188,7 +192,7 @@ def test_mpris2_custom_stop_text(fake_qtile, patched_module, fake_window):
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    fake_qtile.call_later = fake_timer
+    mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
 
@@ -209,7 +213,7 @@ def test_mpris2_no_metadata(fake_qtile, patched_module, fake_window):
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    fake_qtile.call_later = no_op
+    mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
 
@@ -226,7 +230,7 @@ def test_mpris2_no_scroll(fake_qtile, patched_module, fake_window):
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    fake_qtile.call_later = no_op
+    mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
 
@@ -244,7 +248,7 @@ def test_mpris2_clear_after_scroll(fake_qtile, patched_module, fake_window):
     fakebar.width = 10
     fakebar.height = 10
     fakebar.draw = no_op
-    fake_qtile.call_later = no_op
+    mp.timeout_add = fake_timer
     mp._configure(fake_qtile, fakebar)
     mp.configured = True
 


### PR DESCRIPTION
`timeout_add` will now return a handle to the timer so that they can be cancelled individually. Timers are added to a list and
all scheduled timers in the list will be cancelled when `finalize` is called.

Closes #3042