### PR TITLE
[Docs] Fix layouts page in docs

### DIFF
--- a/docs/manual/ref/layouts.rst
+++ b/docs/manual/ref/layouts.rst
@@ -4,44 +4,6 @@
 Built-in Layouts
 ================
 
-.. qtile_class:: libqtile.layout.floating.Floating
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.bsp.Bsp
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.columns.Columns
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.matrix.Matrix
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.max.Max
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.xmonad.MonadTall
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.xmonad.MonadWide
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.ratiotile.RatioTile
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.slice.Slice
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.stack.Stack
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.tile.Tile
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.tree.TreeTab
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.verticaltile.VerticalTile
-    :no-commands:
-
-.. qtile_class:: libqtile.layout.zoomy.Zoomy
+.. qtile_module:: libqtile.layout
+    :baseclass: libqtile.layout.base.Layout
     :no-commands:


### PR DESCRIPTION
(Reason for this is the new `MonadThreeCol` layout is not showing up in the docs)

The layouts reference page does not automatically update for new layouts.

This PR fixes the issue by displaying information for all layouts that subclass `libqtile.layout.base.Layout`, rather than adding layouts individually.