### PR TITLE
Fix max_chars in TextBox widget

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -385,8 +385,8 @@ class _TextBox(_Widget):
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         self.layout = None
         _Widget.__init__(self, width, **config)
-        self._text = text
         self.add_defaults(_TextBox.defaults)
+        self.text = text
 
     @property
     def text(self):

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -183,7 +183,7 @@ class Mpd2(base.ThreadPoolText):
 
     def __init__(self, **config):
         """Constructor."""
-        super().__init__(None, **config)
+        super().__init__("", **config)
 
         self.add_defaults(Mpd2.defaults)
         self.client = MPDClient()

--- a/test/widgets/test_textbox.py
+++ b/test/widgets/test_textbox.py
@@ -46,3 +46,20 @@ def test_text_box_bar_orientations(manager_nospawn, minimal_conf_noscreen, posit
 
     tbox.update("Updated")
     assert tbox.info()["text"] == "Updated"
+
+
+def test_text_box_max_chars(manager_nospawn, minimal_conf_noscreen):
+    """Text boxes are available on any bar position."""
+    textbox = widget.TextBox(text="Testing", max_chars=4)
+
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar([textbox], 10)
+        )
+    ]
+
+    manager_nospawn.start(config)
+    tbox = manager_nospawn.c.widget["textbox"]
+
+    assert tbox.info()["text"] == "Test…"


### PR DESCRIPTION
`max_chars` was only being applied on a subsequent change of text. This change allows `max_chars` to be applied to the initial text set in the widget.