### PR TITLE
Add ability to test logging messages

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,6 +20,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import logging
+import multiprocessing
 
 import pytest
 
@@ -103,8 +105,30 @@ def backend(request, backend_name, xephyr, wayland_session):
 
 
 @pytest.fixture(scope="function")
-def manager_nospawn(request, backend):
+def log_queue():
+    """Creates a new Queue for logging messages run in a backend process."""
+    yield multiprocessing.Queue(-1)
+
+
+@pytest.fixture(scope="function")
+def logger(caplog, log_queue):
+    """
+    Connects logging messages in the backend to a logger in the main thread
+    and returns a caplog fixture  which can access those messages.
+    """
+    root = logging.getLogger()
+    listener = logging.handlers.QueueListener(log_queue, *root.handlers)
+    listener.start()
+
+    yield caplog
+
+    listener.stop()
+
+
+@pytest.fixture(scope="function")
+def manager_nospawn(request, backend, log_queue):
     with TestManager(backend, request.config.getoption("--debuglog")) as manager:
+        manager.log_queue = log_queue
         yield manager
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -174,7 +174,9 @@ class TestManager:
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
-                init_log(self.log_level, log_path=None, log_color=False)
+                logger = init_log(self.log_level, log_path=None, log_color=False)
+                if hasattr(self, "log_queue"):
+                    logger.addHandler(logging.handlers.QueueHandler(self.log_queue))
                 Qtile(
                     kore,
                     config_class(),

--- a/test/widgets/test_image.py
+++ b/test/widgets/test_image.py
@@ -98,3 +98,26 @@ def test_no_scale(manager_nospawn, minimal_conf_noscreen):
 
     info = bar.info()
     assert info["widgets"][0]["width"] == 24
+
+
+def test_no_image(manager_nospawn, minimal_conf_noscreen, logger):
+    img = widget.Image()
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([img], 40))]
+
+    manager_nospawn.start(config)
+
+    assert "Image filename not set!" in logger.text
+
+
+def test_invalid_path(manager_nospawn, minimal_conf_noscreen, logger):
+    filename = "/made/up/file.png"
+    img = widget.Image(filename=filename)
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([img], 40))]
+
+    manager_nospawn.start(config)
+
+    assert f"Image does not exist: {filename}" in logger.text


### PR DESCRIPTION
By default pytest's `caplog` fixture does not work when we run tests in a `manager` process.

This PR adds a `logger` fixture which uses a `QueueHandler` to pass messages from a separate process to the main thread which `caplog` can then read.

The PR also includes an example of its use with `test_images.py`.