### PR TITLE
Revert "Fix icon order in Systray"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,6 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix bug where bars were not reconfigured correctly when screen layout changes.
         - Change timing of `screens_reconfigured` hook. Will now be called ONLY if `cmd_reconfigure_screens`
           has been called and completed.
-        - Fix order of icons in Systray widget when restarting/reloading config.
         - Fix rounding error in PulseVolume widget's reported volume.
 
 Qtile 0.19.0, released 2021-12-22:


### PR DESCRIPTION
This reverts commit ec8270e3688ce16c189208e46ff268696bfe1b85.

From irc:
```
[12:30] <    elcaven> Since the latest updates of qtile, my bar reconfigures weird sometimes (I am guessing it is due to the changes in #3151). It leaves blank spaces
                      in the systray area until a qtile restart and then it fixes itself
[12:31] <    elcaven> in the logs I can see this error: TypeError: '<' not supported between instances of 'str' and 'NoneType'
[13:09] < elParaguayo> | elcaven - that's not the bar, that's some changes we made to systray (3198)
[13:09] < elParaguayo> | I saw that error before but thought I'd got rid of it as I wasn't getting it on my system.
[13:09] < elParaguayo> | I'll take a another look
[14:59] <   elcaven_> | elParaguayo: makes sense, I just connected it to the bar PR because that was one of the latest changes I pulled in
[16:02] < elParaguayo> | can you let me know what icons you had in your tray? It looks like I may need to catch events where there is no name provided (or work out
          why there is no name).
[16:03] <  elcaven__> I had the icon for teams, hexchat and jetbrains toolbox
[16:04] <  elcaven__> also stuff like bluetoothctl, network manager and volicon. like right now after a qtile restart I only have the hexchat icon visible
[16:17] < elParaguayo> | Thanks. If you do `reload_config` instead of `restart`, do you get the same issue?
[16:20] <  elcaven__> is that through the "qtile run-cmd"? normally I just do it through the lazy.restart()
[16:22] <  elcaven__> nvm I found the github issue that reference that it is a part of the lazy commands
[16:25] <    elcaven> so with the reload qtile starts with some empty space next to the bluetooth, network and battery systray entries. After starting hexchat the
                      icon does not appear, after a config reload it does appear correctly and it also fixed the blank space
[16:25] <    elcaven> same thing after starting microsoft teams
[16:26] <    elcaven> and something like jetbrains-toolbox appears correctly from the start
[16:27] < elParaguayo> | weird. I think we should rever that commit for now and see what's going on. It seems the X server doesn't always provide window names.
```