### PR TITLE
Wayland: added basic support for idle inhibit protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 Qtile x.x.x, released xxxx-xx-xx:
     * features
         - Add `lazy.window.center()` command to center a floating window on the screen.
-        - Wayland: added power-output-management-v1 protocol support, added idle protocol
+        - Wayland: added power-output-management-v1 protocol support, added idle protocol, 
+          added idle inhibit protocol
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ MOCK_MODULES = [
     'wlroots.wlr_types.cursor',
     'wlroots.wlr_types.foreign_toplevel_management_v1',
     'wlroots.wlr_types.idle',
+    'wlroots.wlr_types.idle_inhibit_v1',
     'wlroots.wlr_types.keyboard',
     'wlroots.wlr_types.layer_shell_v1',
     'wlroots.wlr_types.output_management_v1',

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -50,6 +50,7 @@ from wlroots.wlr_types import (
 )
 from wlroots.wlr_types.cursor import WarpMode
 from wlroots.wlr_types.idle import Idle
+from wlroots.wlr_types.idle_inhibit_v1 import IdleInhibitorManagerV1, IdleInhibitorV1
 from wlroots.wlr_types.layer_shell_v1 import LayerShellV1, LayerShellV1Layer, LayerSurfaceV1
 from wlroots.wlr_types.output_management_v1 import (
     OutputConfigurationHeadV1,
@@ -166,6 +167,8 @@ class Core(base.Core, wlrq.HasListeners):
             output_power_manager.set_mode_event, self._on_output_power_manager_set_mode
         )
         self.idle = Idle(self.display)
+        _idle_ihibitor_manager = IdleInhibitorManagerV1(self.display)
+        self.add_listener(_idle_ihibitor_manager.new_inhibitor_event, self._on_new_inhibitor)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(
@@ -405,6 +408,19 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_new_virtual_keyboard(self, _listener, virtual_keyboard: VirtualKeyboardV1):
         self._add_new_keyboard(virtual_keyboard.input_device)
+
+    def _on_new_inhibitor(self, _listener, idle_inhibitor: IdleInhibitorV1):
+        logger.debug("Signal: idle_inhibitor new_inhibitor")
+
+        for win in self.qtile.windows_map.values():
+            if isinstance(win, (window.Internal, window.Static)):
+                continue
+            assert isinstance(win, window.Window)
+
+            if win.surface.surface == idle_inhibitor.surface:
+                logger.error(str(win))
+                win.add_idle_inhibitor(idle_inhibitor)
+                break
 
     def _on_output_power_manager_set_mode(self, _listener, mode: OutputPowerV1SetModeEvent):
         logger.debug("Signal: output_power_manager set_mode_event")
@@ -773,6 +789,19 @@ class Core(base.Core, wlrq.HasListeners):
             )
         else:
             self.stacked_windows = self.mapped_windows
+
+    def check_idle_inhibitor(self) -> None:
+        """
+        Checks if any window that is currently mapped has idle inhibitor
+        and if so inhibits idle
+        """
+
+        idle_inhibited = any(
+            win.is_idle_inhibited
+            for win in self.mapped_windows
+            if isinstance(win, window.Window) and not isinstance(win, (window.Internal, window.Static))
+        )
+        self.idle.set_enabled(self.seat, not idle_inhibited)
 
     def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the screen information"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -167,8 +167,8 @@ class Core(base.Core, wlrq.HasListeners):
             output_power_manager.set_mode_event, self._on_output_power_manager_set_mode
         )
         self.idle = Idle(self.display)
