### PR TITLE
Changes to screen_change hook on X11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `place_right` option in the TreeTab layout to place the tab panel on the right side
     * bugfixes
+        - Fix bug where bars were not reconfigured correctly when screen layout changes.
         - Change timing of `screens_reconfigured` hook. Will now be called ONLY if `cmd_reconfigure_screens`
           has been called and completed.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `place_right` option in the TreeTab layout to place the tab panel on the right side
+    * bugfixes
+        - Change timing of `screens_reconfigured` hook. Will now be called ONLY if `cmd_reconfigure_screens`
+          has been called and completed.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -431,7 +431,6 @@ class Core(base.Core, wlrq.HasListeners):
             config.send_failed()
         config.destroy()
         hook.fire("screen_change", None)
-        hook.fire("screens_reconfigured")
 
     def _process_cursor_motion(self, time_msec: int, cx: float, cy: float):
         assert self.qtile

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -721,7 +721,6 @@ class Core(base.Core):
 
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
         hook.fire("screen_change", event)
-        hook.fire("screens_reconfigured")
 
     @contextlib.contextmanager
     def disable_unmap_events(self):

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -249,6 +249,7 @@ class Bar(Gap, configurable.Configurable):
             # We get _configure()-ed with an existing window when screens are getting
             # reconfigured but this screen is present both before and after
             self.window.place(self.x, self.y, width, height, 0, None)
+
         else:
             # Whereas we won't have a window if we're startup up for the first time or
             # the window has been killed by us no longer using the bar's screen
@@ -273,9 +274,6 @@ class Bar(Gap, configurable.Configurable):
             self.window.opacity = self.opacity
             self.window.unhide()
 
-            self.drawer = self.window.create_drawer(width, height)
-            self.drawer.clear(self.background)
-
             self.window.process_window_expose = self.process_window_expose
             self.window.process_button_click = self.process_button_click
             self.window.process_button_release = self.process_button_release
@@ -284,13 +282,21 @@ class Bar(Gap, configurable.Configurable):
             self.window.process_pointer_motion = self.process_pointer_motion
             self.window.process_key_press = self.process_key_press
 
+        # We create a new drawer even if there's already a window to ensure the
+        # drawer is the right size.
+        self.drawer = self.window.create_drawer(width, height)
+        self.drawer.clear(self.background)
+
         self.crashed_widgets = []
         if self._configured:
             for i in self.widgets:
                 self._configure_widget(i)
         else:
             for idx, i in enumerate(self.widgets):
-                if i.configured:
+                # Create a mirror if this widget is being placed on a different bar
+                # We don't do isinstance(i, Mirror) because importing Mirror (at the top)
+                # would give a circular import as libqtile.widget.base imports lbqtile.bar
+                if i.configured and i.bar != self and i.__class__.__name__ != "Mirror":
                     i = i.create_mirror()
                     self.widgets[idx] = i
                 success = self._configure_widget(i)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -292,7 +292,7 @@ class Screen(CommandObject):
         self.width = width if width is not None else 0
         self.height = height if height is not None else 0
 
-    def _configure(self, qtile, index, x, y, width, height, group):
+    def _configure(self, qtile, index, x, y, width, height, group, reconfigure_gaps=False):
         self.qtile = qtile
         self.index = index
         self.x = x
@@ -301,6 +301,9 @@ class Screen(CommandObject):
         self.height = height
         self.set_group(group)
         for i in self.gaps:
+            if reconfigure_gaps:
+                i._configured = False
+                i._borders_drawn = False
             i._configure(qtile, self)
         if self.wallpaper:
             self.wallpaper = os.path.expanduser(self.wallpaper)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -336,8 +336,8 @@ class Qtile(CommandObject):
                 for grp in self.groups:
                     if not grp.screen:
                         break
-
-            scr._configure(self, i, x, y, w, h, grp)
+            reconfigure_gaps = (x, y, w, h) != (scr.x, scr.y, scr.width, scr.height)
+            scr._configure(self, i, x, y, w, h, grp, reconfigure_gaps=reconfigure_gaps)
             screens.append(scr)
 
         for screen in self.screens:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -365,6 +365,8 @@ class Qtile(CommandObject):
                 else:
                     group.hide()
 
+        hook.fire("screens_reconfigured")
+
     def paint_screen(self, screen: Screen, image_path: str, mode: Optional[str] = None) -> None:
         self.core.painter.paint(screen, image_path, mode)
 

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -305,10 +305,7 @@ class Subscribe:
         return self._subscribe("screen_change", func)
 
     def screens_reconfigured(self, func):
-        """Called when all ``screen_change`` hooks have fired.
-
-        This is primarily useful where you want a callback to be triggered once
-        ``qtile.cmd_reconfigure_screens`` has completed (e.g. if
+        """Called once ``qtile.cmd_reconfigure_screens`` has completed (e.g. if
         ``reconfigure_screens`` is set to ``True`` in your config).
 
         **Arguments**


### PR DESCRIPTION
The bar currently prevents multiple reconfigurations to stop margins being added more than once. This causes an issue on a screen change event as bars are not able to be repositioned/resized.

We can fix this by resetting the `configured` flag whenever there's a `screen_change` event.

Fixes #3039
Fixes #3148
Fixes #3150

As part of this PR, I've also changed the timing of the `screens_reconfigured` hook to make this only run after `cmd_screens_reconfigured` has been called and completed.