### PR TITLE
Run layout.show() when restoring them from state

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -168,6 +168,7 @@ class Qtile(CommandObject):
 
         if self._state:
             for screen in self.screens:
+                screen.group.layout.show(screen.get_rect())
                 screen.group.layout_all()
         self._state = None
         self.update_desktops()


### PR DESCRIPTION
This ensures layouts that are visible following a restart have set
themselves properly.

Fixes #3063