### PR TITLE
Another go at implementing z-layers for X11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,12 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to set custom "Undefined" status key value to `Mpd2Widget`.
         - `Mpd2Widget` now searches for artist name in all similar keys (i.e `albumartist`, `performer`, etc.).
         - Add svg support to `CustomLayoutIcon`
+        - added layering controls for X11 (Wayland support coming soon!):
+          - `lazy.window.keep_above()/keep_below()` marks windows to be kept above/below other windows permanently.
+             Calling the functions with no arguments toggles the state, otherwise pass `enable=True` or `enable=False`.
+          - `lazy.window.move_up()/move_down()` moves windows up and down the z axis.
+          - added `only_focused` setting to Max layout, allowing to draw multiple clients on top of each other when
+            set to False
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -106,6 +106,9 @@ configuration variables that control specific aspects of Qtile's behavior:
         custom floating rules among other things if you wish.
 
         See the configuration file for the default `float_rules`.
+    * - ``floats_kept_above``
+      - ``True``
+      - Floating windows are kept above tiled windows (Currently x11 only. Wayland support coming soon.)
     * - ``focus_on_window_activation``
       - ``'smart'``
       - Behavior of the _NET_ACTIVATE_WINDOW message sent by applications

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -124,6 +124,23 @@ Window functions
       - Put the focused window to/from floating mode
     * - ``lazy.window.toggle_fullscreen()``
       - Put the focused window to/from fullscreen mode
+    * - ``lazy.window.move_up()``
+      - Move the window above the next window in the stack.
+    * - ``lazy.window.move_down()``
+      - Move the window below the previous window in the stack.
+    * - ``lazy.window.move_to_top()``
+      - Move the window above all other windows with similar priority
+        (i.e. a "normal" window will not be moved above a ``kept_above`` window).
+    * - ``lazy.window.move_to_bottom()``
+      - Move the window below all other windows with similar priority
+        (i.e. a "normal" window will not be moved below a ``kept_below`` window).
+    * - ``lazy.window.keep_above()``
+      - Keep window above other windows.
+    * - ``lazy.window.keep_below()``
+      - Keep window below other windows.
+    * - ``lazy.window.bring_to_front()``
+      - Bring window above all other windows. Ignores ``kept_above`` priority.
+
 
 Screen functions
 ----------------

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -95,9 +95,6 @@ class Core(CommandObject, metaclass=ABCMeta):
     def warp_pointer(self, x: int, y: int) -> None:
         """Warp the pointer to the given coordinates relative."""
 
-    def update_client_list(self, windows_map: dict[int, WindowType]) -> None:
-        """Update the list of windows being managed"""
-
     @contextlib.contextmanager
     def masked(self):
         """A context manager to suppress window events while operating on many windows."""
