### PR TITLE
Re-introduce configurable key swallowing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,11 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
         - Made the `NetWidget` text formattable.
         - Qtile no longer floods the log following X server disconnection, instead handling those errors.
+        - `Key` and `KeyChord` bindings now have another argument `swallow`.
+          It indicates whether or not the pressed keys should be passed on to the focused client.
+          By default the keys are not passed (swallowed), so this argument is set to `True`.
+          When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
+          function is not executed, e.g. due to failing the `.when()` check.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.
@@ -76,12 +81,6 @@ Qtile 0.22.0, released 2022-09-22:
         - Add icon theme support to `TaskList` widget (available on X11 and Wayland backends).
         - Wayland: Use `qtile cmd-obj -o core -f get_inputs` to get input device identifiers for
           configuring inputs. Also input configs will be updated by config reloads (pywlroots>=0.15.21)
-        - `Key`, `KeyChord`, `Click` and `Drag` bindings now have another argument `swallow`.
-          It indicates whether or not the pressed keys should be passed on to the focused client.
-          By default the keys are not passed (swallowed), so this argument is set to `True`.
-          When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
-          function is not executed, e.g. due to failing the `.when()` check.
-
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,6 +76,12 @@ Qtile 0.22.0, released 2022-09-22:
         - Add icon theme support to `TaskList` widget (available on X11 and Wayland backends).
         - Wayland: Use `qtile cmd-obj -o core -f get_inputs` to get input device identifiers for
           configuring inputs. Also input configs will be updated by config reloads (pywlroots>=0.15.21)
+        - `Key`, `KeyChord`, `Click` and `Drag` bindings now have another argument `swallow`.
+          It indicates whether or not the pressed keys should be passed on to the focused client.
+          By default the keys are not passed (swallowed), so this argument is set to `True`.
+          When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
+          function is not executed, e.g. due to failing the `.when()` check.
+
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ MOCK_MODULES = [
     "xcffib.xfixes",
     "xcffib.xinerama",
     "xcffib.xproto",
+    "xcffib.xtest",
     "xdg.IconTheme",
     "xkbcommon",
 ]

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -266,8 +266,8 @@ class Keyboard(_Device):
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    self.qtile.process_key_event(keysym, mods)
-                    return
+                    if self.qtile.process_key_event(keysym, mods):
+                        return
 
             if self.core.focused_internal:
                 self.core.focused_internal.process_key_press(keysym)

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -266,7 +266,7 @@ class Keyboard(_Device):
             mods = self.keyboard.modifier
             for keysym in keysyms:
                 if (keysym, mods) in self.grabbed_keys:
-                    if self.qtile.process_key_event(keysym, mods):
+                    if self.qtile.process_key_event(keysym, mods)[1]:
                         return
 
             if self.core.focused_internal:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -621,7 +621,7 @@ class Core(base.Core):
         )
         self.flush()
 
-    def fake_keyPress(self, event) -> None:
+    def fake_KeyPress(self, event) -> None:  # noqa: N802
         xtest = self.conn.conn(xcffib.xtest.key)
         # First release the key as it is possibly already pressed
         self.fake_xtest(xtest, event, 3)
@@ -649,7 +649,7 @@ class Core(base.Core):
             # We need to ungrab the key as otherwise we get an event loop
             self.ungrab_key(key)
             # Modifier is pressed, just repeat the event with xtest
-            self.fake_keyPress(event)
+            self.fake_KeyPress(event)
             # Grab the key again
             self.grab_key(key)
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -612,14 +612,38 @@ class Core(base.Core):
     def fake_KeyPress(self, event) -> None:
         xtest = self.conn.conn(xcffib.xtest.key)
         # First release the key as it is possibly already pressed
-        xtest.FakeInput(3, event.detail, xcffib.xproto.Time.CurrentTime, event.root, event.root_x, event.root_y, 0)
+        xtest.FakeInput(
+            3,
+            event.detail,
+            xcffib.xproto.Time.CurrentTime,
+            event.root,
+            event.root_x,
+            event.root_y,
+            0,
+        )
         self.flush()
         # Fake input by...
         # Presssing the key
-        xtest.FakeInput(2, event.detail, xcffib.xproto.Time.CurrentTime, event.root, event.root_x, event.root_y, 0)
+        xtest.FakeInput(
+            2,
+            event.detail,
+            xcffib.xproto.Time.CurrentTime,
+            event.root,
+            event.root_x,
+            event.root_y,
+            0,
+        )
         self.flush()
         # And then releasing again
