### PR TITLE
Add focused window Match to lazy function's .when() check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           whether to draw margin and border when there is only one window.
         - Thermal zone widget.
         - Allow TextBox-based widgets to display in vertical bars.
+        - Added a focused attribute to `lazy.function.when` which can be used to Match on focused windows.
 
 Qtile 0.18.1, released 2021-09-16:
     * features

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -46,7 +46,7 @@ The :class:`EzKey` modifier keys (i.e. ``MASC``) can be overwritten through the
     }
 
 Callbacks can also be configured to work only under certain conditions by using
-the ``when()`` method. Currently, two conditions are supported:
+the ``when()`` method. Currently, the following conditions are supported:
 
 ::  
 
@@ -63,6 +63,10 @@ the ``when()`` method. Currently, two conditions are supported:
 
         # Limit action to when the current window is not floating (default True)
         Key([mod], "f", lazy.window.toggle_fullscreen().when(when_floating=False))
+
+        # Also matches are supported on the current window
+        # For example to match on the wm_class for fullscreen do the following
+        Key([mod], "f", lazy.window.toggle_fullscreen().when(focused=Match(wm_class="yourclasshere"))
     ]
 
 KeyChords

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -17,8 +17,21 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import (
+        Dict,
+        Iterable,
+        List,
+        Optional,
+        Set,
+        Tuple,
+        Union,
+    )
+    from libqtile.config import Match
 
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.graph import (
@@ -46,6 +59,7 @@ class LazyCall:
         self._args = args
         self._kwargs = kwargs
 
+        self._focused: Optional[Match] = None
         self._layouts: Set[str] = set()
         self._when_floating = True
 
@@ -90,18 +104,23 @@ class LazyCall:
         """The kwargs to the given call"""
         return self._kwargs
 
-    def when(self, layout: Optional[Union[Iterable[str], str]] = None,
+    def when(self, focused: Optional[Match] = None, layout: Optional[Union[Iterable[str], str]] = None,
              when_floating: bool = True) -> 'LazyCall':
         """Enable call only for given layout(s) and floating state
 
         Parameters
         ----------
+        focused: Match or None
+            Match criteria to enable call for the current window
         layout: str, Iterable[str], or None
             Restrict call to one or more layouts.
             If None, enable the call for all layouts.
         when_floating: bool
             Enable call when the current window is floating.
         """
+        if focused is not None:
+            self._focused = focused
+
         if layout is not None:
             self._layouts = {layout} if isinstance(layout, str) else set(layout)
 
@@ -110,6 +129,9 @@ class LazyCall:
 
     def check(self, q) -> bool:
         cur_win_floating = q.current_window and q.current_window.floating
+
+        if self._focused and not self._focused.compare(q.current_window):
+            return False
 
         if cur_win_floating and not self._when_floating:
             return False

--- a/test/test_when.py
+++ b/test/test_when.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2021 Jeroen Wijenbergh
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+from libqtile import config
+from libqtile.confreader import Config
+from libqtile.lazy import lazy
+
+
+# Config with multiple keys and when checks
+class WhenConfig(Config):
+    keys = [
+        config.Key(
+            ["control"],
+            "k",
+            lazy.window.toggle_floating(),
+        ),
+        config.Key(
+            ["control"],
+            "j",
+            lazy.window.toggle_floating().when(config.Match(wm_class='TestWindow')),
+        ),
+        config.Key(
+            ["control"],
+            "h",
+            lazy.window.toggle_floating().when(config.Match(wm_class='idonotexist')),
+        ),
+    ]
+
+
+when_config = pytest.mark.parametrize("manager", [WhenConfig], indirect=True)
+
+
+@when_config
+def test_when(manager):
+    # Check if the test window is alive and tiled
+    manager.test_window('one')
+    assert not manager.c.window.info()['floating']
+
+    # This sets the window to floating as there is no when
+    manager.c.simulate_keypress(["control"], "k")
+    assert manager.c.window.info()['floating']
+
+    # This keeps the window floating as the class doesn't match
+    manager.c.simulate_keypress(["control"], "h")
+    assert manager.c.window.info()['floating']
+
+    # This sets the window tiled as the class does match
+    manager.c.simulate_keypress(["control"], "j")
+    assert not manager.c.window.info()['floating']


### PR DESCRIPTION
This adds the focused attribute to `.when()` checks which uses `config.Match` objects.
So this can be used to limit a keybinding on a certain type of focused window.
When swallowing is complete, #3040 can be done with:

```python

Key([MOD], 'h', lazy.layout.left().when(focused=Match(wm_class=re.compile('(?!kitty)'))), desc='move focus left when kitty is not focused')