-        _idle_ihibitor_manager = IdleInhibitorManagerV1(self.display)
-        self.add_listener(_idle_ihibitor_manager.new_inhibitor_event, self._on_new_inhibitor)
+        idle_ihibitor_manager = IdleInhibitorManagerV1(self.display)
+        self.add_listener(idle_ihibitor_manager.new_inhibitor_event, self._on_new_inhibitor)
         PrimarySelectionV1DeviceManager(self.display)
         self._virtual_keyboard_manager_v1 = VirtualKeyboardManagerV1(self.display)
         self.add_listener(
@@ -416,6 +416,8 @@ class Core(base.Core, wlrq.HasListeners):
             return
 
         for win in self.qtile.windows_map.values():
+            if isinstance(win, (window.Internal, window.Static)):
+                continue
             if isinstance(win, window.Window):
                 win.surface.for_each_surface(win.add_idle_inhibitor, idle_inhibitor)
                 if idle_inhibitor.data:
@@ -795,13 +797,14 @@ class Core(base.Core, wlrq.HasListeners):
         and if so inhibits idle
         """
 
-        idle_inhibited = any(
-            win.is_idle_inhibited
-            for win in self.mapped_windows
-            if isinstance(win, window.Window)
-            and not isinstance(win, (window.Internal, window.Static))
-        )
-        self.idle.set_enabled(self.seat, not idle_inhibited)
+        for win in self.mapped_windows:
+            if isinstance(win, (window.Internal, window.Static)):
+                continue
+            if isinstance(win, window.Window) and win.is_idle_inhibited:
+                self.idle.set_enabled(self.seat, False)
+                break
+        else:
+            self.idle.set_enabled(self.seat, True)
 
     def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the screen information"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -795,7 +795,7 @@ class Core(base.Core, wlrq.HasListeners):
         and if so inhibits idle
         """
         for win in self.mapped_windows:
-            if isinstance(win, window.Window) and win.is_idle_inhibited:
+            if win.is_idle_inhibited:
                 self.idle.set_enabled(self.seat, False)
                 break
         else:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -416,9 +416,7 @@ class Core(base.Core, wlrq.HasListeners):
             return
 
         for win in self.qtile.windows_map.values():
-            if isinstance(win, (window.Internal, window.Static)):
-                continue
-            if isinstance(win, window.Window):
+            if isinstance(win, window.Window) and not isinstance(win, window.Internal):
                 win.surface.for_each_surface(win.add_idle_inhibitor, idle_inhibitor)
                 if idle_inhibitor.data:
                     break
@@ -796,10 +794,7 @@ class Core(base.Core, wlrq.HasListeners):
         Checks if any window that is currently mapped has idle inhibitor
         and if so inhibits idle
         """
-
         for win in self.mapped_windows:
-            if isinstance(win, (window.Internal, window.Static)):
-                continue
             if isinstance(win, window.Window) and win.is_idle_inhibited:
                 self.idle.set_enabled(self.seat, False)
                 break

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1441,7 +1441,13 @@ class XWindow(Window):
             height = self.height
 
         self.finalize_listeners()
-        win = Static(self.core, self.qtile, self.surface, self.wid)
+        win = Static(
+            self.core,
+            self.qtile,
+            self.surface,
+            self.wid,
+            idle_inhibitor_count=self._idle_inhibitors_count,
+        )
         if screen is not None:
             win.screen = self.qtile.screens[screen]
         win.place(x, y, width, height, 0, None)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -386,8 +386,10 @@ class Window(base.Window, HasListeners):
         self.borderwidth = width
 
     def add_idle_inhibitor(
-        self, surface: surface.Surface, _x: int, _y: int, inhibitor: IdleInhibitorV1
+        self, surface: surface.Surface, _x: int, _y: int, inhibitor: IdleInhibitorV1 | None
     ) -> None:
+        if inhibitor is None:
+            return
         if surface == inhibitor.surface:
             self._idle_inhibitors_count += 1
             inhibitor.data = self

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -164,7 +164,7 @@ class Window(base.Window, HasListeners):
         else:
             self.core.mapped_windows.remove(self)
         self.core.stack_windows()
-        if hasattr(self, "_idle_inhibitors_count") and self._idle_inhibitors_count > 0:
+        if self._idle_inhibitors_count > 0:
             self.core.check_idle_inhibitor()
 
     def _on_map(self, _listener, _data):
@@ -787,6 +787,7 @@ class Internal(base.Internal, Window):
     def __init__(self, core: Core, qtile: Qtile, x: int, y: int, width: int, height: int):
         self.core = core
         self.qtile = qtile
+        self._idle_inhibitors_count: int = 0
         self._mapped: bool = False
         self._wid: int = self.core.new_wid()
         self.x: int = x
@@ -907,12 +908,14 @@ class Static(base.Static, Window):
         qtile: Qtile,
         surface: SurfaceType,
         wid: int,
+        idle_inhibitor_count: int = 0,
     ):
         base.Static.__init__(self)
         self.core = core
         self.qtile = qtile
         self.surface = surface
         self.screen = qtile.current_screen
+        self._idle_inhibitors_count = idle_inhibitor_count
         self.subsurfaces: list[SubSurface] = []
         self._wid = wid
         self._mapped: bool = False
@@ -1197,6 +1200,7 @@ class XWindow(Window):
         self.bordercolor: list[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self._opacity: float = 1.0
         self._outputs: set[Output] = set()
+        self._idle_inhibitors_count: int = 0
 
         self._app_id: str | None = self.surface.wm_class
         self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.15.6,<0.16.0
+  pywlroots>=0.15.7,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.15.6,<0.16.0
+    pip install pywlroots>=0.15.7,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -92,7 +92,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.15.6,<0.16.0
+    pip install pywlroots>=0.15.7,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     python3 setup.py -q install


### PR DESCRIPTION
This adds support for idle-inhibit-unstable-v1 protocol. It is dependant on flacjacket/pywlroots#75 
It works, but only for applications that only have one surface e.g. mpv for others like Firefox it does not. 

The problem is that the new idle inhibitor event only has reference to the surface it is bound to and currently I can not find any way to associate it with subsurfaces. For that it would require somehing like every window having references all the pointers of subsurfaces but that does not seem like good solution.
The other way would be to ignore if window is mapped and only care about if there is idle inhibitor. This would work but it wouldn't work as described in the protocol.