### PR TITLE
Modernise type annotations and update black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
           LIBDRM: 2.4.109
         strategy:
             matrix:
-                # if you change one of these, be sure to update
-                # /tox.ini:[gh-actions] as well
+                # If you change one of these, be sure to update:
+                # - /tox.ini:[gh-actions]
+                # - /setup.cfg:[mypy]
+                # - /libqtile/scripts/check.py mypy argument
                 python-version: [pypy-3.7, 3.7, 3.8, 3.9, '3.10']
         steps:
             - uses: actions/checkout@v2

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -312,7 +312,7 @@ class Window(_Window, metaclass=ABCMeta):
         """Whether this window has user-defined geometry"""
         return False
 
-    def is_transient_for(self) -> "WindowType" | None:
+    def is_transient_for(self) -> WindowType | None:
         """What window is this window a transient window for?"""
         return None
 

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -13,7 +13,7 @@ from libqtile.command.base import CommandError, CommandObject
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Tuple, Union
+    from typing import Any, Dict, List, Tuple, Union
 
     from libqtile import config
     from libqtile.command.base import ItemT
@@ -140,7 +140,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def __init__(self):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
-        self.reserved_space: Optional[Tuple[int, int, int, int]] = None
+        self.reserved_space: Tuple[int, int, int, int] | None = None
         # Window.cmd_static sets this in case it is hooked to client_new to stop the
         # Window object from being managed, now that a Static is being used instead
         self.defunct: bool = False
@@ -162,15 +162,15 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def kill(self) -> None:
         """Kill the window"""
 
-    def get_wm_class(self) -> Optional[List]:
+    def get_wm_class(self) -> List | None:
         """Return the class(es) of the window"""
         return None
 
-    def get_wm_type(self) -> Optional[str]:
+    def get_wm_type(self) -> str | None:
         """Return the type of the window"""
         return None
 
-    def get_wm_role(self) -> Optional[str]:
+    def get_wm_role(self) -> str | None:
         """Return the role of the window"""
         return None
 
@@ -248,15 +248,15 @@ class Window(_Window, metaclass=ABCMeta):
     qtile: Qtile
 
     # If float_x or float_y are None, the window has never floated
-    float_x: Optional[int]
-    float_y: Optional[int]
+    float_x: int | None
+    float_y: int | None
 
     def __repr__(self):
         return "Window(name=%r, wid=%i)" % (self.name, self.wid)
 
     @property
     @abstractmethod
-    def group(self) -> Optional[_Group]:
+    def group(self) -> _Group | None:
         """The group to which this window belongs."""
 
     @property
@@ -298,7 +298,7 @@ class Window(_Window, metaclass=ABCMeta):
         """Focus this window and optional warp the pointer to it."""
 
     @abstractmethod
-    def togroup(self, group_name: Optional[str] = None, *, switch_group: bool = False) -> None:
+    def togroup(self, group_name: str | None = None, *, switch_group: bool = False) -> None:
         """Move window to a specified group
 
         Also switch to that group if switch_group is True.
@@ -312,7 +312,7 @@ class Window(_Window, metaclass=ABCMeta):
         """Whether this window has user-defined geometry"""
         return False
 
-    def is_transient_for(self) -> Optional["WindowType"]:
+    def is_transient_for(self) -> "WindowType" | None:
         """What window is this window a transient window for?"""
         return None
 
@@ -405,8 +405,8 @@ class Window(_Window, metaclass=ABCMeta):
 
     def cmd_togroup(
         self,
-        group_name: Optional[str] = None,
-        groupName: Optional[str] = None,  # Deprecated  # noqa: N803
+        group_name: str | None = None,
+        groupName: str | None = None,  # Deprecated  # noqa: N803
         switch_group: bool = False,
     ) -> None:
         """Move window to a specified group
@@ -421,7 +421,7 @@ class Window(_Window, metaclass=ABCMeta):
             group_name = groupName
         self.togroup(group_name, switch_group=switch_group)
 
-    def cmd_toscreen(self, index: Optional[int] = None) -> None:
+    def cmd_toscreen(self, index: int | None = None) -> None:
         """Move window to a specified screen.
 
         If index is not specified, we assume the current screen
@@ -480,11 +480,11 @@ class Window(_Window, metaclass=ABCMeta):
     @abstractmethod
     def cmd_static(
         self,
-        screen: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        screen: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
     ) -> None:
         """Makes this window a static window, attached to a Screen.
 
@@ -585,8 +585,8 @@ class Drawer:
     """
 
     # We need to track extent of drawing to know when to redraw.
-    previous_rect: Tuple[int, int, Optional[int], Optional[int]]
-    current_rect: Tuple[int, int, Optional[int], Optional[int]]
+    previous_rect: Tuple[int, int, int | None, int | None]
+    current_rect: Tuple[int, int, int | None, int | None]
 
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         self.qtile = qtile
@@ -723,8 +723,8 @@ class Drawer:
         self,
         offsetx: int = 0,
         offsety: int = 0,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int | None = None,
+        height: int | None = None,
     ):
         """
         A wrapper for the draw operation.
@@ -756,8 +756,8 @@ class Drawer:
         self,
         offsetx: int = 0,
         offsety: int = 0,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int | None = None,
+        height: int | None = None,
     ):
         """
         This draws our cached operations to the Internal window.

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -13,7 +13,7 @@ from libqtile.command.base import CommandError, CommandObject
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Dict, List, Tuple
+    from typing import Any
 
     from libqtile import config
     from libqtile.command.base import ItemT
@@ -55,19 +55,19 @@ class Core(CommandObject, metaclass=ABCMeta):
     def remove_listener(self) -> None:
         """Setup a listener for the given qtile instance"""
 
-    def update_desktops(self, groups: List[_Group], index: int) -> None:
+    def update_desktops(self, groups: list[_Group], index: int) -> None:
         """Set the current desktops of the window manager"""
 
     @abstractmethod
-    def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
+    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the screen information"""
 
     @abstractmethod
-    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Configure the backend to grab the key event"""
 
     @abstractmethod
-    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Release the given key event"""
 
     @abstractmethod
@@ -96,7 +96,7 @@ class Core(CommandObject, metaclass=ABCMeta):
     def warp_pointer(self, x: int, y: int) -> None:
         """Warp the pointer to the given coordinates relative."""
 
-    def update_client_list(self, windows_map: Dict[int, WindowType]) -> None:
+    def update_client_list(self, windows_map: dict[int, WindowType]) -> None:
         """Update the list of windows being managed"""
 
     @contextlib.contextmanager
@@ -114,14 +114,14 @@ class Core(CommandObject, metaclass=ABCMeta):
     def graceful_shutdown(self):
         """Try to close windows gracefully before exiting"""
 
-    def simulate_keypress(self, modifiers: List[str], key: str) -> None:
+    def simulate_keypress(self, modifiers: list[str], key: str) -> None:
         """Simulate a keypress with given modifiers"""
 
     def keysym_from_name(self, name: str) -> int:
         """Get the keysym for a key from its name"""
         raise NotImplementedError
 
-    def cmd_info(self) -> Dict:
+    def cmd_info(self) -> dict:
         """Get basic information about the running backend."""
         return {"backend": self.name, "display_name": self.display_name}
 
@@ -140,7 +140,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def __init__(self):
         self.borderwidth: int = 0
         self.name: str = "<no name>"
-        self.reserved_space: Tuple[int, int, int, int] | None = None
+        self.reserved_space: tuple[int, int, int, int] | None = None
         # Window.cmd_static sets this in case it is hooked to client_new to stop the
         # Window object from being managed, now that a Static is being used instead
         self.defunct: bool = False
@@ -162,7 +162,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def kill(self) -> None:
         """Kill the window"""
 
-    def get_wm_class(self) -> List | None:
+    def get_wm_class(self) -> list | None:
         """Return the class(es) of the window"""
         return None
 
@@ -214,7 +214,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         return None
 
     @abstractmethod
-    def info(self) -> Dict[str, Any]:
+    def info(self) -> dict[str, Any]:
         """
         Return information on this window.
 
@@ -231,7 +231,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         """
         return {}
 
-    def cmd_info(self) -> Dict:
+    def cmd_info(self) -> dict:
         """Return a dictionary of info."""
         return self.info()
 
@@ -331,11 +331,11 @@ class Window(_Window, metaclass=ABCMeta):
         return self.match(*args, **kwargs)
 
     @abstractmethod
-    def cmd_get_position(self) -> Tuple[int, int]:
+    def cmd_get_position(self) -> tuple[int, int]:
         """Get the (x, y) of the window"""
 
     @abstractmethod
-    def cmd_get_size(self) -> Tuple[int, int]:
+    def cmd_get_size(self) -> tuple[int, int]:
         """Get the (width, height) of the window"""
 
     @abstractmethod
@@ -561,7 +561,7 @@ class Static(_Window, metaclass=ABCMeta):
     def __repr__(self):
         return "Static(name=%r, wid=%s)" % (self.name, self.wid)
 
-    def info(self) -> Dict:
+    def info(self) -> dict:
         """Return a dictionary of info."""
         return dict(
             name=self.name,
@@ -585,8 +585,8 @@ class Drawer:
     """
 
     # We need to track extent of drawing to know when to redraw.
-    previous_rect: Tuple[int, int, int | None, int | None]
-    current_rect: Tuple[int, int, int | None, int | None]
+    previous_rect: tuple[int, int, int | None, int | None]
+    current_rect: tuple[int, int, int | None, int | None]
 
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         self.qtile = qtile
@@ -598,7 +598,7 @@ class Drawer:
         self.ctx: cairocffi.Context
         self._reset_surface()
 
-        self.mirrors: Dict[Drawer, bool] = {}
+        self.mirrors: dict[Drawer, bool] = {}
 
         self.current_rect = (0, 0, 0, 0)
         self.previous_rect = (-1, -1, -1, -1)

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -13,7 +13,7 @@ from libqtile.command.base import CommandError, CommandObject
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Dict, List, Tuple, Union
+    from typing import Any, Dict, List, Tuple
 
     from libqtile import config
     from libqtile.command.base import ItemT
@@ -63,11 +63,11 @@ class Core(CommandObject, metaclass=ABCMeta):
         """Get the screen information"""
 
     @abstractmethod
-    def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Configure the backend to grab the key event"""
 
     @abstractmethod
-    def ungrab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Release the given key event"""
 
     @abstractmethod

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -71,7 +71,7 @@ from libqtile.backend.wayland.output import Output
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Sequence, Set, Tuple, Union
+    from typing import Dict, List, Sequence, Set, Tuple
 
     from wlroots.wlr_types import Output as wlrOutput
     from wlroots.wlr_types.data_device_manager import Drag
@@ -758,14 +758,14 @@ class Core(base.Core, wlrq.HasListeners):
         """Get the screen information"""
         return [screen.get_geometry() for screen in self.outputs if screen.wlr_output.enabled]
 
-    def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Configure the backend to grab the key event"""
         keysym = xkb.keysym_from_name(key.key, case_insensitive=True)
         mask_key = wlrq.translate_masks(key.modifiers)
         self.grabbed_keys.append((keysym, mask_key))
         return keysym, mask_key
 
-    def ungrab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Release the given key event"""
         keysym = xkb.keysym_from_name(key.key, case_insensitive=True)
         mask_key = wlrq.translate_masks(key.modifiers)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -71,7 +71,7 @@ from libqtile.backend.wayland.output import Output
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Sequence, Set, Tuple
+    from typing import Sequence
 
     from wlroots.wlr_types import Output as wlrOutput
     from wlroots.wlr_types.data_device_manager import Drag
@@ -105,18 +105,18 @@ class Core(base.Core, wlrq.HasListeners):
         logger.info("Starting core with WAYLAND_DISPLAY=" + self.socket.decode())
 
         # These windows have not been mapped yet; they'll get managed when mapped
-        self.pending_windows: Set[window.WindowType] = set()
+        self.pending_windows: set[window.WindowType] = set()
 
         # mapped_windows contains just regular windows
-        self.mapped_windows: List[window.WindowType] = []  # Ascending in Z
+        self.mapped_windows: list[window.WindowType] = []  # Ascending in Z
         # stacked_windows also contains layer_shell windows from the current output
         self.stacked_windows: Sequence[window.WindowType] = []  # Ascending in Z
         self._current_output: Output | None = None
 
         # set up inputs
-        self.keyboards: List[keyboard.Keyboard] = []
-        self.grabbed_keys: List[Tuple[int, int]] = []
-        self.grabbed_buttons: List[Tuple[int, int]] = []
+        self.keyboards: list[keyboard.Keyboard] = []
+        self.grabbed_keys: list[tuple[int, int]] = []
+        self.grabbed_buttons: list[tuple[int, int]] = []
         DataDeviceManager(self.display)
         self.live_dnd: wlrq.Dnd | None = None
         DataControlManagerV1(self.display)
@@ -127,7 +127,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(self.backend.new_input_event, self._on_new_input)
 
         # set up outputs
-        self.outputs: List[Output] = []
+        self.outputs: list[Output] = []
         self.add_listener(self.backend.new_output_event, self._on_new_output)
         self.output_layout = OutputLayout()
         self.add_listener(self.output_layout.change_event, self._on_output_layout_change)
@@ -174,7 +174,7 @@ class Core(base.Core, wlrq.HasListeners):
             pointer_constraints_v1.new_constraint_event,
             self._on_new_pointer_constraint,
         )
-        self.pointer_constraints: Set[wlrq.PointerConstraint] = set()
+        self.pointer_constraints: set[wlrq.PointerConstraint] = set()
         self.active_pointer_constraint: wlrq.PointerConstraint | None = None
         self._relative_pointer_manager_v1 = RelativePointerManagerV1(self.display)
         self.foreign_toplevel_manager_v1 = ForeignToplevelManagerV1.create(self.display)
@@ -411,7 +411,7 @@ class Core(base.Core, wlrq.HasListeners):
         logger.debug("Signal: xwayland ready")
         assert self._xwayland is not None
         self._xwayland.set_seat(self.seat)
-        self.xwayland_atoms: Dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
+        self.xwayland_atoms: dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
 
     def _on_xwayland_new_surface(self, _listener, surface: xwayland.Surface):
         logger.debug("Signal: xwayland new_surface")
@@ -754,18 +754,18 @@ class Core(base.Core, wlrq.HasListeners):
         else:
             self.stacked_windows = self.mapped_windows
 
-    def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
+    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the screen information"""
         return [screen.get_geometry() for screen in self.outputs if screen.wlr_output.enabled]
 
-    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Configure the backend to grab the key event"""
         keysym = xkb.keysym_from_name(key.key, case_insensitive=True)
         mask_key = wlrq.translate_masks(key.modifiers)
         self.grabbed_keys.append((keysym, mask_key))
         return keysym, mask_key
 
-    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Release the given key event"""
         keysym = xkb.keysym_from_name(key.key, case_insensitive=True)
         mask_key = wlrq.translate_masks(key.modifiers)
@@ -839,7 +839,7 @@ class Core(base.Core, wlrq.HasListeners):
         """Get the keysym for a key from its name"""
         return xkb.keysym_from_name(name, case_insensitive=True)
 
-    def simulate_keypress(self, modifiers: List[str], key: str) -> None:
+    def simulate_keypress(self, modifiers: list[str], key: str) -> None:
         """Simulates a keypress on the focused window."""
         keysym = xkb.keysym_from_name(key, case_insensitive=True)
         mods = wlrq.translate_masks(modifiers)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -71,7 +71,7 @@ from libqtile.backend.wayland.output import Output
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
+    from typing import Dict, List, Sequence, Set, Tuple, Union
 
     from wlroots.wlr_types import Output as wlrOutput
     from wlroots.wlr_types.data_device_manager import Drag
@@ -85,11 +85,11 @@ class Core(base.Core, wlrq.HasListeners):
 
     def __init__(self):
         """Setup the Wayland core backend"""
-        self.qtile: Optional[Qtile] = None
+        self.qtile: Qtile | None = None
         self.desktops: int = 1
         self.current_desktop: int = 0
-        self._hovered_internal: Optional[window.Internal] = None
-        self.focused_internal: Optional[window.Internal] = None
+        self._hovered_internal: window.Internal | None = None
+        self.focused_internal: window.Internal | None = None
 
         self.fd = None
         self.display = Display()
@@ -111,14 +111,14 @@ class Core(base.Core, wlrq.HasListeners):
         self.mapped_windows: List[window.WindowType] = []  # Ascending in Z
         # stacked_windows also contains layer_shell windows from the current output
         self.stacked_windows: Sequence[window.WindowType] = []  # Ascending in Z
-        self._current_output: Optional[Output] = None
+        self._current_output: Output | None = None
 
         # set up inputs
         self.keyboards: List[keyboard.Keyboard] = []
         self.grabbed_keys: List[Tuple[int, int]] = []
         self.grabbed_buttons: List[Tuple[int, int]] = []
         DataDeviceManager(self.display)
-        self.live_dnd: Optional[wlrq.Dnd] = None
+        self.live_dnd: wlrq.Dnd | None = None
         DataControlManagerV1(self.display)
         self.seat = seat.Seat(self.display, "seat0")
         self.add_listener(self.seat.request_set_selection_event, self._on_request_set_selection)
@@ -175,7 +175,7 @@ class Core(base.Core, wlrq.HasListeners):
             self._on_new_pointer_constraint,
         )
         self.pointer_constraints: Set[wlrq.PointerConstraint] = set()
-        self.active_pointer_constraint: Optional[wlrq.PointerConstraint] = None
+        self.active_pointer_constraint: wlrq.PointerConstraint | None = None
         self._relative_pointer_manager_v1 = RelativePointerManagerV1(self.display)
         self.foreign_toplevel_manager_v1 = ForeignToplevelManagerV1.create(self.display)
 