-        xtest.FakeInput(3, event.detail, xcffib.xproto.Time.CurrentTime, event.root, event.root_x, event.root_y, 0)
+        xtest.FakeInput(
+            3,
+            event.detail,
+            xcffib.xproto.Time.CurrentTime,
+            event.root,
+            event.root_x,
+            event.root_y,
+            0,
+        )
         self.flush()
 
     def handle_KeyPress(self, event, *, simulated=False) -> None:  # noqa: N802

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -609,42 +609,27 @@ class Core(base.Core):
             except IndexError:
                 logger.debug("Invalid desktop index: %s", index)
 
+    def fake_xtest(self, xtest, event, input_type) -> None:
+        xtest.FakeInput(
+            input_type,
+            event.detail,
+            xcffib.xproto.Time.CurrentTime,
+            event.root,
+            event.root_x,
+            event.root_y,
+            0,
+        )
+        self.flush()
+
     def fake_KeyPress(self, event) -> None:
         xtest = self.conn.conn(xcffib.xtest.key)
         # First release the key as it is possibly already pressed
-        xtest.FakeInput(
-            3,
-            event.detail,
-            xcffib.xproto.Time.CurrentTime,
-            event.root,
-            event.root_x,
-            event.root_y,
-            0,
-        )
-        self.flush()
+        self.fake_xtest(xtest, event, 3)
         # Fake input by...
         # Presssing the key
-        xtest.FakeInput(
-            2,
-            event.detail,
-            xcffib.xproto.Time.CurrentTime,
-            event.root,
-            event.root_x,
-            event.root_y,
-            0,
-        )
-        self.flush()
+        self.fake_xtest(xtest, event, 2)
         # And then releasing again
-        xtest.FakeInput(
-            3,
-            event.detail,
-            xcffib.xproto.Time.CurrentTime,
-            event.root,
-            event.root_x,
-            event.root_y,
-            0,
-        )
-        self.flush()
+        self.fake_xtest(xtest, event, 3)
 
     def handle_KeyPress(self, event, *, simulated=False) -> None:  # noqa: N802
         assert self.qtile is not None

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -520,7 +520,7 @@ class Core(base.Core):
                 True,
                 self._root.wid,
                 eventmask,
-                xcffib.xproto.GrabMode.Sync,
+                xcffib.xproto.GrabMode.Async,
                 xcffib.xproto.GrabMode.Async,
                 xcffib.xproto.Atom._None,
                 xcffib.xproto.Atom._None,
@@ -658,26 +658,12 @@ class Core(base.Core):
 
         button_code = event.detail
         state = event.state & self._valid_mask
-        root = False
 
         if not event.child:  # The client's handle_ButtonPress will focus it
-            root = True
             self.focus_by_click(event)
 
-        handled = self.qtile.process_button_click(
-            button_code, state, event.event_x, event.event_y
-        )
-
-        # Prevent double clicks on the root window if handled was False
-        if root:
-            handled = True
-
-        if handled:
-            # Swallow the event
-            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.SyncPointer, event.time)
-        else:
-            # Forward the event to any focused client
-            self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
+        self.qtile.process_button_click(button_code, state, event.event_x, event.event_y)
+        self.conn.conn.core.AllowEvents(xcffib.xproto.Allow.ReplayPointer, event.time)
 
     def handle_ButtonRelease(self, event) -> None:  # noqa: N802
         assert self.qtile is not None

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -621,7 +621,7 @@ class Core(base.Core):
         )
         self.flush()
 
-    def fake_KeyPress(self, event) -> None:
+    def fake_keyPress(self, event) -> None:
         xtest = self.conn.conn(xcffib.xtest.key)
         # First release the key as it is possibly already pressed
         self.fake_xtest(xtest, event, 3)
@@ -649,7 +649,7 @@ class Core(base.Core):
             # We need to ungrab the key as otherwise we get an event loop
             self.ungrab_key(key)
             # Modifier is pressed, just repeat the event with xtest
-            self.fake_KeyPress(event)
+            self.fake_keyPress(event)
             # Grab the key again
             self.grab_key(key)
 

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -214,6 +214,13 @@ XCB_CONN_ERRORS = {
     7: "XCB_CONN_CLOSED_FDPASSING_FAILED",
 }
 
