### PR TITLE
Fullscreen: Fix issues with floating windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Qtile x.x.x, released xxxx-xx-xx:
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.
+        - Fix various issues with setting fullscreen windows floating and vice versa.
 
 Qtile 0.20.0, released 2022-01-24:
     * features

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -423,6 +423,7 @@ class Window(base.Window, HasListeners):
                 # if we are setting floating early, e.g. from a hook, we don't have a screen yet
                 self._float_state = FloatStates.FLOATING
         elif (not do_float) and self._float_state != FloatStates.NOT_FLOATING:
+            self.update_fullscreen(False)
             if self._float_state == FloatStates.FLOATING:
                 # store last size
                 self._float_width = self.width
@@ -431,13 +432,16 @@ class Window(base.Window, HasListeners):
             self.group.mark_floating(self, False)
             hook.fire("float_change")
 
+    def update_fullscreen(self, do_full):
+        self.surface.set_fullscreen(do_full)
+        self.ftm_handle.set_fullscreen(do_full)
+
     @property
     def fullscreen(self):
         return self._float_state == FloatStates.FULLSCREEN
 
     @fullscreen.setter
     def fullscreen(self, do_full):
-        self.surface.set_fullscreen(do_full)
         if do_full:
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
             bw = self.group.floating_layout.fullscreen_border_width
@@ -450,8 +454,6 @@ class Window(base.Window, HasListeners):
             )
         elif self._float_state == FloatStates.FULLSCREEN:
             self.floating = False
-
-        self.ftm_handle.set_fullscreen(do_full)
 
     @property
     def maximized(self):
@@ -594,6 +596,7 @@ class Window(base.Window, HasListeners):
         self._reconfigure_floating(x, y, w, h, new_float_state)
 
     def _reconfigure_floating(self, x, y, w, h, new_float_state=FloatStates.FLOATING):
+        self.update_fullscreen(new_float_state == FloatStates.FULLSCREEN)
         if new_float_state == FloatStates.MINIMIZED:
             self.hide()
         else:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -433,6 +433,11 @@ class Window(base.Window, HasListeners):
             hook.fire("float_change")
 
     def update_fullscreen(self, do_full):
+        # already done updating previously
+        if do_full == self.fullscreen:
+            return
+
+        # update surface fullscreen and ftm
         self.surface.set_fullscreen(do_full)
         self.ftm_handle.set_fullscreen(do_full)
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1330,6 +1330,11 @@ class Window(_Window, base.Window):
             self.window.set_property("_NET_WM_STATE", list(new_state))
 
     def update_fullscreen_wm_state(self, do_full):
+        # already done updating previously
+        if do_full == self.fullscreen:
+            return
+
+        # update fullscreen _NET_WM_STATE
         atom = set([self.qtile.core.conn.atoms["_NET_WM_STATE_FULLSCREEN"]])
         prev_state = set(self.window.get_property("_NET_WM_STATE", "ATOM", unpack=int))
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1305,6 +1305,7 @@ class Window(_Window, base.Window):
                 # if we are setting floating early, e.g. from a hook, we don't have a screen yet
                 self._float_state = FloatStates.FLOATING
         elif (not do_float) and self._float_state != FloatStates.NOT_FLOATING:
+            self.update_fullscreen_wm_state(False)
             if self._float_state == FloatStates.FLOATING:
                 # store last size
                 self._float_width = self.width
@@ -1324,19 +1325,25 @@ class Window(_Window, base.Window):
     def toggle_floating(self):
         self.floating = not self.floating
 
+    def set_wm_state(self, old_state, new_state):
+        if new_state != old_state:
+            self.window.set_property("_NET_WM_STATE", list(new_state))
+
+    def update_fullscreen_wm_state(self, do_full):
+        atom = set([self.qtile.core.conn.atoms["_NET_WM_STATE_FULLSCREEN"]])
+        prev_state = set(self.window.get_property("_NET_WM_STATE", "ATOM", unpack=int))
+
+        if do_full:
+            self.set_wm_state(prev_state, prev_state | atom)
+        else:
+            self.set_wm_state(prev_state, prev_state - atom)
+
     @property
     def fullscreen(self):
         return self._float_state == FloatStates.FULLSCREEN
 
     @fullscreen.setter
     def fullscreen(self, do_full):
