### PR TITLE
WL: Typing of wayland backend

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ MOCK_MODULES = [
     'psutil',
     'pywayland',
     'pywayland.protocol.wayland',
+    'pywayland.protocol.wayland.wl_output',
     'pywayland.server',
     'wlroots',
     'wlroots.helper',

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -803,7 +803,7 @@ class Drawer:
     def new_ctx(self):
         return pangocffi.patch_cairo_context(cairocffi.Context(self.surface))
 
-    def set_source_rgb(self, colour: ColorsType, ctx: cairocffi.Context = None):
+    def set_source_rgb(self, colour: ColorsType, ctx: cairocffi.Context | None = None):
         # If an alternate context is not provided then we draw to the
         # drawer's default context
         if ctx is None:

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -192,6 +192,16 @@ class _Window(CommandObject, metaclass=ABCMeta):
         """Whether this window urgently wants focus"""
         return False
 
+    @property
+    def opacity(self) -> float:
+        """The opacity of this window from 0 (transparent) to 1 (opaque)."""
+        return self._opacity
+
+    @opacity.setter
+    def opacity(self, opacity: float) -> None:
+        """Opacity setter."""
+        self._opacity = opacity
+
     @abstractmethod
     def place(
         self,
@@ -264,30 +274,41 @@ class Window(_Window, metaclass=ABCMeta):
         """Whether this window is floating."""
         return False
 
+    @floating.setter
+    def floating(self, do_float: bool) -> None:
+        raise NotImplementedError
+
     @property
     def maximized(self) -> bool:
         """Whether this window is maximized."""
         return False
+
+    @maximized.setter
+    def maximized(self, do_maximize: bool) -> None:
+        raise NotImplementedError
+
+    @property
+    def minimized(self) -> bool:
+        """Whether this window is minimized."""
+        return False
+
+    @minimized.setter
+    def minimized(self, do_minimize: bool) -> None:
+        raise NotImplementedError
 
     @property
     def fullscreen(self) -> bool:
         """Whether this window is fullscreened."""
         return False
 
+    @fullscreen.setter
+    def fullscreen(self, do_full: bool) -> None:
+        raise NotImplementedError
+
     @property
     def wants_to_fullscreen(self) -> bool:
         """Does this window want to be fullscreen?"""
         return False
-
-    @property
-    def opacity(self) -> float:
-        """The opacity of this window from 0 (transparent) to 1 (opaque)."""
-        return self._opacity
-
-    @opacity.setter
-    def opacity(self, opacity: float) -> None:
-        """Opacity setter."""
-        self._opacity = opacity
 
     def match(self, match: config.Match) -> bool:
         """Compare this window against a Match instance."""
@@ -572,6 +593,10 @@ class Static(_Window, metaclass=ABCMeta):
             height=self.height,
             id=self.wid,
         )
+
+    @abstractmethod
+    def cmd_bring_to_front(self) -> None:
+        """Bring the window to the front"""
 
 
 WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -675,7 +675,7 @@ class Core(base.Core, wlrq.HasListeners):
         return max(self.qtile.windows_map.keys(), default=0) + 1
 
     def focus_window(
-        self, win: window.WindowType, surface: Surface = None, enter: bool = True
+        self, win: window.WindowType, surface: Surface | None = None, enter: bool = True
     ) -> None:
         if self.seat.destroyed:
             return

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -78,8 +78,9 @@ from libqtile.backend.wayland.output import Output
 from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
-    from typing import Sequence
+    from typing import Any, Sequence
 
+    from pywayland.server import Listener
     from wlroots.wlr_types import Output as wlrOutput
     from wlroots.wlr_types.data_device_manager import Drag
 
@@ -90,7 +91,7 @@ if typing.TYPE_CHECKING:
 class Core(base.Core, wlrq.HasListeners):
     supports_restarting: bool = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Setup the Wayland core backend"""
         self.qtile: Qtile | None = None
         self.desktops: int = 1
@@ -98,7 +99,7 @@ class Core(base.Core, wlrq.HasListeners):
         self._hovered_internal: window.Internal | None = None
         self.focused_internal: window.Internal | None = None
 
-        self.fd = None
+        self.fd: int | None = None
         self.display = Display()
         self.event_loop = self.display.get_event_loop()
         (
@@ -199,7 +200,7 @@ class Core(base.Core, wlrq.HasListeners):
         # Set up XWayland
         self._xwayland = xwayland.XWayland(self.display, self.compositor, True)
         if self._xwayland:
-            os.environ["DISPLAY"] = self._xwayland.display_name
+            os.environ["DISPLAY"] = self._xwayland.display_name or ""
             logger.info("Set up XWayland with DISPLAY=" + os.environ["DISPLAY"])
             self.add_listener(self._xwayland.ready_event, self._on_xwayland_ready)
             self.add_listener(self._xwayland.new_surface_event, self._on_xwayland_new_surface)
@@ -210,10 +211,10 @@ class Core(base.Core, wlrq.HasListeners):
         self.backend.start()
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "wayland"
 
-    def finalize(self):
+    def finalize(self) -> None:
         for kb in self.keyboards:
             kb.finalize()
         for out in self.outputs:
@@ -234,11 +235,15 @@ class Core(base.Core, wlrq.HasListeners):
     def display_name(self) -> str:
         return self.socket.decode()
 
-    def _on_request_set_selection(self, _listener, event: seat.RequestSetSelectionEvent):
+    def _on_request_set_selection(
+        self, _listener: Listener, event: seat.RequestSetSelectionEvent
+    ) -> None:
         self.seat.set_selection(event._ptr.source, event.serial)
         logger.debug("Signal: seat request_set_selection")
 
-    def _on_request_start_drag(self, _listener, event: seat.RequestStartDragEvent):
+    def _on_request_start_drag(
+        self, _listener: Listener, event: seat.RequestStartDragEvent
+    ) -> None:
         logger.debug("Signal: seat request_start_drag")
 
         if not self.live_dnd and self.seat.validate_pointer_grab_serial(
@@ -248,11 +253,11 @@ class Core(base.Core, wlrq.HasListeners):
         else:
             event.drag.source.destroy()
 
-    def _on_start_drag(self, _listener, event: Drag):
+    def _on_start_drag(self, _listener: Listener, event: Drag) -> None:
         logger.debug("Signal: seat start_drag")
         self.live_dnd = wlrq.Dnd(self, event)
 
-    def _on_new_input(self, _listener, device: input_device.InputDevice):
+    def _on_new_input(self, _listener: Listener, device: input_device.InputDevice) -> None:
         logger.debug("Signal: backend new_input_event")
         if device.device_type == input_device.InputDeviceType.POINTER:
             self._add_new_pointer(device)
@@ -270,7 +275,7 @@ class Core(base.Core, wlrq.HasListeners):
         else:
             self._pending_input_devices.append(device)
 
-    def _on_new_output(self, _listener, wlr_output: wlrOutput):
+    def _on_new_output(self, _listener: Listener, wlr_output: wlrOutput) -> None:
         logger.debug("Signal: backend new_output_event")
 
         wlr_output.init_render(self._allocator, self.renderer)
@@ -292,7 +297,7 @@ class Core(base.Core, wlrq.HasListeners):
         if not self._current_output:
             self._current_output = self.outputs[0]
 
-    def _on_output_layout_change(self, _listener, _data):
+    def _on_output_layout_change(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: output_layout change_event")
         config = OutputConfigurationV1()
 
@@ -307,26 +312,30 @@ class Core(base.Core, wlrq.HasListeners):
         self.output_manager.set_configuration(config)
         self.outputs.sort(key=lambda o: (o.x, o.y))
 
-    def _on_output_manager_apply(self, _listener, config: OutputConfigurationV1):
+    def _on_output_manager_apply(
+        self, _listener: Listener, config: OutputConfigurationV1
+    ) -> None:
         logger.debug("Signal: output_manager apply_event")
         self._output_manager_reconfigure(config, True)
 
-    def _on_output_manager_test(self, _listener, config: OutputConfigurationV1):
+    def _on_output_manager_test(self, _listener: Listener, config: OutputConfigurationV1) -> None:
         logger.debug("Signal: output_manager test_event")
         self._output_manager_reconfigure(config, False)
 
-    def _on_request_cursor(self, _listener, event: seat.PointerRequestSetCursorEvent):
+    def _on_request_cursor(
+        self, _listener: Listener, event: seat.PointerRequestSetCursorEvent
+    ) -> None:
         logger.debug("Signal: seat request_set_cursor_event")
         self.cursor.set_surface(event.surface, event.hotspot)
 
-    def _on_new_xdg_surface(self, _listener, surface: XdgSurface):
+    def _on_new_xdg_surface(self, _listener: Listener, surface: XdgSurface) -> None:
         logger.debug("Signal: xdg_shell new_surface_event")
         if surface.role == XdgSurfaceRole.TOPLEVEL:
             assert self.qtile is not None
             win = window.XdgWindow(self, self.qtile, surface)
             self.pending_windows.add(win)
 
-    def _on_cursor_axis(self, _listener, event: pointer.PointerEventAxis):
+    def _on_cursor_axis(self, _listener: Listener, event: pointer.PointerEventAxis) -> None:
         handled = False
         if event.delta != 0:
             if event.orientation == pointer.AxisOrientation.VERTICAL:
@@ -344,10 +353,10 @@ class Core(base.Core, wlrq.HasListeners):
                 event.source,
             )
 
-    def _on_cursor_frame(self, _listener, _data):
+    def _on_cursor_frame(self, _listener: Listener, _data: Any) -> None:
         self.seat.pointer_notify_frame()
 
-    def _on_cursor_button(self, _listener, event: pointer.PointerEventButton):
+    def _on_cursor_button(self, _listener: Listener, event: pointer.PointerEventButton) -> None:
         assert self.qtile is not None
         self.idle.notify_activity(self.seat)
         pressed = event.button_state == input_device.ButtonState.PRESSED
@@ -363,7 +372,7 @@ class Core(base.Core, wlrq.HasListeners):
         if not handled:
             self.seat.pointer_notify_button(event.time_msec, event.button, event.button_state)
 
-    def _on_cursor_motion(self, _listener, event: pointer.PointerEventMotion):
+    def _on_cursor_motion(self, _listener: Listener, event: pointer.PointerEventMotion) -> None:
         assert self.qtile is not None
         self.idle.notify_activity(self.seat)
 
@@ -390,7 +399,9 @@ class Core(base.Core, wlrq.HasListeners):
         self.cursor.move(dx, dy, input_device=event.device)
         self._process_cursor_motion(event.time_msec, self.cursor.x, self.cursor.y)
 
-    def _on_cursor_motion_absolute(self, _listener, event: pointer.PointerEventMotionAbsolute):
+    def _on_cursor_motion_absolute(
+        self, _listener: Listener, event: pointer.PointerEventMotionAbsolute
+    ) -> None:
         assert self.qtile is not None
         self.idle.notify_activity(self.seat)
         self.cursor.warp(
@@ -401,7 +412,9 @@ class Core(base.Core, wlrq.HasListeners):
         )
         self._process_cursor_motion(event.time_msec, self.cursor.x, self.cursor.y)
 
-    def _on_new_pointer_constraint(self, _listener, wlr_constraint: PointerConstraintV1):
+    def _on_new_pointer_constraint(
+        self, _listener: Listener, wlr_constraint: PointerConstraintV1
+    ) -> None:
         logger.debug("Signal: pointer_constraints new_constraint")
         constraint = wlrq.PointerConstraint(self, wlr_constraint)
         self.pointer_constraints.add(constraint)
@@ -411,10 +424,12 @@ class Core(base.Core, wlrq.HasListeners):
                 self.active_pointer_constraint.disable()
             constraint.enable()
 
-    def _on_new_virtual_keyboard(self, _listener, virtual_keyboard: VirtualKeyboardV1):
+    def _on_new_virtual_keyboard(
+        self, _listener: Listener, virtual_keyboard: VirtualKeyboardV1
+    ) -> None:
         self._add_new_keyboard(virtual_keyboard.input_device)
 
-    def _on_new_inhibitor(self, _listener, idle_inhibitor: IdleInhibitorV1):
+    def _on_new_inhibitor(self, _listener: Listener, idle_inhibitor: IdleInhibitorV1) -> None:
         logger.debug("Signal: idle_inhibitor new_inhibitor")
 
         if self.qtile is None:
@@ -426,13 +441,15 @@ class Core(base.Core, wlrq.HasListeners):
                 if idle_inhibitor.data:
                     break
 
-    def _on_output_power_manager_set_mode(self, _listener, mode: OutputPowerV1SetModeEvent):
+    def _on_output_power_manager_set_mode(
+        self, _listener: Listener, mode: OutputPowerV1SetModeEvent
+    ) -> None:
         logger.debug("Signal: output_power_manager set_mode_event")
         wlr_output = mode.output
         wlr_output.enable(enable=True if mode.mode == OutputPowerManagementV1Mode.ON else False)
         wlr_output.commit()
 
-    def _on_new_layer_surface(self, _listener, layer_surface: LayerSurfaceV1):
+    def _on_new_layer_surface(self, _listener: Listener, layer_surface: LayerSurfaceV1) -> None:
         logger.debug("Signal: layer_shell new_surface_event")
         assert self.qtile is not None
 
@@ -442,18 +459,18 @@ class Core(base.Core, wlrq.HasListeners):
         self.qtile.manage(win)
 
     def _on_new_toplevel_decoration(
-        self, _listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
-    ):
+        self, _listener: Listener, decoration: xdg_decoration_v1.XdgToplevelDecorationV1
+    ) -> None:
         logger.debug("Signal: xdg_decoration new_top_level_decoration")
         decoration.set_mode(xdg_decoration_v1.XdgToplevelDecorationV1Mode.SERVER_SIDE)
 
-    def _on_xwayland_ready(self, _listener, _data):
+    def _on_xwayland_ready(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: xwayland ready")
         assert self._xwayland is not None
         self._xwayland.set_seat(self.seat)
         self.xwayland_atoms: dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
 
-    def _on_xwayland_new_surface(self, _listener, surface: xwayland.Surface):
+    def _on_xwayland_new_surface(self, _listener: Listener, surface: xwayland.Surface) -> None:
         logger.debug("Signal: xwayland new_surface")
         assert self.qtile is not None
         win = window.XWindow(self, self.qtile, surface)
@@ -504,17 +521,19 @@ class Core(base.Core, wlrq.HasListeners):
         config.destroy()
         hook.fire("screen_change", None)
 
-    def _process_cursor_motion(self, time_msec: int, cx: float, cy: float):
+    def _process_cursor_motion(self, time_msec: int, cx: float, cy: float) -> None:
         assert self.qtile
         cx_int = int(cx)
         cy_int = int(cy)
         self.qtile.process_button_motion(cx_int, cy_int)
 
         if len(self.outputs) > 1:
-            current_output = self.output_layout.output_at(cx, cy).data
-            if self._current_output is not current_output:
-                self._current_output = current_output
-                self.stack_windows()
+            current_wlr_output = self.output_layout.output_at(cx, cy)
+            if current_wlr_output:
+                current_output = current_wlr_output.data
+                if self._current_output is not current_output:
+                    self._current_output = current_output
+                    self.stack_windows()
 
         if self.live_dnd:
             self.live_dnd.position(cx, cy)
@@ -554,9 +573,13 @@ class Core(base.Core, wlrq.HasListeners):
                     if isinstance(win, window.Static):
                         self.qtile.focus_screen(win.screen.index, False)
                     else:
-                        if win.group.current_window != win:
+                        if win.group and win.group.current_window != win:
                             win.group.focus(win, False)
-                        if win.group.screen and self.qtile.current_screen != win.group.screen:
+                        if (
+                            win.group
+                            and win.group.screen
+                            and self.qtile.current_screen != win.group.screen
+                        ):
                             self.qtile.focus_screen(win.group.screen.index, False)
 
             if self._hovered_internal:
@@ -582,8 +605,8 @@ class Core(base.Core, wlrq.HasListeners):
 
             if self._hovered_internal:
                 self._hovered_internal.process_button_click(
-                    self.cursor.x - self._hovered_internal.x,
-                    self.cursor.y - self._hovered_internal.y,
+                    int(self.cursor.x - self._hovered_internal.x),
+                    int(self.cursor.y - self._hovered_internal.y),
                     button,
                 )
         else:
@@ -591,17 +614,17 @@ class Core(base.Core, wlrq.HasListeners):
 
             if self._hovered_internal:
                 self._hovered_internal.process_button_release(
-                    self.cursor.x - self._hovered_internal.x,
-                    self.cursor.y - self._hovered_internal.y,
+                    int(self.cursor.x - self._hovered_internal.x),
+                    int(self.cursor.y - self._hovered_internal.y),
                     button,
                 )
 
         return handled
 
-    def _add_new_pointer(self, device: input_device.InputDevice):
+    def _add_new_pointer(self, device: input_device.InputDevice) -> None:
         self.cursor.attach_input_device(device)
 
-    def _add_new_keyboard(self, device: input_device.InputDevice):
+    def _add_new_keyboard(self, device: input_device.InputDevice) -> None:
         self.keyboards.append(inputs.Keyboard(self, device))
         self.seat.set_keyboard(device)
 
@@ -617,7 +640,10 @@ class Core(base.Core, wlrq.HasListeners):
         logger.debug("Adding io watch")
         self.qtile = qtile
         self.fd = lib.wl_event_loop_get_fd(self.event_loop._ptr)
-        asyncio.get_running_loop().add_reader(self.fd, self._poll)
+        if self.fd:
+            asyncio.get_running_loop().add_reader(self.fd, self._poll)
+        else:
+            raise RuntimeError("Failed to get Wayland event loop file descriptor.")
 
     def remove_listener(self) -> None:
         """Remove the listener from the given event loop"""
@@ -760,11 +786,11 @@ class Core(base.Core, wlrq.HasListeners):
                 self.qtile.current_group.focus(win, False)
 
         else:
-            screen = self.qtile.find_screen(self.cursor.x, self.cursor.y)
+            screen = self.qtile.find_screen(int(self.cursor.x), int(self.cursor.y))
             if screen:
                 self.qtile.focus_screen(screen.index, warp=False)
 
-    def _under_pointer(self):
+    def _under_pointer(self) -> tuple[window.WindowType, Surface | None, float, float] | None:
         assert self.qtile is not None
 
         cx = self.cursor.x
@@ -864,7 +890,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.qtile.manage(internal)
         return internal
 
-    def graceful_shutdown(self):
+    def graceful_shutdown(self) -> None:
         """Try to close windows gracefully before exiting"""
         assert self.qtile is not None
 
@@ -881,7 +907,7 @@ class Core(base.Core, wlrq.HasListeners):
                 break
 
     @property
-    def painter(self):
+    def painter(self) -> Any:
         return wlrq.Painter(self)
 
     def remove_output(self, output: Output) -> None:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -192,8 +192,8 @@ class Core(base.Core, wlrq.HasListeners):
             pointer_constraints_v1.new_constraint_event,
             self._on_new_pointer_constraint,
         )
-        self.pointer_constraints: set[wlrq.PointerConstraint] = set()
-        self.active_pointer_constraint: wlrq.PointerConstraint | None = None
+        self.pointer_constraints: set[window.PointerConstraint] = set()
+        self.active_pointer_constraint: window.PointerConstraint | None = None
         self._relative_pointer_manager_v1 = RelativePointerManagerV1(self.display)
         self.foreign_toplevel_manager_v1 = ForeignToplevelManagerV1.create(self.display)
 
@@ -416,7 +416,7 @@ class Core(base.Core, wlrq.HasListeners):
         self, _listener: Listener, wlr_constraint: PointerConstraintV1
     ) -> None:
         logger.debug("Signal: pointer_constraints new_constraint")
-        constraint = wlrq.PointerConstraint(self, wlr_constraint)
+        constraint = window.PointerConstraint(self, wlr_constraint)
         self.pointer_constraints.add(constraint)
 
         if self.seat.pointer_state.focused_surface == wlr_constraint.surface:
@@ -877,7 +877,7 @@ class Core(base.Core, wlrq.HasListeners):
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
 
-    def warp_pointer(self, x: int, y: int) -> None:
+    def warp_pointer(self, x: float, y: float) -> None:
         """Warp the pointer to the coordinates in relative to the output layout"""
         self.cursor.warp(WarpMode.LayoutClosest, x, y)
 

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -10,6 +10,7 @@ from libqtile.backend import base
 if TYPE_CHECKING:
     from libqtile.backend.wayland.window import Internal
     from libqtile.core.manager import Qtile
+    from libqtile.utils import ColorsType
 
 
 class Drawer(base.Drawer):
@@ -39,7 +40,7 @@ class Drawer(base.Drawer):
         offsety: int = 0,
         width: int | None = None,
         height: int | None = None,
-    ):
+    ) -> None:
         if offsetx > self._win.width:  # type: ignore
             return
 
@@ -79,7 +80,7 @@ class Drawer(base.Drawer):
         )
         self._win.damage()  # type: ignore
 
-    def clear(self, colour):
+    def clear(self, colour: ColorsType) -> None:
         # Draw background straight to ImageSurface
         ctx = cairocffi.Context(self._source)
         ctx.save()

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -39,6 +39,9 @@ except ImportError:
     libinput = None
 
 if TYPE_CHECKING:
+    from typing import Any
+
+    from pywayland.server import Listener
     from wlroots.wlr_types import InputDevice
     from wlroots.wlr_types.keyboard import KeyboardKeyEvent
 
@@ -113,7 +116,7 @@ class InputConfig(configurable.Configurable):
         ("kb_repeat_delay", 600, "Keyboard delay in milliseconds before repeating"),
     ]
 
-    def __init__(self, **config):
+    def __init__(self, **config: dict[str, Any]) -> None:
         configurable.Configurable.__init__(self, **config)
         self.add_defaults(InputConfig.defaults)
 
@@ -181,15 +184,15 @@ class Keyboard(HasListeners):
             self._keymaps[(layout, options, variant)] = keymap
         self.keyboard.set_keymap(keymap)
 
-    def _on_destroy(self, _listener, _data):
+    def _on_destroy(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: keyboard destroy")
         self.finalize()
 
-    def _on_modifier(self, _listener, _data):
+    def _on_modifier(self, _listener: Listener, _data: Any) -> None:
         self.seat.set_keyboard(self.device)
         self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)
 
-    def _on_key(self, _listener, event: KeyboardKeyEvent):
+    def _on_key(self, _listener: Listener, event: KeyboardKeyEvent) -> None:
         if self.qtile is None:
             # shushes mypy
             self.qtile = self.core.qtile

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -317,7 +317,7 @@ class Output(HasListeners):
                         self.core.qtile.reserve_space(to_reserve, self.screen)
                         win.reserved_space = to_reserve
 
-                win.place(x + self.x, y + self.y, ww, wh, 0, None)
+                win.place(int(x + self.x), int(y + self.y), int(ww), int(wh), 0, None)
 
         self.core.stack_windows()
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -866,9 +866,12 @@ class XWindow(Window[xwayland.Surface]):
                 self.core.focus_window(win)
                 return
 
-            # Save the client's desired geometry
-            self._width = self._float_width = self.surface.width
-            self._height = self._float_height = self.surface.height
+            # Save the client's desired geometry. xterm seems to have these set to 1, so
+            # let's ignore 1 or below. The float sizes will be fetched when it is floated.
+            if self.surface.width > 1:
+                self._width = self._float_width = self.surface.width
+            if self.surface.height > 1:
+                self._height = self._float_height = self.surface.height
 
             # Get the client's name and class
             title = self.surface.title

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -69,7 +69,7 @@ class ExistingWMException(Exception):
 
 
 class Core(base.Core):
-    def __init__(self, display_name: str = None) -> None:
+    def __init__(self, display_name: str | None = None) -> None:
         """Setup the X11 core backend
 
         :param display_name:

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1256,6 +1256,9 @@ class Static(_Window, base.Static):
         if name == "_NET_WM_STRUT_PARTIAL":
             self.update_strut()
 
+    def cmd_bring_to_front(self):
+        self.window.configure(stackmode=StackMode.Above)
+
 
 class Window(_Window, base.Window):
     _window_mask = (

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -52,7 +52,10 @@ class CommandClient:
     """The object that resolves the commands"""
 
     def __init__(
-        self, command: CommandInterface = None, *, current_node: CommandGraphNode | None = None
+        self,
+        command: CommandInterface | None = None,
+        *,
+        current_node: CommandGraphNode | None = None,
     ) -> None:
         """A client that resolves calls through the command object interface
 
@@ -166,7 +169,7 @@ class InteractiveCommandClient:
     """
 
     def __init__(
-        self, command: CommandInterface = None, *, current_node: GraphType = None
+        self, command: CommandInterface | None = None, *, current_node: GraphType | None = None
     ) -> None:
         """An interactive client that resolves calls through the gives client
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -25,9 +25,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-#
-# required for lazy type annotations
-# can be removed when python 3.7...3.9 support is dropped (see PEP 563)
 from __future__ import annotations
 
 import contextlib
@@ -519,11 +516,11 @@ class Group:
     def __init__(
         self,
         name: str,
-        matches: list[Match] = None,
+        matches: list[Match] | None = None,
         exclusive=False,
         spawn: str | list[str] | None = None,
-        layout: str = None,
-        layouts: list = None,
+        layout: str | None = None,
+        layouts: list | None = None,
         persist=True,
         init=True,
         layout_opts=None,
@@ -644,7 +641,7 @@ class Match:
         wm_type=None,
         wm_instance_class=None,
         net_wm_pid=None,
-        func: Callable[[base.WindowType], bool] = None,
+        func: Callable[[base.WindowType], bool] | None = None,
         wid=None,
     ):
         self._rules = {}

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -600,7 +600,7 @@ class Qtile(CommandObject):
         if win.defunct:
             return
         self.windows_map[win.wid] = win
-        if self.current_screen and not isinstance(win, base.Static):
+        if self.current_screen and isinstance(win, base.Window):
             # Window may have been bound to a group in the hook.
             if not win.group and self.current_screen.group:
                 self.current_screen.group.add(win, focus=win.can_steal_focus)
@@ -630,7 +630,7 @@ class Qtile(CommandObject):
             return result[0]
         return None
 
-    def find_closest_screen(self, x: int, y: int) -> Screen | None:
+    def find_closest_screen(self, x: int, y: int) -> Screen:
         """
         If find_screen returns None, then this basically extends a
         screen vertically and horizontally and see if x,y lies in the
@@ -658,9 +658,7 @@ class Qtile(CommandObject):
             return y_match[0]
         return self._find_closest_closest(x, y, x_match + y_match)
 
-    def _find_closest_closest(
-        self, x: int, y: int, candidate_screens: list[Screen]
-    ) -> Screen | None:
+    def _find_closest_closest(self, x: int, y: int, candidate_screens: list[Screen]) -> Screen:
         """
         if find_closest_screen can't determine one, we've got multiple
         screens, so figure out who is closer.  We'll calculate using
@@ -669,7 +667,7 @@ class Qtile(CommandObject):
         Note that this could return None if x, y is right/below all
         screens.
         """
-        closest_distance: float | None = None  # because mypy only considers first value
+        closest_distance: float | None = None
         if not candidate_screens:
             # try all screens
             candidate_screens = self.screens
@@ -686,7 +684,7 @@ class Qtile(CommandObject):
             if closest_distance is None or distance < closest_distance:
                 closest_distance = distance
                 closest_screen = s
-        return closest_screen
+        return closest_screen or self.screens[0]
 
     def process_button_click(self, button_code: int, modmask: int, x: int, y: int) -> bool:
         handled = False
@@ -1270,7 +1268,7 @@ class Qtile(CommandObject):
 
     def find_window(self, wid: int) -> None:
         window = self.windows_map.get(wid)
-        if window and isinstance(window, base.Window) and window.group:
+        if isinstance(window, base.Window) and window.group:
             if not window.group.screen:
                 self.current_screen.set_group(window.group)
             window.group.focus(window, False)

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from libqtile.backend import base
 from libqtile.extension.dmenu import Dmenu
 from libqtile.scratchpad import ScratchPad
 
@@ -46,7 +47,7 @@ class WindowList(Dmenu):
         self.item_to_win = {}
 
         if self.all_groups:
-            windows = self.qtile.windows_map.values()
+            windows = [w for w in self.qtile.windows_map.values() if isinstance(w, base.Window)]
         else:
             windows = self.qtile.current_group.windows
 

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -49,7 +49,7 @@ class IPCError(Exception):
     pass
 
 
-def find_sockfile(display: str = None):
+def find_sockfile(display: str | None = None):
     """
     Finds the appropriate socket file for the given display.
 

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -139,7 +139,7 @@ class Popup(configurable.Configurable):
     def clear(self) -> None:
         self.drawer.clear(self.background)
 
-    def draw_text(self, x: int = None, y: int = None) -> None:
+    def draw_text(self, x: int | None = None, y: int | None = None) -> None:
         self.layout.draw(
             x or self.horizontal_padding,
             y or self.vertical_padding,

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -216,7 +216,11 @@ class ScratchPad(group._Group):
     """
 
     def __init__(
-        self, name="scratchpad", dropdowns: list[config.DropDown] = None, label="", single=False
+        self,
+        name="scratchpad",
+        dropdowns: list[config.DropDown] | None = None,
+        label="",
+        single=False,
     ):
         group._Group.__init__(self, name, label=label)
         self._dropdownconfig = {dd.name: dd for dd in dropdowns} if dropdowns is not None else {}

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -17,6 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
+from __future__ import annotations
+
 from libqtile import bar
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
@@ -61,7 +64,7 @@ class WidgetBox(base._Widget):
         ("text_open", "[>]", "Text when box is open"),
     ]
 
-    def __init__(self, widgets: list = None, **config):
+    def __init__(self, widgets: list | None = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
         self.box_is_open = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,6 +118,7 @@ warn_unused_configs = True
 warn_unused_ignores = True
 warn_unreachable = True
 no_implicit_optional = True
+disallow_untyped_defs = False
 [mypy-_cffi_backend]
 ignore_missing_imports = True
 [mypy-cairocffi._generated.ffi]
@@ -140,3 +141,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-wlroots.*]
 ignore_missing_imports = True
+[mypy-libqtile.backend.wayland.*]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,6 +117,7 @@ python_version = 3.10
 warn_unused_configs = True
 warn_unused_ignores = True
 warn_unreachable = True
+no_implicit_optional = True
 [mypy-_cffi_backend]
 ignore_missing_imports = True
 [mypy-cairocffi._generated.ffi]

--- a/stubs/cairocffi/__init__.pyi
+++ b/stubs/cairocffi/__init__.pyi
@@ -16,3 +16,5 @@ class CairoError(Exception):
     def __init__(self, message: Any, status: Any) -> None: ...
 Error = CairoError
 STATUS_TO_EXCEPTION: Any
+
+OPERATOR_SOURCE: Any


### PR DESCRIPTION
As more shells were being supported by the Wayland backend, I had
optimistically tried to keep their respective representations together
in one `Window` class and one `Static` class. This has become
increasingly spaghetti-like and prone to introduction of bugs and
confusion.

This change uses a generic base with a dedicated class per shell such
that we have:

- XdgWindow: regular windows of the XDG shell
- XWindow: regular X11 clients connecting via XWayland
- XdgStatic: static windows of th XDG shell, made static by the user
- XStatic: static X11 clients, made static by the user
- LayerStatic: static layer-shell windows that are always static

This also makes it more clear which methods were being passed around by
inheritance by splitting those common to all classes into a new `_Base`.

It also removes a whole bunch of the assert statements and 'type:
ignore' comments that were piling up just to appease mypy.