@@ -854,9 +854,9 @@ class Core(base.Core, wlrq.HasListeners):
 
     def cmd_set_keymap(
         self,
-        layout: Optional[str] = None,
-        options: Optional[str] = None,
-        variant: Optional[str] = None,
+        layout: str | None = None,
+        options: str | None = None,
+        variant: str | None = None,
     ) -> None:
         """
         Set the keymap for the current keyboard.

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -8,8 +8,6 @@ from libqtile import utils
 from libqtile.backend import base
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from libqtile.backend.wayland.window import Internal
     from libqtile.core.manager import Qtile
 
@@ -39,8 +37,8 @@ class Drawer(base.Drawer):
         self,
         offsetx: int = 0,
         offsety: int = 0,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int | None = None,
+        height: int | None = None,
     ):
         if offsetx > self._win.width:  # type: ignore
             return

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -30,8 +30,6 @@ from libqtile.backend.wayland.wlrq import HasListeners
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, Tuple
-
     from wlroots.wlr_types import InputDevice
     from wlroots.wlr_types.keyboard import KeyboardKeyEvent
 
@@ -55,7 +53,7 @@ class Keyboard(HasListeners):
 
         self.keyboard.set_repeat_info(25, 600)
         self.xkb_context = xkb.Context()
-        self._keymaps: Dict[Tuple[str | None, str | None, str | None], xkb.Keymap] = {}
+        self._keymaps: dict[tuple[str | None, str | None, str | None], xkb.Keymap] = {}
         self.set_keymap(None, None, None)
 
         self.add_listener(self.keyboard.modifiers_event, self._on_modifier)

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -30,7 +30,7 @@ from libqtile.backend.wayland.wlrq import HasListeners
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, Optional, Tuple
+    from typing import Dict, Tuple
 
     from wlroots.wlr_types import InputDevice
     from wlroots.wlr_types.keyboard import KeyboardKeyEvent
@@ -55,7 +55,7 @@ class Keyboard(HasListeners):
 
         self.keyboard.set_repeat_info(25, 600)
         self.xkb_context = xkb.Context()
-        self._keymaps: Dict[Tuple[Optional[str], ...], xkb.Keymap] = {}
+        self._keymaps: Dict[Tuple[str | None, str | None, str | None], xkb.Keymap] = {}
         self.set_keymap(None, None, None)
 
         self.add_listener(self.keyboard.modifiers_event, self._on_modifier)
@@ -68,9 +68,7 @@ class Keyboard(HasListeners):
         if self.core.keyboards and self.core.seat.keyboard.destroyed:
             self.seat.set_keyboard(self.core.keyboards[-1].device)
 
-    def set_keymap(
-        self, layout: Optional[str], options: Optional[str], variant: Optional[str]
-    ) -> None:
+    def set_keymap(self, layout: str | None, options: str | None, variant: str | None) -> None:
         """
         Set the keymap for this keyboard.
         """
@@ -80,7 +78,7 @@ class Keyboard(HasListeners):
             keymap = self.xkb_context.keymap_new_from_names(
                 layout=layout, options=options, variant=variant
             )
-            self._keymaps[(layout, options)] = keymap
+            self._keymaps[(layout, options, variant)] = keymap
         self.keyboard.set_keymap(keymap)
 
     def _on_destroy(self, _listener, _data):

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -40,7 +40,7 @@ from libqtile.backend.wayland.wlrq import HasListeners
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import List, Tuple, Union
+    from typing import List, Tuple
 
     from wlroots.wlr_types import Surface
 
@@ -324,7 +324,7 @@ class Output(HasListeners):
 
         self.core.stack_windows()
 
-    def contains(self, rect: Union[WindowType, Dnd]) -> bool:
+    def contains(self, rect: WindowType | Dnd) -> bool:
         """Returns whether the given window is visible on this output."""
         if rect.x + rect.width < self.x:
             return False

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -40,8 +40,6 @@ from libqtile.backend.wayland.wlrq import HasListeners
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import List, Tuple
-
     from wlroots.wlr_types import Surface
 
     from libqtile.backend.wayland.core import Core
@@ -66,7 +64,7 @@ class Output(HasListeners):
         self.add_listener(self._damage.frame_event, self._on_frame)
 
         # The layers enum indexes into this list to get a list of surfaces
-        self.layers: List[List[Static]] = [[] for _ in range(len(LayerShellV1Layer))]
+        self.layers: list[list[Static]] = [[] for _ in range(len(LayerShellV1Layer))]
 
         # This is run during tests, when we want to fix the output's geometry
         if wlr_output.is_headless and "PYTEST_CURRENT_TEST" in os.environ:
@@ -167,7 +165,7 @@ class Output(HasListeners):
                 wlr_output.render_software_cursors(damage=damage)
                 renderer.end()
 
-    def _render_surface(self, surface: Surface, sx: int, sy: int, rdata: Tuple) -> None:
+    def _render_surface(self, surface: Surface, sx: int, sy: int, rdata: tuple) -> None:
         texture = surface.get_texture()
         if texture is None:
             return
@@ -243,7 +241,7 @@ class Output(HasListeners):
                 self.renderer.render_texture_with_matrix(texture, matrix, 1)
                 icon.surface.send_frame_done(now)
 
-    def get_geometry(self) -> Tuple[int, int, int, int]:
+    def get_geometry(self) -> tuple[int, int, int, int]:
         width, height = self.wlr_output.effective_resolution()
         return int(self.x), int(self.y), width, height
 
@@ -313,7 +311,7 @@ class Output(HasListeners):
                         elif state.anchor == LayerSurfaceV1Anchor.RIGHT:
                             space[1] = state.exclusive_zone
 
-                    to_reserve: Tuple[int, int, int, int] = tuple(space)  # type: ignore
+                    to_reserve: tuple[int, int, int, int] = tuple(space)  # type: ignore
                     if win.reserved_space != to_reserve:
                         # Don't reserve more space if it's already been reserved
                         assert self.core.qtile is not None

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -42,7 +42,7 @@ from libqtile.command.base import CommandError
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Optional, Set, Tuple, Union
+    from typing import Dict, List, Set, Tuple, Union
 
     from wlroots.wlr_types.surface import SubSurface as WlrSubSurface
 
@@ -77,7 +77,7 @@ class Window(base.Window, HasListeners):
         self.core = core
         self.qtile = qtile
         self.surface = surface
-        self._group: Optional[_Group] = None
+        self._group: _Group | None = None
         self.popups: List[XdgPopupWindow] = []
         self.subsurfaces: List[SubSurface] = []
         self._mapped: bool = False
@@ -92,13 +92,13 @@ class Window(base.Window, HasListeners):
         self._height: int = 0
 
         assert isinstance(surface, XdgSurface)
-        self._app_id: Optional[str] = surface.toplevel.app_id
+        self._app_id: str | None = surface.toplevel.app_id
         self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()
         surface.data = self.ftm_handle
 
         self._float_state = FloatStates.NOT_FLOATING
-        self.float_x: Optional[int] = None
-        self.float_y: Optional[int] = None
+        self.float_x: int | None = None
+        self.float_y: int | None = None
         self._float_width: int = 0
         self._float_height: int = 0
 
@@ -141,11 +141,11 @@ class Window(base.Window, HasListeners):
         self._height = height
 
     @property
-    def group(self) -> Optional[_Group]:
+    def group(self) -> _Group | None:
         return self._group
 
     @group.setter
-    def group(self, group: Optional[_Group]) -> None:
+    def group(self, group: _Group | None) -> None:
         self._group = group
 
     @property
@@ -297,7 +297,7 @@ class Window(base.Window, HasListeners):
         state = self.surface.toplevel._ptr.current
         return 0 < state.min_width == state.max_width and 0 < state.min_height == state.max_height
 
-    def is_transient_for(self) -> Optional[base.WindowType]:
+    def is_transient_for(self) -> base.WindowType | None:
         """What window is this window a transient window for?"""
         assert isinstance(self.surface, XdgSurface)
         parent = self.surface.toplevel.parent
@@ -333,7 +333,7 @@ class Window(base.Window, HasListeners):
         )
         return pid[0]
 
-    def get_wm_class(self) -> Optional[List]:
+    def get_wm_class(self) -> List | None:
         if self._app_id:
             return [self._app_id]
         return None
@@ -712,11 +712,11 @@ class Window(base.Window, HasListeners):
 
     def cmd_static(
         self,
-        screen: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        screen: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
     ) -> None:
         self.defunct = True
         if screen is None:
@@ -899,7 +899,7 @@ class Static(base.Static, Window):
         self._outputs: Set[Output] = set()
         self._float_state = FloatStates.FLOATING
         self.is_layer = False
-        self._app_id: Optional[str] = None
+        self._app_id: str | None = None
 
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)
@@ -1162,7 +1162,7 @@ class XWindow(Window):
         self.core = core
         self.qtile = qtile
         self.surface = surface
-        self._group: Optional[_Group] = None
+        self._group: _Group | None = None
         self._mapped: bool = False
         self._unmapping: bool = False  # Whether the client or Qtile unmapped this
         self.x = 0
@@ -1171,15 +1171,15 @@ class XWindow(Window):
         self._opacity: float = 1.0
         self._outputs: Set[Output] = set()
 
-        self._app_id: Optional[str] = self.surface.wm_class
+        self._app_id: str | None = self.surface.wm_class
         self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()
         surface.data = self.ftm_handle
 
         # These become non-zero when being mapping for the first time
         self._width: int = 0
         self._height: int = 0
-        self.float_x: Optional[int] = None
-        self.float_y: Optional[int] = None
+        self.float_x: int | None = None
+        self.float_y: int | None = None
         self._float_width: int = 0
         self._float_height: int = 0
         self._float_state = FloatStates.NOT_FLOATING
@@ -1315,7 +1315,7 @@ class XWindow(Window):
             and 0 < hints.min_height == hints.max_height
         )
 
-    def is_transient_for(self) -> Optional[base.WindowType]:
+    def is_transient_for(self) -> base.WindowType | None:
         """What window is this window a transient window for?"""
         parent = self.surface.parent  # type: ignore
         if parent:
@@ -1327,13 +1327,13 @@ class XWindow(Window):
     def get_pid(self) -> int:
         return self.surface.pid  # type: ignore
 
-    def get_wm_type(self) -> Optional[str]:
+    def get_wm_type(self) -> str | None:
         wm_type = self.surface.window_type  # type: ignore
         if wm_type:
             return self.core.xwayland_atoms[wm_type[0]]
         return None
 
-    def get_wm_role(self) -> Optional[str]:
+    def get_wm_role(self) -> str | None:
         return self.surface.role  # type: ignore
 
     def place(
@@ -1391,11 +1391,11 @@ class XWindow(Window):
 
     def cmd_static(
         self,
-        screen: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        screen: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
     ) -> None:
         self.defunct = True
         if self.group:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -42,7 +42,7 @@ from libqtile.command.base import CommandError
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Set, Tuple, Union
+    from typing import Dict, List, Set, Tuple
 
     from wlroots.wlr_types.surface import SubSurface as WlrSubSurface
 
@@ -1065,12 +1065,12 @@ class Static(base.Static, Window):
 class XdgPopupWindow(HasListeners):
     """
     This represents a single `struct wlr_xdg_popup` object and is owned by a single
-    parent window (of `Union[WindowType, XdgPopupWindow]`). wlroots does most of the
+    parent window (of `WindowType | XdgPopupWindow`). wlroots does most of the
     work for us, but we need to listen to certain events so that we know when to render
     frames and we need to unconstrain the popups so they are completely visible.
     """
 
-    def __init__(self, parent: Union[WindowType, XdgPopupWindow], xdg_popup: XdgPopup):
+    def __init__(self, parent: WindowType | XdgPopupWindow, xdg_popup: XdgPopup):
         self.parent = parent
         self.xdg_popup = xdg_popup
         self.core: Core = parent.core
@@ -1123,11 +1123,11 @@ class XdgPopupWindow(HasListeners):
 class SubSurface(HasListeners):
     """
     This represents a single `struct wlr_subsurface` object and is owned by a single
-    parent window (of `Union[WindowType, SubSurface]`). We only need to track them so
+    parent window (of `WindowType | SubSurface`). We only need to track them so
     that we can listen to their commit events and render accordingly.
     """
 
-    def __init__(self, parent: Union[WindowType, SubSurface], subsurface: WlrSubSurface):
+    def __init__(self, parent: WindowType | SubSurface, subsurface: WlrSubSurface):
         self.parent = parent
         self.subsurfaces: List[SubSurface] = []
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -42,8 +42,6 @@ from libqtile.command.base import CommandError
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Dict, List, Set, Tuple
-
     from wlroots.wlr_types.surface import SubSurface as WlrSubSurface
 
     from libqtile.backend.wayland.core import Core
@@ -78,14 +76,14 @@ class Window(base.Window, HasListeners):
         self.qtile = qtile
         self.surface = surface
         self._group: _Group | None = None
-        self.popups: List[XdgPopupWindow] = []
-        self.subsurfaces: List[SubSurface] = []
+        self.popups: list[XdgPopupWindow] = []
+        self.subsurfaces: list[SubSurface] = []
         self._mapped: bool = False
         self.x = 0
         self.y = 0
-        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
+        self.bordercolor: list[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self._opacity: float = 1.0
-        self._outputs: Set[Output] = set()
+        self._outputs: set[Output] = set()
 
         # These become non-zero when being mapping for the first time
         self._width: int = 0
@@ -333,7 +331,7 @@ class Window(base.Window, HasListeners):
         )
         return pid[0]
 
-    def get_wm_class(self) -> List | None:
+    def get_wm_class(self) -> list | None:
         if self._app_id:
             return [self._app_id]
         return None
@@ -579,7 +577,7 @@ class Window(base.Window, HasListeners):
                 self.group.mark_floating(self, True)
             hook.fire("float_change")
 
-    def info(self) -> Dict:
+    def info(self) -> dict:
         """Return a dictionary of info."""
         float_info = {
             "x": self.float_x,
@@ -671,10 +669,10 @@ class Window(base.Window, HasListeners):
     def cmd_place(self, x, y, width, height, borderwidth, bordercolor, above=False, margin=None):
         self.place(x, y, width, height, borderwidth, bordercolor, above, margin)
 
-    def cmd_get_position(self) -> Tuple[int, int]:
+    def cmd_get_position(self) -> tuple[int, int]:
         return self.x, self.y
 
-    def cmd_get_size(self) -> Tuple[int, int]:
+    def cmd_get_size(self) -> tuple[int, int]:
         return self.width, self.height
 
     def cmd_toggle_floating(self) -> None:
@@ -767,7 +765,7 @@ class Internal(base.Internal, Window):
         self._opacity: float = 1.0
         self._width: int = width
         self._height: int = height
-        self._outputs: Set[Output] = set()
+        self._outputs: set[Output] = set()
         self._find_outputs()
         self._reset_texture()
         self._group = None
@@ -857,7 +855,7 @@ class Internal(base.Internal, Window):
         self._find_outputs()
         self.damage()
 
-    def info(self) -> Dict:
+    def info(self) -> dict:
         """Return a dictionary of info."""
         return dict(
             x=self.x,
@@ -886,7 +884,7 @@ class Static(base.Static, Window):
         self.qtile = qtile
         self.surface = surface
         self.screen = qtile.current_screen
-        self.subsurfaces: List[SubSurface] = []
+        self.subsurfaces: list[SubSurface] = []
         self._wid = wid
         self._mapped: bool = False
         self.x = 0
@@ -894,9 +892,9 @@ class Static(base.Static, Window):
         self._width = 0
         self._height = 0
         self.borderwidth: int = 0
-        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
+        self.bordercolor: list[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self.opacity: float = 1.0
-        self._outputs: Set[Output] = set()
+        self._outputs: set[Output] = set()
         self._float_state = FloatStates.FLOATING
         self.is_layer = False
         self._app_id: str | None = None
@@ -1074,7 +1072,7 @@ class XdgPopupWindow(HasListeners):
         self.parent = parent
         self.xdg_popup = xdg_popup
         self.core: Core = parent.core
-        self.popups: List[XdgPopupWindow] = []
+        self.popups: list[XdgPopupWindow] = []
 
         # Keep on output
         if isinstance(parent, XdgPopupWindow):
@@ -1129,7 +1127,7 @@ class SubSurface(HasListeners):
 
     def __init__(self, parent: WindowType | SubSurface, subsurface: WlrSubSurface):
         self.parent = parent
-        self.subsurfaces: List[SubSurface] = []
+        self.subsurfaces: list[SubSurface] = []
 
         self.add_listener(subsurface.destroy_event, self._on_destroy)
         self.add_listener(subsurface.surface.commit_event, parent._on_commit)
@@ -1167,9 +1165,9 @@ class XWindow(Window):
         self._unmapping: bool = False  # Whether the client or Qtile unmapped this
         self.x = 0
         self.y = 0
-        self.bordercolor: List[ffi.CData] = [_rgb((0, 0, 0, 1))]
+        self.bordercolor: list[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self._opacity: float = 1.0
-        self._outputs: Set[Output] = set()
+        self._outputs: set[Output] = set()
 
         self._app_id: str | None = self.surface.wm_class
         self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -39,7 +39,7 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, List, Set
+    from typing import Callable
 
     from pywayland.server import Signal
     from wlroots import xwayland
@@ -94,7 +94,7 @@ buttons = [
 DRM_FORMAT_ARGB8888 = 875713089
 
 
-def translate_masks(modifiers: List[str]) -> int:
+def translate_masks(modifiers: list[str]) -> int:
     """
     Translate a modifier mask specified as a list of strings into an or-ed
     bit representation.
