### PR TITLE
Suppress log messages when exiting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           on focused windows when none is focused. By default we do not match on focused windows,
           to change this set `if_no_focused` to True.
         - Widget with duplicate names will be automatically renamed by appending numeric suffixes
+        - Suppress `ConnectionException` messages when shutting down (X11).
 
 Qtile 0.20.0, released 2022-01-24:
     * features

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -37,6 +37,7 @@ from libqtile import config, hook, utils
 from libqtile.backend import base
 from libqtile.backend.x11 import window, xcbq
 from libqtile.backend.x11.xkeysyms import keysyms
+from libqtile.core.lifecycle import lifecycle
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -322,7 +323,11 @@ class Core(base.Core):
                 pass
             except Exception:
                 error_code = self.conn.conn.has_error()
-                if error_code:
+                if lifecycle.behavior == lifecycle.behavior.TERMINATE:
+                    # We're already shutting down so we don't need to do anything here
+                    # and flooding the log with ConnectionExceptions isn't helpful
+                    return
+                elif error_code:
                     error_string = xcbq.XCB_CONN_ERRORS[error_code]
                     logger.exception(
                         "Shutting down due to X connection error {error_string} ({error_code})".format(


### PR DESCRIPTION
Logs are occasionally filled with `ConnectionException` messages before exiting.

This PR suppresses those messages when we know qtile is already exiting and where losing a connection to the X server is
expected.

Might close #3351 (if my hunch is correct)

NOTE: this is untested as I'm not sure how to trigger the error messages reliably.