### PR TITLE
Fix creation of mirrors in same Bar

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Add `lazy.window.center()` command to center a floating window on the screen.
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
+        - Fix bug where widgets can't be mirrored in same bar.
 
 Qtile 0.20.0, released 2022-01-24:
     * features

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -294,10 +294,10 @@ class Bar(Gap, configurable.Configurable):
                 self._configure_widget(i)
         else:
             for idx, i in enumerate(self.widgets):
-                # Create a mirror if this widget is being placed on a different bar
+                # Create a mirror if this widget is already configured but isn't a Mirror
                 # We don't do isinstance(i, Mirror) because importing Mirror (at the top)
                 # would give a circular import as libqtile.widget.base imports lbqtile.bar
-                if i.configured and i.bar != self and i.__class__.__name__ != "Mirror":
+                if i.configured and i.__class__.__name__ != "Mirror":
                     i = i.create_mirror()
                     self.widgets[idx] = i
                 success = self._configure_widget(i)


### PR DESCRIPTION
One of my previous commits stupidly forgot that people might want to have mirrors of a widget on the same bar (e.g. `Sep`) and prevented this from happening.

This commit corrects that mistake.

Fixes #3272