@@ -261,7 +261,7 @@ class Dnd(HasListeners):
     def __init__(self, core: Core, wlr_drag: data_device_manager.Drag):
         self.core = core
         self.wlr_drag = wlr_drag
-        self._outputs: Set[Output] = set()
+        self._outputs: set[Output] = set()
 
         self.x: float = core.cursor.x
         self.y: float = core.cursor.y
@@ -308,7 +308,7 @@ class Dnd(HasListeners):
             output.damage()
 
 
-def get_xwayland_atoms(xwayland: xwayland.XWayland) -> Dict[int, str]:
+def get_xwayland_atoms(xwayland: xwayland.XWayland) -> dict[int, str]:
     """
     These can be used when matching on XWayland clients with wm_type.
     http://standards.freedesktop.org/wm-spec/latest/ar01s05.html#idm139870830002400

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -39,7 +39,7 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, List, Optional, Set
+    from typing import Callable, Dict, List, Set
 
     from pywayland.server import Signal
     from wlroots import xwayland
@@ -189,7 +189,7 @@ class PointerConstraint(HasListeners):
     def __init__(self, core: Core, wlr_constraint: PointerConstraintV1):
         self.core = core
         self.wlr_constraint = wlr_constraint
-        self.window: Optional[WindowType] = None
+        self.window: WindowType | None = None
         self._warp_target = (0, 0)
         self._needs_warp = False
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -24,7 +24,7 @@ import contextlib
 import os
 import signal
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Tuple
 
 import xcffib
 import xcffib.render
@@ -434,7 +434,7 @@ class Core(base.Core):
             viewport += [group.screen.x, group.screen.y] if group.screen else [0, 0]
         self._root.set_property("_NET_DESKTOP_VIEWPORT", viewport)
 
-    def lookup_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def lookup_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Find the keysym and the modifier mask for the given key"""
         try:
             keysym = xcbq.get_keysym(key.key)
@@ -444,7 +444,7 @@ class Core(base.Core):
 
         return keysym, modmask
 
-    def grab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Map the key to receive events on it"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)
@@ -464,7 +464,7 @@ class Core(base.Core):
                 )
         return keysym, modmask & self._valid_mask
 
-    def ungrab_key(self, key: Union[config.Key, config.KeyChord]) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
         """Ungrab the key corresponding to the given keysym and modifier mask"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -24,7 +24,7 @@ import contextlib
 import os
 import signal
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Tuple, Union
 
 import xcffib
 import xcffib.render
@@ -146,7 +146,7 @@ class Core(base.Core):
         # setup the default cursor
         self._root.set_cursor("left_ptr")
 
-        self.qtile = None  # type: Optional[Qtile]
+        self.qtile = None  # type: Qtile | None
         self._painter = None
 
         numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])[0]
@@ -544,7 +544,7 @@ class Core(base.Core):
             i._reset_mask()
 
     def create_internal(
-        self, x: int, y: int, width: int, height: int, desired_depth: Optional[int] = 32
+        self, x: int, y: int, width: int, height: int, desired_depth: int | None = 32
     ) -> base.Internal:
         assert self.qtile is not None
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -19,12 +19,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import os
 import signal
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Tuple
+from typing import TYPE_CHECKING
 
 import xcffib
 import xcffib.render
@@ -39,6 +41,8 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
+    from typing import Callable, Dict, Iterator, List, Tuple
+
     from libqtile.core.manager import Qtile
 
 _IGNORED_EVENTS = {

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -41,7 +41,7 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict, Iterator, List, Tuple
+    from typing import Callable, Iterator
 
     from libqtile.core.manager import Qtile
 
@@ -56,11 +56,11 @@ _IGNORED_EVENTS = {
 }
 
 
-def get_keys() -> List[str]:
+def get_keys() -> list[str]:
     return list(xcbq.keysyms.keys())
 
 
-def get_modifiers() -> List[str]:
+def get_modifiers() -> list[str]:
     return list(xcbq.ModMasks.keys())
 
 
@@ -169,7 +169,7 @@ class Core(base.Core):
         self.qtile = None
         self.conn.finalize()
 
-    def get_screen_info(self) -> List[Tuple[int, int, int, int]]:
+    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         info = [(s.x, s.y, s.width, s.height) for s in self.conn.pseudoscreens]
 
         if not info:
@@ -335,7 +335,7 @@ class Core(base.Core):
                 logger.exception("Got an exception in poll loop")
         self.flush()
 
-    def _get_target_chain(self, event_type: str, event) -> List[Callable]:
+    def _get_target_chain(self, event_type: str, event) -> list[Callable]:
         """Returns a chain of targets that can handle this event
 
         Finds functions named `handle_X`, either on the window object itself or
@@ -412,7 +412,7 @@ class Core(base.Core):
         """The name of the connected display"""
         return self._display_name
 
-    def update_client_list(self, windows_map: Dict[int, base.WindowType]) -> None:
+    def update_client_list(self, windows_map: dict[int, base.WindowType]) -> None:
         """Updates the client stack list
 
         This is needed for third party tasklists and drag and drop of tabs in
@@ -438,7 +438,7 @@ class Core(base.Core):
             viewport += [group.screen.x, group.screen.y] if group.screen else [0, 0]
         self._root.set_property("_NET_DESKTOP_VIEWPORT", viewport)
 
-    def lookup_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def lookup_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Find the keysym and the modifier mask for the given key"""
         try:
             keysym = xcbq.get_keysym(key.key)
@@ -448,7 +448,7 @@ class Core(base.Core):
 
         return keysym, modmask
 
-    def grab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def grab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Map the key to receive events on it"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)
@@ -468,7 +468,7 @@ class Core(base.Core):
                 )
         return keysym, modmask & self._valid_mask
 
-    def ungrab_key(self, key: config.Key | config.KeyChord) -> Tuple[int, int]:
+    def ungrab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Ungrab the key corresponding to the given keysym and modifier mask"""
         keysym, modmask = self.lookup_key(key)
         codes = self.conn.keysym_to_keycode(keysym)
@@ -837,7 +837,7 @@ class Core(base.Core):
                 break
             time.sleep(0.1)
 
-    def get_mouse_position(self) -> Tuple[int, int]:
+    def get_mouse_position(self) -> tuple[int, int]:
         """
         Get mouse coordinates.
         """

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -9,8 +9,6 @@ from libqtile import utils
 from libqtile.backend import base
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from libqtile.backend.base import Internal
     from libqtile.core.manager import Qtile
 
@@ -137,8 +135,8 @@ class Drawer(base.Drawer):
         self,
         offsetx: int = 0,
         offsety: int = 0,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int | None = None,
+        height: int | None = None,
     ):
 
         self.current_rect = (offsetx, offsety, width, height)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -17,11 +17,13 @@ from libqtile.backend import base
 from libqtile.backend.base import FloatStates
 from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.drawer import Drawer
-from libqtile.command.base import CommandError, ItemT
+from libqtile.command.base import CommandError
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
     from typing import List
+
+    from libqtile.command.base import ItemT
 
 # ICCM Constants
 NoValue = 0x0000

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -379,7 +379,7 @@ class XWindow:
                 self.conn.atoms[prop] if isinstance(prop, str) else prop,
                 self.conn.atoms[type] if isinstance(type, str) else type,
                 0,
-                (2 ** 32) - 1,
+                (2**32) - 1,
             ).reply()
         except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
             logger.debug("X error in GetProperty (wid=%r, prop=%r), ignoring", self.wid, prop)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -21,7 +21,7 @@ from libqtile.command.base import CommandError, ItemT
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import List, Optional
+    from typing import List
 
 # ICCM Constants
 NoValue = 0x0000
@@ -502,8 +502,8 @@ class _Window:
             self._height = None
             self._depth = None
 
-        self.float_x: Optional[int] = None
-        self.float_y: Optional[int] = None
+        self.float_x: int | None = None
+        self.float_y: int | None = None
         self._float_width: int = self._width
         self._float_height: int = self._height
 
@@ -594,7 +594,7 @@ class _Window:
     def update_wm_class(self) -> None:
         self._wm_class = self.window.get_wm_class()
 
-    def get_wm_class(self) -> Optional[List[str]]:
+    def get_wm_class(self) -> List[str] | None:
         return self._wm_class
 
     def get_wm_type(self):
@@ -1159,7 +1159,7 @@ class Static(_Window, base.Static):
 
     def __init__(self, win, qtile, screen, x=None, y=None, width=None, height=None):
         _Window.__init__(self, win, qtile)
-        self._wm_class: Optional[List[str]] = None
+        self._wm_class: List[str] | None = None
         self.update_wm_class()
         self.update_name()
         self.conf_x = x
@@ -1253,7 +1253,7 @@ class Window(_Window, base.Window):
 
     def __init__(self, window, qtile):
         _Window.__init__(self, window, qtile)
-        self._wm_class: Optional[List[str]] = None
+        self._wm_class: List[str] | None = None
         self.update_wm_class()
         self.update_name()
         self.set_group()
@@ -1397,11 +1397,11 @@ class Window(_Window, base.Window):
 
     def cmd_static(
         self,
-        screen: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        screen: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
     ) -> None:
         """Makes this window a static window, attached to a Screen
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -21,8 +21,6 @@ from libqtile.command.base import CommandError
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import List
-
     from libqtile.command.base import ItemT
 
 # ICCM Constants
@@ -596,7 +594,7 @@ class _Window:
     def update_wm_class(self) -> None:
         self._wm_class = self.window.get_wm_class()
 
-    def get_wm_class(self) -> List[str] | None:
+    def get_wm_class(self) -> list[str] | None:
         return self._wm_class
 
     def get_wm_type(self):
@@ -1161,7 +1159,7 @@ class Static(_Window, base.Static):
 
     def __init__(self, win, qtile, screen, x=None, y=None, width=None, height=None):
         _Window.__init__(self, win, qtile)
-        self._wm_class: List[str] | None = None
+        self._wm_class: list[str] | None = None
         self.update_wm_class()
         self.update_name()
         self.conf_x = x
@@ -1255,7 +1253,7 @@ class Window(_Window, base.Window):
 
     def __init__(self, window, qtile):
         _Window.__init__(self, window, qtile)
-        self._wm_class: List[str] | None = None
+        self._wm_class: list[str] | None = None
         self.update_wm_class()
         self.update_name()
         self.set_group()

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -34,9 +34,11 @@
     A minimal EWMH-aware OO layer over xcffib. This is NOT intended to be
     complete - it only implements the subset of functionalty needed by qtile.
 """
+
+from __future__ import annotations
+
 import functools
 import operator
-import typing
 from itertools import chain, repeat
 
 import cairocffi
@@ -791,7 +793,7 @@ def get_keysym(key: str) -> int:
     return keysym
 
 
-def translate_modifiers(mask: int) -> typing.List[str]:
+def translate_modifiers(mask: int) -> list[str]:
     r = []
     for k, v in ModMasks.items():
         if mask & v:
@@ -799,7 +801,7 @@ def translate_modifiers(mask: int) -> typing.List[str]:
     return r
 
 
-def translate_masks(modifiers: typing.List[str]) -> int:
+def translate_masks(modifiers: list[str]) -> int:
     """
     Translate a modifier mask specified as a list of strings into an or-ed
     bit representation.

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -24,11 +24,12 @@ import typing
 from collections import defaultdict
 
 from libqtile import configurable
-from libqtile.command.base import CommandObject, ItemT
+from libqtile.command.base import CommandObject
 from libqtile.log_utils import logger
 from libqtile.utils import has_transparency, rgb
 
 if typing.TYPE_CHECKING:
+    from libqtile.command.base import ItemT
     from libqtile.widget.base import _Widget
 
 

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -440,7 +440,7 @@ class Bar(Gap, configurable.Configurable):
                 i.offsety = offset
                 offset += i.length
 
-    def get_widget_in_position(self, x: int, y: int) -> typing.Optional[_Widget]:
+    def get_widget_in_position(self, x: int, y: int) -> _Widget | None:
         if self.horizontal:
             for i in self.widgets:
                 if x < i.offsetx + i.length:

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -87,7 +87,7 @@ class CommandObject(metaclass=abc.ABCMeta):
             obj = maybe_obj
         return obj
 
-    def items(self, name: str) -> Tuple[bool, Optional[List[Union[str, int]]]]:
+    def items(self, name: str) -> Tuple[bool, List[Union[str, int]] | None]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -114,7 +114,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def _select(self, name: str, sel: Optional[Union[str, int]]) -> Optional[CommandObject]:
+    def _select(self, name: str, sel: Union[str, int] | None) -> CommandObject | None:
         """Select the given item of the given item class
 
         This method is called with the following guarantees:
@@ -126,7 +126,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         Return None if no such object exists
         """
 
-    def command(self, name: str) -> Optional[Callable]:
+    def command(self, name: str) -> Callable | None:
         """Return the command with the given name
 
         Parameters
@@ -154,7 +154,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, Optional[List[Union[str, int]]]]:
+    def cmd_items(self, name) -> Tuple[bool, List[Union[str, int]] | None]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.
@@ -184,7 +184,7 @@ class CommandObject(metaclass=abc.ABCMeta):
             signature = signature.replace(parameters=parameters)
         return str(signature)
 
-    def cmd_eval(self, code: str) -> Tuple[bool, Optional[str]]:
+    def cmd_eval(self, code: str) -> Tuple[bool, str | None]:
         """Evaluates code in the same context as this function
 
         Return value is tuple `(success, result)`, success being a boolean and

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 import abc
 import inspect
 import traceback
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple
 
 from libqtile.command.graph import SelectorType
 from libqtile.log_utils import logger
 
-ItemT = Optional[Tuple[bool, List[Union[str, int]]]]
+ItemT = Optional[Tuple[bool, List[str | int]]]
 
 
 class SelectError(Exception):
@@ -87,7 +87,7 @@ class CommandObject(metaclass=abc.ABCMeta):
             obj = maybe_obj
         return obj
 
-    def items(self, name: str) -> Tuple[bool, List[Union[str, int]] | None]:
+    def items(self, name: str) -> Tuple[bool, List[str | int] | None]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -114,7 +114,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def _select(self, name: str, sel: Union[str, int] | None) -> CommandObject | None:
+    def _select(self, name: str, sel: str | int | None) -> CommandObject | None:
         """Select the given item of the given item class
 
         This method is called with the following guarantees:
@@ -154,7 +154,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, List[Union[str, int]] | None]:
+    def cmd_items(self, name) -> Tuple[bool, List[str | int] | None]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -32,17 +32,17 @@ from typing import TYPE_CHECKING
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Optional, Tuple
+    from typing import Callable, Optional
 
     from libqtile.command.graph import SelectorType
 
-    ItemT = Optional[Tuple[bool, List[str | int]]]
+    ItemT = Optional[tuple[bool, list[str | int]]]
 
 
 class SelectError(Exception):
     """Error raised in resolving a command graph object"""
 
-    def __init__(self, err_string: str, name: str, selectors: List[SelectorType]):
+    def __init__(self, err_string: str, name: str, selectors: list[SelectorType]):
         super().__init__("{}, name: {}, selectors: {}".format(err_string, name, selectors))
         self.name = name
         self.selectors = selectors
@@ -64,7 +64,7 @@ class CommandObject(metaclass=abc.ABCMeta):
     (c.f. docstring for `.items()` and `.select()`).
     """
 
-    def select(self, selectors: List[SelectorType]) -> CommandObject:
+    def select(self, selectors: list[SelectorType]) -> CommandObject:
         """Return a selected object
 
         Recursively finds an object specified by a list of `(name, selector)`
@@ -91,7 +91,7 @@ class CommandObject(metaclass=abc.ABCMeta):
             obj = maybe_obj
         return obj
 
-    def items(self, name: str) -> Tuple[bool, List[str | int] | None]:
+    def items(self, name: str) -> tuple[bool, list[str | int] | None]:
         """Build a list of contained items for the given item class
 
         Returns a tuple `(root, items)` for the specified item class, where:
@@ -146,19 +146,19 @@ class CommandObject(metaclass=abc.ABCMeta):
         return getattr(self, "cmd_" + name, None)
 
     @property
-    def commands(self) -> List[str]:
+    def commands(self) -> list[str]:
         """All of the commands on the given object"""
         cmds = [i[4:] for i in dir(self) if i.startswith("cmd_")]
         return cmds
 
-    def cmd_commands(self) -> List[str]:
+    def cmd_commands(self) -> list[str]:
         """Returns a list of possible commands for this object
 
         Used by __qsh__ for command completion and online help
         """
         return self.commands
 
-    def cmd_items(self, name) -> Tuple[bool, List[str | int] | None]:
+    def cmd_items(self, name) -> tuple[bool, list[str | int] | None]:
         """Returns a list of contained items for the specified name
 
         Used by __qsh__ to allow navigation of the object graph.
@@ -188,7 +188,7 @@ class CommandObject(metaclass=abc.ABCMeta):
             signature = signature.replace(parameters=parameters)
         return str(signature)
 
-    def cmd_eval(self, code: str) -> Tuple[bool, str | None]:
+    def cmd_eval(self, code: str) -> tuple[bool, str | None]:
         """Evaluates code in the same context as this function
 
         Return value is tuple `(success, result)`, success being a boolean and

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -27,12 +27,16 @@ from __future__ import annotations
 import abc
 import inspect
 import traceback
-from typing import Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
-from libqtile.command.graph import SelectorType
 from libqtile.log_utils import logger
 
