### PR TITLE
Wayland: Added support for output-power-management-v1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `lazy.window.center()` command to center a floating window on the screen.
+        - Wayland: added power-output-management-v1 protocol support
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ MOCK_MODULES = [
     'wlroots.wlr_types.layer_shell_v1',
     'wlroots.wlr_types.output_management_v1',
     'wlroots.wlr_types.pointer_constraints_v1',
+    'wlroots.wlr_types.output_power_management_v1',
     'wlroots.wlr_types.server_decoration',
     'wlroots.wlr_types.virtual_keyboard_v1',
     'wlroots.wlr_types.xdg_shell',

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -60,7 +60,11 @@ from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
 )
-from wlroots.wlr_types.output_power_management_v1 import OutputPowerManagerV1, OutputPowerV1SetModeEvent, OutputPowerManagementV1Mode
+from wlroots.wlr_types.output_power_management_v1 import (
+    OutputPowerManagerV1,
+    OutputPowerV1SetModeEvent,
+    OutputPowerManagementV1Mode,
+)
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
@@ -157,7 +161,9 @@ class Core(base.Core, wlrq.HasListeners):
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)
         output_power_manager = OutputPowerManagerV1(self.display)
-        self.add_listener(output_power_manager.set_mode_event, self._on_output_power_manager_set_mode)
+        self.add_listener(
+            output_power_manager.set_mode_event, self._on_output_power_manager_set_mode
+        )
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -60,6 +60,7 @@ from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
 )
+from wlroots.wlr_types.output_power_management_v1 import OutputPowerManagerV1, OutputPowerV1SetModeEvent, OutputPowerManagementV1Mode
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
@@ -155,6 +156,8 @@ class Core(base.Core, wlrq.HasListeners):
         XdgOutputManagerV1(self.display, self.output_layout)
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)
+        self._output_power_manager = OutputPowerManagerV1(self.display)
+        self.add_listener(self._output_power_manager.set_mode_event, self._on_output_power_manager_set_mode)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(
@@ -391,6 +394,12 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_new_virtual_keyboard(self, _listener, virtual_keyboard: VirtualKeyboardV1):
         self._add_new_keyboard(virtual_keyboard.input_device)
+
+    def _on_output_power_manager_set_mode(self, _listener, mode: OutputPowerV1SetModeEvent):
+        logger.debug("Signal: output_power_manager set_mode_event")
+        wlr_output = mode.output
+        wlr_output.enable(enable=True if mode.mode == OutputPowerManagementV1Mode.ON else False)
+        wlr_output.commit()
 
     def _on_new_layer_surface(self, _listener, layer_surface: LayerSurfaceV1):
         logger.debug("Signal: layer_shell new_surface_event")

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -160,8 +160,8 @@ class Core(base.Core, wlrq.HasListeners):
         XdgOutputManagerV1(self.display, self.output_layout)
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)
-        self._output_power_manager = OutputPowerManagerV1(self.display)
-        self.add_listener(self._output_power_manager.set_mode_event, self._on_output_power_manager_set_mode)
+        output_power_manager = OutputPowerManagerV1(self.display)
+        self.add_listener(output_power_manager.set_mode_event, self._on_output_power_manager_set_mode)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -55,15 +55,15 @@ from wlroots.wlr_types.output_management_v1 import (
     OutputConfigurationV1,
     OutputManagerV1,
 )
+from wlroots.wlr_types.output_power_management_v1 import (
+    OutputPowerManagementV1Mode,
+    OutputPowerManagerV1,
+    OutputPowerV1SetModeEvent,
+)
 from wlroots.wlr_types.pointer_constraints_v1 import PointerConstraintsV1, PointerConstraintV1
 from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
-)
-from wlroots.wlr_types.output_power_management_v1 import (
-    OutputPowerManagerV1,
-    OutputPowerV1SetModeEvent,
-    OutputPowerManagementV1Mode,
 )
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -60,11 +60,7 @@ from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
 )
-from wlroots.wlr_types.output_power_management_v1 import (
-    OutputPowerManagerV1,
-    OutputPowerV1SetModeEvent,
-    OutputPowerManagementV1Mode,
-)
+from wlroots.wlr_types.output_power_management_v1 import OutputPowerManagerV1, OutputPowerV1SetModeEvent, OutputPowerManagementV1Mode
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
@@ -231,7 +227,9 @@ class Core(base.Core, wlrq.HasListeners):
     def _on_request_start_drag(self, _listener, event: seat.RequestStartDragEvent):
         logger.debug("Signal: seat request_start_drag")
 
