### PR TITLE
Ability to scale battery icon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           added idle inhibit protocol
         - Add MonadThreeCol layout based on XMonad's ThreeColumns.
         - Add `lazy.screen.set_wallpaper` command.
+        - Added ability to scale the battery icon's size
     * bugfixes
         - Fix `Systray` crash on `reconfigure_screens`.
         - Fix bug where widgets can't be mirrored in same bar.

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -481,7 +481,7 @@ class BatteryIcon(base._Widget):
 
         base._Widget.__init__(self, length=bar.CALCULATED, **config)
         self.add_defaults(self.defaults)
-        self.scale = 1.0 / self.scale
+        self.scale = 1.0 / self.scale  # type: float
 
         self.length_type = bar.STATIC
         self.length = 0

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -455,6 +455,7 @@ class BatteryIcon(base._Widget):
         ("battery", 0, "Which battery should be monitored"),
         ("update_interval", 60, "Seconds between status updates"),
         ("theme_path", default_icon_path(), "Path of the icons"),
+        ("scale", 1, "Scale factor relative to the bar height.  " "Defaults to 1"),
     ]  # type: list[tuple[str, Any, str]]
 
     icon_names = (
@@ -480,6 +481,7 @@ class BatteryIcon(base._Widget):
 
         base._Widget.__init__(self, length=bar.CALCULATED, **config)
         self.add_defaults(self.defaults)
+        self.scale = 1.0 / self.scale
 
         self.length_type = bar.STATIC
         self.length = 0
@@ -510,7 +512,8 @@ class BatteryIcon(base._Widget):
 
     def setup_images(self) -> None:
         d_imgs = images.Loader(self.theme_path)(*self.icon_names)
-        new_height = self.bar.height - self.image_padding
+
+        new_height = self.bar.height * self.scale - self.image_padding
         for key, img in d_imgs.items():
             img.resize(height=new_height)
             if img.width > self.length:


### PR DESCRIPTION
Very simple change to allow the user to scale the battery icon, which is especially useful when using custom icons or if you simply want a smaller icon.

This is achieved by introducing a new argument to BatteryIcon, `scale`, whose functionality is basically copied from `CurrentLayoutIcon`.

To be honest, this behaviour can be applied to other widgets, such as Image. 