### PR TITLE
x11: Only relayout upon hint update when increments update when floating

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -619,6 +619,9 @@ class _Window:
         except (xcffib.xproto.WindowError, xcffib.xproto.AccessError):
             return
 
+        width_inc = self.hints["width_inc"]
+        height_inc = self.hints["height_inc"]
+
         if normh:
             self.hints.update(normh)
 
@@ -633,9 +636,12 @@ class _Window:
         if h and "InputHint" in h["flags"]:
             self.hints["input"] = h["input"]
 
-        if getattr(self, "group", None):
-            if self.group.floating_layout.match(self):
-                self.floating = True
+        if (
+            self.group
+            and self.floating
+            and width_inc != self.hints["width_inc"]
+            and height_inc != self.hints["height_inc"]
+        ):
             self.group.layout_all()
 
         return


### PR DESCRIPTION
When `WM_NORMAL_HINTS` are updated we are uncondtionally re-laying out
the group. The client 'reaper' is getting into a never ending loop
because when it is placed it updates its hints. The `group.layout_all()`
call was added in 07e658a so that updates to width and height increment
hints are respect. This change removes the call except for specifically
when these hints are updated while the window is floating, as we do not
respect these hints in tiled windows anyway.

Fixes #3292