### PR TITLE
Remove docs test from CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -113,4 +113,4 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, packaging, pep8, codestyle, docstyle, mypy, docs, vulture
+    3.10: py310, packaging, pep8, codestyle, docstyle, mypy, vulture


### PR DESCRIPTION
We now have a hook to ReadTheDocs so that docs are built for pull requests and a status is shown for successful/failed builds.

The `docs` test has been removed from CI but is still available in `tox.ini` so users can still run `tox -e docs` to test locally.