### PR TITLE
Clicking on bar should focus that screen

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -446,6 +446,11 @@ class Bar(Gap, configurable.Configurable):
         return None
 
     def process_button_click(self, x: int, y: int, button: int) -> None:
+        # If we're clicking on a bar that's not on the current screen, focus that screen
+        if self.screen is not self.qtile.current_screen:
+            index = self.qtile.screens.index(self.screen)
+            self.qtile.focus_screen(index, warp=False)
+
         widget = self.get_widget_in_position(x, y)
         if widget:
             widget.button_press(


### PR DESCRIPTION
Currently, clicking on a widget on a different bar does not focus that screen. This results in undesirable consequences such as changing group but new windows open on focused screen (#3165) and changing layouts on focused screen (#3166).

This PR addresses that issue by checking the whether the bar's screen is the focused screen when the bar is clicked. If the bar is not on the focused screen then the screen is focused before the click event is passed to the widget.

Fixes #3165
Fixes #3166

Happy to discuss alternative approaches to fixing this (e.g. I'm aware there was a previous discussion about when another screen should be focused).