### PR TITLE
WL: Fix unfocussable static windows

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -903,6 +903,11 @@ class Static(base.Static, Window):
             self._app_id = surface.toplevel.app_id
             self.add_listener(surface.toplevel.set_title_event, self._on_set_title)
             self.add_listener(surface.toplevel.set_app_id_event, self._on_set_app_id)
+            self.ftm_handle = surface.data
+            assert self.ftm_handle
+            self.add_listener(
+                self.ftm_handle.request_close_event, self._on_foreign_request_close
+            )
             self._find_outputs()
             self.screen = qtile.current_screen
 


### PR DESCRIPTION
There is a bug where focussing static windows fails because
`win.ftm_handle` for the static window is accessed in
`Core.focus_window` but this attribute doesn't exist on static windows.
This change sets the attribute on static windows and uses it to enable
close requests via the protocol. Other requests don't make sense for
static windows (i.e.  maximise, minimise etc) so are not listened for.