### PR TITLE
Fix reconfigure screens bug

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -64,7 +64,7 @@ class Gap(CommandObject):
         self.height = None
         self.horizontal = None
 
-    def _configure(self, qtile, screen):
+    def _configure(self, qtile, screen, **kwargs):
         self.qtile = qtile
         self.screen = screen
         self.size = self.initial_size
@@ -194,9 +194,14 @@ class Bar(Gap, configurable.Configurable):
         self.future = None
         self._borders_drawn = False
 
-    def _configure(self, qtile, screen):
-        # We only want to adjust margin sizes once unless there's a new strut
-        if not self._configured or self._add_strut:
+    def _configure(self, qtile, screen, reconfigure=False):
+        """
+        Configure the bar. `reconfigure` is set to True when screen dimensions
+        change, forcing a recalculation of the bar's dimensions.
+        """
+        # We only want to adjust margin sizes once unless there's a new strut or we're
+        # reconfiguring the bar because the screen has changed
+        if not self._configured or self._add_strut or reconfigure:
             Gap._configure(self, qtile, screen)
             self._borders_drawn = False
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -305,10 +305,7 @@ class Screen(CommandObject):
         self.height = height
         self.set_group(group)
         for i in self.gaps:
-            if reconfigure_gaps:
-                i._configured = False
-                i._borders_drawn = False
-            i._configure(qtile, self)
+            i._configure(qtile, self, reconfigure=reconfigure_gaps)
         if self.wallpaper:
             self.wallpaper = os.path.expanduser(self.wallpaper)
             self.paint(self.wallpaper, self.wallpaper_mode)


### PR DESCRIPTION
When reconfiguring screens, we checked to see if the screen size or position has changed. If they had, we reset the `_configured` flag on the bar to reconfigure it again. This had an unintended side effect where we had configured widgets in an "unconfigured" bar. In that scenario, the bar replaces the widgets with `Mirror` instances which causes a number of issues (including `Systray` raising a `ConfigError`).

This PR fixes the issue by leaving the `_configured` flag unchanged but passes a `reconfigure` argument to the bar to force it to reconfigure its size and position when required.

From IRC:

```
[08:05] <    elcaven> | elParaguayo: I am on the git version (0.20.1.dev33+gc1f50739) and I still seem to get that error about the one Systray even when only using my laptop
[08:07] <    elcaven> my config: https://paste.rs/KZQ.py and my autostart script: https://paste.rs/7E2
[13:27] < elParaguayo> | elcaven: argh!
[13:27] < elParaguayo> | let me take a look.
[13:32] < elParaguayo> | Also, what's in your screen_change script?
[13:38] < elParaguayo> | If you comment out the "autorandr" line in your startup script, do you still get the issue?
[13:38] < elParaguayo> | (just trying to pinpoint the cause)
[13:39] <    elcaven> this is in my screen_change script: https://github.com/elcaven/dotfiles/blob/master/qtile/scripts/screen_change.sh
[13:39] < elParaguayo> | And, just to rule out another option, are you definitely running the qtile git version (as opposed to having it installed locally but you're
          actually running a system-wide installation)
[13:39] < elParaguayo> | Appreciate thats unlikely!
[13:40] <    elcaven> I install it through the AUR so I assume it is actually using the git version, best way to check is to run "qtile --version"?
[13:42] < elParaguayo> | It's weird. I can't recreate this.
[13:44] <    elcaven> Ill check if commenting out the autorandr command makes a difference, brb since irc will stop
[13:44] < elParaguayo> | hang on
[13:44] < elParaguayo> | I've recreated this - autorandr caused a crash for me too
[13:45] <    elcaven> that's kinda odd tho that that causes it, because as far as I know it just creates an xrandr script
[13:46] <    elcaven> unless it somehows messes up the timings
[13:48] < elParaguayo> | Yeah, it's doing something weird. If I create 2 profiles with different scaling, it doesn't resize the bar correctly sometimes so it's a
          bigger issue than just the Systray crash (that's just one symptom)
[13:48] < elParaguayo> | Thanks for reporting. Will investigate more.
[13:48] <    elcaven> I had noticed before that when using multiple monitors and unplugging one, it seems the bar stretches out still on the one monitor
[13:49] <    elcaven> a config reload fixes it tho
[13:50] < elParaguayo> | yeah, but we shouldn't have to do that.
[13:54] < elParaguayo> | Hmm. Can recreate with xrandr too.
[13:57] <    elcaven> apologies for bringing up an annoying one :D
[13:58] < elParaguayo> | Not at all. Really glad you did this.
[13:59] < elParaguayo> | I think I've narrowed down the issue too. Unsurprisingly, it was something I changed...
[14:00] <    elcaven> oh I know that feeling all too well, finding a bug only to git blame the specific place where it is and seeing your own name there
[14:03] < elParaguayo> | :D
[14:10] < elParaguayo> | cool. have got a fix for this.
[14:10] < elParaguayo> | Are you able to test a PR?
[14:11] <    elcaven> should be able to, if I edit the PKGBUILD
[14:13] < elParaguayo> | ok - hang on. Found another bug...
[14:19] < elParaguayo> | this will take me a bit longer to fix...
[14:34] < elParaguayo> | elcaven: ok - have a potential fix. If you change PKGBUILD source line to
          'source=("git://github.com/elparaguayo/qtile.git#branch=fix-screen-reconfigure-mirror-bug")' can you see how you get on?
[15:04] <    elcaven> sure thing, let me see
[15:08] <   elcaven_> it seems that that branch does indeed fix the issue, the bar loaded properly on login
[15:10] <   elcaven_> cannot check multi monitor at the moment tho unfortunately
[16:47] < elParaguayo> | I think this also shows that the test in our test suite isn't working as intended
[16:47] < elParaguayo> | Thanks for checking it out
```