+# Some opcodes from xproto.h, used for faking input.
+XCB_KEY_PRESS = 2
+XCB_KEY_RELEASE = 3
+XCB_BUTTON_PRESS = 4
+XCB_BUTTON_RELEASE = 5
+XCB_MOTION_NOTIFY = 6
+
 
 class MaskMap:
     """

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -154,15 +154,12 @@ class KeyChord:
 
 
 class Mouse:
-    def __init__(
-        self, modifiers: list[str], button: str, *commands: LazyCall, swallow: bool = True
-    ):
+    def __init__(self, modifiers: list[str], button: str, *commands: LazyCall) -> None:
         self.modifiers = modifiers
         self.button = button
         self.commands = commands
         self.button_code = int(self.button.replace("Button", ""))
         self.modmask: int = 0
-        self.swallow = swallow
 
 
 class Drag(Mouse):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -70,7 +70,15 @@ class Key:
         Configures when we swallow the key binding. (Optional)
         Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
-    def __init__(self, modifiers: list[str], key: str, *commands: LazyCall, desc: str = "", swallow: bool = True) -> None:
+
+    def __init__(
+        self,
+        modifiers: list[str],
+        key: str,
+        *commands: LazyCall,
+        desc: str = "",
+        swallow: bool = True,
+    ) -> None:
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
@@ -110,6 +118,7 @@ class KeyChord:
         Configures when we swallow the key binding of the chord. (Optional)
         Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
+
     def __init__(
         self,
         modifiers: list[str],
@@ -145,7 +154,9 @@ class KeyChord:
 
 
 class Mouse:
-    def __init__(self, modifiers: list[str], button: str, *commands: LazyCall, swallow: bool = True):
+    def __init__(
+        self, modifiers: list[str], button: str, *commands: LazyCall, swallow: bool = True
+    ):
         self.modifiers = modifiers
         self.button = button
         self.commands = commands

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -66,16 +66,16 @@ class Key:
         commands should be separated by commas.
     desc:
         Description to be added to the key binding. (Optional)
-
+    swallow:
+        Configures when we swallow the key binding. (Optional)
+        Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
-
-    def __init__(
-        self, modifiers: list[str], key: str, *commands: LazyCall, desc: str = ""
-    ) -> None:
+    def __init__(self, modifiers: list[str], key: str, *commands: LazyCall, desc: str = "", swallow: bool = True) -> None:
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
         self.desc = desc
+        self.swallow = swallow
 
     def __repr__(self) -> str:
         return "<Key (%s, %s)>" % (self.modifiers, self.key)
@@ -106,8 +106,10 @@ class KeyChord:
         A string to describe the chord. This attribute is not directly used by Qtile
         but users may want to access this when creating scripts to show configured
         keybindings.
+    swallow:
+        Configures when we swallow the key binding of the chord. (Optional)
+        Setting it to False will forward the key binding to the focused window after the commands have been executed.
     """
-
     def __init__(
         self,
         modifiers: list[str],
@@ -116,6 +118,7 @@ class KeyChord:
         mode: bool | str = False,
         name: str = "",
         desc: str = "",
+        swallow: bool = True,
     ):
         self.modifiers = modifiers
         self.key = key
@@ -135,18 +138,20 @@ class KeyChord:
             )
             self.name = mode
             self.mode = True
+        self.swallow = swallow
 
     def __repr__(self) -> str:
         return "<KeyChord (%s, %s)>" % (self.modifiers, self.key)
 
 
 class Mouse:
-    def __init__(self, modifiers: list[str], button: str, *commands: LazyCall) -> None:
+    def __init__(self, modifiers: list[str], button: str, *commands: LazyCall, swallow: bool = True):
         self.modifiers = modifiers
         self.button = button
         self.commands = commands
         self.button_code = int(self.button.replace("Button", ""))
         self.modmask: int = 0
