### PR TITLE
Handle UnicodeDecodeErrors in window name

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -126,7 +126,10 @@ class XWindow:
         return r.value.to_string()
 
     def _property_utf8(self, r):
-        return r.value.to_utf8()
+        try:
+            return r.value.to_utf8()
+        except UnicodeDecodeError:
+            return r.value.to_string()
 
     def send_event(self, synthevent, mask=EventMask.NoEvent):
         self.conn.conn.core.SendEvent(False, self.wid, mask, synthevent.pack())


### PR DESCRIPTION
Currently, a UnicodeDecodeError is unhandled meaning a `Window` object is not created where this error arises.

This PR adds handling for the error by falling back to the window's `wm_class` for the name.

Fixes #3161