### PR TITLE
Update instructions for installation on fedora

### DIFF
--- a/docs/manual/install/fedora.rst
+++ b/docs/manual/install/fedora.rst
@@ -2,9 +2,4 @@
 Installing on Fedora
 ====================
 
-Stable versions of Qtile are currently packaged for current versions of Fedora.
-To install this package, run:
-
-.. code-block:: bash
-
-    dnf -y install qtile
+Stable versions of Qtile are not currently packaged for the current version of Fedora. Users are advised to follow the instructions of :ref:`installing-from-source`.


### PR DESCRIPTION
I tried to install qtile with the current  instructions but dnf didn't found it. Currently fedora project lists it as unmaintained in it's official website https://src.fedoraproject.org/rpms/qtile