### PR TITLE
Fix Systray icon ordering - v2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix bug where bars were not reconfigured correctly when screen layout changes.
         - Change timing of `screens_reconfigured` hook. Will now be called ONLY if `cmd_reconfigure_screens`
           has been called and completed.
+        - Fix order of icons in Systray widget when restarting/reloading config.
         - Fix rounding error in PulseVolume widget's reported volume.
 
 Qtile 0.19.0, released 2021-12-22:

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -47,7 +47,16 @@ class Icon(window._Window):
     def __init__(self, win, qtile, systray):
         window._Window.__init__(self, win, qtile)
         self.systray = systray
+        # win.get_name() may return None when apps provide a temporary window before the icon window
+        # we need something in self.name in order to sort icons so we use the window's WID.
+        self.name = win.get_name() or str(win.wid)
         self.update_size()
+
+    def __eq__(self, other):
+        if not isinstance(other, Icon):
+            return False
+
+        return self.window.wid == other.window.wid
 
     def update_size(self):
         icon_size = self.systray.icon_size
@@ -78,8 +87,8 @@ class Icon(window._Window):
 
     def handle_DestroyNotify(self, event):  # noqa: N802
         wid = event.window
-        del self.qtile.windows_map[wid]
-        del self.systray.icons[wid]
+        icon = self.qtile.windows_map.pop(wid)
+        self.systray.tray_icons.remove(icon)
         self.systray.bar.draw()
         return False
 
@@ -112,17 +121,17 @@ class Systray(window._Window, base._Widget):
     def __init__(self, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(Systray.defaults)
-        self.icons = {}
+        self.tray_icons = []
         self.screen = 0
         self._name = config.get("name", "systray")
         self._wm_class: Optional[List[str]] = None
 
     def calculate_length(self):
         if self.bar.horizontal:
-            length = sum(i.width for i in self.icons.values())
+            length = sum(i.width for i in self.tray_icons)
         else:
-            length = sum(i.height for i in self.icons.values())
-        length += self.padding * len(self.icons)
+            length = sum(i.height for i in self.tray_icons)
+        length += self.padding * len(self.tray_icons)
         return length
 
     def _configure(self, qtile, bar):
@@ -189,8 +198,10 @@ class Systray(window._Window, base._Widget):
         if opcode == atoms["_NET_SYSTEM_TRAY_OPCODE"] and message == 0:
             w = window.XWindow(self.conn, wid)
             icon = Icon(w, self.qtile, self)
-            self.icons[wid] = icon
-            self.qtile.windows_map[wid] = icon
+            if icon not in self.tray_icons:
+                self.tray_icons.append(icon)
+                self.tray_icons.sort(key=lambda icon: icon.name)
+                self.qtile.windows_map[wid] = icon
 
             self.conn.conn.core.ChangeSaveSet(SetMode.Insert, wid)
             self.conn.conn.core.ReparentWindow(wid, parent.wid, 0, 0)
@@ -211,7 +222,7 @@ class Systray(window._Window, base._Widget):
         offset = self.padding
         self.drawer.clear(self.background or self.bar.background)
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
-        for pos, icon in enumerate(self.icons.values()):
+        for pos, icon in enumerate(self.tray_icons):
             icon.window.set_attribute(backpixmap=self.drawer.pixmap)
             if self.bar.horizontal:
                 xoffset = self.offsetx + offset
@@ -251,8 +262,8 @@ class Systray(window._Window, base._Widget):
         self.hide()
 
         root = self.qtile.core._root.wid
-        for wid in self.icons:
-            self.conn.conn.core.ReparentWindow(wid, root, 0, 0)
+        for icon in self.tray_icons:
+            self.conn.conn.core.ReparentWindow(icon.window.wid, root, 0, 0)
         self.conn.conn.flush()
 
         del self.qtile.windows_map[self.wid]


### PR DESCRIPTION
This PR tries to fix the order of icons in Systray by sorting by application name. However, in certain circumstances, no window
name is available so we use the window's WID as a name in order to be able to sort the list of icons.

@elcaven - could you check that this fixes the issue you and I discussed in IRC?
