### PR TITLE
Fix finalisation of layouts

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -281,8 +281,10 @@ class Qtile(CommandObject):
                 widget.finalize()
             self.widgets_map.clear()
 
-            for layout in self.config.layouts:
-                layout.finalize()
+            # For layouts we need to finalize each clone of a layout in each group
+            for group in self.groups:
+                for layout in group.layouts:
+                    layout.finalize()
 
             for screen in self.screens:
                 for gap in screen.gaps:

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -475,6 +475,8 @@ class TreeTab(Layout):
             client.hide()
 
     def finalize(self):
+        if self._panel:
+            self._panel.kill()
         Layout.finalize(self)
         if self._drawer is not None:
             self._drawer.finalize()


### PR DESCRIPTION
Previously, when finalising layouts, the manager loops over `self.config.layouts`. However, layouts are cloned per group and so the config layouts do not represent the layouts that are actually in use.

This is particularly problematic for the `TreeTab` layout which creates an `Internal` window for the panel which needs to be killed when the layout is finalised.

This PR fixes this issue by looping over layouts in each group to finalise them. It also ensures that the `TreeTab._panel` is killed.

Fixes #3171