### PR TITLE
WL: Don't remove idle inhibit listener upon destroy

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -216,7 +216,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         # We don't have reference to the inhibitor, but it doesn't really
         # matter we only need to keep count of how many inhibitors there are
         self._idle_inhibitors_count -= 1
-        listener.remove()
+        self._listeners.remove(listener)
         if self._idle_inhibitors_count == 0:
             self.core.check_idle_inhibitor()
 
@@ -1239,7 +1239,7 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
         # We don't have reference to the inhibitor, but it doesn't really
         # matter we only need to keep count of how many inhibitors there are
         self._idle_inhibitors_count -= 1
-        listener.remove()
+        self._listeners.remove(listener)
         if self._idle_inhibitors_count == 0:
             self.core.check_idle_inhibitor()
 


### PR DESCRIPTION
This causes it to get double-removed, accessing invalid memory and
causing a crash.

Fixes #3361

--

I'm not 100% certain about the logic here, but it _does_ fix the issue. I'm still investigate if this is the right thing - if it isn't then we risk a memory leak with listeners that don't get removed until the client exits.