### PR TITLE
Hide non-commandable windows from IPC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `place_right` option in the TreeTab layout to place the tab panel on the right side
+    * bugfixes
+        - Remove non-commandable windows from IPC. Fixes bug where IPC would fail when trying to get info
+          on all windows but Systray has icons (which are non-commandable `_Window`s.)
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -770,7 +770,9 @@ class Qtile(CommandObject):
         elif name == "bar":
             return False, [x.position for x in self.current_screen.gaps]
         elif name == "window":
-            return True, list(self.windows_map.keys())
+            windows: List[Union[str, int]]
+            windows = [k for k, v in self.windows_map.items() if isinstance(v, CommandObject)]
+            return True, windows
         elif name == "screen":
             return True, list(range(len(self.screens)))
         elif name == "core":
@@ -796,7 +798,11 @@ class Qtile(CommandObject):
             if sel is None:
                 return self.current_window
             else:
-                return self.windows_map.get(sel)  # type: ignore
+                windows: Dict[Union[str, int], base._Window]
+                windows = {
+                    k: v for k, v in self.windows_map.items() if isinstance(v, CommandObject)
+                }
+                return windows.get(sel)
         elif name == "screen":
             if sel is None:
                 return self.current_screen


### PR DESCRIPTION
Some windows are not instances of `CommandObject` and will trigger an error if a user attempts to access these via IPC. This PR hides non-commandable windows from the command graph.

Fixes #3157

The alternative approach is to make `libqtile.backend.x11.window._Window` inherit `CommandObject` but that would make Systray icons commandable which I don't think is desirable but happy to discuss here.