+        self.swallow = swallow
 
 
 class Drag(Mouse):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1165,6 +1165,9 @@ class Qtile(CommandObject):
     def simulate_keypress(self, modifiers: list[str], key: str) -> None:
         """Simulates a keypress on the focused window.
 
+        This triggers internal bindings only; for full simulation see external tools
+        such as xdotool or ydotool.
+
         Parameters
         ==========
         modifiers :

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -412,7 +412,9 @@ class Qtile(CommandObject):
     def paint_screen(self, screen: Screen, image_path: str, mode: str | None = None) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(self, keysym: int, mask: int) -> Tuple[Optional[Union[Key, KeyChord]], bool]:
+    def process_key_event(
+        self, keysym: int, mask: int
+    ) -> Tuple[Optional[Union[Key, KeyChord]], bool]:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.debug("Ignoring unknown keysym: %s, mask: %s", keysym, mask)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -60,7 +60,7 @@ from libqtile.utils import (
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Optional, Tuple, Union
+    from typing import Any, Callable
 
     from typing_extensions import Literal
 
@@ -412,9 +412,7 @@ class Qtile(CommandObject):
     def paint_screen(self, screen: Screen, image_path: str, mode: str | None = None) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(
-        self, keysym: int, mask: int
-    ) -> Tuple[Optional[Union[Key, KeyChord]], bool]:
+    def process_key_event(self, keysym: int, mask: int) -> tuple[Key | KeyChord | None, bool]:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.debug("Ignoring unknown keysym: %s, mask: %s", keysym, mask)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -773,7 +773,7 @@ class Qtile(CommandObject):
                         status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs))
                         if status in (interface.ERROR, interface.EXCEPTION):
                             logger.error("Mouse command error %s: %s", i.name, val)
-                        handled = m.swallow
+                        handled = True
             elif isinstance(m, Drag):
                 if m.start:
                     i = m.start
@@ -793,7 +793,7 @@ class Qtile(CommandObject):
 
                 self._drag = (x, y, val[0], val[1], m.commands)
                 self.core.grab_pointer()
-                handled = m.swallow
+                handled = True
 
         return handled
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -412,11 +412,11 @@ class Qtile(CommandObject):
     def paint_screen(self, screen: Screen, image_path: str, mode: str | None = None) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
-    def process_key_event(self, keysym: int, mask: int) -> bool:
+    def process_key_event(self, keysym: int, mask: int) -> Tuple[Optional[Union[Key, KeyChord]], bool]:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
             logger.debug("Ignoring unknown keysym: %s, mask: %s", keysym, mask)
-            return False
+            return (None, False)
 
         if isinstance(key, KeyChord):
             self.grab_chord(key)
@@ -436,9 +436,9 @@ class Qtile(CommandObject):
             # We never swallow when no commands have been executed,
             # even when key.swallow is set to True
             elif not executed:
-                return False
+                return (key, False)
         # Return whether we have handled the key based on the key's swallow parameter
-        return key.swallow
+        return (key, key.swallow)
 
     def grab_keys(self) -> None:
         """Re-grab all of the keys configured in the key map

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -60,7 +60,7 @@ from libqtile.utils import (
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
+    from typing import Any, Callable, Optional, Tuple, Union
 
     from typing_extensions import Literal
 

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -47,22 +47,6 @@ class SwallowConfig(Config):
         ),
     ]
 
-    mouse = [
-        config.Click(
-            [],
-            "Button1",
-            lazy.function(swallow_nop),
-        ),
-        config.Click(["control"], "Button3", lazy.function(swallow_nop), swallow=False),
-        config.Click(["mod4"], "Button3", lazy.function(swallow_nop).when(layout="idonotexist")),
-        config.Click(
-            [],
-            "Button3",
-            lazy.function(swallow_nop).when(layout="idonotexist"),
-            lazy.function(swallow_nop),
-        ),
-    ]
-
 
 # Helper to send process_key_event to the core manager
 # It also looks up the keysym and mask to pass to it
@@ -102,24 +86,11 @@ def test_swallow(manager_nospawn):
     for index, key in enumerate(SwallowConfig.keys):
         assert send_process_key_event(manager, key) == expectedswallow[index]
 
-    # Loop over all the mouse bindings in the config and assert
-    for index, binding in enumerate(SwallowConfig.mouse):
-        assert send_process_button_click(manager, binding) == expectedswallow[index]
-
     not_used_key = config.Key(
         ["control"],
         "h",
         lazy.function(swallow_nop),
     )
 
-    not_used_mouse = config.Click(
-        [],
-        "Button2",
-        lazy.function(swallow_nop),
-    )
-
     # This key is not defined in the config so it should not be handled
     assert not send_process_key_event(manager, not_used_key)
