### PR TITLE
WL: Don't AttributeError during Static.get_wm_class()

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -892,6 +892,7 @@ class Static(base.Static, Window):
         self._outputs: List[Output] = []
         self._float_state = FloatStates.FLOATING
         self.is_layer = False
+        self._app_id: Optional[str] = None  # Not used by layer-shell surfaces
 
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)


### PR DESCRIPTION
When this method is called and the static window is a layer-shell
surface, the window has no `_app_id` attribute set. This needs to be set
manually in `Static.__init__`, just to `None`, so that when
`get_wm_class()` is called and `self._app_id` is checked, it doesn't
AttributeError.