### PR TITLE
Better handling of wrong paths in StatusNotifier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Qtile x.x.x, released xxxx-xx-xx:
         - Widget with duplicate names will be automatically renamed by appending numeric suffixes
         - Fix resizing of wallpaper when screen scale changes (X11)
         - Two small bugfixes for `StatusNotifier` - better handling of Ayatana indicators
+        - Fix bug where StatusNotifierItem crashes due to invalid object paths (e.g. Zoom)
 
 Qtile 0.20.0, released 2022-01-24:
     * features


### PR DESCRIPTION
Some apps (e.g. Zoom) seem to broadcast the wrong path to the StatusNotifierItem. Where the broadcast path is wrong, we should fall back to the default just to check whether that one works.

Fixes #3418