### PR TITLE
Two fixes for extensions

### DIFF
--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -47,13 +47,15 @@ class _Extension(configurable.Configurable):
         configurable.Configurable.__init__(self, **config)
         self.add_defaults(_Extension.defaults)
         _Extension.installed_extensions.append(self)
-        self._check_colors()
 
     def _check_colors(self):
         """
         dmenu needs colours to be in #rgb or #rrggbb format.
 
         Checks colour value, removes invalid values and adds # if missing.
+
+        NB This should not be called in _Extension.__init__ as _Extension.global_defaults
+        may not have been set at this point.
         """
         for c in ["background", "foreground", "selected_background", "selected_foreground"]:
             col = getattr(self, c, None)
@@ -74,6 +76,7 @@ class _Extension(configurable.Configurable):
 
     def _configure(self, qtile):
         self.qtile = qtile
+        self._check_colors()
 
     def run(self):
         """

--- a/libqtile/extension/command_set.py
+++ b/libqtile/extension/command_set.py
@@ -18,8 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from os import system
-
 from libqtile.extension.dmenu import Dmenu
 
 
@@ -61,7 +59,7 @@ class CommandSet(Dmenu):
 
         if self.pre_commands:
             for cmd in self.pre_commands:
-                system(cmd)
+                self.qtile.cmd_spawn(cmd)
 
         out = super(CommandSet, self).run(items=self.commands.keys())
 
@@ -76,4 +74,4 @@ class CommandSet(Dmenu):
         if sout not in self.commands:
             return
 
-        system(self.commands[sout])
+        self.qtile.cmd_spawn(self.commands[sout])

--- a/test/extension/test_base.py
+++ b/test/extension/test_base.py
@@ -35,7 +35,27 @@ parameters = [
 @pytest.mark.parametrize("value,expected", parameters)
 def test_valid_colours(value, expected):
     extension = _Extension(foreground=value)
+    extension._configure(None)
     assert extension.foreground == expected
+
+
+def test_valid_colours_extension_defaults(monkeypatch):
+    defaults = {
+        "foreground": "00ff00",
+        "background": "000000",
+        "selected_foreground": "000000",
+        "selected_background": "00ff00",
+    }
+    extension = _Extension(foreground="0000ff")
+
+    # Set defaults after widget is created to mimic behaviour of extension being
+    # initialised in config.
+    monkeypatch.setattr(_Extension, "global_defaults", defaults)
+    extension._configure(None)
+    assert extension.foreground == "#0000ff"
+    assert extension.background == "#000000"
+    assert extension.selected_foreground == "#000000"
+    assert extension.selected_background == "#00ff00"
 
 
 def test_base_methods():


### PR DESCRIPTION
More like one fix and one improvement...

First commit changes timing of colour checks to ensure we don't set a value before `extension_defaults` from the config have been applied. This will close #3093.

Second commit replaces `CommandSet`'s use of `os.system` with `qtile.cmd_spawn`.