### PR TITLE
Quicker window switching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - New widget: GenPollCommand
         - Add ability to add a group at a specified index
         - Add ability to open the `WidgetBox` widgets at startup.
+        - Add ability to swap focused window based on index, and change the order of windows inside current group
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.
@@ -117,6 +118,7 @@ Qtile 0.20.0, released 2022-01-24:
         - Fix bug where `Battery` widget did not retrieve `background` from `widget_defaults`.
         - Fix bug where widgets in a `WidgetBox` are rendered on top of bar borders.
 
+        - Add ability to swap focused window based on index, and change the order of windows inside current group
 Qtile 0.19.0, released 2021-12-22:
     * features
         - Add ability to draw borders to the Bar. Can customise size and colour per edge.

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1384,6 +1384,32 @@ class Qtile(CommandObject):
         mb.start_input(prompt, self.find_window, "window", strict_completer=True)
 
     @expose_command()
+    def switch_window(self, location: int) -> None:
+        """
+        Change to the window at the specified index in the current group.
+        """
+        windows = self.current_group.windows
+        if location < 1 or location > len(windows):
+            return
+
+        self.current_group.focus(windows[location - 1])
+
+    @expose_command()
+    def change_window_order(self, new_location: int) -> None:
+        """
+        Change the order of the current window within the current group.
+        """
+        if new_location < 1 or new_location > len(self.current_group.windows):
+            return
+
+        windows = self.current_group.windows
+        current_window_index = windows.index(self.current_window)
+
+        temp = windows[current_window_index]
+        windows[current_window_index] = windows[new_location - 1]
+        windows[new_location - 1] = temp
+
+    @expose_command()
     def next_urgent(self) -> None:
         """Focus next window with urgent hint"""
         try:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -526,6 +526,33 @@ class _Group(CommandObject):
                 return win.info()
 
     @expose_command()
+    def focus_by_index(self, index: int) -> None:
+        """
+        Change to the window at the specified index in the current group.
+        """
+        windows = self.windows
+        if index < 0 or index > len(windows) - 1:
+            return
+
+        self.focus(windows[index])
+
+    @expose_command()
+    def swap_window_order(self, new_location: int) -> None:
+        """
+        Change the order of the current window within the current group.
+        """
+        if new_location < 0 or new_location > len(self.windows) - 1:
+            return
+
+        windows = self.windows
+        current_window_index = windows.index(self.current_window)
+
+        windows[current_window_index], windows[new_location] = (
+            windows[new_location],
+            windows[current_window_index],
+        )
+
+    @expose_command()
     def switch_groups(self, name):
         """Switch position of current group with name"""
         self.qtile.switch_groups(self.name, name)

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -164,6 +164,16 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             None,
             "Path to icon theme to be used by pyxdg for icons. ``None`` will use default icon theme.",
         ),
+        (
+            "window_name_location",
+            False,
+            "Whether to show the location of the window in the title.",
+        ),
+        (
+            "window_name_location_offset",
+            0,
+            "The offset given to window loction",
+        ),
     ]
 
     def __init__(self, **config):
@@ -227,7 +237,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         elif window is window.group.current_window:
             markup_str = self.markup_focused
 
-        window_name = window.name if window and window.name else "?"
+        window_location = (
+            f"[{window.group.windows.index(window) + self.window_name_location_offset}] "
+            if self.window_name_location
+            else ""
+        )
+        window_name = window_location + window.name if window and window.name else "?"
 
         if callable(self.parse_text):
             try:

--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -209,6 +209,37 @@ def test_focus_cycle(manager):
 
 
 @each_layout_config
+def test_swap_window_order(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+
+    window_order = manager.c.group.info().get("windows")
+    assert window_order == ["one", "two", "three"]
+
+    # Swap window on index 0 with index 2
+    manager.c.group.focus_by_name("one")
+    manager.c.group.swap_window_order(2)
+    window_order = manager.c.group.info().get("windows")
+    assert window_order == ["three", "two", "one"]
+    assert_focused(manager, "one")
+
+    # Swap window on index 1 with index 0
+    manager.c.group.focus_by_name("two")
+    manager.c.group.swap_window_order(0)
+    window_order = manager.c.group.info().get("windows")
+    assert window_order == ["two", "three", "one"]
+    assert_focused(manager, "two")
+
+    # Swap window on index 0 with index out of bounds
+    manager.c.group.focus_by_name("two")
+    manager.c.group.swap_window_order(3)
+    window_order = manager.c.group.info().get("windows")
+    assert window_order == ["two", "three", "one"]
+    assert_focused(manager, "two")
+
+
+@each_layout_config
 def test_focus_back(manager):
     # No exception must be raised without windows
     manager.c.group.focus_back()

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -69,6 +69,28 @@ def test_window_order(manager):
 
 
 @group_config
+def test_focus_by_index(manager):
+    manager.c.group["a"].toscreen()
+    manager.test_window("one")
+    manager.test_window("two")
+
+    info = manager.c.group.info()
+    assert info.get("focus") == "two"
+
+    manager.c.group.focus_by_index(1)
+    info = manager.c.group.info()
+    assert info.get("focus") == "two"
+
+    manager.c.group.focus_by_index(3)
+    info = manager.c.group.info()
+    assert info.get("focus") == "two"
+
+    manager.c.group.focus_by_index(0)
+    info = manager.c.group.info()
+    assert info.get("focus") == "one"
+
+
+@group_config
 def test_toscreen_toggle(manager):
     assert manager.c.group.info()["name"] == "a"  # Start on "a"
     manager.c.group["b"].toscreen()

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -115,6 +115,7 @@ def test_complete(manager):
     sh = QSh(command)
     assert sh._complete("c", "c") == [
         "cd",
+        "change_window_order",
         "commands",
         "critical",
     ]


### PR DESCRIPTION
Switch window in the same manner as switching group. Increasing the speed and consistency when working with multiple windows in a group. Also altered the Tasklist for better navigation with this feature.

Config example
```

groups = [Group(i) for i in "123456789"]

for index, i in enumerate(groups, 1):
    keys.extend(
        [
            Key(
                ["mod1"],
                i.name,
                lazy.switch_window(index)
            ),
            Key(
                ["mod1", "shift"],
                i.name,
                lazy.change_window_order(index)
            ),
        ]
    )

```