### PR TITLE
Fix StatusNotifier reconfigure bug

### DIFF
--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -590,9 +590,6 @@ class StatusNotifier(base._Widget):
         )
 
     def _configure(self, qtile, bar):
-        if self.configured:
-            return
-
         if has_xdg and self.icon_theme:
             host.icon_theme = self.icon_theme
 


### PR DESCRIPTION
StatusNotifier._configure returns immediately if the widget is configured, but this stops a new drawer object being created.

This, in turn, creates issues in `qtile-extras` when injecting decoration code.

See: https://github.com/elParaguayo/qtile-extras/issues/12