### PR TITLE
Lazy when: Solve focused matching when there are no windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.
         - Fix various issues with setting fullscreen windows floating and vice versa.
+        - Fix a bug where a .when() check for lazy functions errors out when matching
+          on focused windows when none is focused. By default we do not match on focused windows,
+          to change this set `if_no_focused` to True.
 
 Qtile 0.20.0, released 2022-01-24:
     * features


### PR DESCRIPTION
With #3114 we can match on focused windows in keybindings. However, if there are no windows there is a problem as a `NoneType` does not have e.g. a `wm_class`. We need to extend the `Match` class to not error out when we match against a `NoneType`.

So we need to add a configurable empty parameter to lazycalls, to then match if there are no focused windows:

```python
Key([MOD], 'h', lazy.function(somefunction).when(focused=Match(wm_class=re.compile('(?!kitty)')), if_no_focused=True), desc='execute somefunction when the focused client is not kitty or when there are no focused windows')
```
This needs to be configurable (default to `False`) as these negative regexes are possible.