### PR TITLE
Add lazy.screen.set_wallpaper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Wayland: added power-output-management-v1 protocol support, added idle protocol,
           added idle inhibit protocol
         - Add MonadThreeCol layout based on XMonad's ThreeColumns.
+        - Add `lazy.screen.set_wallpaper` command.
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -110,6 +110,19 @@ Window functions
     * - ``lazy.window.toggle_fullscreen()``
       - Put the focused window to/from fullscreen mode
 
+Screen functions
+----------------
+
+.. list-table::
+    :widths: 20 80
+    :header-rows: 1
+
+    * - function
+      - description
+    * - ``lazy.screen.set_wallpaper(path, mode=None)``
+      - Set the wallpaper to the specificied image. Possible modes: ``None`` no resizing,
+        ``'fill'`` centre and resize to fill screen, ``'stretch'`` stretch to fill screen.
+
 ScratchPad DropDown functions
 -----------------------------
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -475,6 +475,10 @@ class Screen(CommandObject):
         group = self.qtile.groups_map.get(group_name)
         self.toggle_group(group, warp=warp)
 
+    def cmd_set_wallpaper(self, path, mode=None):
+        """Set the wallpaper to the given file."""
+        self.paint(path, mode)
+
 
 class Group:
     """Represents a "dynamic" group


### PR DESCRIPTION
Exposes a command to allow users to change wallpapers via the command interface. Includes an example in the docs.