### PR TITLE
Fix Systray bug in WidgetBox

### DIFF
--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -120,7 +120,7 @@ class WidgetBox(base._Widget):
                 # are separate _Window instances.
                 # Systray unhides icons when it draws so we only need to hide them.
                 if isinstance(widget, Systray):
-                    for icon in widget.icons.values():
+                    for icon in widget.tray_icons:
                         icon.hide()
 
             except ValueError:


### PR DESCRIPTION
9069a0e broke WidgetBox if there was a Systray widget in the box as tray icons were not removed correctly. This was due to renaming the list that contains the icons.

This PR fixes the issue by ensuring that icons are correctly hidden when closing the box.

Fixes #3224