### PR TITLE
WL: Implement XWayland support

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -61,6 +61,7 @@ from wlroots.wlr_types.server_decoration import (
 )
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
+from wlroots import xwayland
 from xkbcommon import xkb
 
 from libqtile import hook
@@ -87,15 +88,17 @@ class Core(base.Core, wlrq.HasListeners):
         self.qtile: Optional[Qtile] = None
         self.desktops: int = 1
         self.current_desktop: int = 0
+        self._hovered_internal: Optional[window.Internal] = None
+        self.focused_internal: Optional[window.Internal] = None
 
+        self.fd = None
         self.display = Display()
         self.event_loop = self.display.get_event_loop()
         self.compositor, self.backend = wlroots_helper.build_compositor(self.display)
         self.renderer = self.backend.renderer
         self.socket = self.display.add_socket()
-        self.fd = None
-        self._hovered_internal: Optional[window.Internal] = None
-        self.focused_internal: Optional[window.Internal] = None
+        os.environ["WAYLAND_DISPLAY"] = self.socket.decode()
+        logger.info("Starting core with WAYLAND_DISPLAY=" + self.socket.decode())
 
         # These windows have not been mapped yet; they'll get managed when mapped
         self.pending_windows: List[window.WindowType] = []
@@ -172,9 +175,17 @@ class Core(base.Core, wlrq.HasListeners):
         self._relative_pointer_manager_v1 = RelativePointerManagerV1(self.display)
         self.foreign_toplevel_manager_v1 = ForeignToplevelManagerV1.create(self.display)
 
-        # start
-        os.environ["WAYLAND_DISPLAY"] = self.socket.decode()
-        logger.info("Starting core with WAYLAND_DISPLAY=" + self.socket.decode())
+        # Set up XWayland
+        self._xwayland = xwayland.XWayland.create(self.display, self.compositor, True)
+        if self._xwayland:
+            os.environ["DISPLAY"] = self._xwayland.display_name
+            logger.info("Set up XWayland with DISPLAY=" + os.environ["DISPLAY"])
+            self.add_listener(self._xwayland.ready_event, self._on_xwayland_ready)
+            self.add_listener(self._xwayland.new_surface_event, self._on_xwayland_new_surface)
+        else:
+            logger.info("Failed to set up XWayland. Continuing without.")
+
+        # Start
         self.backend.start()
 
     @property
@@ -187,6 +198,8 @@ class Core(base.Core, wlrq.HasListeners):
         for out in self.outputs:
             out.finalize()
 
+        if self._xwayland:
+            self._xwayland.destroy()
         self.finalize_listeners()
         self.cursor_manager.destroy()
         self.cursor.destroy()
@@ -386,6 +399,18 @@ class Core(base.Core, wlrq.HasListeners):
     ):
         logger.debug("Signal: xdg_decoration new_top_level_decoration")
         decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
