### PR TITLE
Fix render issue for WidgetBox with bar borders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Release notification name from dbus when finalising `Notify` widget. This allows other notification
           managers to request the name.
         - Fix bug where `Battery` widget did not retrieve `background` from `widget_defaults`.
+        - Fix bug where widgets in a `WidgetBox` are rendered on top of bar borders.
 
 Qtile 0.19.0, released 2021-12-22:
     * features

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -93,6 +93,7 @@ class WidgetBox(base._Widget):
                 self.widgets[idx] = w
             self.qtile.register_widget(w)
             w._configure(self.qtile, self.bar)
+            w.offsety = self.bar.border_width[0]
 
             # In case the widget is mirrored, we need to draw it once so the
             # mirror can copy the surface but draw it off screen


### PR DESCRIPTION
Widgets in the WidgetBox are not being offset vertically and so draw over the bar's border.

This PR adds the `offsety` attribute for widgets in the widget box.