### PR TITLE
Wayland: Added support for idle protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `lazy.window.center()` command to center a floating window on the screen.
-        - Wayland: added power-output-management-v1 protocol support
+        - Wayland: added power-output-management-v1 protocol support, added idle protocol
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ MOCK_MODULES = [
     'wlroots.wlr_types',
     'wlroots.wlr_types.cursor',
     'wlroots.wlr_types.foreign_toplevel_management_v1',
+    'wlroots.wlr_types.idle',
     'wlroots.wlr_types.keyboard',
     'wlroots.wlr_types.layer_shell_v1',
     'wlroots.wlr_types.output_management_v1',

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -49,6 +49,7 @@ from wlroots.wlr_types import (
     xdg_decoration_v1,
 )
 from wlroots.wlr_types.cursor import WarpMode
+from wlroots.wlr_types.idle import Idle
 from wlroots.wlr_types.layer_shell_v1 import LayerShellV1, LayerShellV1Layer, LayerSurfaceV1
 from wlroots.wlr_types.output_management_v1 import (
     OutputConfigurationHeadV1,
@@ -164,6 +165,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(
             output_power_manager.set_mode_event, self._on_output_power_manager_set_mode
         )
+        self.idle = Idle(self.display)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(
@@ -339,6 +341,7 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_button(self, _listener, event: pointer.PointerEventButton):
         assert self.qtile is not None
+        self.idle.notify_activity(self.seat)
         pressed = event.button_state == input_device.ButtonState.PRESSED
         if pressed:
             self._focus_by_click()
@@ -354,6 +357,7 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_motion(self, _listener, event: pointer.PointerEventMotion):
         assert self.qtile is not None
+        self.idle.notify_activity(self.seat)
 
         dx = event.delta_x
         dy = event.delta_y
@@ -380,6 +384,7 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_motion_absolute(self, _listener, event: pointer.PointerEventMotionAbsolute):
         assert self.qtile is not None
+        self.idle.notify_activity(self.seat)
         self.cursor.warp(
             WarpMode.AbsoluteClosest,
             event.x,

--- a/libqtile/backend/wayland/keyboard.py
+++ b/libqtile/backend/wayland/keyboard.py
@@ -115,4 +115,5 @@ class Keyboard(HasListeners):
                 self.core.focused_internal.process_key_press(keysym)
                 return
 
+        self.core.idle.notify_activity(self.seat)
         self.seat.keyboard_notify_key(event)

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.15.5,<0.16.0
+  pywlroots>=0.15.6,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.15.5,<0.16.0
+    pip install pywlroots>=0.15.6,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -92,7 +92,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.15.5,<0.16.0
+    pip install pywlroots>=0.15.6,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install


### PR DESCRIPTION
This adds support for KDE idle protocol as implemented in wlroots. ~~It is dependant on flacjacket/pywlroots#74~~ 
It seems to work fine but I am not sure what actions should be considered an activity. Currently only mouse activity and keyboard activity is considered, but it should probably consider things like playing videos or games. But I am not really sure how to implement that. This should also help with #2852