### PR TITLE
Fix more issues with Systray in Widgetbox

### DIFF
--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -79,13 +79,16 @@ class WidgetBox(base._Widget):
         base._Widget._configure(self, qtile, bar)
 
         self.layout = self.drawer.textlayout(
-            self.text_closed,
+            self.text_open if self.box_is_open else self.text_closed,
             self.foreground,
             self.font,
             self.fontsize,
             self.fontshadow,
             markup=False,
         )
+
+        if self.configured:
+            return
 
         for idx, w in enumerate(self.widgets):
             if w.configured:
@@ -99,6 +102,10 @@ class WidgetBox(base._Widget):
             # mirror can copy the surface but draw it off screen
             w.offsetx = self.bar.width
             self.qtile.call_soon(w.draw)
+
+            # Setting the configured flag for widgets was moved to Bar._configure so we need to
+            # set it here.
+            w.configured = True
 
         # Disable drawing of the widget's contents
         for w in self.widgets:


### PR DESCRIPTION
WidgetBox tries to reconfigure widgets when it is, itself, reconfigured.

There is a bug where widgets in the box weren't being marked as configured since we moved the setting of this flag to Bar._configure.

This is particularly problematic when Systray is in the box for two reasons:
1. If the box is open when the bar is reconfigured, the bar sees an unconfigured Systray and tries to configure it and so creates a config error.
2. If the box is closed, widgetbox still tries to reconfigure the Systray and so also triggers a config error.

This PR addresses both of these scenarios by:
1. Ensuring the configured flag is set by the widgetbox
2. Only configuring widgets in the box when the box is configured for the first time.
3. Adding tests for systray and widgetbox for `screens_reconfigured` events.