-        atom = set([self.qtile.core.conn.atoms["_NET_WM_STATE_FULLSCREEN"]])
-        prev_state = set(self.window.get_property("_NET_WM_STATE", "ATOM", unpack=int))
-
-        def set_state(old_state, new_state):
-            if new_state != old_state:
-                self.window.set_property("_NET_WM_STATE", list(new_state))
-
         if do_full:
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
 
@@ -1348,13 +1355,9 @@ class Window(_Window, base.Window):
                 screen.height - 2 * bw,
                 new_float_state=FloatStates.FULLSCREEN,
             )
-            set_state(prev_state, prev_state | atom)
             return
 
         if self._float_state == FloatStates.FULLSCREEN:
-            # The order of calling set_state() and then
-            # setting self.floating = False is important
-            set_state(prev_state, prev_state - atom)
             self.floating = False
             return
 
@@ -1467,6 +1470,7 @@ class Window(_Window, base.Window):
         return (self.x, self.y)
 
     def _reconfigure_floating(self, new_float_state=FloatStates.FLOATING):
+        self.update_fullscreen_wm_state(new_float_state == FloatStates.FULLSCREEN)
         if new_float_state == FloatStates.MINIMIZED:
             self.state = IconicState
             self.hide()

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -252,9 +252,9 @@ class _Group(CommandObject):
         win.group = self
         if self.qtile.config.auto_fullscreen and win.wants_to_fullscreen:
             win._float_state = FloatStates.FULLSCREEN
-        elif self.floating_layout.match(win):
+        elif self.floating_layout.match(win) and not win.fullscreen:
             win._float_state = FloatStates.FLOATING
-        if win.floating:
+        if win.floating and not win.fullscreen:
             self.floating_layout.add(win)
         if not win.floating or win.fullscreen:
             self.tiled_windows.add(win)
@@ -292,7 +292,8 @@ class _Group(CommandObject):
                 or self.layout.focus_first()
             )
 
-            self.tiled_windows.remove(win)
+            if win in self.tiled_windows:
+                self.tiled_windows.remove(win)
 
         # a notification may not have focus
         if hadfocus:
@@ -317,9 +318,9 @@ class _Group(CommandObject):
                         i.remove(win)
                         if win is self.current_window:
                             i.blur()
-                self.floating_layout.add(win)
-                if win is self.current_window:
-                    self.floating_layout.focus(win)
+                    self.floating_layout.add(win)
+                    if win is self.current_window:
+                        self.floating_layout.focus(win)
         else:
             self.floating_layout.remove(win)
             self.floating_layout.blur()


### PR DESCRIPTION
Fullscreen windows still had some rough corners.

- Explicitly check for windows to remove in the tiled window
set. Sometimes windows were not guaranteed to be added, e.g. floating
windows newly added to a group. Fixes https://github.com/qtile/qtile/issues/3323. This makes a lot of sense and was suggested by @m-col
- Make sure that the _NET_WM_STATE is correctly updated when floating
a fullscreen windows. Fixes an issue in #3308
- Make sure that windows are only added to the floating layout if they
are not fullscreen. Fixes an issue in #3308

Still needs some testing on the wayland backend. I have not updated my wayland dependencies just yet so I will get to that soon. In the meantime lots of manual testing needed as I want to make sure we iron out these issues once and for all

Some thoughts:

The Qtile code for fullscreening and floating is weird to work with. IMO we should look into how we can completely separate the floating code and fullscreen code. Fullscreen windows should not be floating windows but should be a completely different state. This is something for a future PR though