### PR TITLE
Fix mypy errors

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -128,7 +128,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         Return None if no such object exists
         """
 
-    def command(self, name: str) -> Callable:
+    def command(self, name: str) -> Optional[Callable]:
         """Return the command with the given name
 
         Parameters
@@ -170,6 +170,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         if name in self.commands:
             command = self.command(name)
+            assert command
             signature = self._get_command_signature(command)
             spec = name + signature
             htext = inspect.getdoc(command) or ""

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -148,10 +148,13 @@ class QtileCommandInterface(CommandInterface):
             The keyword arguments to pass into the command graph call.
         """
         obj = self._command_object.select(call.selectors)
-
+        cmd = None
         try:
             cmd = obj.command(call.name)
         except SelectError:
+            pass
+
+        if cmd is None:
             return "No such command."
 
         logger.debug("Command: %s(%s, %s)", call.name, args, kwargs)

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -103,7 +103,7 @@ def rgb(x: ColorType) -> Tuple[float, float, float, float]:
         vals = tuple(int(i, 16) for i in (x[0:2], x[2:4], x[4:6]))
         if len(x) == 8:
             alpha = int(x[6:8], 16) / 255.0
-        vals += (alpha,)
+        vals += (alpha,)  # type: ignore
         return rgb(vals)  # type: ignore
     raise ValueError("Invalid RGB specifier.")
 


### PR DESCRIPTION
A couple of mypy failures have cropped up recently. This addresses both:
1) CommandObject.command can return None rather than Callable
2) alpha value in rgb gives a tuple of (int, int, int, float)