### PR TITLE
Update cpu.py

### DIFF
--- a/libqtile/widget/cpu.py
+++ b/libqtile/widget/cpu.py
@@ -50,7 +50,10 @@ class CPU(base.ThreadPoolText):
 
         variables["load_percent"] = round(psutil.cpu_percent(), 1)
         freq = psutil.cpu_freq()
-        variables["freq_current"] = round(freq.current / 1000, 1)
+        if(float(psutil.__version__[:-2]) <= 5.8):
+            variables["freq_current"] = round(freq.current / 1000, 1)
+        else:
+            variables["freq_current"] = round(freq.current, 1)
         variables["freq_max"] = round(freq.max / 1000, 1)
         variables["freq_min"] = round(freq.min / 1000, 1)
 


### PR DESCRIPTION
From psutil 5.9.0 changelog:
  - 1851_, [Linux]: `cpu_freq()`_ is slow on systems with many CPUs. Read current
  frequency values for all CPUs from ``/proc/cpuinfo`` instead of opening many
  files in ``/sys`` fs.  (patch by marxin)

Adding a check to make it compatible with older and newer versions of psutil, since we don't need to divide by 1000 anymore.