### PR TITLE
WL: XWayland window request_configure should just give them the geometry

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1254,7 +1254,6 @@ class XWindow(Window):
             # Add event listeners
             self.add_listener(self.surface.surface.commit_event, self._on_commit)
             self.add_listener(self.surface.request_fullscreen_event, self._on_request_fullscreen)
-            self.add_listener(self.surface.request_configure_event, self._on_request_configure)
             self.add_listener(self.surface.set_title_event, self._on_set_title)
             self.add_listener(self.surface.set_class_event, self._on_set_class)
             self.add_listener(
@@ -1309,11 +1308,6 @@ class XWindow(Window):
         logger.debug("Signal: xwindow request_fullscreen")
         if self.qtile.config.auto_fullscreen:
             self.fullscreen = not self.fullscreen
-
-    def _on_request_configure(self, _listener, event: xwayland.SurfaceConfigureEvent):
-        logger.debug("Signal: xwindow request_configure")
-        self.surface.configure(event.x, event.y, event.width, event.height)  # type: ignore
-        self.floating = True
 
     def _on_set_title(self, _listener, _data):
         logger.debug("Signal: xwindow set_title")

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1082,6 +1082,7 @@ class Static(base.Static, Window):
             else:
                 self.surface.configure(x, y, self._width, self._height)
             self.paint_borders(bordercolor, borderwidth)
+            self._find_outputs()
         self.damage()
 
     def cmd_bring_to_front(self) -> None:


### PR DESCRIPTION
And not also float the window - this was based on the incorrect
assumption that they would be requesting a new geometry via this
request, rather than using it to be configured with the new geometry
we've just given them. I dont really understand this but it seems to
work.