### PR TITLE
Move some layout/widget constructor args to defaults

### DIFF
--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -24,9 +24,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
 import math
 
 from libqtile.layout.base import _SimpleLayoutBase
+from libqtile.log_utils import logger
 
 
 class Matrix(_SimpleLayoutBase):
@@ -40,13 +43,19 @@ class Matrix(_SimpleLayoutBase):
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
+        ("columns", 2, "Number of columns"),
         ("margin", 0, "Margin of the layout (int or list of ints [N E S W])"),
     ]
 
-    def __init__(self, columns=2, **config):
+    def __init__(self, _columns: int | None = None, **config):
         _SimpleLayoutBase.__init__(self, **config)
         self.add_defaults(Matrix.defaults)
-        self.columns = columns
+        if _columns:
+            logger.warning(
+                "The use of a positional argument in Matrix is deprecated. "
+                "Please update your config to use columns=..."
+            )
+            self.columns = _columns
 
     @property
     def rows(self):

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -40,12 +40,15 @@ To execute a python command in qtile, begin with by 'qshell:'
 
 
 """
+from __future__ import annotations
+
 import os.path
 
 import cairocffi
 from xdg.IconTheme import getIconPath
 
 from libqtile import bar
+from libqtile.images import Img
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -59,15 +62,6 @@ class LaunchBar(base._Widget):
     Widget requirements: pyxdg_.
 
     .. _pyxdg: https://freedesktop.org/wiki/Software/pyxdg/
-
-    Parameters
-    ==========
-    progs :
-        a list of tuples ``(software_name, command_to_execute, comment)``, for
-        example::
-
-            ('thunderbird', 'thunderbird -safe-mode', 'launch thunderbird in safe mode')
-            ('logout', 'qshell:self.qtile.cmd_shutdown()', 'logout from qtile')
     """
 
     orientations = base.ORIENTATION_HORIZONTAL
@@ -82,17 +76,32 @@ class LaunchBar(base._Widget):
         ("fontsize", None, "Font pixel size. Calculated if None."),
         ("fontshadow", None, "Font shadow color, default is None (no shadow)"),
         ("foreground", "#ffffff", "Text colour."),
+        (
+            "progs",
+            [],
+            "A list of tuples (software_name, command_to_execute, comment), for example:"
+            " [('thunderbird', 'thunderbird -safe-mode', 'launch thunderbird in safe mode'), "
+            " ('logout', 'qshell:self.qtile.cmd_shutdown()', 'logout from qtile')]",
+        ),
     ]
 
-    def __init__(self, progs=None, width=bar.CALCULATED, **config):
+    def __init__(
+        self, _progs: list[tuple[str, str, str]] | None = None, width=bar.CALCULATED, **config
+    ):
         base._Widget.__init__(self, width, **config)
-        if progs is None:
-            progs = []
         self.add_defaults(LaunchBar.defaults)
-        self.surfaces = {}
-        self.icons_files = {}
-        self.icons_widths = {}
-        self.icons_offsets = {}
+        self.surfaces: dict[str, Img | base._TextBox] = {}
+        self.icons_files: dict[str, str | None] = {}
+        self.icons_widths: dict[str, int] = {}
+        self.icons_offsets: dict[str, int] = {}
+
+        if _progs:
+            logger.warning(
+                "The use of a positional argument in LaunchBar is deprecated. "
+                "Please update your config to use progs=[...]."
+            )
+            config["progs"] = _progs
+
         # For now, ignore the comments but may be one day it will be useful
         self.progs = dict(
             enumerate(
@@ -102,7 +111,7 @@ class LaunchBar(base._Widget):
                         "cmd": prog[1],
                         "comment": prog[2] if len(prog) > 2 else None,
                     }
-                    for prog in progs
+                    for prog in config["progs"]
                 ]
             )
         )

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -353,10 +353,9 @@ class Prompt(base._TextBox):
         ("visual_bell_time", 0.2, "Visual bell duration (in seconds)."),
     ]
 
-    def __init__(self, name="prompt", **config) -> None:
+    def __init__(self, **config) -> None:
         base._TextBox.__init__(self, "", bar.CALCULATED, **config)
         self.add_defaults(Prompt.defaults)
-        self.name = name
         self.active = False
         self.completer = None  # type: AbstractCompleter | None
 

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -17,12 +17,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from libqtile import bar
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class WidgetBox(base._Widget):
@@ -62,14 +66,21 @@ class WidgetBox(base._Widget):
         ),
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
-    ]
+        ("widgets", list(), "A list of widgets to include in the box"),
+    ]  # type: list[tuple[str, Any, str]]
 
-    def __init__(self, widgets: list | None = None, **config):
+    def __init__(self, _widgets: list[base._Widget] | None = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
         self.box_is_open = False
-        self.widgets = widgets if widgets is not None else []
         self.add_callbacks({"Button1": self.cmd_toggle})
+
+        if _widgets:
+            logger.warning(
+                "The use of a positional argument in WidgetBox is deprecated. "
+                "Please update your config to use widgets=[...]."
+            )
+            self.widgets = _widgets
 
         self.close_button_location: str
         if self.close_button_location not in ["left", "right"]:

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -42,8 +42,8 @@ class WindowCount(base._TextBox):
         ("show_zero", False, "Show window count when no windows"),
     ]  # type: list[tuple[str, Any, str]]
 
