### PR TITLE
Update chord functionality for consistent interface

### DIFF
--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -122,8 +122,8 @@ shrink it etc. as many times as needed. To exit the mode, press <escape>.
 Keyboard grabbing
 -----------------
 
-A KeyChord may specify the optional parameter `grab_keyboard`, which defaults to
-True:
+A KeyChord may specify the optional parameter ``grab_keyboard``, which defaults
+to True:
 
 ::
 
@@ -143,7 +143,7 @@ useful for modes, in order to allow you to interact with an application normally
 while also issuing commands from the mode.
 
 If it is set to True (the default), then any key pressed while a KeyChord is
-active will be consumed by QTile and will not be passed to the application.
+active will be consumed by Qtile and will not be passed to the application.
 Also, for chords which do not set a mode, any key (even one not bound in the
 chord) will cause the chord to deactivate and return to the main keymap.
 

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -89,12 +89,6 @@ the config file.
 
 The above code will launch xterm when the user presses Mod + z, followed by x.
 
-.. warning::
-    Users should note that key chords are aborted by pressing <escape>. In the
-    above example, if the user presses Mod + z, any following key presses will
-    still be sent to the currently focussed window. If <escape> has not been
-    pressed, the next press of x will launch xterm.
-
 Modes
 -----
 
@@ -124,6 +118,34 @@ shrink it etc. as many times as needed. To exit the mode, press <escape>.
     If using modes, users may also wish to use the Chord widget
     (:class:`libqtile.widget.chord.Chord`) as this will display the name of the
     currently active mode on the bar.
+
+Keyboard grabbing
+-----------------
+
+A KeyChord may specify the optional parameter `grab_keyboard`, which defaults to
+True:
+
+::
+
+    from libqtile.config import Key, KeyChord
+
+    keys = [
+        KeyChord([mod], "z", [
+            Key([], "g", lazy.spawn("xterm")),
+        ],
+        grab_keyboard=False,
+        mode="spawn")
+    ]
+
+If this is set to False, then keys not bound in the KeyChord will be passed
+through to the focused application and the chord will remain open. This can be
+useful for modes, in order to allow you to interact with an application normally
+while also issuing commands from the mode.
+
+If it is set to True (the default), then any key pressed while a KeyChord is
+active will be consumed by QTile and will not be passed to the application.
+Also, for chords which do not set a mode, any key (even one not bound in the
+chord) will cause the chord to deactivate and return to the main keymap.
 
 Chains
 ------

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -62,6 +62,14 @@ class Core(CommandObject, metaclass=ABCMeta):
     def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
         """Get the screen information"""
 
+    def grab_keyboard(self) -> None:
+        """Grab the entire keyboard, passing on all key events"""
+        raise NotImplementedError()
+
+    def ungrab_keyboard(self) -> None:
+        """Release the keyboard and process key events normally"""
+        raise NotImplementedError()
+
     @abstractmethod
     def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Configure the backend to grab the key event"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -110,6 +110,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.keyboards: List[keyboard.Keyboard] = []
         self.grabbed_keys: List[Tuple[int, int]] = []
         self.grabbed_buttons: List[Tuple[int, int]] = []
+        self.keyboard_grabbed: bool = False
         DataDeviceManager(self.display)
         self.live_dnd: Optional[wlrq.Dnd] = None
         DataControlManagerV1(self.display)
@@ -709,6 +710,12 @@ class Core(base.Core, wlrq.HasListeners):
     def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
         """Get the screen information"""
         return [screen.get_geometry() for screen in self.outputs if screen.wlr_output.enabled]
+
+    def grab_keyboard(self) -> None:
+        self.keyboard_grabbed = True
+
+    def ungrab_keyboard(self) -> None:
+        self.keyboard_grabbed = False
 
     def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Configure the backend to grab the key event"""

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -111,12 +111,15 @@ class Keyboard(HasListeners):
             keysyms = [xkb_keysym[0][i] for i in range(nsyms)]
             mods = self.keyboard.modifier
             for keysym in keysyms:
-                if (keysym, mods) in self.grabbed_keys:
+                if (keysym, mods) in self.grabbed_keys or self.core.keyboard_grabbed:
                     self.qtile.process_key_event(keysym, mods)
                     return
 
             if self.core.focused_internal:
                 self.core.focused_internal.process_key_press(keysym)
                 return
+
+        if self.core.keyboard_grabbed:
+            return
 
         self.seat.keyboard_notify_key(event)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -444,6 +444,18 @@ class Core(base.Core):
 
         return keysym, modmask
 
+    def grab_keyboard(self) -> None:
+        self.conn.conn.core.GrabKeyboard(
+            True,
+            self._root.wid,
+            xcffib.xproto.Time.CurrentTime,
+            xcffib.xproto.GrabMode.Async,
+            xcffib.xproto.GrabMode.Async,
+        )
+
+    def ungrab_keyboard(self) -> None:
+        self.conn.conn.core.UngrabKeyboard(xcffib.xproto.Time.CurrentTime)
+
     def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
         """Map the key to receive events on it"""
         keysym, modmask = self.lookup_key(key)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -95,6 +95,7 @@ class KeyChord:
         key: str,
         submappings: List[Union[Key, KeyChord]],
         mode: str = "",
+        grab_keyboard: bool = True,
     ):
         self.modifiers = modifiers
         self.key = key
@@ -102,6 +103,7 @@ class KeyChord:
         submappings.append(Key([], "Escape"))
         self.submappings = submappings
         self.mode = mode
+        self.grab_keyboard = grab_keyboard
 
     def __repr__(self):
         return "<KeyChord (%s, %s)>" % (self.modifiers, self.key)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -87,6 +87,11 @@ class KeyChord:
         A string with vim like mode name. If it's set, the chord mode will
         not be left after a keystroke (except for Esc which always leaves the
         current chord/mode).
+    grab_keyboard:
+        A boolean (default True) controlling whether Qtile grabs exclusive
+        control of the keyboard while this keychord is active. If False, keys
+        not bound in the keychord will pass through to the focused application
+        and leave the chord active.
     """
 
     def __init__(

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -424,13 +424,10 @@ class Qtile(CommandObject):
             hook.fire("enter_chord", chord.mode)
 
         self.ungrab_keys()
-        self.core.grab_keyboard()
+        if chord.grab_keyboard:
+            self.core.grab_keyboard()
         for key in chord.submappings:
-            # TODO figure out how to do this without reaching into backend
-            # internals
-            keysym, mask_key = self.core.lookup_key(key)
-            mask_key &= self.core._valid_mask
-            self.keys_map[(keysym, mask_key)] = key
+            self.grab_key(key)
 
     def cmd_ungrab_chord(self) -> None:
         """Leave a chord mode"""


### PR DESCRIPTION
An initial pass at fixes to address the issue in #3196.

This is not ready to merge yet, for at least the following reasons:

1. This code only handles the x11 backend. I don't understand Wayland keyboard handling, nor have a Wayland setup to test on, so I can't write that immediately. Any advice on doing Wayland-backend development from within an x11 environment is welcome.
2. This patch has `grab_chord` in the manager deal directly with internals of the x11 backend core. I don't quite understand the purpose of `_valid_mask` in that core, so I don't know what arrangement would be best to provide the necessary information here.
3. This code currently treats modal chords the same as non-modal chords: i.e. any keypresses that are not mapped in the chord are silently consumed and do not pass through to the application. (However, unlike non-modal chords, modal chords still remain active until Esc is pressed.) I don't know if this is actually the best policy. Comments welcome.

Despite this, I figured I'd get the pull request open in order to solicit advice. 