### PR TITLE
WL: logger call is using wrong string format

### DIFF
--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -340,4 +340,4 @@ def configure_device(device: InputDevice, configs: dict[str, InputConfig]) -> No
     elif device.device_type == input_device.InputDeviceType.KEYBOARD:
         _configure_keyboard(device, conf)
     else:
-        logger.warning("Device not configured. Type '{}' not recognised.", device.device_type)
+        logger.warning("Device not configured. Type '%s' not recognised.", device.device_type)


### PR DESCRIPTION
This will raise an exception when called.