### PR TITLE
Add command to centre floating windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           managers to request the name.
         - Fix bug where `Battery` widget did not retrieve `background` from `widget_defaults`.
         - Fix bug where widgets in a `WidgetBox` are rendered on top of bar borders.
+        - Add `lazy.window.center()` command to center a floating window on the screen.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -492,6 +492,30 @@ class Window(_Window, metaclass=ABCMeta):
         """
         self.defunct = True
 
+    def cmd_center(self) -> None:
+        """Centers a floating window on the screen."""
+        if not self.floating:
+            return
+
+        if not (self.group and self.group.screen):
+            return
+
+        screen = self.group.screen
+
+        x = (screen.width - self.width) // 2  # type: ignore
+        y = (screen.height - self.height) // 2  # type: ignore
+
+        self.place(
+            x,
+            y,
+            self.width,  # type: ignore
+            self.height,  # type: ignore
+            self.borderwidth,
+            self.bordercolor,  # type: ignore
+            above=True,
+            respect_hints=True,
+        )
+
 
 class Internal(_Window, metaclass=ABCMeta):
     """An Internal window belonging to Qtile."""

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -127,3 +127,24 @@ def test_bring_front_click(manager, bring_front_click):
         assert wins.index(wids[2]) < wins.index(wids[1]) < wins.index(wids[0])
     else:
         assert wins.index(wids[0]) < wins.index(wids[1]) < wins.index(wids[2])
+
+
+@bare_config
+def test_center_window(manager):
+    """Check that floating windows are centered correctly."""
+    manager.test_window("one")
+
+    manager.c.window.set_position_floating(50, 50)
+    manager.c.window.set_size_floating(200, 100)
+    info = manager.c.window.info()
+    assert info["x"] == 50
+    assert info["y"] == 50
+    assert info["width"] == 200
+    assert info["height"] == 100
+
+    manager.c.window.center()
+    info = manager.c.window.info()
+    assert info["x"] == (800 - 200) / 2  # (screen width - window width) / 2
+    assert info["y"] == (600 - 100) / 2  # (screen height - window height) / 2
+    assert info["width"] == 200
+    assert info["height"] == 100


### PR DESCRIPTION
This is from a discussion in the qtile-dev group: add a new `cmd_center` to position a floating window in the middle of the screen.

Draft for now:
 - [x] needs a test
 - [ ] to discuss how this should behave on non-floating windows