-ItemT = Optional[Tuple[bool, List[str | int]]]
+if TYPE_CHECKING:
+    from typing import Callable, List, Optional, Tuple
+
+    from libqtile.command.graph import SelectorType
+
+    ItemT = Optional[Tuple[bool, List[str | int]]]
 
 
 class SelectError(Exception):

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -29,7 +29,7 @@ clients to do this interaction.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 from libqtile.command.base import SelectError
 from libqtile.command.graph import (
@@ -47,7 +47,7 @@ class CommandClient:
     """The object that resolves the commands"""
 
     def __init__(
-        self, command: CommandInterface = None, *, current_node: Optional[CommandGraphNode] = None
+        self, command: CommandInterface = None, *, current_node: CommandGraphNode | None = None
     ) -> None:
         """A client that resolves calls through the command object interface
 
@@ -70,14 +70,14 @@ class CommandClient:
         self._command = command
         self._current_node = current_node if current_node is not None else CommandGraphRoot()
 
-    def navigate(self, name: str, selector: Optional[str]) -> CommandClient:
+    def navigate(self, name: str, selector: str | None) -> CommandClient:
         """Resolve the given object in the command graph
 
         Parameters
         ----------
         name: str
             The name of the command graph object to resolve.
-        selector: Optional[str]
+        selector: str | None
             If given, the selector to use to select the next object, and if
             None, then selects the default object.
 
@@ -285,7 +285,7 @@ class InteractiveCommandClient:
         return _normalize_item(object_type, item)
 
 
-def _normalize_item(object_type: Optional[str], item: str) -> Union[str, int]:
+def _normalize_item(object_type: str | None, item: str) -> Union[str, int]:
     if object_type in ["group", "widget", "bar"]:
         return str(item)
     elif object_type in ["layout", "window", "screen"]:

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -44,8 +44,8 @@ from libqtile.ipc import Client, find_sockfile
 if TYPE_CHECKING:
     from typing import Any, List, Tuple
 
-    from libqtile.command.interface import SelectorType
     from libqtile.command.graph import GraphType
+    from libqtile.command.interface import SelectorType
 
 
 class CommandClient:

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -29,7 +29,7 @@ clients to do this interaction.
 
 from __future__ import annotations
 
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile.command.base import SelectError
 from libqtile.command.graph import (
@@ -37,10 +37,15 @@ from libqtile.command.graph import (
     CommandGraphNode,
     CommandGraphObject,
     CommandGraphRoot,
-    GraphType,
 )
-from libqtile.command.interface import CommandInterface, IPCCommandInterface, SelectorType
+from libqtile.command.interface import CommandInterface, IPCCommandInterface
 from libqtile.ipc import Client, find_sockfile
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
+
+    from libqtile.command.interface import SelectorType
+    from libqtile.command.graph import GraphType
 
 
 class CommandClient:

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -29,7 +29,7 @@ clients to do this interaction.
 
 from __future__ import annotations
 
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Tuple
 
 from libqtile.command.base import SelectError
 from libqtile.command.graph import (
@@ -137,7 +137,7 @@ class CommandClient:
         command_call = self._current_node.call("commands")
         return self._command.execute(command_call, (), {})
 
-    def items(self, name: str) -> Tuple[bool, List[Union[str, int]]]:
+    def items(self, name: str) -> Tuple[bool, List[str | int]]:
         """Get the available items"""
         items_call = self._current_node.call("items")
         return self._command.execute(items_call, (name,), {})
@@ -234,7 +234,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.navigate(name, None)
         return self.__class__(self._command, current_node=next_node)
 
-    def __getitem__(self, name: Union[str, int]) -> InteractiveCommandClient:
+    def __getitem__(self, name: str | int) -> InteractiveCommandClient:
         """Get the selected element of the currently selected object
 
         From the current command graph object, select the instance with the
@@ -275,7 +275,7 @@ class InteractiveCommandClient:
         next_node = self._current_node.parent.navigate(self._current_node.object_type, name)
         return self.__class__(self._command, current_node=next_node)
 
-    def normalize_item(self, item: str) -> Union[str, int]:
+    def normalize_item(self, item: str) -> str | int:
         "Normalize the item according to Qtile._items()."
         object_type = (
             self._current_node.object_type
@@ -285,7 +285,7 @@ class InteractiveCommandClient:
         return _normalize_item(object_type, item)
 
 
-def _normalize_item(object_type: str | None, item: str) -> Union[str, int]:
+def _normalize_item(object_type: str | None, item: str) -> str | int:
     if object_type in ["group", "widget", "bar"]:
         return str(item)
     elif object_type in ["layout", "window", "screen"]:

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -42,7 +42,7 @@ from libqtile.command.interface import CommandInterface, IPCCommandInterface
 from libqtile.ipc import Client, find_sockfile
 
 if TYPE_CHECKING:
-    from typing import Any, List, Tuple
+    from typing import Any
 
     from libqtile.command.graph import GraphType
     from libqtile.command.interface import SelectorType
@@ -128,21 +128,21 @@ class CommandClient:
         return self._command.execute(call, args, kwargs)
 
     @property
-    def children(self) -> List[str]:
+    def children(self) -> list[str]:
         """Get the children of the current location in the command graph"""
         return self._current_node.children
 
     @property
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         return self._current_node.selectors
 
     @property
-    def commands(self) -> List[str]:
+    def commands(self) -> list[str]:
         """Get the commands available on the current object"""
         command_call = self._current_node.call("commands")
         return self._command.execute(command_call, (), {})
 
-    def items(self, name: str) -> Tuple[bool, List[str | int]]:
+    def items(self, name: str) -> tuple[bool, list[str | int]]:
         """Get the available items"""
         items_call = self._current_node.call("items")
         return self._command.execute(items_call, (name,), {})

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import abc
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-SelectorType = Tuple[str, Optional[Union[str, int]]]
+SelectorType = Tuple[str, Optional[str | int]]
 GraphType = Union["CommandGraphNode", "CommandGraphCall"]
 
 
@@ -41,7 +41,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def selector(self) -> Union[str, int] | None:
+    def selector(self) -> str | int | None:
         """The selector for the current node"""
 
     @property
@@ -59,7 +59,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
     def children(self) -> List[str]:
         """The child objects that are contained within this object"""
 
-    def navigate(self, name: str, selector: Union[str, int] | None) -> CommandGraphNode:
+    def navigate(self, name: str, selector: str | int | None) -> CommandGraphNode:
         """Navigate from the current node to the specified child"""
         if name in self.children:
             return _COMMAND_GRAPH_MAP[name](selector, self)
@@ -135,7 +135,7 @@ class CommandGraphRoot(CommandGraphNode):
 class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
     """An object in the command graph that contains a collection of objects"""
 
-    def __init__(self, selector: Union[str, int] | None, parent: CommandGraphNode) -> None:
+    def __init__(self, selector: str | int | None, parent: CommandGraphNode) -> None:
         """A container object in the command graph
 
         Parameters
@@ -150,7 +150,7 @@ class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
         self._parent = parent
 
     @property
-    def selector(self) -> Union[str, int] | None:
+    def selector(self) -> str | int | None:
         """The selector for the current node"""
         return self._selector
 

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -26,10 +26,12 @@ abstract command graph
 from __future__ import annotations
 
 import abc
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING
 
-SelectorType = Tuple[str, Optional[str | int]]
-GraphType = Union["CommandGraphNode", "CommandGraphCall"]
+if TYPE_CHECKING:
+    from typing import Dict, List, Optional, Tuple, Type, Union
+
+    SelectorType = Tuple[str, Optional[str | int]]
 
 
 class CommandGraphNode(metaclass=abc.ABCMeta):
@@ -215,3 +217,6 @@ _COMMAND_GRAPH_MAP: Dict[str, Type[CommandGraphObject]] = {
     "screen": _ScreenGraphNode,
     "core": _CoreGraphNode,
 }
+
+
+GraphType = Union[CommandGraphNode, CommandGraphCall]

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -41,7 +41,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def selector(self) -> Optional[Union[str, int]]:
+    def selector(self) -> Union[str, int] | None:
         """The selector for the current node"""
 
     @property
@@ -51,7 +51,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def parent(self) -> Optional[CommandGraphNode]:
+    def parent(self) -> CommandGraphNode | None:
         """The parent of the current node"""
 
     @property
@@ -59,7 +59,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
     def children(self) -> List[str]:
         """The child objects that are contained within this object"""
 
-    def navigate(self, name: str, selector: Optional[Union[str, int]]) -> CommandGraphNode:
+    def navigate(self, name: str, selector: Union[str, int] | None) -> CommandGraphNode:
         """Navigate from the current node to the specified child"""
         if name in self.children:
             return _COMMAND_GRAPH_MAP[name](selector, self)
@@ -135,12 +135,12 @@ class CommandGraphRoot(CommandGraphNode):
 class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
     """An object in the command graph that contains a collection of objects"""
 
-    def __init__(self, selector: Optional[Union[str, int]], parent: CommandGraphNode) -> None:
+    def __init__(self, selector: Union[str, int] | None, parent: CommandGraphNode) -> None:
         """A container object in the command graph
 
         Parameters
         ----------
-        selector: Optional[str]
+        selector: str | None
             The name of the selected element within the command graph.  If not
             given, corresponds to the default selection of this type of object.
         parent: CommandGraphNode
@@ -150,7 +150,7 @@ class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
         self._parent = parent
 
     @property
-    def selector(self) -> Optional[Union[str, int]]:
+    def selector(self) -> Union[str, int] | None:
         """The selector for the current node"""
         return self._selector
 

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -29,9 +29,9 @@ import abc
 from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Tuple, Type
+    from typing import Optional, Type
 
-    SelectorType = Tuple[str, Optional[str | int]]
+    SelectorType = tuple[str, Optional[str | int]]
 
 
 class CommandGraphNode(metaclass=abc.ABCMeta):
@@ -48,7 +48,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         """The selectors resolving the location of the node in the command graph"""
 
     @property
@@ -58,7 +58,7 @@ class CommandGraphNode(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def children(self) -> List[str]:
+    def children(self) -> list[str]:
         """The child objects that are contained within this object"""
 
     def navigate(self, name: str, selector: str | int | None) -> CommandGraphNode:
@@ -97,7 +97,7 @@ class CommandGraphCall:
         return self._name
 
     @property
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         """The selectors resolving the location of the node in the command graph"""
         return self.parent.selectors
 
@@ -119,7 +119,7 @@ class CommandGraphRoot(CommandGraphNode):
         return None
 
     @property
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         """The selectors resolving the location of the node in the command graph"""
         return []
 
@@ -129,7 +129,7 @@ class CommandGraphRoot(CommandGraphNode):
         return None
 
     @property
-    def children(self) -> List[str]:
+    def children(self) -> list[str]:
         """All of the child elements in the root of the command graph"""
         return ["bar", "group", "layout", "screen", "widget", "window", "core"]
 
@@ -157,7 +157,7 @@ class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
         return self._selector
 
     @property
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         """The selectors resolving the location of the node in the command graph"""
         selectors = self.parent.selectors + [(self.object_type, self.selector)]
         return selectors
@@ -205,10 +205,10 @@ class _WindowGraphNode(CommandGraphObject):
 
 class _CoreGraphNode(CommandGraphObject):
     object_type = "core"
-    children: List[str] = []
+    children: list[str] = []
 
 
-_COMMAND_GRAPH_MAP: Dict[str, Type[CommandGraphObject]] = {
+_COMMAND_GRAPH_MAP: dict[str, Type[CommandGraphObject]] = {
     "bar": _BarGraphNode,
     "group": _GroupGraphNode,
     "layout": _LayoutGraphNode,

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -26,10 +26,10 @@ abstract command graph
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from typing import Dict, List, Optional, Tuple, Type, Union
+    from typing import Dict, List, Optional, Tuple, Type
 
     SelectorType = Tuple[str, Optional[str | int]]
 

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -24,7 +24,7 @@ The interface to execute commands on the command graph
 
 import traceback
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple
 
 from libqtile import ipc
 from libqtile.command.base import CommandError, CommandException, CommandObject, SelectError
@@ -90,7 +90,7 @@ class CommandInterface(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: str | int) -> bool:
         """Check if the given item exists
 
         Parameters
@@ -170,7 +170,7 @@ class QtileCommandInterface(CommandInterface):
         cmd = obj.command(command)
         return cmd is not None
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: str | int) -> bool:
         """Check if the given item exists
 
         Parameters
@@ -251,7 +251,7 @@ class IPCCommandInterface(CommandInterface):
         commands = self.execute(cmd_call, (), {})
         return command in commands
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: str | int) -> bool:
         """Check if the given item exists
 
         Resolves the available commands for the given command node of the given

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -34,7 +34,7 @@ from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Tuple
+    from typing import Any
 
     from libqtile.command.graph import SelectorType
 
@@ -43,7 +43,7 @@ ERROR = 1
 EXCEPTION = 2
 
 
-def format_selectors(selectors: List[SelectorType]) -> str:
+def format_selectors(selectors: list[SelectorType]) -> str:
     """Build the path to the selected command graph node"""
     path_elements = []
     for name, selector in selectors:
@@ -63,7 +63,7 @@ class CommandInterface(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def execute(self, call: CommandGraphCall, args: Tuple, kwargs: Dict) -> Any:
+    def execute(self, call: CommandGraphCall, args: tuple, kwargs: dict) -> Any:
         """Execute the given call, returning the result of the execution
 
         Perform the given command graph call, calling the function with the
@@ -130,7 +130,7 @@ class QtileCommandInterface(CommandInterface):
         """
         self._command_object = command_object
 
-    def execute(self, call: CommandGraphCall, args: Tuple, kwargs: Dict) -> Any:
+    def execute(self, call: CommandGraphCall, args: tuple, kwargs: dict) -> Any:
         """Execute the given call, returning the result of the execution
 
         Perform the given command graph call, calling the function with the
@@ -214,7 +214,7 @@ class IPCCommandInterface(CommandInterface):
         """
         self._client = ipc_client
 
-    def execute(self, call: CommandGraphCall, args: Tuple, kwargs: Dict) -> Any:
+    def execute(self, call: CommandGraphCall, args: tuple, kwargs: dict) -> Any:
         """Execute the given call, returning the result of the execution
 
         Executes the given command over the given IPC client.  Returns the
@@ -290,12 +290,12 @@ class IPCCommandServer:
     def __init__(self, qtile) -> None:
         """Wrapper around the ipc server for communitacing with the IPCCommandInterface
 
-        Sets up the IPC server such that it will receive and send messages to
+        sets up the IPC server such that it will receive and send messages to
         and from the IPCCommandInterface.
         """
         self.qtile = qtile
 
-    def call(self, data: Tuple[List[SelectorType], str, Tuple, Dict]) -> Tuple[int, Any]:
+    def call(self, data: tuple[list[SelectorType], str, tuple, dict]) -> tuple[int, Any]:
         """Receive and parse the given data"""
         selectors, name, args, kwargs = data
         try:

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -22,14 +22,21 @@
 The interface to execute commands on the command graph
 """
 
+from __future__ import annotations
+
 import traceback
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import ipc
 from libqtile.command.base import CommandError, CommandException, CommandObject, SelectError
-from libqtile.command.graph import CommandGraphCall, CommandGraphNode, SelectorType
+from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.log_utils import logger
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Tuple
+
+    from libqtile.command.graph import SelectorType
 
 SUCCESS = 0
 ERROR = 1

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import contextlib
 import os.path
 import sys
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Union
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
@@ -266,16 +266,16 @@ class Screen(CommandObject):
 
     def __init__(
         self,
-        top: Optional[BarType] = None,
-        bottom: Optional[BarType] = None,
-        left: Optional[BarType] = None,
-        right: Optional[BarType] = None,
-        wallpaper: Optional[str] = None,
-        wallpaper_mode: Optional[str] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        top: BarType | None = None,
+        bottom: BarType | None = None,
+        left: BarType | None = None,
+        right: BarType | None = None,
+        wallpaper: str | None = None,
+        wallpaper_mode: str | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
     ):
 
         self.top = top
@@ -528,7 +528,7 @@ class Group:
         layout_opts=None,
         screen_affinity=None,
         position=sys.maxsize,
-        label: Optional[str] = None,
+        label: str | None = None,
     ):
         self.name = name
         self.label = label

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,14 +33,18 @@ from __future__ import annotations
 import contextlib
 import os.path
 import sys
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
-from libqtile.bar import Bar, BarType
-from libqtile.command.base import CommandObject, ItemT
+from libqtile.bar import Bar
+from libqtile.command.base import CommandObject
 
 if TYPE_CHECKING:
+    from typing import Callable, List
+
+    from libqtile.bar import BarType
+    from libqtile.command.base import ItemT
     from libqtile.group import _Group
 
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import contextlib
 import os.path
 import sys
-from typing import TYPE_CHECKING, Callable, List, Union
+from typing import TYPE_CHECKING, Callable, List
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
@@ -93,7 +93,7 @@ class KeyChord:
         self,
         modifiers: List[str],
         key: str,
-        submappings: List[Union[Key, KeyChord]],
+        submappings: List[Key | KeyChord],
         mode: str = "",
     ):
         self.modifiers = modifiers
@@ -520,7 +520,7 @@ class Group:
         name: str,
         matches: List[Match] = None,
         exclusive=False,
-        spawn: Union[str, List[str]] = None,
+        spawn: str | List[str] | None = None,
         layout: str = None,
         layouts: List = None,
         persist=True,

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -41,7 +41,7 @@ from libqtile.bar import Bar
 from libqtile.command.base import CommandObject
 
 if TYPE_CHECKING:
-    from typing import Callable, List
+    from typing import Callable
 
     from libqtile.bar import BarType
     from libqtile.command.base import ItemT
@@ -65,7 +65,7 @@ class Key:
         description to be added to the key binding
     """
 
-    def __init__(self, modifiers: List[str], key: str, *commands, desc: str = ""):
+    def __init__(self, modifiers: list[str], key: str, *commands, desc: str = ""):
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
@@ -95,9 +95,9 @@ class KeyChord:
 
     def __init__(
         self,
-        modifiers: List[str],
+        modifiers: list[str],
         key: str,
-        submappings: List[Key | KeyChord],
+        submappings: list[Key | KeyChord],
         mode: str = "",
     ):
         self.modifiers = modifiers
@@ -112,7 +112,7 @@ class KeyChord:
 
 
 class Mouse:
-    def __init__(self, modifiers: List[str], button: str, *commands, **kwargs):
+    def __init__(self, modifiers: list[str], button: str, *commands, **kwargs):
         self.modifiers = modifiers
         self.button = button
         self.commands = commands
@@ -522,11 +522,11 @@ class Group:
     def __init__(
         self,
         name: str,
-        matches: List[Match] = None,
+        matches: list[Match] = None,
         exclusive=False,
-        spawn: str | List[str] | None = None,
+        spawn: str | list[str] | None = None,
         layout: str = None,
-        layouts: List = None,
+        layouts: list = None,
         persist=True,
         init=True,
         layout_opts=None,

--- a/libqtile/configurable.py
+++ b/libqtile/configurable.py
@@ -19,11 +19,10 @@
 # SOFTWARE.
 
 import copy
-from typing import Dict
 
 
 class Configurable:
-    global_defaults = {}  # type: Dict
+    global_defaults = {}  # type: dict
 
     def __init__(self, **config):
         self._variable_defaults = {}

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 from libqtile.backend.x11 import core
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List
+    from typing import Any
 
     from typing_extensions import Literal
 
@@ -44,7 +44,7 @@ class ConfigError(Exception):
 
 
 config_pyi_header = """
-from typing import Any, Dict, List
+from typing import Any
 from typing_extensions import Literal
 from libqtile.config import Group, Key, Mouse, Rule, Screen
 from libqtile.layout.base import Layout
@@ -54,20 +54,20 @@ from libqtile.layout.base import Layout
 
 class Config:
     # All configuration options
-    keys: List[Key]
-    mouse: List[Mouse]
-    groups: List[Group]
+    keys: list[Key]
+    mouse: list[Mouse]
+    groups: list[Group]
     dgroups_key_binder: Any
-    dgroups_app_rules: List[Rule]
+    dgroups_app_rules: list[Rule]
     follow_mouse_focus: bool
     focus_on_window_activation: Literal["focus", "smart", "urgent", "never"]
     cursor_warp: bool
-    layouts: List[Layout]
+    layouts: list[Layout]
     floating_layout: Layout
-    screens: List[Screen]
+    screens: list[Screen]
     auto_fullscreen: bool
-    widget_defaults: Dict[str, Any]
-    extension_defaults: Dict[str, Any]
+    widget_defaults: dict[str, Any]
+    extension_defaults: dict[str, Any]
     bring_front_click: bool | Literal["floating_only"]
     reconfigure_screens: bool
     wmname: str

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 from libqtile.backend.x11 import core
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Union
+    from typing import Any, Dict, List
 
     from typing_extensions import Literal
 
@@ -44,7 +44,7 @@ class ConfigError(Exception):
 
 
 config_pyi_header = """
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 from typing_extensions import Literal
 from libqtile.config import Group, Key, Mouse, Rule, Screen
 from libqtile.layout.base import Layout
@@ -68,7 +68,7 @@ class Config:
     auto_fullscreen: bool
     widget_defaults: Dict[str, Any]
     extension_defaults: Dict[str, Any]
-    bring_front_click: Union[bool, Literal["floating_only"]]
+    bring_front_click: bool | Literal["floating_only"]
     reconfigure_screens: bool
     wmname: str
     auto_minimize: bool

--- a/libqtile/core/lifecycle.py
+++ b/libqtile/core/lifecycle.py
@@ -2,7 +2,6 @@ import atexit
 import enum
 import os
 import sys
-from typing import Optional
 
 from libqtile.log_utils import logger
 
@@ -20,7 +19,7 @@ class LifeCycle:
     # referenced here when atexit fires will NOT be finalized properly.
     def __init__(self) -> None:
         self.behavior = Behavior.NONE
-        self.state_file: Optional[str] = None
+        self.state_file: str | None = None
         atexit.register(self._atexit)
 
     def _atexit(self) -> None:

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import signal
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Callable, Dict
 
 from libqtile.log_utils import logger
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class LoopContext(contextlib.AbstractAsyncContextManager):
     def __init__(
         self,
-        signals: Optional[Dict[signal.Signals, Callable]] = None,
+        signals: Dict[signal.Signals, Callable] | None = None,
     ) -> None:
         super().__init__()
         self._signals = signals or {}

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import signal
-from typing import TYPE_CHECKING, Callable, Dict
+from typing import TYPE_CHECKING
 
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
+    from typing import Callable, Dict
+
     from libqtile.core.manager import Qtile
 
 

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Callable, Dict
+    from typing import Callable
 
     from libqtile.core.manager import Qtile
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class LoopContext(contextlib.AbstractAsyncContextManager):
     def __init__(
         self,
-        signals: Dict[signal.Signals, Callable] | None = None,
+        signals: dict[signal.Signals, Callable] | None = None,
     ) -> None:
         super().__init__()
         self._signals = signals or {}

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -54,7 +54,7 @@ from libqtile.utils import get_cache_dir, lget, send_notification
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+    from typing import Any, Callable, Dict, List, Tuple, Union
 
     from typing_extensions import Literal
 
@@ -73,16 +73,16 @@ class Qtile(CommandObject):
         kore: base.Core,
         config,  # mypy doesn't like the config's dynamic attributes
         no_spawn: bool = False,
-        state: Optional[str] = None,
-        socket_path: Optional[str] = None,
+        state: str | None = None,
+        socket_path: str | None = None,
     ):
         self.core = kore
         self.config = config
         self.no_spawn = no_spawn
-        self._state: Optional[Union[QtileState, str]] = state
+        self._state: Union[QtileState, str] | None = state
         self.socket_path = socket_path
 
-        self._drag: Optional[Tuple] = None
+        self._drag: Tuple | None = None
         self.mouse_map: Dict[int, List[Union[Click, Drag]]] = {}
 
         self.windows_map: Dict[int, base.WindowType] = {}
@@ -97,7 +97,7 @@ class Qtile(CommandObject):
 
         libqtile.init(self)
 
-        self._stopped_event: Optional[asyncio.Event] = None
+        self._stopped_event: asyncio.Event | None = None
 
         self.server = IPCCommandServer(self)
 
@@ -176,7 +176,7 @@ class Qtile(CommandObject):
 
     def _prepare_socket_path(
         self,
-        socket_path: Optional[str] = None,
+        socket_path: str | None = None,
     ) -> str:
         if socket_path is None:
             socket_path = ipc.find_sockfile(self.core.display_name)
@@ -367,7 +367,7 @@ class Qtile(CommandObject):
 
         hook.fire("screens_reconfigured")
 
-    def paint_screen(self, screen: Screen, image_path: str, mode: Optional[str] = None) -> None:
+    def paint_screen(self, screen: Screen, image_path: str, mode: str | None = None) -> None:
         self.core.painter.paint(screen, image_path, mode)
 
     def process_key_event(self, keysym: int, mask: int) -> None:
@@ -481,9 +481,9 @@ class Qtile(CommandObject):
     def add_group(
         self,
         name: str,
-        layout: Optional[str] = None,
-        layouts: Optional[List[Layout]] = None,
-        label: Optional[str] = None,
+        layout: str | None = None,
+        layouts: List[Layout] | None = None,
+        label: str | None = None,
     ) -> bool:
         if name not in self.groups_map.keys():
             g = _Group(name, layout, label=label)
@@ -549,7 +549,7 @@ class Qtile(CommandObject):
         return self.current_screen.group
 
     @property
-    def current_window(self) -> Optional[base.Window]:
+    def current_window(self) -> base.Window | None:
         return self.current_screen.group.current_window
 
     def reserve_space(
@@ -619,7 +619,7 @@ class Qtile(CommandObject):
             del self.windows_map[wid]
             self.core.update_client_list(self.windows_map)
 
-    def find_screen(self, x: int, y: int) -> Optional[Screen]:
+    def find_screen(self, x: int, y: int) -> Screen | None:
         """Find a screen based on the x and y offset"""
         result = []
         for i in self.screens:
@@ -629,7 +629,7 @@ class Qtile(CommandObject):
             return result[0]
         return None
 
-    def find_closest_screen(self, x: int, y: int) -> Optional[Screen]:
+    def find_closest_screen(self, x: int, y: int) -> Screen | None:
         """
         If find_screen returns None, then this basically extends a
         screen vertically and horizontally and see if x,y lies in the
@@ -659,7 +659,7 @@ class Qtile(CommandObject):
 
     def _find_closest_closest(
         self, x: int, y: int, candidate_screens: List[Screen]
-    ) -> Optional[Screen]:
+    ) -> Screen | None:
         """
         if find_closest_screen can't determine one, we've got multiple
         screens, so figure out who is closer.  We'll calculate using
@@ -668,7 +668,7 @@ class Qtile(CommandObject):
         Note that this could return None if x, y is right/below all
         screens.
         """