@@ -252,6 +249,60 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
         """
         return {}
+
+    @expose_command()
+    def keep_above(self, enable: bool | None = None):
+        """Keep this window above all others"""
+
+    @expose_command()
+    def keep_below(self, enable: bool | None = None):
+        """Keep this window below all others"""
+
+    @expose_command()
+    def move_up(self, force: bool = False) -> None:
+        """
+        Move this window above the next window along the z axis.
+
+        Will not raise a "normal" window (i.e. one that is not "kept_above/below")
+        above a window that is marked as "kept_above".
+
+        Will not raise a window where "keep_below" is True unless
+        force is set to True.
+        """
+
+    @expose_command()
+    def move_down(self, force: bool = False) -> None:
+        """
+        Move this window below the previous window along the z axis.
+
+        Will not lower a "normal" window (i.e. one that is not "kept_above/below")
+        below a window that is marked as "kept_below".
+
+        Will not lower a window where "keep_above" is True unless
+        force is set to True.
+        """
+
+    @expose_command()
+    def move_to_top(self) -> None:
+        """
+        Move this window above all windows in the current layer
+        e.g. if you have 3 windows all with "keep_above" set, calling
+        this method will move the window to the top of those three windows.
+
+        Calling this on a "normal" window will not raise it above a "kept_above"
+        window.
+        """
+
+    @expose_command()
+    def move_to_bottom(self) -> None:
+        """
+        Move this window below all windows in the current layer
+        e.g. if you have 3 windows all with "keep_above" set, calling
+        this method will move the window to the bottom of those three windows.
+
+        Calling this on a "normal" window will not raise it below a "kept_below"
+        window.
+        """
 
 
 class Window(_Window, metaclass=ABCMeta):

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -448,42 +448,6 @@ class XFixes:
         self.conn.xfixes.ext.SelectSelectionInput(window.wid, _selection, self.selection_mask)
 
 
-class NetWmState:
-    """NetWmState is a descriptor for _NET_WM_STATE_* properties"""
-
-    def __init__(self, prop_name):
-        self.prop_name = prop_name
-
-    def __get__(self, xcbq_win, cls):
-        try:
-            atom = self.atom
-        except AttributeError:
-            atom = xcbq_win.conn.atoms[self.prop_name]
-            self.atom = atom
-        reply = xcbq_win.get_property("_NET_WM_STATE", "ATOM", unpack=int)
-        if atom in reply:
-            return True
-        return False
-
-    def __set__(self, xcbq_win, value):
-        try:
-            atom = self.atom
-        except AttributeError:
-            atom = xcbq_win.conn.atoms[self.prop_name]
-            self.atom = atom
-
-        value = bool(value)
-        reply = list(xcbq_win.get_property("_NET_WM_STATE", "ATOM", unpack=int))
-        is_set = atom in reply
-        if is_set and not value:
-            reply.remove(atom)
-            xcbq_win.set_property("_NET_WM_STATE", reply)
-        elif value and not is_set:
-            reply.append(atom)
-            xcbq_win.set_property("_NET_WM_STATE", reply)
-        return
-
-
 class Connection:
     _extmap = {
         "xinerama": Xinerama,

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import typing
 from collections import defaultdict
 
-from libqtile import configurable
+from libqtile import configurable, hook
 from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import has_transparency, rgb
@@ -307,6 +307,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                 ", ".join(self.qtile.renamed_widgets),
             )
             self.qtile.renamed_widgets.clear()
+
+        hook.subscribe.setgroup(self.keep_below)
+        hook.subscribe.startup_complete(self.keep_below)
 
         self._remove_crashed_widgets()
         self.draw()
@@ -677,6 +680,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             width of a vertical bar.
         """
         self.process_button_click(x, y, button)
+
+    def keep_below(self):
+        self.window.keep_below(enable=True)
 
 
 BarType = typing.Union[Bar, Gap]

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -67,6 +67,7 @@ class Config:
     widget_defaults: dict[str, Any]
     extension_defaults: dict[str, Any]
     bring_front_click: bool | Literal["floating_only"]
+    floats_kept_above: bool
     reconfigure_screens: bool
     wmname: str
     auto_minimize: bool

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -675,7 +675,7 @@ class Qtile(CommandObject):
             # Window may have been bound to a group in the hook.
             if not win.group and self.current_screen.group:
                 self.current_screen.group.add(win, focus=win.can_steal_focus)
-        self.core.update_client_list(self.windows_map)
+
         hook.fire("client_managed", win)
 
     def unmanage(self, wid: int) -> None:
@@ -690,7 +690,7 @@ class Qtile(CommandObject):
                     group = c.group
                     c.group.remove(c)
             del self.windows_map[wid]
-            self.core.update_client_list(self.windows_map)
+
             if isinstance(c, base.Window):
                 # Put the group back on the window so hooked functions can access it.
                 c.group = group

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -256,6 +256,8 @@ class _Group(CommandObject):
             win._float_state = FloatStates.FULLSCREEN
         elif self.floating_layout.match(win) and not win.fullscreen:
             win._float_state = FloatStates.FLOATING