-
-    # This mouse binding is not defined in the config so it should not be handled
-    assert not send_process_button_click(manager, not_used_mouse)

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import pytest
 from libqtile import config
 from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.core import Core
@@ -59,23 +60,8 @@ def send_process_key_event(manager, key):
     return output[1] == "True"
 
 
-# Helper to send process_button_click to the core manager
-# It also looks up the button code and mask to pass to it
-def send_process_button_click(manager, mouse):
-    modmask = xcbq.translate_masks(mouse.modifiers)
-    output = manager.c.eval(
-        f"self.process_button_click({mouse.button_code}, {modmask}, {0}, {0})"
-    )
-    # Assert if eval successful
-    assert output[0]
-    # Convert the string to a bool
-    return output[1] == "True"
-
-
-def test_swallow(manager_nospawn):
-    manager = manager_nospawn
-    manager.start(SwallowConfig)
-
+@pytest.mark.parametrize("manager", [SwallowConfig], indirect=True)
+def test_swallow(manager):
     # The first key needs to be True as swallowing is not set here
     # We expect the second key to not be handled, as swallow is set to False
     # The third needs to not be swallowed as the layout .when(...) check does not succeed

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2021 Jeroen Wijenbergh
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from libqtile import config
+from libqtile.backend.x11 import xcbq
+from libqtile.backend.x11.core import Core
+from libqtile.confreader import Config
+from libqtile.lazy import lazy
+
+
+# Function that does nothing
+def swallow_nop(qtile):
+    pass
+
+
+# Config with multiple keys and swallow parameters
+class SwallowConfig(Config):
+    keys = [
+        config.Key(
+            ["control"],
+            "k",
+            lazy.function(swallow_nop),
+        ),
+        config.Key(
+            ["control"],
+            "j",
+            lazy.function(swallow_nop),
+            swallow=False
+        ),
+        config.Key(
+            ["control"],
+            "i",
+            lazy.function(swallow_nop).when(layout='idonotexist')
+        ),
+        config.Key(
+            ["control"],
+            "o",
+            lazy.function(swallow_nop).when(layout='idonotexist'),
+            lazy.function(swallow_nop)
+        ),
+    ]
+
+    mouse = [
+        config.Click(
+            [],
+            "Button1",
+            lazy.function(swallow_nop),
+        ),
+        config.Click(
+            ["control"],
+            "Button3",
+            lazy.function(swallow_nop),
+            swallow=False
+        ),
+        config.Click(
+            ["mod4"],
+            "Button3",
+            lazy.function(swallow_nop).when(layout='idonotexist')
+        ),
+        config.Click(
+            [],
+            "Button3",
+            lazy.function(swallow_nop).when(layout='idonotexist'),
+            lazy.function(swallow_nop)
+        ),
+    ]
+
+
+# Helper to send process_key_event to the core manager
+# It also looks up the keysym and mask to pass to it
+def send_process_key_event(manager, key):
+    keysym, mask = Core.lookup_key(None, key)
+    output = manager.c.eval(f"self.process_key_event({keysym}, {mask})")
+    # Assert if eval successful
+    assert output[0]
+    # Convert the string to a bool
+    return output[1] == 'True'
+
+
+# Helper to send process_button_click to the core manager
+# It also looks up the button code and mask to pass to it
+def send_process_button_click(manager, mouse):
+    modmask = xcbq.translate_masks(mouse.modifiers)
+    output = manager.c.eval(f"self.process_button_click({mouse.button_code}, {modmask}, {0}, {0})")
+    # Assert if eval successful
+    assert output[0]
+    # Convert the string to a bool
+    return output[1] == 'True'
+
+
+def test_swallow(manager_nospawn):
+    manager = manager_nospawn
+    manager.start(SwallowConfig)
+
+    # The first key needs to be True as swallowing is not set here
+    # We expect the second key to not be handled, as swallow is set to False
+    # The third needs to not be swallowed as the layout .when(...) check does not succeed
+    # The fourth needs to be True as one of the functions is executed due to passing the .when(...) check
+    expectedswallow = [True, False, False, True]
+
+    # Loop over all the keys in the config and assert
+    for index, key in enumerate(SwallowConfig.keys):
+        assert send_process_key_event(manager, key) == expectedswallow[index]
+
+    # Loop over all the mouse bindings in the config and assert
+    for index, binding in enumerate(SwallowConfig.mouse):
+        assert send_process_button_click(manager, binding) == expectedswallow[index]
+
+    not_used_key = config.Key(
+        ["control"],
+        "h",
+        lazy.function(swallow_nop),
+    )
+
+    not_used_mouse = config.Click(
+        [],
+        "Button2",
+        lazy.function(swallow_nop),
+    )
+
+    # This key is not defined in the config so it should not be handled
+    assert not send_process_key_event(manager, not_used_key)
+
+    # This mouse binding is not defined in the config so it should not be handled
+    assert not send_process_button_click(manager, not_used_mouse)

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -86,7 +86,7 @@ class SwallowConfig(Config):
 # It also looks up the keysym and mask to pass to it
 def send_process_key_event(manager, key):
     keysym, mask = Core.lookup_key(None, key)
