### PR TITLE
Add _wm_class to Icon in Systray

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -777,7 +777,11 @@ class Qtile(CommandObject):
             return False, [x.position for x in self.current_screen.gaps]
         elif name == "window":
             windows: list[str | int]
-            windows = [k for k, v in self.windows_map.items() if isinstance(v, CommandObject)]
+            windows = [
+                k
+                for k, v in self.windows_map.items()
+                if isinstance(v, CommandObject) and not isinstance(v, _Widget)
+            ]
             return True, windows
         elif name == "screen":
             return True, list(range(len(self.screens)))
@@ -806,7 +810,9 @@ class Qtile(CommandObject):
             else:
                 windows: dict[str | int, base._Window]
                 windows = {
-                    k: v for k, v in self.windows_map.items() if isinstance(v, CommandObject)
+                    k: v
+                    for k, v in self.windows_map.items()
+                    if isinstance(v, CommandObject) and not isinstance(v, _Widget)
                 }
                 return windows.get(sel)
         elif name == "screen":
@@ -1228,7 +1234,11 @@ class Qtile(CommandObject):
 
     def cmd_windows(self) -> list[dict[str, Any]]:
         """Return info for each client window"""
-        return [i.info() for i in self.windows_map.values() if not isinstance(i, base.Internal)]
+        return [
+            i.info()
+            for i in self.windows_map.values()
+            if not isinstance(i, (base.Internal, _Widget)) and isinstance(i, CommandObject)
+        ]
 
     def cmd_internal_windows(self) -> list[dict[str, Any]]:
         """Return info for each internal window (bars, for example)"""

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -50,6 +50,7 @@ class Icon(window._Window):
         # we need something in self.name in order to sort icons so we use the window's WID.
         self.name = win.get_name() or str(win.wid)
         self.update_size()
+        self._wm_class: list[str] | None = None
 
     def __eq__(self, other):
         if not isinstance(other, Icon):

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1198,3 +1198,21 @@ def test_cmd_reload_config(manager_nospawn):
         assert manager_nospawn.c.eval("self.core.wmname") == (True, "LG3D")
     assert "dd" in manager_nospawn.c.groups()["S"]["windows"]  # First dropdown persists
     assert "dd" in manager_nospawn.c.groups()["1"]["windows"]  # Second orphans to group
+
+
+class CommandsConfig(Config):
+    screens = [
+        libqtile.config.Screen(
+            bottom=libqtile.bar.Bar([libqtile.widget.Systray()], 20),
+        )
+    ]
+
+
+@pytest.mark.parametrize("manager", [CommandsConfig], indirect=True)
+def test_windows_from_commands(manager):
+    manager.test_window("one")
+    assert len(manager.c.items("window")) == 2  # This command returns windows including bars
+    windows = manager.c.windows()  # Whereas this one is just regular windows
+    assert len(windows) == 1
+    # And the Systray is absent
+    assert "TestWindow" in windows[0]["wm_class"]


### PR DESCRIPTION
87ac116 added this attribute to the X11 window classes, for use in the
`info()` command to report the wm_class of windows. This was left off
the `Icon` class in systray.py, leading to AttributeErrors when there
are icons.