### PR TITLE
docs: Fix imports of autostart hook example

### DIFF
--- a/docs/manual/config/hooks.rst
+++ b/docs/manual/config/hooks.rst
@@ -59,6 +59,8 @@ We can then subscribe to ``startup_once`` to run this script:
     import os
     import subprocess
 
+    from libqtile import hook
+
     @hook.subscribe.startup_once
     def autostart():
         home = os.path.expanduser('~/.config/qtile/autostart.sh')


### PR DESCRIPTION
I had problems to get the autostart example running because of a missing import statement. I hope my documentation improvement safes time for others.

http://docs.qtile.org/en/latest/manual/config/hooks.html?highlight=autostart#examples