### PR TITLE
Add test for systray icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
                   libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev libpciaccess-dev \
                   dbus-x11 libnotify-bin \
                   xwayland libxcb-composite0-dev libxcb-icccm4-dev libxcb-res0-dev \
-                  libxcb-render0-dev libxcb-res0-dev libxcb-xfixes0-dev 
+                  libxcb-render0-dev libxcb-res0-dev libxcb-xfixes0-dev vlc volumeicon-alsa
                 sudo pip -q install meson PyGObject
                 pip -q install "tox<4" tox-gh-actions 
             - name: Build wayland

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -288,3 +288,8 @@ class Systray(window._Window, base._Widget):
         self.conn.conn.core.DestroyWindow(self.wid)
 
         Systray._instances -= 1
+
+    def info(self):
+        info = window._Window.info(self)
+        info["widget"] = base._Widget.info(self)
+        return info

--- a/test/widgets/test_systray.py
+++ b/test/widgets/test_systray.py
@@ -17,11 +17,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import shutil
+
 import pytest
 
 import libqtile.bar
 import libqtile.config
 from libqtile import widget
+from test.helpers import Retry
 
 
 def test_no_duplicates_multiple_instances(manager_nospawn, minimal_conf_noscreen, backend_name):
@@ -91,3 +94,47 @@ def test_systray_reconfigure_screens(manager_nospawn, minimal_conf_noscreen, bac
     manager_nospawn.c.reconfigure_screens()
 
     assert manager_nospawn.c.bar["top"].info()["widgets"][0]["name"] == "systray"
+
+
+def test_systray_icons(manager_nospawn, minimal_conf_noscreen, backend_name):
+    """Check icons are placed correctly."""
+
+    @Retry(ignore_exceptions=(AssertionError))
+    def wait_for_icons():
+        _, icons = manager_nospawn.c.widget["systray"].eval("len(self.tray_icons)")
+        assert int(icons) == 2
+
+    if backend_name == "wayland":
+        pytest.skip("Skipping test on Wayland.")
+
+    for prog in ("volumeicon", "vlc"):
+        if shutil.which(prog) is None:
+            pytest.skip(f"{prog} must be installed. Skipping test.")
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([widget.Systray()], 40))]
+
+    manager_nospawn.start(config)
+
+    # No icons at this stage so length is 0
+    assert manager_nospawn.c.widget["systray"].info()["widget"]["length"] == 0
+
+    manager_nospawn.c.spawn("volumeicon")
+    manager_nospawn.c.spawn("vlc")
+
+    wait_for_icons()
+
+    # We now have two icons so widget should expand to leave space in bar for icons
+    assert manager_nospawn.c.widget["systray"].info()["widget"]["length"] > 0
+
+    # Check positioning of icon
+    _, x = manager_nospawn.c.widget["systray"].eval("self.tray_icons[0].x")
+    _, y = manager_nospawn.c.widget["systray"].eval("self.tray_icons[0].y")
+
+    # Positions are relative to bar
+    assert (int(x), int(y)) == (3, 10)
+
+    # Icons should be in alphabetical order
+    _, order = manager_nospawn.c.widget["systray"].eval("[i.name for i in self.tray_icons]")
+
+    assert order == "['vlc', 'volumeicon']"


### PR DESCRIPTION
Adds a new test which loads two apps and checks:
a) That icons are created and placed
b) That icons are ordered alphabetically

Posting as draft for now in case @m-col has any ideas for additional things to test (e.g. if icons' positions are relative to the bar then we should probably test that the icons' parent is actually the bar and not the root window).