### PR TITLE
Keep a fullscreen window in the layout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,8 @@ Qtile 0.19.0, released 2021-12-22:
         - Allow TextBox-based widgets to display in vertical bars.
         - Added a focused attribute to `lazy.function.when` which can be used to Match on focused windows.
         - Allow to update Image widget with update() function by giving a new path.
+    * bugfixes
+        - Windows are now properly re-ordered in the layouts when toggled on and off fullscreen
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -149,6 +149,29 @@ each_delegate_layout_config = pytest.mark.parametrize(
 
 
 @each_layout_config
+def test_window_order_fullscreen(manager):
+    # Add a window to fullscreen
+    manager.test_window("tofullscreen")
+
+    # windows to add after the fullscreen window
+    windows_after = ["two", "three"]
+
+    # Add some windows before
+    for win in windows_after:
+        manager.test_window(win)
+
+    windows_order = manager.c.layout.info()["clients"]
+
+    # Focus window and toggle fullscreen
+    manager.c.group.focus_by_name("tofullscreen")
+    manager.c.window.toggle_fullscreen()
+    manager.c.window.toggle_fullscreen()
+
+    # Windows must be sorted in the same order as they were created
+    assert windows_order == manager.c.layout.info()["clients"]
+
+
+@each_layout_config
 def test_window_types(manager):
     if manager.backend.name == "wayland" and not has_wayland_notifications:
         pytest.skip("Notification tests for Wayland need gtk-layer-shell")

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -36,7 +36,7 @@ class GroupConfig(Config):
         libqtile.config.Group("a"),
         libqtile.config.Group("b"),
     ]
-    layouts = [layout.Max()]
+    layouts = [layout.MonadTall()]
     floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
@@ -66,6 +66,47 @@ def test_window_order(manager):
         manager.kill_window(windows[win_to_remove])
         del windows[win_to_remove]
         assert windows_name == manager.c.group.info()["windows"]
+
+
+@group_config
+def test_tiled_window_set(manager):
+    # Add windows
+    one = manager.test_window("one")
+    two = manager.test_window("two")
+    tofloat = manager.test_window("tofloat")
+    tofullscreen = manager.test_window("tofullscreen")
+
+    # All windows are tiled in the beginning
+    assert manager.c.group.info()["tiled_windows"] == {"one", "two", "tofloat", "tofullscreen"}
+
+    # Set floating
+    manager.c.group.focus_by_name("tofloat")
+    manager.c.window.toggle_floating()
+
+    # Now it does not contain the window that is floating
+    assert manager.c.group.info()["tiled_windows"] == {"one", "two", "tofullscreen"}
+
+    # Fullscreen windows are still tiled in the group
+    manager.c.group.focus_by_name("tofullscreen")
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.group.info()["tiled_windows"] == {"one", "two", "tofullscreen"}
+
+    # Disabling fullscreen is also the same
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.group.info()["tiled_windows"] == {"one", "two", "tofullscreen"}
+
+    # The floating window is tiled again
+    # The set ontains the floating window again
+    manager.c.group.focus_by_name("tofloat")
+    manager.c.window.toggle_floating()
+    assert manager.c.group.info()["tiled_windows"] == {"one", "two", "tofloat", "tofullscreen"}
+
+    # Removing windows
+    manager.kill_window(one)
+    manager.kill_window(two)
+    manager.kill_window(tofullscreen)
+    manager.kill_window(tofloat)
+    assert manager.c.group.info()["tiled_windows"] == set()
 
 
 @group_config


### PR DESCRIPTION
This is the most simple fix to #1482 I could come up with

Instead of removing a fullscreen window from the layout it keeps it both in the floating layout and tiled layout. This needs group to keep track of the windows that are in the tiled layouts as these layouts do not have a way to get the clients in the layout (`.clients` does not work for all layouts)

Note that this does not fix the behaviour that when a floating window is set to fullscreen and then non fullscreen again it will be tiled again.