-        closest_distance: Optional[float] = None  # because mypy only considers first value
+        closest_distance: float | None = None  # because mypy only considers first value
         if not candidate_screens:
             # try all screens
             candidate_screens = self.screens
@@ -784,7 +784,7 @@ class Qtile(CommandObject):
             return True, []
         return None
 
-    def _select(self, name: str, sel: Optional[Union[str, int]]) -> Optional[CommandObject]:
+    def _select(self, name: str, sel: Union[str, int] | None) -> CommandObject | None:
         if name == "group":
             if sel is None:
                 return self.current_group
@@ -987,7 +987,7 @@ class Qtile(CommandObject):
         """List of all addressible widget names"""
         return list(self.widgets_map.keys())
 
-    def cmd_to_layout_index(self, index: str, name: Optional[str] = None) -> None:
+    def cmd_to_layout_index(self, index: str, name: str | None = None) -> None:
         """Switch to the layout with the given index in self.layouts.
 
         Parameters
@@ -1003,7 +1003,7 @@ class Qtile(CommandObject):
             group = self.current_group
         group.use_layout(index)
 
-    def cmd_next_layout(self, name: Optional[str] = None) -> None:
+    def cmd_next_layout(self, name: str | None = None) -> None:
         """Switch to the next layout.
 
         Parameters
@@ -1017,7 +1017,7 @@ class Qtile(CommandObject):
             group = self.current_group
         group.use_next_layout()
 
-    def cmd_prev_layout(self, name: Optional[str] = None) -> None:
+    def cmd_prev_layout(self, name: str | None = None) -> None:
         """Switch to the previous layout.
 
         Parameters
@@ -1368,7 +1368,7 @@ class Qtile(CommandObject):
         command: str = "%s",
         complete: str = "cmd",
         shell: bool = True,
-        aliases: Optional[Dict[str, str]] = None,
+        aliases: Dict[str, str] | None = None,
     ) -> None:
         """Spawn a command using a prompt widget, with tab-completion.
 
@@ -1457,9 +1457,9 @@ class Qtile(CommandObject):
     def cmd_addgroup(
         self,
         group: str,
-        label: Optional[str] = None,
-        layout: Optional[str] = None,
-        layouts: Optional[List[Layout]] = None,
+        label: str | None = None,
+        layout: str | None = None,
+        layouts: List[Layout] | None = None,
     ) -> bool:
         """Add a group with the given name"""
         return self.add_group(name=group, layout=layout, layouts=layouts, label=label)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -54,7 +54,7 @@ from libqtile.utils import get_cache_dir, lget, send_notification
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Tuple, Union
+    from typing import Any, Callable, Dict, List, Tuple
 
     from typing_extensions import Literal
 
@@ -79,18 +79,18 @@ class Qtile(CommandObject):
         self.core = kore
         self.config = config
         self.no_spawn = no_spawn
-        self._state: Union[QtileState, str] | None = state
+        self._state: QtileState | str | None = state
         self.socket_path = socket_path
 
         self._drag: Tuple | None = None
-        self.mouse_map: Dict[int, List[Union[Click, Drag]]] = {}
+        self.mouse_map: Dict[int, List[Click | Drag]] = {}
 
         self.windows_map: Dict[int, base.WindowType] = {}
         self.widgets_map: Dict[str, _Widget] = {}
         self.groups_map: Dict[str, _Group] = {}
         self.groups: List[_Group] = []
 
-        self.keys_map: Dict[Tuple[int, int], Union[Key, KeyChord]] = {}
+        self.keys_map: Dict[Tuple[int, int], Key | KeyChord] = {}
         self.chord_stack: List[KeyChord] = []
 
         self.screens: List[Screen] = []
@@ -401,12 +401,12 @@ class Qtile(CommandObject):
         for key in self.keys_map.values():
             self.grab_key(key)
 
-    def grab_key(self, key: Union[Key, KeyChord]) -> None:
+    def grab_key(self, key: Key | KeyChord) -> None:
         """Grab the given key event"""
         keysym, mask_key = self.core.grab_key(key)
         self.keys_map[(keysym, mask_key)] = key
 
-    def ungrab_key(self, key: Union[Key, KeyChord]) -> None:
+    def ungrab_key(self, key: Key | KeyChord) -> None:
         """Ungrab a given key event"""
         keysym, mask_key = self.core.ungrab_key(key)
         self.keys_map.pop((keysym, mask_key))
@@ -454,7 +454,7 @@ class Qtile(CommandObject):
         for key in self.config.keys:
             self.grab_key(key)
 
-    def grab_button(self, button: Union[Click, Drag]) -> None:
+    def grab_button(self, button: Click | Drag) -> None:
         """Grab the given mouse button event"""
         try:
             button.modmask = self.core.grab_button(button)
@@ -775,7 +775,7 @@ class Qtile(CommandObject):
         elif name == "bar":
             return False, [x.position for x in self.current_screen.gaps]
         elif name == "window":
-            windows: List[Union[str, int]]
+            windows: List[str | int]
             windows = [k for k, v in self.windows_map.items() if isinstance(v, CommandObject)]
             return True, windows
         elif name == "screen":
@@ -784,7 +784,7 @@ class Qtile(CommandObject):
             return True, []
         return None
 
-    def _select(self, name: str, sel: Union[str, int] | None) -> CommandObject | None:
+    def _select(self, name: str, sel: str | int | None) -> CommandObject | None:
         if name == "group":
             if sel is None:
                 return self.current_group
@@ -803,7 +803,7 @@ class Qtile(CommandObject):
             if sel is None:
                 return self.current_window
             else:
-                windows: Dict[Union[str, int], base._Window]
+                windows: Dict[str | int, base._Window]
                 windows = {
                     k: v for k, v in self.windows_map.items() if isinstance(v, CommandObject)
                 }
@@ -937,7 +937,7 @@ class Qtile(CommandObject):
         result.add([])
         rows = []
 
-        def walk_binding(k: Union[Key, KeyChord], mode: str) -> None:
+        def walk_binding(k: Key | KeyChord, mode: str) -> None:
             nonlocal rows
             modifiers, name = ", ".join(k.modifiers), k.key
             if isinstance(k, Key):
@@ -1097,7 +1097,7 @@ class Qtile(CommandObject):
             return
         self.restart()
 
-    def cmd_spawn(self, cmd: Union[str, List[str]], shell: bool = False) -> int:
+    def cmd_spawn(self, cmd: str | List[str], shell: bool = False) -> int:
         """Run cmd, in a shell or not (default).
 
         cmd may be a string or a list (similar to subprocess.Popen).

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -36,7 +36,7 @@ import libqtile
 from libqtile import bar, hook, ipc, utils
 from libqtile.backend import base
 from libqtile.command import interface
-from libqtile.command.base import CommandError, CommandException, CommandObject, ItemT
+from libqtile.command.base import CommandError, CommandException, CommandObject
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import IPCCommandServer, QtileCommandInterface
 from libqtile.config import Click, Drag, Key, KeyChord, Match, Rule
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Literal
 
+    from libqtile.command.base import ItemT
     from libqtile.layout.base import Layout
 
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -54,7 +54,7 @@ from libqtile.utils import get_cache_dir, lget, send_notification
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Dict, List, Tuple
+    from typing import Any, Callable
 
     from typing_extensions import Literal
 
@@ -83,18 +83,18 @@ class Qtile(CommandObject):
         self._state: QtileState | str | None = state
         self.socket_path = socket_path
 
-        self._drag: Tuple | None = None
-        self.mouse_map: Dict[int, List[Click | Drag]] = {}
+        self._drag: tuple | None = None
+        self.mouse_map: dict[int, list[Click | Drag]] = {}
 
-        self.windows_map: Dict[int, base.WindowType] = {}
-        self.widgets_map: Dict[str, _Widget] = {}
-        self.groups_map: Dict[str, _Group] = {}
-        self.groups: List[_Group] = []
+        self.windows_map: dict[int, base.WindowType] = {}
+        self.widgets_map: dict[str, _Widget] = {}
+        self.groups_map: dict[str, _Group] = {}
+        self.groups: list[_Group] = []
 
-        self.keys_map: Dict[Tuple[int, int], Key | KeyChord] = {}
-        self.chord_stack: List[KeyChord] = []
+        self.keys_map: dict[tuple[int, int], Key | KeyChord] = {}
+        self.chord_stack: list[KeyChord] = []
 
-        self.screens: List[Screen] = []
+        self.screens: list[Screen] = []
 
         libqtile.init(self)
 
@@ -307,7 +307,7 @@ class Qtile(CommandObject):
             config = self.config.fake_screens
         else:
             # Alias screens with the same x and y coordinates, taking largest
-            xywh = {}  # type: Dict[Tuple[int, int], Tuple[int, int]]
+            xywh = {}  # type: dict[tuple[int, int], tuple[int, int]]
             for sx, sy, sw, sh in self.core.get_screen_info():
                 pos = (sx, sy)
                 width, height = xywh.get(pos, (0, 0))
@@ -483,7 +483,7 @@ class Qtile(CommandObject):
         self,
         name: str,
         layout: str | None = None,
-        layouts: List[Layout] | None = None,
+        layouts: list[Layout] | None = None,
         label: str | None = None,
     ) -> bool:
         if name not in self.groups_map.keys():
@@ -555,7 +555,7 @@ class Qtile(CommandObject):
 
     def reserve_space(
         self,
-        reserved_space: Tuple[int, int, int, int],  # [left, right, top, bottom]
+        reserved_space: tuple[int, int, int, int],  # [left, right, top, bottom]
         screen: Screen,
     ) -> None:
         """