+            if self.qtile.config.floats_kept_above:
+                win.keep_above(enable=True)
         if win.floating and not win.fullscreen:
             self.floating_layout.add_client(win)
         if not win.floating or win.fullscreen:

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -37,6 +37,7 @@ class Max(_SimpleLayoutBase):
         ("border_focus", "#0000ff", "Border colour(s) for the window when focused"),
         ("border_normal", "#000000", "Border colour(s) for the window when not focused"),
         ("border_width", 0, "Border width."),
+        ("only_focused", True, "Only draw the focused window"),
     ]
 
     def __init__(self, **config):
@@ -47,7 +48,7 @@ class Max(_SimpleLayoutBase):
         return super().add_client(client, 1)
 
     def configure(self, client, screen_rect):
-        if self.clients and client is self.clients.current_client:
+        if not self.only_focused or (self.clients and client is self.clients.current_client):
             client.place(
                 screen_rect.x,
                 screen_rect.y,
@@ -58,6 +59,13 @@ class Max(_SimpleLayoutBase):
                 margin=self.margin,
             )
             client.unhide()
+            if (
+                not self.only_focused
+                and self.clients
+                and client is self.clients.current_client
+                and len(self.clients) > 1
+            ):
+                client.move_to_top()
         else:
             client.hide()
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -169,6 +169,7 @@ dgroups_key_binder = None
 dgroups_app_rules = []  # type: list
 follow_mouse_focus = True
 bring_front_click = False
+floats_kept_above = True
 cursor_warp = False
 floating_layout = layout.Floating(
     float_rules=[

--- a/test/backend/x11/test_xcore.py
+++ b/test/backend/x11/test_xcore.py
@@ -31,6 +31,7 @@ def test_net_client_list(xmanager, conn):
         assert len(clients) == number
 
     # ManagerConfig has a Bar, which should not appear in _NET_CLIENT_LIST
+    xmanager.c.eval("self.core.update_client_lists()")
     assert_clients(0)
     one = xmanager.test_window("one")
     assert_clients(1)

--- a/test/layouts/test_max.py
+++ b/test/layouts/test_max.py
@@ -56,12 +56,52 @@ class MaxConfig(Config):
 max_config = pytest.mark.parametrize("manager", [MaxConfig], indirect=True)
 
 
+class MaxLayeredConfig(Config):
+    auto_fullscreen = True
+    groups = [
+        libqtile.config.Group("a"),
+        libqtile.config.Group("b"),
+        libqtile.config.Group("c"),
+        libqtile.config.Group("d"),
+    ]
+    layouts = [layout.Max(only_focused=False)]
+    floating_layout = libqtile.layout.floating.Floating()
+    keys = []
+    mouse = []
+    screens = []
+
+
+maxlayered_config = pytest.mark.parametrize("manager", [MaxLayeredConfig], indirect=True)
+
+
+def assert_z_stack(manager, windows):
+    if manager.backend.name != "x11":
+        # TODO: Test wayland backend when proper Z-axis is implemented there
+        return
+    stack = manager.backend.get_all_windows()
+    wins = [(w["name"], stack.index(w["id"])) for w in manager.c.windows()]
+    wins.sort(key=lambda x: x[1])
+    assert [x[0] for x in wins] == windows
+
+
 @max_config
 def test_max_simple(manager):
     manager.test_window("one")
     assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ["one"])
     manager.test_window("two")
     assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ["one", "two"])
+
+
+@maxlayered_config
+def test_max_layered(manager):
+    manager.test_window("one")
+    assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ["one"])
+    manager.test_window("two")
+    assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ["one", "two"])
 
 
 @max_config
@@ -70,19 +110,47 @@ def test_max_updown(manager):
     manager.test_window("two")
     manager.test_window("three")
     assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    assert_z_stack(manager, ["one", "two", "three"])
     manager.c.layout.up()
     assert manager.c.get_groups()["a"]["focus"] == "two"
     manager.c.layout.down()
     assert manager.c.get_groups()["a"]["focus"] == "three"
