### PR TITLE
Re-enable issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,17 +1,11 @@
-name: "Issue template"
-description: Required
+name: "Report an issue"
+description: "Our tracker for bugs and other issues with the core project"
 labels: ["unconfirmed"]
 body:
   - type: markdown
     attributes:
      value: |
        Please note that this tracker is only for bugs or other issues with the core project.
-
-       Have a **general question**?
-       There are [community contact](https://github.com/qtile/qtile#community) options for that, or ask at [Q&A](https://github.com/qtile/qtile/discussions/categories/q-a).
-
-       Have a **feature idea**?
-       Please post it on the discussions board as an [idea](https://github.com/qtile/qtile/discussions/categories/ideas).
   - type: markdown
     attributes:
      value: |
@@ -21,7 +15,7 @@ body:
        - If relevant, the problematic part of your config.
   - type: textarea
     attributes:
-      label: "The bug:"
+      label: "The issue:"
       value: I wanted to do X, but Y happened, and I expected Z. I think this is a bug.
     validations:
       render: markdown

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature request
+    about: Propose any new features here on our ideas board
+    url: https://github.com/qtile/qtile/discussions/categories/ideas
+  - name: Question
+    about: Ask the community a question
+    url: https://github.com/qtile/qtile#community

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,12 @@ Community
 =========
 
 Qtile is supported by a dedicated group of users. If you need any help, please
-don't hesitate to fire off an email to our mailing list or join us on IRC.
+don't hesitate to fire off an email to our mailing list or join us on IRC. You
+can also ask questions on the discussions board.
 
 :Mailing List: https://groups.google.com/group/qtile-dev
 :IRC: irc://irc.oftc.net:6667/qtile
+:Q&A: https://github.com/qtile/qtile/discussions/categories/q-a
 
 Example code
 ============


### PR DESCRIPTION
Github has updated its template feature which supports disabling blank
templates, and adding additional links to the template selection page.
This re-enables the template, and adds links to the template page to
direct feature requests and general questions to more appropriate
channels.

--

It might be worth discussing where we enable blank templates. I've disabled them here. Is there any reason we should allow them?