@@ -576,7 +576,7 @@ class Qtile(CommandObject):
 
     def free_reserved_space(
         self,
-        reserved_space: Tuple[int, int, int, int],  # [left, right, top, bottom]
+        reserved_space: tuple[int, int, int, int],  # [left, right, top, bottom]
         screen: Screen,
     ):
         """
@@ -659,7 +659,7 @@ class Qtile(CommandObject):
         return self._find_closest_closest(x, y, x_match + y_match)
 
     def _find_closest_closest(
-        self, x: int, y: int, candidate_screens: List[Screen]
+        self, x: int, y: int, candidate_screens: list[Screen]
     ) -> Screen | None:
         """
         if find_closest_screen can't determine one, we've got multiple
@@ -776,7 +776,7 @@ class Qtile(CommandObject):
         elif name == "bar":
             return False, [x.position for x in self.current_screen.gaps]
         elif name == "window":
-            windows: List[str | int]
+            windows: list[str | int]
             windows = [k for k, v in self.windows_map.items() if isinstance(v, CommandObject)]
             return True, windows
         elif name == "screen":
@@ -804,7 +804,7 @@ class Qtile(CommandObject):
             if sel is None:
                 return self.current_window
             else:
-                windows: Dict[str | int, base._Window]
+                windows: dict[str | int, base._Window]
                 windows = {
                     k: v for k, v in self.windows_map.items() if isinstance(v, CommandObject)
                 }
@@ -888,7 +888,7 @@ class Qtile(CommandObject):
 
         pdb.set_trace()
 
-    def cmd_groups(self) -> Dict[str, Dict[str, Any]]:
+    def cmd_groups(self) -> dict[str, dict[str, Any]]:
         """Return a dictionary containing information for all groups
 
         Examples
@@ -984,7 +984,7 @@ class Qtile(CommandObject):
             result.add(row)
         return str(result)
 
-    def cmd_list_widgets(self) -> List[str]:
+    def cmd_list_widgets(self) -> list[str]:
         """List of all addressible widget names"""
         return list(self.widgets_map.keys())
 
@@ -1032,7 +1032,7 @@ class Qtile(CommandObject):
             group = self.current_group
         group.use_previous_layout()
 
-    def cmd_screens(self) -> List[Dict[str, Any]]:
+    def cmd_screens(self) -> list[dict[str, Any]]:
         """Return a list of dictionaries providing information on all screens"""
         lst = [
             dict(
@@ -1098,7 +1098,7 @@ class Qtile(CommandObject):
             return
         self.restart()
 
-    def cmd_spawn(self, cmd: str | List[str], shell: bool = False) -> int:
+    def cmd_spawn(self, cmd: str | list[str], shell: bool = False) -> int:
         """Run cmd, in a shell or not (default).
 
         cmd may be a string or a list (similar to subprocess.Popen).
@@ -1226,15 +1226,15 @@ class Qtile(CommandObject):
         """Move to the previous screen"""
         self.focus_screen((self.screens.index(self.current_screen) - 1) % len(self.screens))
 
-    def cmd_windows(self) -> List[Dict[str, Any]]:
+    def cmd_windows(self) -> list[dict[str, Any]]:
         """Return info for each client window"""
         return [i.info() for i in self.windows_map.values() if not isinstance(i, base.Internal)]
 
-    def cmd_internal_windows(self) -> List[Dict[str, Any]]:
+    def cmd_internal_windows(self) -> list[dict[str, Any]]:
         """Return info for each internal window (bars, for example)"""
         return [i.info() for i in self.windows_map.values() if isinstance(i, base.Internal)]
 
-    def cmd_qtile_info(self) -> Dict:
+    def cmd_qtile_info(self) -> dict:
         """Returns a dictionary of info on the Qtile instance"""
         return {}
 
@@ -1369,7 +1369,7 @@ class Qtile(CommandObject):
         command: str = "%s",
         complete: str = "cmd",
         shell: bool = True,
-        aliases: Dict[str, str] | None = None,
+        aliases: dict[str, str] | None = None,
     ) -> None:
         """Spawn a command using a prompt widget, with tab-completion.
 
@@ -1460,7 +1460,7 @@ class Qtile(CommandObject):
         group: str,
         label: str | None = None,
         layout: str | None = None,
-        layouts: List[Layout] | None = None,
+        layouts: list[Layout] | None = None,
     ) -> bool:
         """Add a group with the given name"""
         return self.add_group(name=group, layout=layout, layouts=layouts, label=label)
@@ -1471,8 +1471,8 @@ class Qtile(CommandObject):
 
     def cmd_add_rule(
         self,
-        match_args: Dict[str, Any],
-        rule_args: Dict[str, Any],
+        match_args: dict[str, Any],
+        rule_args: dict[str, Any],
         min_priorty: bool = False,
     ):
         """Add a dgroup rule, returns rule_id needed to remove it
@@ -1552,7 +1552,7 @@ class Qtile(CommandObject):
         else:
             tracemalloc.stop()
 
-    def cmd_tracemalloc_dump(self) -> Tuple[bool, str]:
+    def cmd_tracemalloc_dump(self) -> tuple[bool, str]:
         """Dump tracemalloc snapshot"""
         import tracemalloc
 

--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -21,13 +21,10 @@
 import re
 import shlex
 from subprocess import PIPE, Popen
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile import configurable
 from libqtile.log_utils import logger
-
-if TYPE_CHECKING:
-    from typing import Any, List, Tuple
 
 RGB = re.compile(r"^#?([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$")
 
@@ -35,7 +32,7 @@ RGB = re.compile(r"^#?([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$")
 class _Extension(configurable.Configurable):
     """Base Extension class"""
 
-    installed_extensions = []  # type: List
+    installed_extensions = []  # type: list
 
     defaults = [
         ("font", "sans", "defines the font name to be used"),
@@ -104,7 +101,7 @@ class RunCommand(_Extension):
         #       modified it, all the other objects would see the modified list;
         #       use a string or a tuple instead, which are immutable
         ("command", None, "the command to be launched (string or list with arguments)"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         _Extension.__init__(self, **config)

--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -21,10 +21,13 @@
 import re
 import shlex
 from subprocess import PIPE, Popen
-from typing import Any, List, Tuple  # noqa: F401
+from typing import TYPE_CHECKING
 
 from libqtile import configurable
 from libqtile.log_utils import logger
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 RGB = re.compile(r"^#?([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$")
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -26,10 +26,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from libqtile import hook, utils
 from libqtile.backend.base import FloatStates
-from libqtile.command.base import CommandObject, ItemT
+from libqtile.command.base import CommandObject
 from libqtile.log_utils import logger
+
+if TYPE_CHECKING:
+    from libqtile.command.base import ItemT
 
 
 class _Group(CommandObject):

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -32,16 +32,12 @@
 
 import asyncio
 import contextlib
-from typing import TYPE_CHECKING
 
 from libqtile import utils
 from libqtile.log_utils import logger
 
-if TYPE_CHECKING:
-    from typing import Dict, Set
-
-subscriptions = {}  # type: Dict
-SKIPLOG = set()  # type: Set
+subscriptions = {}  # type: dict
+SKIPLOG = set()  # type: set
 
 
 def clear():

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -32,10 +32,13 @@
 
 import asyncio
 import contextlib
-from typing import Dict, Set
+from typing import TYPE_CHECKING
 
 from libqtile import utils
 from libqtile.log_utils import logger
+
+if TYPE_CHECKING:
+    from typing import Dict, Set
 
 subscriptions = {}  # type: Dict
 SKIPLOG = set()  # type: Set

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -31,7 +31,7 @@ import marshal
 import os.path
 import socket
 import struct
-from typing import Any, Optional, Tuple
+from typing import Any, Tuple
 
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
@@ -89,14 +89,14 @@ class _IPC:
     """A helper class to handle properly packing and unpacking messages"""
 
     @staticmethod
-    def unpack(data: bytes, *, is_json: Optional[bool] = None) -> Tuple[Any, bool]:
+    def unpack(data: bytes, *, is_json: bool | None = None) -> Tuple[Any, bool]:
         """Unpack the incoming message
 
         Parameters
         ----------
         data: bytes
             The incoming message to unpack
-        is_json: Optional[bool]
+        is_json: bool | None
             If the message should be unpacked as json.  By default, try to
             unpack json and fallback gracefully to marshalled bytes.
 
@@ -195,7 +195,7 @@ class Server:
     def __init__(self, socket_path: str, handler) -> None:
         self.socket_path = socket_path
         self.handler = handler
-        self.server = None  # type: Optional[asyncio.AbstractServer]
+        self.server = None  # type: asyncio.AbstractServer | None
 
         if os.path.exists(socket_path):
             os.unlink(socket_path)

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -24,6 +24,9 @@
     run the same Python version, and that clients must be trusted (as
     un-marshalling untrusted data can result in arbitrary code execution).
 """
+
+from __future__ import annotations
+
 import asyncio
 import fcntl
 import json
@@ -31,10 +34,13 @@ import marshal
 import os.path
 import socket
 import struct
-from typing import Any, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
+
+if TYPE_CHECKING:
+    from typing import Any, Tuple
 
 HDRFORMAT = "!L"
 HDRLEN = struct.calcsize(HDRFORMAT)

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -34,13 +34,10 @@ import marshal
 import os.path
 import socket
 import struct
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
-
-if TYPE_CHECKING:
-    from typing import Any, Tuple
 
 HDRFORMAT = "!L"
 HDRLEN = struct.calcsize(HDRFORMAT)
@@ -95,7 +92,7 @@ class _IPC:
     """A helper class to handle properly packing and unpacking messages"""
 
     @staticmethod
-    def unpack(data: bytes, *, is_json: bool | None = None) -> Tuple[Any, bool]:
+    def unpack(data: bytes, *, is_json: bool | None = None) -> tuple[Any, bool]:
         """Unpack the incoming message
 
         Parameters
@@ -108,7 +105,7 @@ class _IPC:
 
         Returns
         -------
-        Tuple[Any, bool]
+        tuple[Any, bool]
             A tuple of the unpacked object and a boolean denoting if the
             message was deserialized using json.  If True, the return message
             should be packed as json.

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -29,7 +29,7 @@ from libqtile import configurable
 from libqtile.command.base import CommandObject
 
 if TYPE_CHECKING:
-    from typing import Any, List, Tuple
+    from typing import Any
 
     from libqtile.command.base import ItemT
 
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
     """This class defines the API that should be exposed by all layouts"""
 
-    defaults = []  # type: List[Tuple[str, Any, str]]
+    defaults = []  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         # name is a little odd; we can't resolve it until the class is defined

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -19,12 +19,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import configurable
-from libqtile.command.base import CommandObject, ItemT
+from libqtile.command.base import CommandObject
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
+
+    from libqtile.command.base import ItemT
 
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -28,7 +28,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Optional
+from typing import List
 
 from libqtile.backend.base import Window
 from libqtile.config import Match
@@ -67,7 +67,7 @@ class Floating(Layout):
     ]
 
     def __init__(
-        self, float_rules: Optional[List[Match]] = None, no_reposition_rules=None, **config
+        self, float_rules: List[Match] | None = None, no_reposition_rules=None, **config
     ):
         """
         If you have certain apps that you always want to float you can provide

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -30,8 +30,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from libqtile.backend.base import Window
 from libqtile.config import Match
 from libqtile.layout.base import Layout
@@ -69,7 +67,7 @@ class Floating(Layout):
     ]
 
     def __init__(
-        self, float_rules: List[Match] | None = None, no_reposition_rules=None, **config
+        self, float_rules: list[Match] | None = None, no_reposition_rules=None, **config
     ):
         """
         If you have certain apps that you always want to float you can provide
@@ -100,7 +98,7 @@ class Floating(Layout):
         correct location on the screen.
         """
         Layout.__init__(self, **config)
-        self.clients: List[Window] = []
+        self.clients: list[Window] = []
         self.focused = None
         self.group = None
 

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -28,6 +28,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 from typing import List
 
 from libqtile.backend.base import Window

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -32,7 +32,7 @@
 from libqtile import hook
 from libqtile.layout.base import Layout
 
-to_superscript = dict(zip(map(ord, u"0123456789"), map(ord, u"⁰¹²³⁴⁵⁶⁷⁸⁹")))
+to_superscript = dict(zip(map(ord, "0123456789"), map(ord, "⁰¹²³⁴⁵⁶⁷⁸⁹")))
 
 
 class TreeNode:

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -28,8 +28,8 @@ from libqtile.command.interface import CommandInterface
 if TYPE_CHECKING:
     from typing import Dict, Iterable, List, Set, Tuple
 
-    from libqtile.config import Match
     from libqtile.command.graph import SelectorType
+    from libqtile.config import Match
 
 
 class LazyCall:

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -26,23 +26,23 @@ from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.command.interface import CommandInterface
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, List, Set, Tuple
+    from typing import Iterable
 
     from libqtile.command.graph import SelectorType
     from libqtile.config import Match
 
 
 class LazyCall:
-    def __init__(self, call: CommandGraphCall, args: Tuple, kwargs: Dict) -> None:
+    def __init__(self, call: CommandGraphCall, args: tuple, kwargs: dict) -> None:
         """The lazily evaluated command graph call
 
         Parameters
         ----------
         call: CommandGraphCall
             The call that is made
-        args: Tuple
+        args: tuple
             The args passed to the call when it is evaluated.
-        kwargs: Dict
+        kwargs: dict
             The kwargs passed to the call when it is evaluated.
         """
         self._call = call
@@ -50,7 +50,7 @@ class LazyCall:
         self._kwargs = kwargs
 
         self._focused: Match | None = None
-        self._layouts: Set[str] = set()
+        self._layouts: set[str] = set()
         self._when_floating = True
 
     def __call__(self, *args, **kwargs):
@@ -71,7 +71,7 @@ class LazyCall:
         return LazyCall(self._call, (*self._args, *args), {**self._kwargs, **kwargs})
 
     @property
-    def selectors(self) -> List[SelectorType]:
+    def selectors(self) -> list[SelectorType]:
         """The selectors for the given call"""
         return self._call.selectors
 
@@ -81,12 +81,12 @@ class LazyCall:
         return self._call.name
 
     @property
-    def args(self) -> Tuple:
+    def args(self) -> tuple:
         """The args to the given call"""
         return self._args
 
     @property
-    def kwargs(self) -> Dict:
+    def kwargs(self) -> dict:
         """The kwargs to the given call"""
         return self._kwargs
 
@@ -139,7 +139,7 @@ class LazyCommandInterface(CommandInterface):
     lazily evaluated commands.
     """
 
-    def execute(self, call: CommandGraphCall, args: Tuple, kwargs: Dict) -> LazyCall:
+    def execute(self, call: CommandGraphCall, args: tuple, kwargs: dict) -> LazyCall:
         """Lazily evaluate the given call"""
         return LazyCall(call, args, kwargs)
 

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
         Dict,
         Iterable,
         List,
-        Optional,
         Set,
         Tuple,
         Union,
@@ -55,7 +54,7 @@ class LazyCall:
         self._args = args
         self._kwargs = kwargs
 
-        self._focused: Optional[Match] = None
+        self._focused: Match | None = None
         self._layouts: Set[str] = set()
         self._when_floating = True
 
@@ -98,8 +97,8 @@ class LazyCall:
 
     def when(
         self,
-        focused: Optional[Match] = None,
-        layout: Optional[Union[Iterable[str], str]] = None,
+        focused: Match | None = None,
+        layout: Union[Iterable[str], str] | None = None,
         when_floating: bool = True,
     ) -> "LazyCall":
         """Enable call only for given layout(s) and floating state

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -21,19 +21,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from typing import (
-        Dict,
-        Iterable,
-        List,
-        Set,
-        Tuple,
-    )
-    from libqtile.config import Match
-
 from libqtile.command.client import InteractiveCommandClient
-from libqtile.command.graph import CommandGraphCall, CommandGraphNode, SelectorType
+from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.command.interface import CommandInterface
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterable, List, Set, Tuple
+
+    from libqtile.config import Match
+    from libqtile.command.graph import SelectorType
 
 
 class LazyCall:

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
         List,
         Set,
         Tuple,
-        Union,
     )
     from libqtile.config import Match
 
