### PR TITLE
Add JSON encoder to IPC for set types

### DIFF
--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -129,12 +129,19 @@ class _IPC:
     def pack(msg: Any, *, is_json: bool = False) -> bytes:
         """Pack the object into a message to pass"""
         if is_json:
-            json_obj = json.dumps(msg)
+            json_obj = json.dumps(msg, default=_IPC._json_encoder)
             return json_obj.encode()
 
         msg_bytes = marshal.dumps(msg)
         size = struct.pack(HDRFORMAT, len(msg_bytes))
         return size + msg_bytes
+
+    @staticmethod
+    def _json_encoder(field: Any) -> Any:
+        """Convert non-serializable types to ones understood by stdlib json module"""
+        if isinstance(field, set):
+            return list(field)
+        raise ValueError(f"Tried to JSON serialize unsupported type {type(field)}: {field}")
 
 
 class Client:

--- a/test/test_ipc.py
+++ b/test/test_ipc.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 Jaakko Sirén
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from libqtile.ipc import _IPC
+
+
+def test_ipc_json_encoder_supports_sets():
+    serialized = _IPC.pack({"foo": set()}, is_json=True)
+    assert serialized == b'{"foo": []}'
+
+
+def test_ipc_json_throws_error_on_unsupported_field():
+    class NonSerializableType:
+        ...
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Tried to JSON serialize unsupported type <class '"
+            "test.test_ipc.test_ipc_json_throws_error_on_unsupported_field.<locals>.NonSerializableType"
+            "'>.*"
+        ),
+    ):
+        _IPC.pack({"foo": NonSerializableType()}, is_json=True)
+
+
+def test_ipc_marshall_error_on_unsupported_field():
+    class NonSerializableType:
+        ...
+
+    with pytest.raises(ValueError, match="unmarshallable object"):
+        _IPC.pack({"foo": NonSerializableType()})


### PR DESCRIPTION
Closes #3360. Fixes bug in which groups couldn't be listed over IPC when using JSON
encoding.