+
+    def _on_xwayland_ready(self, _listener, _data):
+        logger.debug("Signal: xwayland ready")
+        assert self._xwayland is not None
+        self._xwayland.set_seat(self.seat)
+        self._xwayland_atoms: Dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
+
+    def _on_xwayland_new_surface(self, _listener, surface: xwayland.Surface):
+        logger.debug("Signal: xwayland new_surface")
+        assert self.qtile is not None
+        win = window.XWindow(self, self.qtile, surface)
+        self.pending_windows.append(win)
 
     def _output_manager_reconfigure(self, config: OutputConfigurationV1, apply: bool) -> None:
         """
@@ -618,17 +643,29 @@ class Core(base.Core, wlrq.HasListeners):
             if not win.surface.current.keyboard_interactive:
                 return
 
+        if isinstance(win.surface, xwayland.Surface):
+            if not win.surface.or_surface_wants_focus:
+                return
+
         previous_surface = self.seat.keyboard_state.focused_surface
         if previous_surface == surface:
             return
 
-        if previous_surface is not None and previous_surface.is_xdg_surface:
+        if previous_surface is not None:
             # Deactivate the previously focused surface
-            previous_xdg_surface = XdgSurface.from_surface(previous_surface)
-            if not win or win.surface != previous_xdg_surface:
-                previous_xdg_surface.set_activated(False)
-                if previous_xdg_surface.data:
-                    previous_xdg_surface.data.set_activated(False)
+            if previous_surface.is_xdg_surface:
+                previous_xdg_surface = XdgSurface.from_surface(previous_surface)
+                if not win or win.surface != previous_xdg_surface:
+                    previous_xdg_surface.set_activated(False)
+                    if previous_xdg_surface.data:
+                        previous_xdg_surface.data.set_activated(False)
+
+            elif previous_surface.is_xwayland_surface:
+                prev_xwayland_surface = xwayland.Surface.from_wlr_surface(previous_surface)
+                if not win or win.surface != prev_xwayland_surface:
+                    prev_xwayland_surface.activate(False)
+                    if prev_xwayland_surface.data:
+                        prev_xwayland_surface.data.set_activated(False)
 
         if not win:
             self.seat.keyboard_clear_focus()
@@ -637,6 +674,10 @@ class Core(base.Core, wlrq.HasListeners):
         logger.debug("Focussing new window")
         if surface.is_xdg_surface and isinstance(win.surface, XdgSurface):
             win.surface.set_activated(True)
+            win.ftm_handle.set_activated(True)
+
+        elif surface.is_xwayland_surface and isinstance(win.surface, xwayland.Surface):
+            win.surface.activate(True)
             win.ftm_handle.set_activated(True)
 
         if enter and self.seat.keyboard._ptr:  # This pointer is NULL when headless

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -35,7 +35,7 @@ from wlroots.wlr_types.layer_shell_v1 import (
     LayerSurfaceV1Anchor,
 )
 
-from libqtile.backend.wayland.window import Internal, Static
+from libqtile.backend.wayland.window import Internal, Static, XWindow
 from libqtile.backend.wayland.wlrq import HasListeners
 from libqtile.log_utils import logger
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -26,7 +26,7 @@ import typing
 import cairocffi
 import pywayland
 import wlroots.wlr_types.foreign_toplevel_management_v1 as ftm
-from wlroots import ffi
+from wlroots import ffi, xwayland
 from wlroots.util.box import Box
 from wlroots.util.edges import Edges
 from wlroots.wlr_types import Texture
@@ -65,12 +65,15 @@ def _rgb(color: ColorType) -> ffi.CData:
     return ffi.new("float[4]", utils.rgb(color))
 
 
-# Window manages XdgSurfaces, Static manages XdgSurfaces and LayerSurfaceV1s
-SurfaceType = typing.Union[XdgSurface, LayerSurfaceV1]
+# Window manages XdgSurface
+# Static manages XdgSurface, LayerSurfaceV1 and xwayland.Surface (override-redirect)
+# XWindow manages xwayland.Surface
+SurfaceType = typing.Union[XdgSurface, LayerSurfaceV1, xwayland.Surface]
 
 
 class Window(base.Window, HasListeners):
     def __init__(self, core: Core, qtile: Qtile, surface: SurfaceType):
+        assert isinstance(surface, XdgSurface)
         base.Window.__init__(self)
         self.core = core
         self.qtile = qtile
@@ -89,7 +92,6 @@ class Window(base.Window, HasListeners):
         self._width: int = 0
         self._height: int = 0
 
-        assert isinstance(surface, XdgSurface)
         self._app_id: Optional[str] = surface.toplevel.app_id
         self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()
         surface.data = self.ftm_handle
@@ -312,15 +314,15 @@ class Window(base.Window, HasListeners):
         for output in self._outputs:
             output.damage()
 
-    def hide(self):
+    def hide(self) -> None:
         if self.mapped:
             self.surface.unmap_event.emit()
 
-    def unhide(self):
+    def unhide(self) -> None:
         if not self.mapped:
             self.surface.map_event.emit()
 
-    def kill(self):
+    def kill(self) -> None:
         self.surface.send_close()
 
     def get_pid(self) -> int:
@@ -882,6 +884,7 @@ class Static(base.Static, Window):
         self.core = core
         self.qtile = qtile
         self.surface = surface
+        self.screen = qtile.current_screen
         self.subsurfaces: List[SubSurface] = []
         self._wid = wid
         self._mapped: bool = False
@@ -895,7 +898,7 @@ class Static(base.Static, Window):
         self._outputs: Set[Output] = set()
         self._float_state = FloatStates.FLOATING
         self.is_layer = False
-        self._app_id: Optional[str] = None  # Not used by layer-shell surfaces
+        self._app_id: Optional[str] = None
 
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)
@@ -910,17 +913,22 @@ class Static(base.Static, Window):
             self.screen = self.output.screen
             self.mapped = True
             self._outputs.add(self.output)
-        else:
+
+        elif isinstance(surface, XdgSurface):
             if surface.toplevel.title:
                 self.name = surface.toplevel.title
             self._app_id = surface.toplevel.app_id
             self.add_listener(surface.toplevel.set_title_event, self._on_set_title)
             self.add_listener(surface.toplevel.set_app_id_event, self._on_set_app_id)
-            self.ftm_handle = surface.data
-            assert self.ftm_handle
-            self.add_listener(self.ftm_handle.request_close_event, self._on_foreign_request_close)
             self._find_outputs()
-            self.screen = qtile.current_screen
+
+        else:  # xwayland.Surface
+            self._app_id = self.surface.wm_class
+            self._find_outputs()
+
+        if ftm_handle := surface.data:
+            self.ftm_handle = ftm_handle
+            self.add_listener(self.ftm_handle.request_close_event, self._on_foreign_request_close)
 
     def finalize(self):
         self.finalize_listeners()
@@ -996,7 +1004,7 @@ class Static(base.Static, Window):
 
         hook.fire("client_focus", self)
 
-    def kill(self):
+    def kill(self) -> None:
         if self.is_layer:
             self.surface.close()
         else:
@@ -1021,7 +1029,10 @@ class Static(base.Static, Window):
         if self.is_layer:
             self.surface.configure(width, height)
         else:
-            self.surface.set_size(int(width), int(height))
+            if isinstance(self.surface, XdgSurface):
+                self.surface.set_size(int(width), int(height))
+            else:
+                self.surface.configure(x, y, self._width, self._height)
             self.paint_borders(bordercolor, borderwidth)
         self.damage()
 
@@ -1123,3 +1134,241 @@ class SubSurface(HasListeners):
 
     def _on_new_subsurface(self, _listener, subsurface: WlrSubSurface):
         self.subsurfaces.append(SubSurface(self, subsurface))
+
+
+class XWindow(Window):
+    """
+    A client window connecting to the X server via XWayland.
+    """
+
+    def __init__(self, core: Core, qtile: Qtile, surface: SurfaceType):
+        assert isinstance(surface, xwayland.Surface)
+        base.Window.__init__(self)
+        self.core = core
+        self.qtile = qtile
+        self.surface = surface
+        self._group: Optional[_Group] = None
+        self._mapped: bool = False
+        self.x = 0
+        self.y = 0
+        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
+        self._opacity: float = 1.0
+        self._outputs: Set[Output] = set()
+
+        self._app_id: Optional[str] = self.surface.wm_class
+        self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()
+        surface.data = self.ftm_handle
+
+        # These become non-zero when being mapping for the first time
+        self._width: int = 0
+        self._height: int = 0
+        self.float_x: Optional[int] = None
+        self.float_y: Optional[int] = None
+        self._float_width: int = 0
+        self._float_height: int = 0
+        self._float_state = FloatStates.NOT_FLOATING
+
+        self.add_listener(surface.map_event, self._on_map)
+        self.add_listener(surface.unmap_event, self._on_unmap)
+        self.add_listener(surface.destroy_event, self._on_destroy)
+
+    def finalize(self):
+        self.finalize_listeners()
+        self.ftm_handle.destroy()
+
+    def _on_map(self, _listener, _data):
+        logger.debug("Signal: xwindow map")
+
+        if self in self.core.pending_windows:
+            self.core.pending_windows.remove(self)
+            self._wid = self.core.new_wid()
+            logger.debug(f"Managing new XWayland window with window ID: {self.wid}")
+
+            # Make it static if it isn't a regular window
+            if self.surface.override_redirect:
+                self.cmd_static(
+                    None, self.surface.x, self.surface.y, self.surface.width, self.surface.height
+                )
+                return
+
+            # Save the client's desired geometry
+            self._width = self._float_width = self.surface.width
+            self._height = self._float_height = self.surface.height
+
+            # Get the client's name and class
+            if title := self.surface.title:
+                self.name = title
+                self.ftm_handle.set_title(self.name)
+            self._app_id = self.surface.wm_class
+            self.ftm_handle.set_app_id(self._app_id)
+
+            # Add event listeners
+            self.add_listener(self.surface.surface.commit_event, self._on_commit)
+            self.add_listener(self.surface.request_fullscreen_event, self._on_request_fullscreen)
+            self.add_listener(self.surface.request_configure_event, self._on_request_configure)
+            self.add_listener(self.surface.set_title_event, self._on_set_title)
+            self.add_listener(self.surface.set_class_event, self._on_set_class)
+            self.add_listener(
+                self.ftm_handle.request_maximize_event, self._on_foreign_request_maximize
+            )
+            self.add_listener(
+                self.ftm_handle.request_minimize_event, self._on_foreign_request_minimize
+            )
+            self.add_listener(
+                self.ftm_handle.request_activate_event, self._on_foreign_request_activate
+            )
+            self.add_listener(
+                self.ftm_handle.request_fullscreen_event, self._on_foreign_request_fullscreen
+            )
+            self.add_listener(self.ftm_handle.request_close_event, self._on_foreign_request_close)
+
+            self.qtile.manage(self)
+
+        if self.group.screen:
+            self.mapped = True
+            self.core.focus_window(self)
+
+    def _on_request_fullscreen(self, _listener, _data):
+        logger.debug("Signal: xwindow request_fullscreen")
+        if self.qtile.config.auto_fullscreen:
+            self.fullscreen = not self.fullscreen
+
+    def _on_request_configure(self, _listener, event: xwayland.SurfaceConfigureEvent):
+        logger.debug("Signal: xwindow request_configure")
+        self.surface.configure(event.x, event.y, event.width, even.height)
+        self.floating = True
+
+    def _on_set_title(self, _listener, _data):
+        logger.debug("Signal: xwindow set_title")
+        title = self.surface.title
+        if title != self.name:
+            self.name = title
+            self.ftm_handle.set_title(title)
+            hook.fire("client_name_updated", self)
+
+    def _on_set_class(self, _listener, _data):
+        logger.debug("Signal: xwindow set_class")
+        self._app_id = self.surface.wm_class
+        self.ftm_handle.set_app_id(self._app_id)
+
+    def kill(self) -> None:
+        self.surface.close()
+
+    def has_fixed_size(self) -> bool:
+        hints = self.surface.size_hints
+        # TODO: Maybe consider these flags too:
+        # "PMinSize" in self.hints["flags"] and "PMaxSize" in self.hints["flags"]
+        return (
+            hints
+            and 0 < hints.min_width == hints.max_width
+            and 0 < hints.min_height == hints.max_height
+        )
+
+    def is_transient_for(self) -> Optional[base.WindowType]:
+        """What window is this window a transient window for?"""
+        assert isinstance(self.surface, xwayland.Surface)
+        if parent := self.surface.parent:
+            for win in self.qtile.windows_map.values():
+                if isinstance(win, XWindow) and win.surface == parent:
+                    return win
+        return None
+
+    def get_pid(self) -> int:
+        return self.surface.pid
+
+    def get_wm_type(self) -> Optional[str]:
+        if wm_type := self.surface.window_type:
+            return self.core._xwayland_wm_atoms[wm_type[0]]
+
+    def get_wm_role(self) -> Optional[str]:
+        return self.surface.role
+
+    def place(
+        self,
+        x,
+        y,
+        width,
+        height,
+        borderwidth,
+        bordercolor,
+        above=False,
+        margin=None,
+        respect_hints=False,
+    ):
+
+        # Adjust the placement to account for layout margins, if there are any.
+        if margin is not None:
+            if isinstance(margin, int):
+                margin = [margin] * 4
+            x += margin[3]
+            y += margin[0]
+            width -= margin[1] + margin[3]
+            height -= margin[0] + margin[2]
+
+        if respect_hints:
+            hints = self.surface.size_hints
+            width = max(width, hints.min_width)
+            height = max(height, hints.min_height)
+            if hints.max_width > 0:
+                width = min(width, hints.max_width)
+            if hints.max_height > 0:
+                height = min(height, hints.max_height)
+
+        # save x and y float offset
+        if self.group is not None and self.group.screen is not None:
+            self.float_x = x - self.group.screen.x
+            self.float_y = y - self.group.screen.y
+
+        self.x = x
+        self.y = y
+        self._width = int(width)
+        self._height = int(height)
+        self.surface.configure(x, y, self._width, self._height)
+        self.paint_borders(bordercolor, borderwidth)
+
+        if above and self._mapped:
+            self.core.mapped_windows.remove(self)
+            self.core.mapped_windows.append(self)
+            self.core.stack_windows()
+
+        prev_outputs = self._outputs.copy()
+        self._find_outputs()
+        for output in self._outputs | prev_outputs:
+            output.damage()
+
+    def cmd_static(
+        self,
+        screen: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
+        self.defunct = True
+        if self.group:
+            self.group.remove(self)
+        if x is None:
+            x = self.x + self.borderwidth
+        if y is None:
+            y = self.y + self.borderwidth
+        if width is None:
+            width = self.width
+        if height is None:
+            height = self.height
+
+        self.finalize_listeners()
+        win = Static(self.core, self.qtile, self.surface, self.wid)
+        if screen is not None:
+            win.screen = self.qtile.screens[screen]
+        win.place(x, y, width, height, 0, None)
+        self.qtile.windows_map[self.wid] = win
+
+        if self.mapped:
+            win._mapped = True
+            z = self.core.mapped_windows.index(self)
+            self.core.mapped_windows[z] = win
+            self.core.stack_windows()
+        else:
+            win.mapped = True
+
+        hook.fire("client_managed", win)

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from typing import Callable, List, Optional, Set
 
     from pywayland.server import Signal
+    from wlroots import xwayland
     from wlroots.wlr_types import Box, data_device_manager
 
     from libqtile.backend.wayland.core import Core
@@ -305,3 +306,32 @@ class Dnd(HasListeners):
         self._outputs = {o for o in self.core.outputs if o.contains(self)}
         for output in self._outputs:
             output.damage()
+
+
+def get_xwayland_atoms(xwayland: xwayland.XWayland) -> Dict[str, int]:
+    """
+    These can be used when matching on XWayland clients with wm_type.
+    http://standards.freedesktop.org/wm-spec/latest/ar01s05.html#idm139870830002400
+    """
+    xwayland_wm_types = {
+        "_NET_WM_WINDOW_TYPE_DESKTOP": "desktop",
+        "_NET_WM_WINDOW_TYPE_DOCK": "dock",
+        "_NET_WM_WINDOW_TYPE_TOOLBAR": "toolbar",
+        "_NET_WM_WINDOW_TYPE_MENU": "menu",
+        "_NET_WM_WINDOW_TYPE_UTILITY": "utility",
+        "_NET_WM_WINDOW_TYPE_SPLASH": "splash",
+        "_NET_WM_WINDOW_TYPE_DIALOG": "dialog",
+        "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU": "dropdown",
+        "_NET_WM_WINDOW_TYPE_POPUP_MENU": "menu",
+        "_NET_WM_WINDOW_TYPE_TOOLTIP": "tooltip",
+        "_NET_WM_WINDOW_TYPE_NOTIFICATION": "notification",
+        "_NET_WM_WINDOW_TYPE_COMBO": "combo",
+        "_NET_WM_WINDOW_TYPE_DND": "dnd",
+        "_NET_WM_WINDOW_TYPE_NORMAL": "normal",
+    }
+
+    atoms = {}
+    for atom, name in xwayland_wm_types.items():
+        atoms[xwayland.get_atom(atom)] = name
+
+    return atoms

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -710,7 +710,7 @@ class Match:
             elif property_name == "net_wm_pid":
                 value = client.get_pid()
             elif property_name == "wid":
-                value = client.window.wid
+                value = client.wid
             else:
                 value = client.get_wm_type()
 


### PR DESCRIPTION
This is adds support for X-only clients through XWayland.

XWayland must be installed on the system. It's lazy to startup, so will
only be started when the first X connection is made. This adds a bit of
delay to that first client's startup, but it's better there than at
Qtile's startup. Users could start it up themselves in a startup hook to
avoid the delay.

Override-redirect windows (such as rofi, dmenu) are managed as `Static`
windows, which seems to work fine. Everything else is a `Window`.

Support is provided by wlroots, via pywlroots, which must have been
built with XWayland support (i.e. if XCB was present on the system when
it was build).

--

Currently this requires this PR: https://github.com/flacjacket/pywlroots/pull/69

Any feedback and live testing is greatly appreciated. I do not use any X-only clients myself, but it would be good to test many different clients to check they all work as expected.