@@ -98,7 +97,7 @@ class LazyCall:
     def when(
         self,
         focused: Match | None = None,
-        layout: Union[Iterable[str], str] | None = None,
+        layout: Iterable[str] | str | None = None,
         when_floating: bool = True,
     ) -> "LazyCall":
         """Enable call only for given layout(s) and floating state
@@ -152,7 +151,7 @@ class LazyCommandInterface(CommandInterface):
         """Lazily resolve the given command"""
         return True
 
-    def has_item(self, node: CommandGraphNode, object_type: str, item: Union[str, int]) -> bool:
+    def has_item(self, node: CommandGraphNode, object_type: str, item: str | int) -> bool:
         """Lazily resolve the given item"""
         return True
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -24,8 +24,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List  # noqa: F401
-
 from libqtile import bar, layout, widget
 from libqtile.config import Click, Drag, Group, Key, Match, Screen
 from libqtile.lazy import lazy
@@ -159,7 +157,7 @@ mouse = [
 ]
 
 dgroups_key_binder = None
-dgroups_app_rules = []  # type: List
+dgroups_app_rules = []  # type: list
 follow_mouse_focus = True
 bring_front_click = False
 cursor_warp = False

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -20,14 +20,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from libqtile import config, group, hook
 from libqtile.backend.base import FloatStates
 from libqtile.config import Match
-
-if TYPE_CHECKING:
-    from typing import Dict, List
 
 
 class WindowVisibilityToggler:
@@ -221,13 +216,13 @@ class ScratchPad(group._Group):
     """
 
     def __init__(
-        self, name="scratchpad", dropdowns: List[config.DropDown] = None, label="", single=False
+        self, name="scratchpad", dropdowns: list[config.DropDown] = None, label="", single=False
     ):
         group._Group.__init__(self, name, label=label)
         self._dropdownconfig = {dd.name: dd for dd in dropdowns} if dropdowns is not None else {}
-        self.dropdowns: Dict[str, DropDownToggler] = {}
-        self._spawned: Dict[str, Match] = {}
-        self._to_hide: List[str] = []
+        self.dropdowns: dict[str, DropDownToggler] = {}
+        self._spawned: dict[str, Match] = {}
+        self._to_hide: list[str] = []
         self._single = single
 
     def _check_unsubscribe(self):

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -18,11 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from libqtile import config, group, hook
 from libqtile.backend.base import FloatStates
 from libqtile.config import Match
+
+if TYPE_CHECKING:
+    from typing import Dict, List
 
 
 class WindowVisibilityToggler:

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -98,7 +98,7 @@ def type_check_config_args(config_file):
     try:
         # we want to use Literal, which is in 3.8. If people have a mypy that
         # is too old, they can upgrade; this is an optional check anyways.
-        subprocess.check_call(["mypy", "--python-version=3.8", config_file])
+        subprocess.check_call(["mypy", "--python-version=3.10", config_file])
         print("config file type checking succeeded")
     except subprocess.CalledProcessError as e:
         print("config file type checking failed: {}".format(e))

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -25,12 +25,13 @@
     This can be used standalone or in other shell scripts.
 """
 
+from __future__ import annotations
+
 import argparse
 import itertools
 import pprint
 import sys
 import textwrap
-from typing import List
 
 from libqtile.command.base import CommandError, CommandException, SelectError
 from libqtile.command.client import CommandClient
@@ -88,7 +89,7 @@ def print_commands(prefix: str, obj: CommandClient) -> None:
         print(formatting.format(line[0], line[1]))
 
 
-def get_object(client: CommandClient, argv: List[str]) -> CommandClient:
+def get_object(client: CommandClient, argv: list[str]) -> CommandClient:
     """
     Constructs a path to object and returns given object (if it exists).
     """
@@ -125,7 +126,7 @@ def get_object(client: CommandClient, argv: List[str]) -> CommandClient:
     return client
 
 
-def run_function(client: CommandClient, funcname: str, args: List[str]) -> str:
+def run_function(client: CommandClient, funcname: str, args: list[str]) -> str:
     "Run command with specified args on given object."
     try:
         ret = client.call(funcname, *args)

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -7,7 +7,7 @@ from libqtile.scripts import check, cmd_obj, migrate, run_cmd, shell, start, top
 
 try:
     # Python>3.7 can get the version from importlib
-    from importlib.metadata import distribution  # type: ignore
+    from importlib.metadata import distribution
 
     VERSION = distribution("qtile").version
 except ModuleNotFoundError:

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -29,7 +29,7 @@ import struct
 import sys
 import termios
 from importlib import import_module
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 
 from libqtile.command.client import CommandClient
 from libqtile.command.interface import (
@@ -62,7 +62,7 @@ class QSh:
         self._completekey = completekey
         self._builtins = [i[3:] for i in dir(self) if i.startswith("do_")]
 
-    def complete(self, arg, state) -> Optional[str]:
+    def complete(self, arg, state) -> str | None:
         buf = self.readline.get_line_buffer()
         completers = self._complete(buf, arg)
         if completers and state < len(completers):
@@ -116,9 +116,7 @@ class QSh:
                 ret.append("  ".join(sl))
         return "\n".join(ret)
 
-    def _ls(
-        self, client: CommandClient, object_type: Optional[str]
-    ) -> Tuple[List[str], List[str]]:
+    def _ls(self, client: CommandClient, object_type: str | None) -> Tuple[List[str], List[str]]:
         if object_type is not None:
             allow_root, items = client.items(object_type)
             str_items = [str(i) for i in items]
@@ -130,7 +128,7 @@ class QSh:
         else:
             return client.children, []
 
-    def _find_path(self, path: str) -> Tuple[Optional[CommandClient], Optional[str]]:
+    def _find_path(self, path: str) -> Tuple[CommandClient | None, str | None]:
         """Find an object relative to the current node
 
         Finds and returns the command graph node that is defined relative to
@@ -142,7 +140,7 @@ class QSh:
 
     def _find_node(
         self, src: CommandClient, *paths: str
-    ) -> Tuple[Optional[CommandClient], Optional[str]]:
+    ) -> Tuple[CommandClient | None, str | None]:
         """Find an object in the command graph
 
         Return the object in the command graph at the specified path relative
@@ -181,7 +179,7 @@ class QSh:
         next_node = src.navigate(path, None)
         return self._find_node(next_node, *next_path)
 
-    def do_cd(self, arg: Optional[str]) -> str:
+    def do_cd(self, arg: str | None) -> str:
         """Change to another path.
 
         Examples
@@ -209,7 +207,7 @@ class QSh:
 
         return format_selectors(self._command_client.selectors) or "/"
 
-    def do_ls(self, arg: Optional[str]) -> str:
+    def do_ls(self, arg: str | None) -> str:
         """List contained items on a node.
 
         Examples
@@ -254,7 +252,7 @@ class QSh:
         """
         return format_selectors(self._command_client.selectors) or "/"
 
-    def do_help(self, arg: Optional[str]) -> str:
+    def do_help(self, arg: str | None) -> str:
         """Give help on commands and builtins
 
         When invoked without arguments, provides an overview of all commands. When

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -42,7 +42,7 @@ from libqtile.command.interface import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, List, Tuple
+    from typing import Any
 
 
 def terminal_width():
@@ -74,7 +74,7 @@ class QSh:
             return completers[state]
         return None
 
-    def _complete(self, buf, arg) -> List[str]:
+    def _complete(self, buf, arg) -> list[str]:
         if not re.search(r" |\(", buf) or buf.startswith("help "):
             options = self._builtins + self._command_client.commands
             lst = [i for i in options if i.startswith(arg)]
@@ -121,7 +121,7 @@ class QSh:
                 ret.append("  ".join(sl))
         return "\n".join(ret)
 
-    def _ls(self, client: CommandClient, object_type: str | None) -> Tuple[List[str], List[str]]:
+    def _ls(self, client: CommandClient, object_type: str | None) -> tuple[list[str], list[str]]:
         if object_type is not None:
             allow_root, items = client.items(object_type)
             str_items = [str(i) for i in items]
@@ -133,7 +133,7 @@ class QSh:
         else:
             return client.children, []
 
-    def _find_path(self, path: str) -> Tuple[CommandClient | None, str | None]:
+    def _find_path(self, path: str) -> tuple[CommandClient | None, str | None]:
         """Find an object relative to the current node
 
         Finds and returns the command graph node that is defined relative to
@@ -145,7 +145,7 @@ class QSh:
 
     def _find_node(
         self, src: CommandClient, *paths: str
-    ) -> Tuple[CommandClient | None, str | None]:
+    ) -> tuple[CommandClient | None, str | None]:
         """Find an object in the command graph
 
         Return the object in the command graph at the specified path relative

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -21,6 +21,8 @@
     A command shell for Qtile.
 """
 
+from __future__ import annotations
+
 import fcntl
 import inspect
 import pprint
@@ -29,7 +31,7 @@ import struct
 import sys
 import termios
 from importlib import import_module
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile.command.client import CommandClient
 from libqtile.command.interface import (
@@ -38,6 +40,9 @@ from libqtile.command.interface import (
     CommandInterface,
     format_selectors,
 )
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 
 def terminal_width():

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import asyncio
 import glob
 import importlib
@@ -28,7 +30,13 @@ from collections import defaultdict
 from collections.abc import Sequence
 from random import randint
 from shutil import which
-from typing import List, Tuple, Union
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List, Tuple, Union
+
+    ColorType = Union[str, Tuple[int, int, int], Tuple[int, int, int, float]]
+    ColorsType = Union[ColorType, List[ColorType]]
 
 try:
     from dbus_next import Message, Variant
@@ -65,10 +73,6 @@ def shuffle_down(lst):
         c = lst[0]
         lst.remove(c)
         lst.append(c)
-
-
-ColorType = Union[str, Tuple[int, int, int], Tuple[int, int, int, float]]
-ColorsType = Union[ColorType, List[ColorType]]
 
 
 def rgb(x: ColorType) -> Tuple[float, float, float, float]:

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -33,10 +33,10 @@ from shutil import which
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import List, Tuple, Union
+    from typing import Union
 
-    ColorType = Union[str, Tuple[int, int, int], Tuple[int, int, int, float]]
-    ColorsType = Union[ColorType, List[ColorType]]
+    ColorType = Union[str, tuple[int, int, int], tuple[int, int, int, float]]
+    ColorsType = Union[ColorType, list[ColorType]]
 
 try:
     from dbus_next import Message, Variant
@@ -75,7 +75,7 @@ def shuffle_down(lst):
         lst.append(c)
 
 
-def rgb(x: ColorType) -> Tuple[float, float, float, float]:
+def rgb(x: ColorType) -> tuple[float, float, float, float]:
     """
     Returns a valid RGBA tuple.
 

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -25,7 +25,6 @@ import enum
 import os
 import shlex
 from functools import partial
-from typing import Dict
 
 from libqtile.log_utils import logger
 from libqtile.widget import base
@@ -67,7 +66,7 @@ class Backlight(base.InLoopPollText):
         )
     """
 
-    filenames: Dict = {}
+    filenames: dict = {}
 
     defaults = [
         ("backlight_name", "acpi_video0", "ACPI name of a backlight device"),

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -67,7 +67,7 @@ class Backlight(base.InLoopPollText):
         )
     """
 
-    filenames = {}  # type: Dict
+    filenames: Dict = {}
 
     defaults = [
         ("backlight_name", "acpi_video0", "ACPI name of a backlight device"),

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -68,6 +68,8 @@ if TYPE_CHECKING:
 # | ORIENTATION_BOTH       | Widget displayed   | Widget displayed   |
 # |                        | horizontally       | vertically         |
 # +------------------------+--------------------+--------------------+
+
+
 class _Orientations(int):
     def __new__(cls, value, doc):
         return super().__new__(cls, value)

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -29,18 +29,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import asyncio
 import copy
 import math
 import subprocess
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import bar, configurable, confreader
 from libqtile.command import interface
-from libqtile.command.base import CommandError, CommandObject, ItemT
+from libqtile.command.base import CommandError, CommandObject
 from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
 
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
+
+    from libqtile.command.base import ItemT
 
 # Each widget class must define which bar orientation(s) it supports by setting
 # these bits in an 'orientations' class attribute. Simply having the attribute

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -44,7 +44,7 @@ from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Any, List, Tuple
+    from typing import Any
 
     from libqtile.command.base import ItemT
 
@@ -140,7 +140,7 @@ class _Widget(CommandObject, configurable.Configurable):
             {},
             "Dict of mouse button press callback functions. Acceps functions and ``lazy`` calls.",
         ),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, length, **config):
         """
@@ -164,7 +164,7 @@ class _Widget(CommandObject, configurable.Configurable):
             raise confreader.ConfigError("Widget width must be an int")
 
         self.configured = False
-        self._futures: List[asyncio.TimerHandle] = []
+        self._futures: list[asyncio.TimerHandle] = []
 
     @property
     def length(self):
@@ -383,7 +383,7 @@ class _TextBox(_Widget):
         ("markup", True, "Whether or not to use pango markup"),
         ("fmt", "{}", "How to format the text"),
         ("max_chars", 0, "Maximum number of characters to display in widget."),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         self.layout = None
@@ -553,7 +553,7 @@ class InLoopPollText(_TextBox):
             "Update interval in seconds, if none, the "
             "widget updates whenever the event loop is idle.",
         ),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, default_text="N/A", width=bar.CALCULATED, **config):
         _TextBox.__init__(self, default_text, width, **config)
@@ -608,7 +608,7 @@ class ThreadPoolText(_TextBox):
             600,
             "Update interval in seconds, if none, the " "widget updates whenever it's done.",
         ),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text, **config):
         super().__init__(text, width=bar.CALCULATED, **config)
@@ -658,7 +658,7 @@ class PaddingMixin(configurable.Configurable):
         ("padding", 3, "Padding inside the box"),
         ("padding_x", None, "X Padding. Overrides 'padding' if set"),
         ("padding_y", None, "Y Padding. Overrides 'padding' if set"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     padding_x = configurable.ExtraFallback("padding_x", "padding")
     padding_y = configurable.ExtraFallback("padding_y", "padding")
@@ -676,7 +676,7 @@ class MarginMixin(configurable.Configurable):
         ("margin", 3, "Margin inside the box"),
         ("margin_x", None, "X Margin. Overrides 'margin' if set"),
         ("margin_y", None, "Y Margin. Overrides 'margin' if set"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     margin_x = configurable.ExtraFallback("margin_x", "margin")
     margin_y = configurable.ExtraFallback("margin_y", "margin")

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -29,6 +29,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import os
 import platform
 import re
@@ -37,13 +39,18 @@ from abc import ABC, abstractclassmethod
 from enum import Enum, unique
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from libqtile import bar, configurable, images
 from libqtile.images import Img
 from libqtile.log_utils import logger
-from libqtile.utils import ColorsType, send_notification
+from libqtile.utils import send_notification
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Tuple
+
+    from libqtile.utils import ColorsType
 
 
 @unique

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -48,7 +48,7 @@ from libqtile.utils import send_notification
 from libqtile.widget import base
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Tuple
+    from typing import Any
 
     from libqtile.utils import ColorsType
 
@@ -192,7 +192,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
         ),
     ]
 
-    filenames = {}  # type: Dict
+    filenames = {}  # type: dict
 
     BAT_DIR = "/sys/class/power_supply"
 
@@ -221,7 +221,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
                 return bats[0]
         return "BAT0"
 
-    def _load_file(self, name) -> Tuple[str, str] | None:
+    def _load_file(self, name) -> tuple[str, str] | None:
         path = os.path.join(self.BAT_DIR, self.battery, name)
         if "energy" in name or "power" in name:
             value_type = "uW"
@@ -244,7 +244,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             # See https://github.com/qtile/qtile/pull/1516 for rationale
             return "-1", "N/A"
 
-    def _get_param(self, name) -> Tuple[str, str]:
+    def _get_param(self, name) -> tuple[str, str]:
         if name in self.filenames and self.filenames[name]:
             result = self._load_file(self.filenames[name])
             if result is not None:
@@ -448,7 +448,7 @@ class BatteryIcon(base._Widget):
         ("battery", 0, "Which battery should be monitored"),
         ("update_interval", 60, "Seconds between status updates"),
         ("theme_path", default_icon_path(), "Path of the icons"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     icon_names = (
         "battery-missing",
@@ -477,7 +477,7 @@ class BatteryIcon(base._Widget):
         self.length_type = bar.STATIC
         self.length = 0
         self.image_padding = 0
-        self.surfaces = {}  # type: Dict[str, Img]
+        self.surfaces = {}  # type: dict[str, Img]
         self.current_icon = "battery-missing"
 
         self._battery = self._load_battery(**config)

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -37,7 +37,7 @@ from abc import ABC, abstractclassmethod
 from enum import Enum, unique
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple
 
 from libqtile import bar, configurable, images
 from libqtile.images import Img
@@ -214,7 +214,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
                 return bats[0]
         return "BAT0"
 
-    def _load_file(self, name) -> Optional[Tuple[str, str]]:
+    def _load_file(self, name) -> Tuple[str, str] | None:
         path = os.path.join(self.BAT_DIR, self.battery, name)
         if "energy" in name or "power" in name:
             value_type = "uW"
@@ -305,8 +305,8 @@ class _LinuxBattery(_Battery, configurable.Configurable):
 class Battery(base.ThreadPoolText):
     """A text-based battery monitoring widget currently supporting FreeBSD"""
 
-    background: Optional[ColorsType]
-    low_background: Optional[ColorsType]
+    background: ColorsType | None
+    low_background: ColorsType | None
 
     defaults = [
         ("charge_char", "^", "Character to indicate the battery is charging"),

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Tuple
+from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -47,7 +47,7 @@ class GenPollUrl(base.ThreadPoolText):
         ("user_agent", "Qtile", "Set the user agent"),
         ("headers", {}, "Extra Headers"),
         ("xml", False, "Is XML?"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         base.ThreadPoolText.__init__(self, "", **config)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -32,10 +32,13 @@
 
 import itertools
 from functools import partial
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import bar, hook
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 
 class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -32,20 +32,17 @@
 
 import itertools
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile import bar, hook
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import Any, List, Tuple
 
 
 class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
     defaults = [
         ("borderwidth", 3, "Current group border width"),
         ("center_aligned", True, "center-aligned group box"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         base._TextBox.__init__(self, width=bar.CALCULATED, **config)

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -168,7 +168,7 @@ class KeyboardLayout(base.InLoopPollText):
         self.backend.set_keyboard(self.configured_keyboards[0], self.option)
 
     def next_keyboard(self):
-        """Set the next layout in the list of configured keyboard layouts as
+        """set the next layout in the list of configured keyboard layouts as
         new current layout in use
 
         If the current keyboard layout is not in the list, it will set as new

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -34,8 +34,6 @@ from libqtile.log_utils import logger
 from libqtile.widget import base
 
 if TYPE_CHECKING:
-    from typing import Optional
-
     from libqtile.core.manager import Qtile
 
 
@@ -54,7 +52,7 @@ class _BaseLayoutBackend(metaclass=ABCMeta):
         Examples: "us", "us dvorak".  In case of error returns "unknown".
         """
 
-    def set_keyboard(self, layout: str, options: Optional[str]) -> None:
+    def set_keyboard(self, layout: str, options: str | None) -> None:
         """
         Set the keyboard layout with specified options.
         """
@@ -85,7 +83,7 @@ class _X11LayoutBackend(_BaseLayoutBackend):
             keyboard += " " + match_variant.group("variant")
         return keyboard
 
-    def set_keyboard(self, layout: str, options: Optional[str]) -> None:
+    def set_keyboard(self, layout: str, options: str | None) -> None:
         command = ["setxkbmap"]
         command.extend(layout.split(" "))
         if options:
@@ -106,8 +104,8 @@ class _WaylandLayoutBackend(_BaseLayoutBackend):
     def get_keyboard(self) -> str:
         return self._layout
 
-    def set_keyboard(self, layout: str, options: Optional[str]) -> None:
-        maybe_variant: Optional[str] = None
+    def set_keyboard(self, layout: str, options: str | None) -> None:
+        maybe_variant: str | None = None
         if " " in layout:
             layout_name, maybe_variant = layout.split(" ", maxsplit=1)
         else:

--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -24,9 +24,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import mailbox
 import os.path
-from typing import Dict
 
 from libqtile.widget import base
 
@@ -103,12 +104,12 @@ class Maildir(base.ThreadPoolText):
 
         return s.join(('<span foreground="{}">'.format(color), "</span>"))
 
-    def format_text(self, state: Dict[str, int]) -> str:
+    def format_text(self, state: dict[str, int]) -> str:
         """Converts the state of the subfolders to a string
 
         Parameters
         ==========
-        state: Dict[str, int]
+        state: dict[str, int]
             a dictionary mapping subfolder labels to new mail values
 
         Returns

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -17,8 +17,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+from __future__ import annotations
+
 from math import log
-from typing import Tuple
 
 import psutil
 
@@ -76,12 +78,11 @@ class Net(base.ThreadPoolText):
                 self.interface = [self.interface]
             else:
                 raise AttributeError(
-                    "Invalid Argument passed: %s\nAllowed Types: List, String, None"
-                    % self.interface
+                    "Invalid Argument passed: %s\nAllowed Types: list, str, None" % self.interface
                 )
         self.stats = self.get_stats()
 
-    def convert_b(self, num_bytes: float) -> Tuple[float, str]:
+    def convert_b(self, num_bytes: float) -> tuple[float, str]:
         """Converts the number of bytes to the correct unit"""
 
         num_bytes *= self.byte_multiplier

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -95,7 +95,7 @@ class Net(base.ThreadPoolText):
         else:
             power = self.allowed_prefixes.index(self.prefix)
 
-        converted_bytes = num_bytes / self.factor ** power
+        converted_bytes = num_bytes / self.factor**power
         unit = self.units[power]
 
         return converted_bytes, unit

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -21,10 +21,13 @@
 # SOFTWARE.
 
 import time
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from libqtile.widget.generic_poll_text import GenPollUrl
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 # See documentation: https://openweathermap.org/current
 QUERY_URL = "http://api.openweathermap.org/data/2.5/weather?"

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -21,13 +21,10 @@
 # SOFTWARE.
 
 import time
-from typing import TYPE_CHECKING
+from typing import Any
 from urllib.parse import urlencode
 
 from libqtile.widget.generic_poll_text import GenPollUrl
-
-if TYPE_CHECKING:
-    from typing import Any, List, Tuple
 
 # See documentation: https://openweathermap.org/current
 QUERY_URL = "http://api.openweathermap.org/data/2.5/weather?"
@@ -258,7 +255,7 @@ class OpenWeather(GenPollUrl):
             dict(),
             "Dictionary of weather symbols. Can be used to override default symbols.",
         ),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         GenPollUrl.__init__(self, **config)

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -37,7 +37,7 @@ import os
 import pickle
 import string
 from collections import deque
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 from libqtile import bar, hook, pangocffi, utils
 from libqtile.command.base import CommandObject, SelectError
@@ -53,7 +53,7 @@ class AbstractCompleter(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         pass
 
     @abc.abstractmethod
@@ -84,11 +84,11 @@ class FileCompleter(AbstractCompleter):
     def __init__(self, qtile, _testing=False) -> None:
         self._testing = _testing
         self.qtile = qtile
-        self.thisfinal = None  # type: Optional[str]
-        self.lookup = None  # type: Optional[List[Tuple[str, str]]]
+        self.thisfinal = None  # type: str | None
+        self.lookup = None  # type: List[Tuple[str, str]] | None
         self.reset()
 
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         return self.thisfinal
 
     def reset(self) -> None:
@@ -128,14 +128,14 @@ class QshCompleter(AbstractCompleter):
     def __init__(self, qtile: CommandObject) -> None:
         q = QtileCommandInterface(qtile)
         self.client = InteractiveCommandClient(q)
-        self.thisfinal = None  # type: Optional[str]
+        self.thisfinal = None  # type: str | None
         self.reset()
 
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         return self.thisfinal
 
     def reset(self) -> None:
-        self.lookup = None  # type: Optional[List[Tuple[str, str]]]
+        self.lookup = None  # type: List[Tuple[str, str]] | None
         self.path = ""
         self.offset = -1
 
@@ -181,11 +181,11 @@ class QshCompleter(AbstractCompleter):
 class GroupCompleter(AbstractCompleter):
     def __init__(self, qtile: CommandObject) -> None:
         self.qtile = qtile
-        self.thisfinal = None  # type: Optional[str]
-        self.lookup = None  # type: Optional[List[Tuple[str, str]]]
+        self.thisfinal = None  # type: str | None
+        self.lookup = None  # type: List[Tuple[str, str]] | None
         self.offset = -1
 
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         """Returns the current actual value"""
         return self.thisfinal
 
@@ -217,11 +217,11 @@ class GroupCompleter(AbstractCompleter):
 class WindowCompleter(AbstractCompleter):
     def __init__(self, qtile: CommandObject) -> None:
         self.qtile = qtile
-        self.thisfinal = None  # type: Optional[str]
-        self.lookup = None  # type: Optional[List[Tuple[str, str]]]
+        self.thisfinal = None  # type: str | None
+        self.lookup = None  # type: List[Tuple[str, str]] | None
         self.offset = -1
 
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         """Returns the current actual value"""
         return self.thisfinal
 
@@ -260,12 +260,12 @@ class CommandCompleter:
     DEFAULTPATH = "/bin:/usr/bin:/usr/local/bin"
 
     def __init__(self, qtile, _testing=False):
-        self.lookup = None  # type: Optional[List[Tuple[str, str]]]
+        self.lookup = None  # type: List[Tuple[str, str]] | None
         self.offset = -1
-        self.thisfinal = None  # type: Optional[str]
+        self.thisfinal = None  # type: str | None
         self._testing = _testing
 
-    def actual(self) -> Optional[str]:
+    def actual(self) -> str | None:
         """Returns the current actual value"""
         return self.thisfinal
 
@@ -357,7 +357,7 @@ class Prompt(base._TextBox):
         self.add_defaults(Prompt.defaults)
         self.name = name
         self.active = False
-        self.completer = None  # type: Optional[AbstractCompleter]
+        self.completer = None  # type: AbstractCompleter | None
 
         # If history record is on, get saved history or create history record
         if self.record_history:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -39,7 +39,6 @@ import os
 import pickle
 import string
 from collections import deque
-from typing import TYPE_CHECKING
 
 from libqtile import bar, hook, pangocffi, utils
 from libqtile.command.base import CommandObject, SelectError
@@ -47,9 +46,6 @@ from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import CommandError, QtileCommandInterface
 from libqtile.log_utils import logger
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import List, Tuple
 
 
 class AbstractCompleter(metaclass=abc.ABCMeta):
@@ -90,7 +86,7 @@ class FileCompleter(AbstractCompleter):
         self._testing = _testing
         self.qtile = qtile
         self.thisfinal = None  # type: str | None
-        self.lookup = None  # type: List[Tuple[str, str]] | None
+        self.lookup = None  # type: list[tuple[str, str]] | None
         self.reset()
 
     def actual(self) -> str | None:
@@ -140,7 +136,7 @@ class QshCompleter(AbstractCompleter):
         return self.thisfinal
 
     def reset(self) -> None:
-        self.lookup = None  # type: List[Tuple[str, str]] | None
+        self.lookup = None  # type: list[tuple[str, str]] | None
         self.path = ""
         self.offset = -1
 
@@ -187,7 +183,7 @@ class GroupCompleter(AbstractCompleter):
     def __init__(self, qtile: CommandObject) -> None:
         self.qtile = qtile
         self.thisfinal = None  # type: str | None
-        self.lookup = None  # type: List[Tuple[str, str]] | None
+        self.lookup = None  # type: list[tuple[str, str]] | None
         self.offset = -1
 
     def actual(self) -> str | None:
@@ -223,7 +219,7 @@ class WindowCompleter(AbstractCompleter):
     def __init__(self, qtile: CommandObject) -> None:
         self.qtile = qtile
         self.thisfinal = None  # type: str | None
-        self.lookup = None  # type: List[Tuple[str, str]] | None
+        self.lookup = None  # type: list[tuple[str, str]] | None
         self.offset = -1
 
     def actual(self) -> str | None:
@@ -265,7 +261,7 @@ class CommandCompleter:
     DEFAULTPATH = "/bin:/usr/bin:/usr/local/bin"
 
     def __init__(self, qtile, _testing=False):
-        self.lookup = None  # type: List[Tuple[str, str]] | None
+        self.lookup = None  # type: list[tuple[str, str]] | None
         self.offset = -1
         self.thisfinal = None  # type: str | None
         self._testing = _testing
@@ -741,10 +737,10 @@ class Prompt(base._TextBox):
         self.history = {x: self._dedup_deque(self.history[x]) for x in self.completers}
 
     def _dedup_deque(self, dq):
-        return deque(_LastUpdatedOrderedDict.fromkeys(dq))
+        return deque(_LastUpdatedOrdereddict.fromkeys(dq))
 
 
-class _LastUpdatedOrderedDict(dict):
+class _LastUpdatedOrdereddict(dict):
     """Store items in the order the keys were last added."""
 
     def __setitem__(self, key, value):

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -31,13 +31,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import abc
 import glob
 import os
 import pickle
 import string
 from collections import deque
-from typing import List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import bar, hook, pangocffi, utils
 from libqtile.command.base import CommandObject, SelectError
@@ -45,6 +47,9 @@ from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import CommandError, QtileCommandInterface
 from libqtile.log_utils import logger
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import List, Tuple
 
 
 class AbstractCompleter(metaclass=abc.ABCMeta):

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -21,6 +21,7 @@
 import asyncio
 import os
 from functools import partial
+# dbus_next is incompatible with deferred type evaluation
 from typing import Callable, List, Optional
 
 import cairocffi

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -21,6 +21,7 @@
 import asyncio
 import os
 from functools import partial
+
 # dbus_next is incompatible with deferred type evaluation
 from typing import Callable, List, Optional
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -26,7 +26,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from typing import TYPE_CHECKING
+from typing import List
 
 import xcffib
 from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, SetMode
@@ -36,8 +36,6 @@ from libqtile.backend.x11 import window
 from libqtile.confreader import ConfigError
 from libqtile.widget import base
 
-if TYPE_CHECKING:
-    from typing import List
 
 XEMBED_PROTOCOL_VERSION = 0
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -36,7 +36,6 @@ from libqtile.backend.x11 import window
 from libqtile.confreader import ConfigError
 from libqtile.widget import base
 
-
 XEMBED_PROTOCOL_VERSION = 0
 
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -26,7 +26,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from typing import List
+
+from __future__ import annotations
 
 import xcffib
 from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, SetMode
@@ -127,7 +128,7 @@ class Systray(window._Window, base._Widget):
         self.tray_icons = []
         self.screen = 0
         self._name = config.get("name", "systray")
-        self._wm_class: List[str] | None = None
+        self._wm_class: list[str] | None = None
 
     def calculate_length(self):
         if self.bar.horizontal:
@@ -220,7 +221,7 @@ class Systray(window._Window, base._Widget):
                 self.tray_icons.sort(key=lambda icon: icon.name)
                 self.qtile.windows_map[wid] = icon
 
-            self.conn.conn.core.ChangeSaveSet(SetMode.Insert, wid)
+            self.conn.conn.core.ChangeSaveset(SetMode.Insert, wid)
             self.conn.conn.core.ReparentWindow(wid, parent.wid, 0, 0)
             self.conn.conn.flush()
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -37,7 +37,7 @@ from libqtile.confreader import ConfigError
 from libqtile.widget import base
 
 if TYPE_CHECKING:
-    from typing import List, Optional
+    from typing import List
 
 XEMBED_PROTOCOL_VERSION = 0
 
@@ -130,7 +130,7 @@ class Systray(window._Window, base._Widget):
         self.tray_icons = []
         self.screen = 0
         self._name = config.get("name", "systray")
-        self._wm_class: Optional[List[str]] = None
+        self._wm_class: List[str] | None = None
 
     def calculate_length(self):
         if self.bar.horizontal:

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -23,13 +23,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile import bar
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import Any, List, Tuple
 
 
 class TextBox(base._TextBox):
@@ -41,7 +38,7 @@ class TextBox(base._TextBox):
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
         ("padding", None, "Padding left and right. Calculated if None."),
         ("foreground", "#ffffff", "Foreground colour."),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, text=text, width=width, **config)

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -23,10 +23,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import bar
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 
 class TextBox(base._TextBox):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -148,13 +148,13 @@ class Volume(base._TextBox):
             self.drawer.ctx.paint()
         elif self.emoji:
             if self.volume <= 0:
-                self.text = u"\U0001f507"
+                self.text = "\U0001f507"
             elif self.volume <= 30:
-                self.text = u"\U0001f508"
+                self.text = "\U0001f508"
             elif self.volume < 80:
-                self.text = u"\U0001f509"
+                self.text = "\U0001f509"
             elif self.volume >= 80:
-                self.text = u"\U0001f50a"
+                self.text = "\U0001f50a"
         else:
             if self.volume == -1:
                 self.text = "M"

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -18,10 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, List, Tuple
+from typing import TYPE_CHECKING
 
 from libqtile import bar, hook
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import Any, List, Tuple
 
 
 class WindowCount(base._TextBox):

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -18,13 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import TYPE_CHECKING
+from __future__ import annotations
+
+from typing import Any
 
 from libqtile import bar, hook
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import Any, List, Tuple
 
 
 class WindowCount(base._TextBox):
@@ -41,7 +40,7 @@ class WindowCount(base._TextBox):
         ("foreground", "#ffffff", "Foreground colour."),
         ("text_format", "{num}", "Format for message"),
         ("show_zero", False, "Show window count when no windows"),
-    ]  # type: List[Tuple[str, Any, str]]
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, text=text, width=width, **config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,10 +109,11 @@ balanced_wrapping = true
 default_section = THIRDPARTY
 known_first_party = libqtile,test
 include_trailing_comma = true
+profile = black
 
 [mypy]
 mypy_path = stubs
-python_version = 3.7
+python_version = 3.10
 warn_unused_configs = True
 warn_unused_ignores = True
 warn_unreachable = True

--- a/test/backend/x11/test_window.py
+++ b/test/backend/x11/test_window.py
@@ -751,7 +751,7 @@ def test_net_frame_extents(xmanager):
 
     def assert_frame(wid, frame):
         r = conn.conn.core.GetProperty(
-            False, wid, conn.atoms["_NET_FRAME_EXTENTS"], conn.atoms["CARDINAL"], 0, (2 ** 32) - 1
+            False, wid, conn.atoms["_NET_FRAME_EXTENTS"], conn.atoms["CARDINAL"], 0, (2**32) - 1
         ).reply()
         assert r.value.to_atoms() == frame
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
 [testenv:pep8]
 deps =
     flake8
-    flake8-black
+    flake8-black>=0.2.4
     flake8-isort
     flake8-tidy-imports
     pep8-naming
@@ -81,7 +81,7 @@ commands =
 
 [testenv:mypy]
 deps =
-    mypy == 0.930
+    mypy == 0.931
     bowler
     dbus-next
     xcffib >= 0.10.1


### PR DESCRIPTION
5 commits:

- Turn `Optional[X]` into `X | None`
- Turn `Union[X, Y]` into `X | Y`
- Move all type check-time imports behind `typing.TYPE_CHECKING` guard
- Update black version
- Use built-ins for types e.g. `List` -> `list`, `Dict` -> `dict` now that they are supported directly