### PR TITLE
Better error handling in CheckUpdates widget

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -47,6 +47,7 @@ class CheckUpdates(base.ThreadPoolText):
         ("colour_have_updates", "ffffff", "Colour when there are updates."),
         ("restart_indicator", "", "Indicator to represent reboot is required. (Ubuntu only)"),
         ("no_update_string", "", "String to display if no updates available"),
+        ("error_string", "", "String to display if there is an error while checking updates"),
     ]
 
     def __init__(self, **config):
@@ -100,7 +101,9 @@ class CheckUpdates(base.ThreadPoolText):
         try:
             updates = self.call_process(self.cmd, shell=True)
         except CalledProcessError:
-            updates = ""
+            logger.error("CheckUpdates widget failed to check updates (non-zero return code).")
+            return self.error_string
+
         num_updates = self.custom_command_modify(len(updates.splitlines()))
 
         if num_updates < 0:

--- a/test/widgets/test_check_updates.py
+++ b/test/widgets/test_check_updates.py
@@ -126,11 +126,7 @@ def test_update_available_with_execute(manager_nospawn, minimal_conf_noscreen, m
 
 def test_update_process_error(fake_qtile, fake_window):
     """test output where update check gives error"""
-    cu7 = CheckUpdates(
-        distro=good_distro,
-        custom_command=cmd_error,
-        no_update_string="ERROR",
-    )
+    cu7 = CheckUpdates(distro=good_distro, custom_command=cmd_error, error_string="ERROR")
     fakebar = FakeBar([cu7], window=fake_window)
     cu7._configure(fake_qtile, fakebar)
     text = cu7.poll()


### PR DESCRIPTION
Currently, any error when checking updates is swallowed silently and displayed as no updates. This PR adds a log message and the ability to display text when an error occurs.

Fixes #3158