-        if not self.live_dnd and self.seat.validate_pointer_grab_serial(event.origin, event.serial):
+        if not self.live_dnd and self.seat.validate_pointer_grab_serial(
+            event.origin, event.serial
+        ):
             self.seat.start_pointer_drag(event.drag, event.serial)
         else:
             event.drag.source.destroy()
@@ -366,7 +364,9 @@ class Core(base.Core, wlrq.HasListeners):
         )
 
         if self.active_pointer_constraint:
-            if not self.active_pointer_constraint.rect.contains_point(self.cursor.x + dx, self.cursor.y + dy):
+            if not self.active_pointer_constraint.rect.contains_point(
+                self.cursor.x + dx, self.cursor.y + dy
+            ):
                 return
 
         self.cursor.move(dx, dy, input_device=event.device)
@@ -410,7 +410,9 @@ class Core(base.Core, wlrq.HasListeners):
         logger.info(f"Managing new layer_shell window with window ID: {wid}")
         self.qtile.manage(win)
 
-    def _on_new_toplevel_decoration(self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1):
+    def _on_new_toplevel_decoration(
+        self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
+    ):
         logger.debug("Signal: xdg_decoration new_top_level_decoration")
         decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
 
@@ -637,7 +639,9 @@ class Core(base.Core, wlrq.HasListeners):
         assert self.qtile is not None
         return max(self.qtile.windows_map.keys(), default=0) + 1
 
-    def focus_window(self, win: window.WindowType, surface: Surface = None, enter: bool = True) -> None:
+    def focus_window(
+        self, win: window.WindowType, surface: Surface = None, enter: bool = True
+    ) -> None:
         if self.seat.destroyed:
             return
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -60,7 +60,11 @@ from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
 )
-from wlroots.wlr_types.output_power_management_v1 import OutputPowerManagerV1, OutputPowerV1SetModeEvent, OutputPowerManagementV1Mode
+from wlroots.wlr_types.output_power_management_v1 import (
+    OutputPowerManagerV1,
+    OutputPowerV1SetModeEvent,
+    OutputPowerManagementV1Mode,
+)
 from wlroots.wlr_types.virtual_keyboard_v1 import VirtualKeyboardManagerV1, VirtualKeyboardV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
@@ -227,9 +231,7 @@ class Core(base.Core, wlrq.HasListeners):
     def _on_request_start_drag(self, _listener, event: seat.RequestStartDragEvent):
         logger.debug("Signal: seat request_start_drag")
 
-        if not self.live_dnd and self.seat.validate_pointer_grab_serial(
-            event.origin, event.serial
-        ):
+        if not self.live_dnd and self.seat.validate_pointer_grab_serial(event.origin, event.serial):
             self.seat.start_pointer_drag(event.drag, event.serial)
         else:
             event.drag.source.destroy()
@@ -364,9 +366,7 @@ class Core(base.Core, wlrq.HasListeners):
         )
 
         if self.active_pointer_constraint:
-            if not self.active_pointer_constraint.rect.contains_point(
-                self.cursor.x + dx, self.cursor.y + dy
-            ):
+            if not self.active_pointer_constraint.rect.contains_point(self.cursor.x + dx, self.cursor.y + dy):
                 return
 
         self.cursor.move(dx, dy, input_device=event.device)
@@ -410,9 +410,7 @@ class Core(base.Core, wlrq.HasListeners):
         logger.info(f"Managing new layer_shell window with window ID: {wid}")
         self.qtile.manage(win)
 
-    def _on_new_toplevel_decoration(
-        self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
-    ):
+    def _on_new_toplevel_decoration(self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1):
         logger.debug("Signal: xdg_decoration new_top_level_decoration")
         decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
 
@@ -639,9 +637,7 @@ class Core(base.Core, wlrq.HasListeners):
         assert self.qtile is not None
         return max(self.qtile.windows_map.keys(), default=0) + 1
 
-    def focus_window(
-        self, win: window.WindowType, surface: Surface = None, enter: bool = True
-    ) -> None:
+    def focus_window(self, win: window.WindowType, surface: Surface = None, enter: bool = True) -> None:
         if self.seat.destroyed:
             return
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.15.3,<0.16.0
+  pywlroots>=0.15.5,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.15.3,<0.16.0
+    pip install pywlroots>=0.15.5,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -92,7 +92,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.15.3,<0.16.0
+    pip install pywlroots>=0.15.5,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install


### PR DESCRIPTION
This adds basic support for output-power-management protocol. It is dependant on flacjacket/pywlroots#73