### PR TITLE
Grab keys in async mode when we swallow

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -454,6 +454,11 @@ class Core(base.Core):
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)
 
+        grab_mode = xcffib.xproto.GrabMode.Async
+        # If the key needs to be passed, we need to grab sync
+        if not key.swallow:
+            grab_mode = xcffib.xproto.GrabMode.Sync
+
         for code in codes:
             if code == 0:
                 logger.warning(f"Can't grab {key} (unknown keysym: {hex(keysym)})")
@@ -465,7 +470,7 @@ class Core(base.Core):
                     modmask | amask,
                     code,
                     xcffib.xproto.GrabMode.Async,
-                    xcffib.xproto.GrabMode.Sync,
+                    grab_mode,
                 )
         return keysym, modmask & self._valid_mask
 
@@ -509,12 +514,17 @@ class Core(base.Core):
         if isinstance(mouse, config.Drag):
             eventmask |= EventMask.ButtonRelease
 
+        grab_mode = xcffib.xproto.GrabMode.Async
+        # If the key needs to be passed, we need to grab sync
+        if not mouse.swallow:
+            grab_mode = xcffib.xproto.GrabMode.Sync
+
         for amask in self._auto_modmasks():
             self.conn.conn.core.GrabButton(
                 True,
                 self._root.wid,
                 eventmask,
-                xcffib.xproto.GrabMode.Sync,
+                grab_mode,
                 xcffib.xproto.GrabMode.Async,
                 xcffib.xproto.Atom._None,
                 xcffib.xproto.Atom._None,


### PR DESCRIPTION
Clients such as dmenu immediately grab the keyboard on opening. Dmenu
is used for extensions such as CommandSet.
This is a problem as when we grab the key in sync mode, it is only
ungrabbed on key release. Grabbing the key in sync mode is only needed
when we want the key to not be swallowed (passed to the client), so
let's grab in Async mode when it should be swallowed.

Co-authored-by: m-col as he came up with the idea, I only implemented it.

Fixes #3092 

Note that I can't add a test for this, manual testing is needed. My initial testing is that it works perfectly :+1: 

Not sure if we want to add somewhere in the docs about the fact that CommandSet or similar functions wont work with `swallow=False`? Not sure why someone would even want to set `swallow=False` for commands like these though. If an user really wants to set swallow to `False` with commands that immediately grab the keyboard, we need to implement on release keybindings.