### PR TITLE
Fix icon order in Systray

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix bug where bars were not reconfigured correctly when screen layout changes.
         - Change timing of `screens_reconfigured` hook. Will now be called ONLY if `cmd_reconfigure_screens`
           has been called and completed.
+        - Fix order of icons in Systray widget when restarting/reloading config.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -42,7 +42,14 @@ class Icon(window._Window):
     def __init__(self, win, qtile, systray):
         window._Window.__init__(self, win, qtile)
         self.systray = systray
+        self.name = win.get_name()
         self.update_size()
+
+    def __eq__(self, other):
+        if not isinstance(other, Icon):
+            return False
+
+        return self.window.wid == other.window.wid
 
     def update_size(self):
         icon_size = self.systray.icon_size
@@ -73,8 +80,9 @@ class Icon(window._Window):
 
     def handle_DestroyNotify(self, event):  # noqa: N802
         wid = event.window
+        icon = self.qtile.windows_map[wid]
+        self.systray.tray_icons.remove(icon)
         del self.qtile.windows_map[wid]
-        del self.systray.icons[wid]
         self.systray.bar.draw()
         return False
 
@@ -107,16 +115,16 @@ class Systray(window._Window, base._Widget):
     def __init__(self, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(Systray.defaults)
-        self.icons = {}
+        self.tray_icons = []
         self.screen = 0
         self._name = config.get("name", "systray")
 
     def calculate_length(self):
         if self.bar.horizontal:
-            length = sum(i.width for i in self.icons.values())
+            length = sum(i.width for i in self.tray_icons)
         else:
-            length = sum(i.height for i in self.icons.values())
-        length += self.padding * len(self.icons)
+            length = sum(i.height for i in self.tray_icons)
+        length += self.padding * len(self.tray_icons)
         return length
 
     def _configure(self, qtile, bar):
@@ -183,8 +191,10 @@ class Systray(window._Window, base._Widget):
         if opcode == atoms["_NET_SYSTEM_TRAY_OPCODE"] and message == 0:
             w = window.XWindow(self.conn, wid)
             icon = Icon(w, self.qtile, self)
-            self.icons[wid] = icon
-            self.qtile.windows_map[wid] = icon
+            if icon not in self.tray_icons:
+                self.tray_icons.append(icon)
+                self.tray_icons.sort(key=lambda icon: icon.name)
+                self.qtile.windows_map[wid] = icon
 
             self.conn.conn.core.ChangeSaveSet(SetMode.Insert, wid)
             self.conn.conn.core.ReparentWindow(wid, parent.wid, 0, 0)
@@ -205,7 +215,7 @@ class Systray(window._Window, base._Widget):
         offset = self.padding
         self.drawer.clear(self.background or self.bar.background)
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
-        for pos, icon in enumerate(self.icons.values()):
+        for pos, icon in enumerate(self.tray_icons):
             icon.window.set_attribute(backpixmap=self.drawer.pixmap)
             if self.bar.horizontal:
                 xoffset = self.offsetx + offset
@@ -245,8 +255,8 @@ class Systray(window._Window, base._Widget):
         self.hide()
 
         root = self.qtile.core._root.wid
-        for wid in self.icons:
-            self.conn.conn.core.ReparentWindow(wid, root, 0, 0)
+        for icon in self.tray_icons:
+            self.conn.conn.core.ReparentWindow(icon.window.wid, root, 0, 0)
         self.conn.conn.flush()
 
         del self.qtile.windows_map[self.wid]


### PR DESCRIPTION
To prevent icon order changing after restart/reloading config, icons are now ordered by application name.