### PR TITLE
Fix Volume widget compatibility with different commands and PipeWire

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -75,7 +75,7 @@ class Volume(base._TextBox):
         (
             "get_volume_command",
             None,
-            "Command to get the current volume."
+            "Command to get the current volume. "
             "The expected output should include 1-3 numbers and a ``%`` sign.",
         ),
         ("check_mute_command", None, "Command to check mute status"),

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -41,8 +41,7 @@ __all__ = [
     "Volume",
 ]
 
-re_vol = re.compile(r"\[(\d?\d?\d?)%\]")
-
+re_vol = re.compile(r"(\d?\d?\d?)%")
 
 class Volume(base._TextBox):
     """Widget that display and change volume
@@ -73,6 +72,8 @@ class Volume(base._TextBox):
         ("volume_up_command", None, "Volume up command"),
         ("volume_down_command", None, "Volume down command"),
         ("get_volume_command", None, "Command to get the current volume"),
+        ("check_mute_command", None, "Command to check mute status"),
+        ("check_mute_string", "[off]", "String to look for to check muted status in the output of ``check_mute_command``."),
         (
             "step",
             2,
@@ -186,16 +187,22 @@ class Volume(base._TextBox):
             if self.get_volume_command:
                 get_volume_cmd = self.get_volume_command
 
-            mixer_out = self.call_process(get_volume_cmd)
+            mixer_out = subprocess.getoutput(get_volume_cmd)
         except subprocess.CalledProcessError:
             return -1
 
-        if "[off]" in mixer_out:
+        check_mute = mixer_out
+        if self.check_mute_command:
+            check_mute = subprocess.getoutput(self.check_mute_command)
+        
+        if self.check_mute_string in check_mute:
             return -1
 
         volgroups = re_vol.search(mixer_out)
         if volgroups:
             return int(volgroups.groups()[0])
+        elif "pamixer" in self.get_volume_command:
+            return mixer_out
         else:
             # this shouldn't happen
             return -1

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -73,7 +73,11 @@ class Volume(base._TextBox):
         ("volume_down_command", None, "Volume down command"),
         ("get_volume_command", None, "Command to get the current volume"),
         ("check_mute_command", None, "Command to check mute status"),
-        ("check_mute_string", "[off]", "String to look for to check muted status in the output of ``check_mute_command``."),
+        (
+            "check_mute_string",
+            "[off]",
+            "String to look for to check muted status in the output of ``check_mute_command``."
+        ),
         (
             "step",
             2,
@@ -194,7 +198,7 @@ class Volume(base._TextBox):
         check_mute = mixer_out
         if self.check_mute_command:
             check_mute = subprocess.getoutput(self.check_mute_command)
-        
+
         if self.check_mute_string in check_mute:
             return -1
 

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -82,7 +82,9 @@ class Volume(base._TextBox):
         (
             "check_mute_string",
             "[off]",
-            "String to look for to check muted status in the output of ``check_mute_command``.",
+            """String expected from check_mute_command when volume is
+            muted. When the output of the command matches this string, the
+            audio source is treated as muted.""",
         ),
         (
             "step",

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -72,7 +72,12 @@ class Volume(base._TextBox):
         ("volume_app", None, "App to control volume"),
         ("volume_up_command", None, "Volume up command"),
         ("volume_down_command", None, "Volume down command"),
-        ("get_volume_command", None, "Command to get the current volume"),
+        (
+            "get_volume_command",
+            None, 
+            "Command to get the current volume."
+            "The expected output should include 1-3 numbers and a ``%`` sign.",
+        ),
         ("check_mute_command", None, "Command to check mute status"),
         (
             "check_mute_string",

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -82,9 +82,9 @@ class Volume(base._TextBox):
         (
             "check_mute_string",
             "[off]",
-            """String expected from check_mute_command when volume is
-            muted. When the output of the command matches this string, the
-            audio source is treated as muted.""",
+            "String expected from check_mute_command when volume is muted."
+            "When the output of the command matches this string, the"
+            "audio source is treated as muted.",
         ),
         (
             "step",

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -41,7 +41,7 @@ __all__ = [
     "Volume",
 ]
 
-re_vol = re.compile(r"(\d?\d?\d?)%")
+re_vol = re.compile(r"(\d?\d?\d?)%?")
 
 
 class Volume(base._TextBox):
@@ -206,8 +206,6 @@ class Volume(base._TextBox):
         volgroups = re_vol.search(mixer_out)
         if volgroups:
             return int(volgroups.groups()[0])
-        elif "pamixer" in self.get_volume_command:
-            return mixer_out
         else:
             # this shouldn't happen
             return -1

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -74,7 +74,7 @@ class Volume(base._TextBox):
         ("volume_down_command", None, "Volume down command"),
         (
             "get_volume_command",
-            None, 
+            None,
             "Command to get the current volume."
             "The expected output should include 1-3 numbers and a ``%`` sign.",
         ),

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -43,6 +43,7 @@ __all__ = [
 
 re_vol = re.compile(r"(\d?\d?\d?)%")
 
+
 class Volume(base._TextBox):
     """Widget that display and change volume
 
@@ -76,7 +77,7 @@ class Volume(base._TextBox):
         (
             "check_mute_string",
             "[off]",
-            "String to look for to check muted status in the output of ``check_mute_command``."
+            "String to look for to check muted status in the output of ``check_mute_command``.",
         ),
         (
             "step",

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -41,7 +41,7 @@ __all__ = [
     "Volume",
 ]
 
-re_vol = re.compile(r"(\d?\d?\d?)%?")
+re_vol = re.compile(r"(\d?\d?\d?)%")
 
 
 class Volume(base._TextBox):


### PR DESCRIPTION
Fixes broken functionality of the Volume widget when trying to use commands other than `amixer` (e.g.  #2616) .

This also addresses the incompatibility of the widget with PipeWire (e.g. #2614), possibly making the `PulseVolume` widget unnecessary.

Added two additional configuration parameters, `check_mute_command` and `check_mute_string`, since different audio utilities show the mute status in different ways, and they will fail the hardcoded search for `[off]` in `mixer_out`. This way the user can specify the output that Qtile should look for in their custom command.