-    output = manager.c.eval(f"self.process_key_event({keysym}, {mask})")
+    output = manager.c.eval(f"self.process_key_event({keysym}, {mask})[1]")
     # Assert if eval successful
     assert output[0]
     # Convert the string to a bool

--- a/test/test_swallow.py
+++ b/test/test_swallow.py
@@ -37,22 +37,13 @@ class SwallowConfig(Config):
             "k",
             lazy.function(swallow_nop),
         ),
-        config.Key(
-            ["control"],
-            "j",
-            lazy.function(swallow_nop),
-            swallow=False
-        ),
-        config.Key(
-            ["control"],
-            "i",
-            lazy.function(swallow_nop).when(layout='idonotexist')
-        ),
+        config.Key(["control"], "j", lazy.function(swallow_nop), swallow=False),
+        config.Key(["control"], "i", lazy.function(swallow_nop).when(layout="idonotexist")),
         config.Key(
             ["control"],
             "o",
-            lazy.function(swallow_nop).when(layout='idonotexist'),
-            lazy.function(swallow_nop)
+            lazy.function(swallow_nop).when(layout="idonotexist"),
+            lazy.function(swallow_nop),
         ),
     ]
 
@@ -62,22 +53,13 @@ class SwallowConfig(Config):
             "Button1",
             lazy.function(swallow_nop),
         ),
-        config.Click(
-            ["control"],
-            "Button3",
-            lazy.function(swallow_nop),
-            swallow=False
-        ),
-        config.Click(
-            ["mod4"],
-            "Button3",
-            lazy.function(swallow_nop).when(layout='idonotexist')
-        ),
+        config.Click(["control"], "Button3", lazy.function(swallow_nop), swallow=False),
+        config.Click(["mod4"], "Button3", lazy.function(swallow_nop).when(layout="idonotexist")),
         config.Click(
             [],
             "Button3",
-            lazy.function(swallow_nop).when(layout='idonotexist'),
-            lazy.function(swallow_nop)
+            lazy.function(swallow_nop).when(layout="idonotexist"),
+            lazy.function(swallow_nop),
         ),
     ]
 
@@ -90,18 +72,20 @@ def send_process_key_event(manager, key):
     # Assert if eval successful
     assert output[0]
     # Convert the string to a bool
-    return output[1] == 'True'
+    return output[1] == "True"
 
 
 # Helper to send process_button_click to the core manager
 # It also looks up the button code and mask to pass to it
 def send_process_button_click(manager, mouse):
     modmask = xcbq.translate_masks(mouse.modifiers)
-    output = manager.c.eval(f"self.process_button_click({mouse.button_code}, {modmask}, {0}, {0})")
+    output = manager.c.eval(
+        f"self.process_button_click({mouse.button_code}, {modmask}, {0}, {0})"
+    )
     # Assert if eval successful
     assert output[0]
     # Convert the string to a bool
-    return output[1] == 'True'
+    return output[1] == "True"
 
 
 def test_swallow(manager_nospawn):


### PR DESCRIPTION
Continuation of #2925 and #3102

~Instead of grabbing keys sync, which has problems in Dmenu (as it grabs the keyboard). Let's use XSendEvent. Note that mouse buttons are still grabbed sync, but this does not interfere with dmenu. If someone thinks this is unreasonable I could also use XSendEvent here.~

In the discussion here, we have figured out that XSendEvent would not work for every client. In this pr I'm using XTest