### PR TITLE
Fix double parsing of 'fmt' in Pomodoro widget

### DIFF
--- a/libqtile/widget/pomodoro.py
+++ b/libqtile/widget/pomodoro.py
@@ -29,7 +29,6 @@ class Pomodoro(base.ThreadPoolText):
     """Pomodoro technique widget"""
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
-        ("fmt", "{}", "fmt"),
         ("num_pomodori", 4, "Number of pomodori to do in a cycle"),
         ("length_pomodori", 25, "Length of one pomodori in minutes"),
         ("length_short_break", 5, "Length of a short break in minutes"),
@@ -171,4 +170,4 @@ class Pomodoro(base.ThreadPoolText):
         send_notification("Pomodoro", message, urgent=urgent)
 
     def poll(self):
-        return self.fmt.format(self._get_text())
+        return self._get_text()


### PR DESCRIPTION
By using a variable called 'fmt' which is also used by `base._TextBox`, the string formatting happense twice.

Closes #3070

Test didn't pick it up as it wasn't being run through a `manager` instance.
