### PR TITLE
WL: finalize all keyboards and outputs, not every other

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -215,9 +215,9 @@ class Core(base.Core, wlrq.HasListeners):
         return "wayland"
 
     def finalize(self) -> None:
-        for kb in self.keyboards:
+        for kb in self.keyboards.copy():
             kb.finalize()
-        for out in self.outputs:
+        for out in self.outputs.copy():
             out.finalize()
 
         self.finalize_listeners()


### PR DESCRIPTION
Here we're looping over `core.keyboards` and `core.outputs` and
finalizing the object we get in each loop, but during that step we
remove that item from the list, resulting in us only finalizing every
other keyboard/output. We need to loop over copies of those lists
instead.