+    assert_z_stack(manager, ["one", "two", "three"])
+    manager.c.layout.down()
+    assert manager.c.get_groups()["a"]["focus"] == "one"
+    assert_z_stack(manager, ["one", "two", "three"])
 
 
-@max_config
+@maxlayered_config
+def test_layered_max_updown(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    assert_z_stack(manager, ["one", "two", "three"])
+    manager.c.layout.up()
+    assert manager.c.get_groups()["a"]["focus"] == "two"
+    assert_z_stack(manager, ["one", "three", "two"])
+    manager.c.layout.up()
+    assert manager.c.get_groups()["a"]["focus"] == "one"
+    assert_z_stack(manager, ["three", "two", "one"])
+    manager.c.layout.down()
+    assert manager.c.get_groups()["a"]["focus"] == "two"
+    assert_z_stack(manager, ["three", "one", "two"])
+    manager.c.layout.down()
+    assert manager.c.get_groups()["a"]["focus"] == "three"
+    assert_z_stack(manager, ["one", "two", "three"])
+
+
+@pytest.mark.parametrize("manager", [MaxConfig, MaxLayeredConfig], indirect=True)
 def test_max_remove(manager):
     manager.test_window("one")
     two = manager.test_window("two")
     assert manager.c.layout.info()["clients"] == ["one", "two"]
+    assert_z_stack(manager, ["one", "two"])
     manager.kill_window(two)
     assert manager.c.layout.info()["clients"] == ["one"]
+    assert_z_stack(manager, ["one"])
 
 
 @max_config
@@ -98,6 +166,32 @@ def test_max_window_focus_cycle(manager):
 
     # test preconditions
     assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+
+    # Floats are kept above in stacking order
+    assert_z_stack(manager, ["one", "two", "three", "float1", "float2"])
+    # last added window has focus
+    assert_focused(manager, "three")
+
+    # assert window focus cycle, according to order in layout
+    assert_focus_path(manager, "float1", "float2", "one", "two", "three")
+
+
+@maxlayered_config
+def test_layered_max_window_focus_cycle(manager):
+    # setup 3 tiled and two floating clients
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
+
+    # test preconditions
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+
+    # Floats kept above by default
+    assert_z_stack(manager, ["one", "two", "three", "float1", "float2"])
     # last added window has focus
     assert_focused(manager, "three")
 


### PR DESCRIPTION
This is based on #2194 (without which this would have taken much, much longer).

The code here is not necessarily as neat as that other PR earlier but I've tried to make it a bit easier to follow.

The changes I've made here implement the following rules:
 - when pinning a layer by `cmd_keep_above/below` the window will be added to the top (for `above`) or bottom (for `below`) of that layer
 - `cmd_move_above/below` moves the window above or below the next client in that layer. e.g. if you have 3 windows in the same 'layer', if you do `cmd_move_above` on the bottom window, it will then appear between the other two windows.
 - Add an option to default config for floating windows to be automatically be pinned to the above layer (pretty sure it's not working yet)

Issues to be fixed:
- [x] Moving up/down seems to include an extra layer (i.e. needs more calls than necessary)
- [ ] When a window is `kept_above`, clicking on another window puts it on top of the `kept_above` window.
- [ ] ... there will be more as we test this

Things to do:
 - [x] more testing
 - [x] do we implement `cmd_to_top/bottom` to prevent need for multiple `move_above/below` calls (and rename the latter to `move_up/down`?
 - [x] fix default option to pin new floating windows
 - [ ] Wayland implementation?
 - [x] Fix CI failures (because they're going to happen!)
 
Known issues:
- [x] Child windows not spawning above parent (e.g. gimp export options)

Would be good if some people can test this and provide input. Would also like to hear suggestions for other changes.

Closes #753
Closes #1145
Closes #1260
Closes #1403