### PR TITLE
Fix typo in SysTray

### DIFF
--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -221,7 +221,7 @@ class Systray(window._Window, base._Widget):
                 self.tray_icons.sort(key=lambda icon: icon.name)
                 self.qtile.windows_map[wid] = icon
 
-            self.conn.conn.core.ChangeSaveset(SetMode.Insert, wid)
+            self.conn.conn.core.ChangeSaveSet(SetMode.Insert, wid)
             self.conn.conn.core.ReparentWindow(wid, parent.wid, 0, 0)
             self.conn.conn.flush()
 


### PR DESCRIPTION
4c98020e introduced a typo in Systray which results in icons being displayed incorrectly.

This wasn't caught by tests because we don't really test the Systray widget...

See https://www.reddit.com/r/qtile/comments/sh9dtc/my_system_tray_has_detached_and_is_at_the_top_of/ for more.