### PR TITLE
WL: ensure Drawers use Internal's current texture

### DIFF
--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -19,14 +19,13 @@ class Drawer(base.Drawer):
     A helper class for drawing and text layout.
 
     1. We stage drawing operations locally in memory using a cairo RecordingSurface.
-    2. Then apply these operations to our ImageSurface self._source
-    3. Then copy the pixels onto the wlr_texture self._target
+    2. Then apply these operations to our ImageSurface self._source.
+    3. Then copy the pixels onto the window's wlr_texture.
     """
 
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         base.Drawer.__init__(self, qtile, win, width, height)
 
-        self._target = win.texture
         self._stride = cairocffi.ImageSurface.format_stride_for_width(
             cairocffi.FORMAT_ARGB32, self.width
         )
@@ -72,10 +71,10 @@ class Drawer(base.Drawer):
             context.paint()
 
         # Copy drawn ImageSurface data into rendered wlr_texture
-        self._target.write_pixels(
+        self._win.texture.write_pixels(  # type: ignore
             self._stride,
-            width,  # type: ignore
-            height,  # type: ignore
+            width,
+            height,
             cairocffi.cairo.cairo_image_surface_get_data(self._source._pointer),
             dst_x=offsetx,
             dst_y=offsety,


### PR DESCRIPTION
Wayland backend internal windows use a fixed-size buffer that gets
replaced when the window is resized. Drawers are saving the window's
texture upon creation but are not using new buffers when the window
creates a new one. Instead, this makes Drawers always get the buffer
from the window so that it's always drawing to the correct buffer.

This fixes the TreeTab panel which appears to be broken under Wayland.
It will also be causing problems where internal window resizing is
required.