### PR TITLE
Add `os.path.expanduser` to `utils.scan_files`

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -335,6 +335,7 @@ def scan_files(dirpath, *names):
     ['/wallpapers/w2.jpg', '/wallpapers/w3.jpg']})
 
     """
+    dirpath = os.path.expanduser(dirpath)
     files = defaultdict(list)
 
     for name in names:


### PR DESCRIPTION
`images.Loader` uses `utils.scan_files` to locate files in folders.

If users have a theme_path including `~` then `scan_files` will not convert this to the correct path and the `Loader` will fail.

See https://github.com/elParaguayo/qtile-extras/issues/12#issuecomment-987137291 for an example.