### PR TITLE
Testing StatusNotifier widget

### DIFF
--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -563,7 +563,7 @@ class StatusNotifier(base._Widget):
     defaults = [
         ('icon_size', 16, 'Icon width'),
         ('icon_theme', None, 'Name of theme to use for app icons'),
-        ('padding', 5, 'Padding between icons'),
+        ('padding', 3, 'Padding between icons'),
     ]
 
     def __init__(self, **config):
@@ -611,15 +611,17 @@ class StatusNotifier(base._Widget):
 
     def find_icon_at_pos(self, x, y):
         """returns StatusNotifierItem object for icon in given position"""
-        xoffset = self.padding
-        if x < xoffset:
+        offset = self.padding
+        val = x if self.bar.horizontal else y
+
+        if val < offset:
             return None
 
         for icon in self.available_icons:
-            xoffset += self.icon_size
-            if x < xoffset:
+            offset += self.icon_size
+            if val < offset:
                 return icon
-            xoffset += self.padding
+            offset += self.padding
 
         return None
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -313,12 +313,15 @@ class TestManager:
         if not success():
             raise AssertionError("Window could not be killed...")
 
-    def test_window(self, name, floating=False, wm_type="normal"):
+    def test_window(self, name, floating=False, wm_type="normal", export_sni=False):
         """
         Create a simple window in X or Wayland. If `floating` is True then the wmclass
         is set to "dialog", which triggers auto-floating based on `default_float_rules`.
         `wm_type` can be changed from "normal" to "notification", which creates a window
         that not only floats but does not grab focus.
+
+        Setting `export_sni` to True will publish a simplified StatusNotifierItem interface
+        on DBus.
 
         Windows created with this method must have their process killed explicitly, no
         matter what type they are.
@@ -326,7 +329,10 @@ class TestManager:
         python = sys.executable
         path = Path(__file__).parent / "scripts" / "window.py"
         wmclass = "dialog" if floating else "TestWindow"
-        return self._spawn_window(python, path, "--name", wmclass, name, wm_type)
+        args = [python, path, "--name", wmclass, name, wm_type]
+        if export_sni:
+            args.append("export_sni_interface")
+        return self._spawn_window(*args)
 
     def test_notification(self, name="notification"):
         return self.test_window(name, wm_type="notification")

--- a/test/widgets/test_statusnotifier.py
+++ b/test/widgets/test_statusnotifier.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2021 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+import pytest
+
+import libqtile.bar
+import libqtile.config
+import libqtile.confreader
+import libqtile.layout
+import libqtile.widget
+from test.helpers import Retry  # noqa: I001
+
+
+@Retry(ignore_exceptions=(AssertionError, ))
+def wait_for_icon(widget, hidden=True, prop="width"):
+    width = widget.info()[prop]
+    if hidden:
+        assert width == 0
+    else:
+        assert width > 0
+
+
+@Retry(ignore_exceptions=(AssertionError, ))
+def check_fullscreen(windows, fullscreen=True):
+    full = windows()[0]["fullscreen"]
+    assert full is fullscreen
+
+
+@pytest.fixture(scope="function")
+def sni_config(request, manager_nospawn):
+    """
+    Fixture provides a manager instance with StatusNotifier in the bar.
+
+    Widget can be customised via parameterize.
+    """
+    class SNIConfig(libqtile.confreader.Config):
+        """Config for the test."""
+        auto_fullscreen = True
+        keys = [
+        ]
+        mouse = []
+        groups = [
+            libqtile.config.Group("a"),
+        ]
+        layouts = [libqtile.layout.Max()]
+        floating_layout = libqtile.resources.default_config.floating_layout
+        screens = [
+            libqtile.config.Screen(
+                top=libqtile.bar.Bar(
+                    [
+                        libqtile.widget.StatusNotifier(
+                            **getattr(request, "param", dict())
+                        )
+                    ],
+                    50,
+                ),
+            )
+        ]
+
+    yield SNIConfig
+
+
+@pytest.mark.usefixtures("dbus")
+def test_statusnotifier_defaults(manager_nospawn, sni_config):
+    """Check that widget displays and removes icon."""
+    manager_nospawn.start(sni_config)
+    widget = manager_nospawn.c.widget["statusnotifier"]
+    assert widget.info()["width"] == 0
+
+    win = manager_nospawn.test_window("TestSNI", export_sni=True)
+    wait_for_icon(widget, hidden=False)
+
+    # Kill it and icon disappears
+    manager_nospawn.kill_window(win)
+    wait_for_icon(widget, hidden=True)
+
+
+@pytest.mark.usefixtures("dbus")
+def test_statusnotifier_defaults_vertical_bar(manager_nospawn, sni_config):
+    """Check that widget displays and removes icon."""
+    screen = sni_config.screens[0]
+    screen.left = screen.top
+    screen.top = None
+    manager_nospawn.start(sni_config)
+    widget = manager_nospawn.c.widget["statusnotifier"]
+    assert widget.info()["height"] == 0
+
+    win = manager_nospawn.test_window("TestSNI", export_sni=True)
+    wait_for_icon(widget, hidden=False, prop="height")
+
+    # Kill it and icon disappears
+    manager_nospawn.kill_window(win)
+    wait_for_icon(widget, hidden=True, prop="height")
+
+
+@pytest.mark.parametrize("sni_config", [{"icon_size": 35}], indirect=True)
+@pytest.mark.usefixtures("dbus")
+def test_statusnotifier_icon_size(manager_nospawn, sni_config):
+    """Check that widget displays and removes icon."""
+    manager_nospawn.start(sni_config)
+    widget = manager_nospawn.c.widget["statusnotifier"]
+    assert widget.info()["width"] == 0
+
+    win = manager_nospawn.test_window("TestSNI", export_sni=True)
+    wait_for_icon(widget, hidden=False)
+
+    # Width should be icon_size (35) + 2 * padding (3) = 41
+    assert widget.info()["width"] == 41
+
+    manager_nospawn.kill_window(win)
+
+
+@pytest.mark.usefixtures("dbus")
+def test_statusnotifier_left_click(manager_nospawn, sni_config):
+    """Check `activate` method when left-clicking widget."""
+    manager_nospawn.start(sni_config)
+    widget = manager_nospawn.c.widget["statusnotifier"]
+    windows = manager_nospawn.c.windows
+
+    assert widget.info()["width"] == 0
+
+    win = manager_nospawn.test_window("TestSNILeftClick", export_sni=True)
+    wait_for_icon(widget, hidden=False)
+
+    # Check we have window and that it's not fullscreen
+    assert len(windows()) == 1
+    check_fullscreen(windows, False)
+
+    # Left click will toggle fullscreen
+    manager_nospawn.c.bar["top"].fake_button_press(0, "top", 10, 0, 1)
+    check_fullscreen(windows, True)
+
+    # Left click again will restore window
+    manager_nospawn.c.bar["top"].fake_button_press(0, "top", 10, 0, 1)
+    check_fullscreen(windows, False)
+
+    manager_nospawn.kill_window(win)
+    assert not windows()
+
+
+@pytest.mark.usefixtures("dbus")
+def test_statusnotifier_left_click_vertical_bar(manager_nospawn, sni_config):
+    """Check `activate` method when left-clicking widget in vertical bar."""
+    screen = sni_config.screens[0]
+    screen.left = screen.top
+    screen.top = None
+
+    manager_nospawn.start(sni_config)
+    widget = manager_nospawn.c.widget["statusnotifier"]
+    windows = manager_nospawn.c.windows
+
+    assert widget.info()["height"] == 0
+
+    win = manager_nospawn.test_window("TestSNILeftClick", export_sni=True)
+    wait_for_icon(widget, hidden=False, prop="height")
+
+    # Check we have window and that it's not fullscreen
+    assert len(windows()) == 1
+    check_fullscreen(windows, False)
+
+    # Left click will toggle fullscreen
+    manager_nospawn.c.bar["left"].fake_button_press(0, "left", 0, 10, 1)
+    check_fullscreen(windows, True)
+
+    # Left click again will restore window
+    manager_nospawn.c.bar["left"].fake_button_press(0, "left", 0, 10, 1)
+    check_fullscreen(windows, False)
+
+    manager_nospawn.kill_window(win)
+    assert not windows()


### PR DESCRIPTION
Adds two basic tests for the StatusNotifier widget:
1) Check that icon is added and removed from widget
2) Check that left-clicking the widget triggers the
   item's "Activate" method.

There's probably more parts of the widget that should be tested but this is a good start.