### PR TITLE
x11: move x11 connection used by many tests into fixture

### DIFF
--- a/test/backend/x11/conftest.py
+++ b/test/backend/x11/conftest.py
@@ -170,6 +170,13 @@ def xmanager(request, xephyr):
         yield manager
 
 
+@pytest.fixture(scope="function")
+def conn(xmanager):
+    conn = Connection(xmanager.display)
+    yield conn
+    conn.finalize()
+
+
 class XBackend(Backend):
     name = "x11"
 

--- a/test/backend/x11/test_xcbq.py
+++ b/test/backend/x11/test_xcbq.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 import xcffib
 import xcffib.testing
@@ -7,14 +5,7 @@ import xcffib.testing
 from libqtile.backend.x11 import window, xcbq
 
 
-@pytest.fixture(scope="function", autouse=True)
-def xdisplay(request):
-    with xcffib.testing.XvfbTest(width=1280, height=720):
-        yield os.environ["DISPLAY"]
-
-
-def test_new_window(xdisplay):
-    conn = xcbq.Connection(xdisplay)
+def test_new_window(conn):
     win = conn.create_window(1, 2, 640, 480)
     assert isinstance(win, window.XWindow)
     geom = win.get_geometry()

--- a/test/backend/x11/test_xcore.py
+++ b/test/backend/x11/test_xcore.py
@@ -1,7 +1,7 @@
 import pytest
 
 from libqtile.backend import get_core
-from libqtile.backend.x11 import core, xcbq
+from libqtile.backend.x11 import core
 from test.test_manager import ManagerConfig
 
 
@@ -25,9 +25,7 @@ def test_color_pixel(xmanager):
 
 
 @pytest.mark.parametrize("xmanager", [ManagerConfig], indirect=True)
-def test_net_client_list(xmanager):
-    conn = xcbq.Connection(xmanager.display)
-
+def test_net_client_list(xmanager, conn):
     def assert_clients(number):
         clients = conn.default_screen.root.get_property("_NET_CLIENT_LIST", unpack=int)
         assert len(clients) == number


### PR DESCRIPTION
Many x11-backend tests use a manually created connection to the X server
and finalize it after use. Let's move that out into a fixture for them
to use to ensure connections are finalized and clean up the code a bit.