-    def __init__(self, text=" ", width=bar.CALCULATED, **config):
-        base._TextBox.__init__(self, text=text, width=width, **config)
+    def __init__(self, width=bar.CALCULATED, **config):
+        base._TextBox.__init__(self, width=width, **config)
         self.add_defaults(WindowCount.defaults)
         self._count = 0
 

--- a/test/layouts/test_matrix.py
+++ b/test/layouts/test_matrix.py
@@ -139,3 +139,8 @@ def test_unknown_client():
     # Without the return statement in "configure" the following
     # code would result in an error
     assert matrix.configure("fakeclient", None) is None
+
+
+def test_deprecated_configuration(caplog):
+    _ = layout.Matrix(2)
+    assert "The use of a positional argument in Matrix is deprecated." in caplog.text

--- a/test/widgets/test_launchbar.py
+++ b/test/widgets/test_launchbar.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import sys
+from types import ModuleType
+
+from libqtile import widget
+
+
+class MockXDG(ModuleType):
+    def getIconPath(*args, **kwargs):  # noqa: N802
+        pass
+
+
+def test_deprecated_configuration(caplog, monkeypatch):
+    monkeypatch.setitem(sys.modules, "xdg.IconTheme", MockXDG("xdg.IconTheme"))
+    _ = widget.LaunchBar(
+        [("thunderbird", "thunderbird -safe-mode", "launch thunderbird in safe mode")]
+    )
+    records = [r for r in caplog.records if r.msg.startswith("The use of")]
+    assert records
+    assert "The use of a positional argument in LaunchBar is deprecated." in records[0].msg

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -1,3 +1,22 @@
+# Copyright (c) 2021-22 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import pytest
 
 import libqtile.config
@@ -11,7 +30,7 @@ def test_widgetbox_widget(fake_qtile, fake_window):
     tb_two = TextBox(name="tb_two", text="TB TWO")
 
     # Give widgetbox invalid value for button location
-    widget_box = WidgetBox([tb_one, tb_two], close_button_location="middle", fontsize=10)
+    widget_box = WidgetBox(widgets=[tb_one, tb_two], close_button_location="middle", fontsize=10)
 
     # Create a bar and set attributes needed to run widget
     fakebar = FakeBar([widget_box], window=fake_window)
@@ -56,7 +75,9 @@ def test_widgetbox_widget(fake_qtile, fake_window):
 def test_widgetbox_mirror(manager_nospawn, minimal_conf_noscreen):
     config = minimal_conf_noscreen
     tbox = TextBox(text="Text Box")
-    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([tbox, WidgetBox([tbox])], 10))]
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([tbox, WidgetBox(widgets=[tbox])], 10))
+    ]
 
     manager_nospawn.start(config)
 
@@ -69,7 +90,9 @@ def test_widgetbox_mirror(manager_nospawn, minimal_conf_noscreen):
 def test_widgetbox_mouse_click(manager_nospawn, minimal_conf_noscreen):
     config = minimal_conf_noscreen
     tbox = TextBox(text="Text Box")
-    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox([tbox])], 10))]
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox(widgets=[tbox])], 10))
+    ]
 
     manager_nospawn.start(config)
 
@@ -91,7 +114,9 @@ def test_widgetbox_with_systray_reconfigure_screens_box_open(
         pytest.skip("Skipping test on Wayland.")
 
     config = minimal_conf_noscreen
-    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox([Systray()])], 10))]
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox(widgets=[Systray()])], 10))
+    ]
 
     manager_nospawn.start(config)
 
@@ -116,7 +141,9 @@ def test_widgetbox_with_systray_reconfigure_screens_box_closed(
         pytest.skip("Skipping test on Wayland.")
 
     config = minimal_conf_noscreen
-    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox([Systray()])], 10))]
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([WidgetBox(widgets=[Systray()])], 10))
+    ]
 
     manager_nospawn.start(config)
 
@@ -130,3 +157,10 @@ def test_widgetbox_with_systray_reconfigure_screens_box_closed(
     # Check that we've still got a Systray widget in the box.
     _, name = manager_nospawn.c.widget["widgetbox"].eval("self.widgets[0].name")
     assert name == "systray"
+
+
+def test_deprecated_configuration(caplog):
+    tray = Systray()
+    box = WidgetBox([tray])
+    assert box.widgets == [tray]
+    assert "The use of a positional argument in WidgetBox is deprecated." in caplog.text


### PR DESCRIPTION
By having `columns` as a kwarg in `Matrix.__init__` the argument was excluded from the configuration table in the docs.

Moving it to `defaults` should make configuration a bit clearer for users.