### PR TITLE
Release Notification service from dbus on finalize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,8 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Fix rounding error in PulseVolume widget's reported volume.
         - Remove ability to have multiple `Systray` widgets. Additional `Systray` widgets will result in a
           ConfigError.
+        - Release notification name from dbus when finalising `Notify` widget. This allows other notification
+          managers to request the name.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -26,7 +26,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import asyncio
 from os import path
 
 from libqtile import bar, pangocffi, utils
@@ -189,3 +189,17 @@ class Notify(base._TextBox):
         """Invoke the notification's default action"""
         if self.action:
             self.invoke()
+
+    def finalize(self):
+        asyncio.create_task(self._finalize())
+
+    async def _finalize(self):
+        task = notifier.unregister(self.update)
+
+        # If the notifier has no more callbacks then it needs to be stopped.
+        # The returned task will handle the release of the service name from
+        # dbus. We await it here to make sure it's finished before we
+        # complete the finalisation of this widget.
+        if task:
+            await task
+        base._TextBox.finalize(self)


### PR DESCRIPTION
Reloading the config when a `Notify` widget was previously used but now is not, the dbus interface remains in a registered state. This prevents other processes from registering on that interface.

This PR adds a `finalize` method to the `Notify` widget which releases the name from dbus.

Fixes #3223