### PR TITLE
Fix resizing of wallpaper when screen scaled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           on focused windows when none is focused. By default we do not match on focused windows,
           to change this set `if_no_focused` to True.
         - Widget with duplicate names will be automatically renamed by appending numeric suffixes
+        - Fix resizing of wallpaper when screen scale changes (X11)
 
 Qtile 0.20.0, released 2022-01-24:
     * features


### PR DESCRIPTION
Wallpaper was drawn based on the screen's `width/height_in_pixels` but this doesn't take account of scaling.

This PR draws wallpapers based on `screen.width/height` instead.

Closes #3370