### PR TITLE
Place upper bound limit of pywlroots version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.14.10
+  pywlroots>=0.14.10,<0.15.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.14.10
+    pip install pywlroots>=0.14.10,<0.15.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -90,7 +90,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.14.10
+    pip install pywlroots>=0.14.10,<0.15.0
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install


### PR DESCRIPTION
The latest version of pywlroots has some breaking changes that will need
to be accounted for here before we can support that version.