### PR TITLE
Fix Imap widget

### DIFF
--- a/libqtile/widget/imapwidget.py
+++ b/libqtile/widget/imapwidget.py
@@ -83,11 +83,11 @@ class ImapWidget(base.ThreadPoolText):
     def poll(self):
         im = imaplib.IMAP4_SSL(self.server, 993)
         if self.password == 'Gnome Keyring Error':
-            self.text = 'Gnome Keyring Error'
+            text = 'Gnome Keyring Error'
         else:
             im.login(self.user, self.password)
             status, response = im.status(self.mbox, '(UNSEEN)')
-            self.text = response[0].decode()
-            self.text = self.label + ': ' + re.sub(r'\).*$', '', re.sub(r'^.*N\s', '', self.text))
+            text = response[0].decode()
+            text = self.label + ': ' + re.sub(r'\).*$', '', re.sub(r'^.*N\s', '', text))
             im.logout()
-        return self.text
+        return text


### PR DESCRIPTION
`poll()` method was modifying `self.text` in place before returning the value. However, `self.text` is a property setter which sets the layout text. The widget should only update the text value by returning the value from `poll()`.