### PR TITLE
Add 'icon_only' shortcut in TaskList widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
           function is not executed, e.g. due to failing the `.when()` check.
         - Thermal zone widget.
+        - Add 'icon_only' option to TaskListwidget.
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -154,6 +154,11 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             'Icon size. '
             '(Calculated if set to None. Icons are hidden if set to 0.)'
         ),
+        (
+            'icon_only',
+            False,
+            'Hide all text and just show icons (X11 only)'
+        )
     ]
 
     def __init__(self, **config):
@@ -304,6 +309,17 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             # Disable icons
             self.icon_size = 0
             logger.warning("TaskList icons not supported in Wayland.")
+            if self.icon_only:
+                self.icon_only = False
+                logger.info("'icon_only' mode disabled.")
+
+        if self.icon_only:
+            if self.icon_size == 0:
+                self.icon_size = None
+            self.parse_text = lambda _: ""
+            self.text_minimized = ""
+            self.text_maximized = ""
+            self.text_floating = ""
 
         if self.icon_size is None:
             self.icon_size = self.bar.height - 2 * (self.borderwidth +


### PR DESCRIPTION
Based on discussion in #3065.

Setting 'icon_only=True' disables all text output for TaskList widget. X11 only.