### PR TITLE
Add Python 3.10 to tox and github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 # if you change one of these, be sure to update
                 # /tox.ini:[gh-actions] as well
-                python-version: [pypy-3.7, 3.7, 3.8, 3.9]
+                python-version: [pypy-3.7, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2
             - name: Set up python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     flake8-tidy-imports
     pep8-naming
 commands =
-    flake8 {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test
+    flake8 {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test --exclude=test/configs/syntaxerr.py,**/_ffi*.py
 
 [testenv:codestyle]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py37,
     py38,
     py39,
+    py310,
     docs,
     pep8,
     codestyle,
@@ -110,4 +111,5 @@ python =
     pypy-3.7: pypy3
     3.7: py37
     3.8: py38
-    3.9: py39, packaging, pep8, codestyle, docstyle, mypy, docs, vulture
+    3.9: py39
+    3.10: py310, packaging, pep8, codestyle, docstyle, mypy, docs, vulture

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ envlist =
 # that our tests use.
 setenv = LC_CTYPE = en_US.UTF-8
 # Pass Display down to have it for the tests available
-passenv = DISPLAY TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = DISPLAY WAYLAND_DISPLAY
 whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,9 @@ commands =
     pip install pywlroots>=0.14.10
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
-    python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
+# py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
+    !py310: python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
+    py310: python3 -m pytest --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
 
 [testenv:packaging]
 deps =
@@ -76,7 +78,6 @@ skip_install = true
 commands =
     - pydocstyle --match "(?!(test)?_).*\.py" libqtile/
 
-
 [testenv:mypy]
 deps =
     mypy
@@ -94,7 +95,8 @@ commands =
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install
-    python3 -m pytest -W error -- test/test_check.py test/test_migrate.py
+# py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
+    python3 -m pytest -- test/test_check.py test/test_migrate.py
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
This adds a py310 tox env which is used for all test envs (i.e. mypy, pep8 etc). py39 is then only used for the pytest run. No envs are removed, because pypy only supports Python 3.7 so in the meantime it might be best to continue support for pypy and py37 while we can.