### PR TITLE
Fix global_defaults for Battery widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           ConfigError.
         - Release notification name from dbus when finalising `Notify` widget. This allows other notification
           managers to request the name.
+        - Fix bug where `Battery` widget did not retrieve `background` from `widget_defaults`.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -339,9 +339,12 @@ class Battery(base.ThreadPoolText):
         self._battery = self._load_battery(**config)
         self._has_notified = False
 
+    def _configure(self, qtile, bar):
         if not self.low_background:
             self.low_background = self.background
         self.normal_background = self.background
+
+        base.ThreadPoolText._configure(self, qtile, bar)
 
     @staticmethod
     def _load_battery(**config):


### PR DESCRIPTION
Similar to #3203, the Battery widget reads a property in `__init__` which prevents it being set by global defaults.

This PR fixes the issue by moving the property read to `_configure`.

Fixes #3228