### PR TITLE
Use system python version for mypy in qtile check

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -98,7 +98,7 @@ def type_check_config_args(config_file):
     try:
         # we want to use Literal, which is in 3.8. If people have a mypy that
         # is too old, they can upgrade; this is an optional check anyways.
-        subprocess.check_call(["mypy", "--python-version=3.10", config_file])
+        subprocess.check_call(["mypy", config_file])
         print("config file type checking succeeded")
     except subprocess.CalledProcessError as e:
         print("config file type checking failed: {}".format(e))

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -95,8 +95,7 @@ def type_check_config_args(config_file):
     if shutil.which("mypy") is None:
         print("mypy not found, can't type check config file" "install it and try again")
         return
-    ver = sys.version_info
-    if (ver.major < 3) or (ver.major == 3 and ver.minor < 8):
+    if  sys.version_info.minor < 8:  # < 3.8
         print(
             "mypy check not supported for the current version of python, "
             + "please update python to at least 3.8 and try again"

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -95,7 +95,7 @@ def type_check_config_args(config_file):
     if shutil.which("mypy") is None:
         print("mypy not found, can't type check config file" "install it and try again")
         return
-    if  sys.version_info.minor < 8:  # < 3.8
+    if sys.version_info.minor < 8:  # < 3.8
         print(
             "mypy check not supported for the current version of python, "
             + "please update python to at least 3.8 and try again"

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -95,9 +95,14 @@ def type_check_config_args(config_file):
     if shutil.which("mypy") is None:
         print("mypy not found, can't type check config file" "install it and try again")
         return
+    ver = sys.version_info
+    if (ver.major < 3) or (ver.major == 3 and ver.minor < 8):
+        print(
+            "mypy check not supported for the current version of python, "
+            + "please update python to at least 3.8 and try again"
+        )
+        return
     try:
-        # we want to use Literal, which is in 3.8. If people have a mypy that
-        # is too old, they can upgrade; this is an optional check anyways.
         subprocess.check_call(["mypy", config_file])
         print("config file type checking succeeded")
     except subprocess.CalledProcessError as e:

--- a/tox.ini
+++ b/tox.ini
@@ -113,6 +113,6 @@ commands =
 python =
     pypy-3.7: pypy3
     3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310, packaging, pep8, codestyle, docstyle, mypy, vulture
+    3.8: py38, mypy
+    3.9: py39, mypy
+    3.10: py310, mypy, packaging, pep8, codestyle, docstyle, vulture


### PR DESCRIPTION
Instead of hardcoding the python version, this instead lets mypy decide it based on the system python version. The version restriction was originally put in place due to `Literal` being used, which is only available in 3.8+, so the mypy check is skipped if the current python version is older than that.

Closes #3342.