### PR TITLE
Add save and load layout feature to Columns

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,5 +63,6 @@ Tips & Tricks
 
     manual/howto/widget
     manual/howto/git
+    manual/howto/save-load-layout
 
 * :ref:`genindex`

--- a/docs/manual/howto/save-load-layout.rst
+++ b/docs/manual/howto/save-load-layout.rst
@@ -1,0 +1,119 @@
+.. _save-load-layout:
+
+====================
+Save and load layout
+====================
+
+.. note:: Currently only ``Columns`` support layout saving and loading.
+
+Layout can be saved to and restored from json files using ``save_layout`` and ``load_layout`` commands on the ``Layout`` object.
+
+Window positions, sizes, and in general things that are controlled by ``Layout`` will be saved and restored.
+
+Note ``load-layout`` does not create any windows. Instead, it uses the window matching rules defined in the json file to match against open windows, and apply saved stylings to those matched windows. See `Layout files`_ for more info.
+
+By default qtile will look for layout files in ``CONFIG_DIRECTORY/layouts``, e.g. ``~/.config/qtile/layouts``
+
+Typical workflow
+================
+
+To save layout:
+
+- Create some windows
+
+- Save layout using ``save-layout`` command
+
+- Edit the generated json file with more accurate window matching rules
+
+Then to load layout:
+
+- Create the same windows
+
+- Load layout using ``load-layout`` command
+
+``save-layout`` examples
+========================
+
+.. code-block:: bash
+
+    # Save current layout to default location (i.e. ~/.config/qtile/layouts/my_layout.json)
+    qtile cmd-obj -o layout -f save_layout -a my_layout
+
+    # Save current layout to a specified place
+    qtile cmd-obj -o layout -f save_layout -a "/tmp/my_layout.json"
+
+``load-layout`` examples
+========================
+
+.. code-block:: bash
+
+    # Load ~/.config/qtile/layouts/my_layout.json
+    qtile cmd-obj -o layout -f save_layout -a my_layout
+
+    # Load /tmp/my_layout.json
+    qtile cmd-obj -o layout -f load_layout -a "/tmp/my_layout.json"
+
+Layout files
+============
+
+Using ``Columns`` as example, the json file produced by ``save_layout`` will look something like:
+
+.. code-block:: json
+
+    {
+        "name": "columns",
+        "columns": [
+            {
+                "split": true,
+                "insert_position": 0,
+                "width": 100,
+                "windows": [
+                    {
+                        "title": "my_window",
+                        "wm_type": "...",
+                        "wm_class": "...",
+                        "role": "...",
+                        "focus": true
+                    },
+                    {
+                        "title": "my_other_window",
+                        "wm_type": "...",
+                        "wm_class": "...",
+                        "role": "...",
+                        "focus": true
+                    }
+                ],
+                "heights": [
+                    100
+                ],
+                "current": 0
+            }
+        ]
+    }
+
+Most fields such as ``split``, ``insert_position`` are taken directly from the ``Columns`` object. These fields will be used to configure the ``Columns`` object when the layout is loaded.
+
+Each item in ``windows`` is used to create a ``Match`` object. These match objects are used to match against open windows in the current layout. Styling is then applied to matched windows.
+
+E.g. the above layout file will place the window with title "my_window" at the top of first column. Then place "my_other_window" below "my_window" in the same column.
+
+All constructor arguments for ``Match`` are supported:
+
+.. qtile_class:: libqtile.config.Match
+    :no-commands:
+    :noindex:
+
+Using regex to match windows
+============================
+
+Suffix field name with ``_regex`` to use regex matching instead. All fields except ``net_wm_pid`` support ``_regex``.
+
+When both the ``_regex`` and non-regex fields are given, ``_regex`` field takes precedence.
+
+E.g. the following example matches any window with a title that contains "foobar"
+
+.. code-block:: json
+
+    {
+        "title_regex": ".*foobar.*"
+    }

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -31,7 +31,6 @@ import contextlib
 import os.path
 import sys
 from typing import TYPE_CHECKING
-import re
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
@@ -745,23 +744,6 @@ class Match:
 
     def __repr__(self):
         return "<Match %s>" % self._rules
-
-    @staticmethod
-    def _resolve_config_field_predicate(config, field_name):
-        regex_field_name = field_name + "_regex"
-        if regex_field_name in config:
-            return re.compile(config[regex_field_name])
-        else:
-            return config.get(field_name, None)
-
-    @classmethod
-    def from_config(cls, config):
-        return cls(
-            title=cls._resolve_config_field_predicate(config, "wm_name"),
-            wm_class=cls._resolve_config_field_predicate(config, "wm_class"),
-            role=cls._resolve_config_field_predicate(config, "wm_role"),
-            wm_type=cls._resolve_config_field_predicate(config, "wm_type"),
-        )
 
 
 class Rule:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -31,6 +31,7 @@ import contextlib
 import os.path
 import sys
 from typing import TYPE_CHECKING
+import re
 
 from libqtile import configurable, hook, utils
 from libqtile.backend import base
@@ -728,6 +729,14 @@ class Match:
             return False
         return True
 
+    def find_matching(self, clients):
+        """finds the first matching client from a list of clients"""
+        for client in clients:
+            if self.compare(client):
+                return client
+
+        return None
+
     def map(self, callback, clients):
         """Apply callback to each client that matches this Match"""
         for c in clients:
@@ -736,6 +745,23 @@ class Match:
 
     def __repr__(self):
         return "<Match %s>" % self._rules
+
+    @staticmethod
+    def _resolve_config_field_predicate(config, field_name):
+        regex_field_name = field_name + "_regex"
+        if regex_field_name in config:
+            return re.compile(config[regex_field_name])
+        else:
+            return config.get(field_name, None)
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(
+            title=cls._resolve_config_field_predicate(config, "wm_name"),
+            wm_class=cls._resolve_config_field_predicate(config, "wm_class"),
+            role=cls._resolve_config_field_predicate(config, "wm_role"),
+            wm_type=cls._resolve_config_field_predicate(config, "wm_type"),
+        )
 
 
 class Rule:

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -17,7 +17,8 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, TypedDict, cast
+import sys
+from typing import List, Optional, Tuple, cast
 
 from libqtile.backend.base import WindowType
 from libqtile.layout.base import Layout, _ClientList
@@ -28,6 +29,11 @@ from libqtile.layout.serialize import (
     WindowSerDes,
 )
 from libqtile.log_utils import logger
+
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 
 class _Column(_ClientList):

--- a/libqtile/layout/serialize.py
+++ b/libqtile/layout/serialize.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 import json
 import os.path
 import re
+import sys
 from os import getenv
 from pathlib import Path
-from typing import Optional, Pattern, TypedDict, cast
+from typing import Optional, Pattern, cast
 
 from libqtile.backend.base import Window, WindowType
 from libqtile.config import Match
+
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 
 class SerializedLayout(TypedDict):

--- a/libqtile/layout/serialize.py
+++ b/libqtile/layout/serialize.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import json
+
+from libqtile.log_utils import logger
+
+
+class SerializedLayout:
+    def __init__(self, name):
+        self.data = {}
+        self["name"] = name
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+
+    @staticmethod
+    def _resolve_path(name: str) -> Path:
+        """
+        If name consists of just one part, e.g. "my_layout" then path will resolve to ~/.config/qtile/layouts/my_layout.json
+        Otherwise name is treated as a path
+        """
+
+        path = Path(name)
+
+        if len(path.parts) == 1:
+            if path.suffix != ".json":
+                path = path.with_suffix(".json")
+            path = Path.joinpath(Path("~/.config/qtile/layouts"), path).expanduser()
+        else:
+            path = path.expanduser()
+
+        return path
+
+    def save_to(self, name):
+        path = self._resolve_path(name)
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with path.open("w") as f:
+            json.dump(self.data, f, indent=4)
+
+    @classmethod
+    def load_from(cls, name, check_layout_name=None):
+        path = cls._resolve_path(name)
+
+        with path.open() as f:
+            data = json.load(f)
+
+        if check_layout_name is not None and data["name"] != check_layout_name:
+            logger.error(f"Loaded layout does not have expected name {check_layout_name}: {data}")
+            return None
+
+        serialized_layout = SerializedLayout(None)
+        serialized_layout.data = data
+        return serialized_layout
+
+
+def serialize_window(window, is_focus: bool):
+    wm_class = window.get_wm_class()
+    if wm_class != None:
+        wm_class = None if len(wm_class) == 0 else wm_class[0]
+
+    serialized_window = {
+        "wm_name": window.name,
+        "wm_class": wm_class,
+        "wm_role": window.get_wm_role(),
+        "wm_type": window.get_wm_type(),
+    }
+
+    if is_focus:
+        serialized_window["focus"] = True
+
+    return serialized_window

--- a/libqtile/layout/serialize.py
+++ b/libqtile/layout/serialize.py
@@ -1,23 +1,24 @@
-from pathlib import Path
+from __future__ import annotations
+
 import json
+import os.path
+import re
+from os import getenv
+from pathlib import Path
+from typing import Optional, Pattern, TypedDict, cast
 
-from libqtile.log_utils import logger
+from libqtile.backend.base import Window, WindowType
+from libqtile.config import Match
 
 
-class SerializedLayout:
-    def __init__(self, name):
-        self.data = {}
-        self["name"] = name
+class SerializedLayout(TypedDict):
+    name: str
 
-    def __getitem__(self, key):
-        return self.data[key]
 
-    def __setitem__(self, key, value):
-        self.data[key] = value
-
+class LayoutSerDes:
     @staticmethod
-    def _resolve_path(name: str) -> Path:
-        """
+    def resolve_path(name: str) -> Path:
+        """resolves path to layout file
         If name consists of just one part, e.g. "my_layout" then path will resolve to ~/.config/qtile/layouts/my_layout.json
         Otherwise name is treated as a path
         """
@@ -27,49 +28,109 @@ class SerializedLayout:
         if len(path.parts) == 1:
             if path.suffix != ".json":
                 path = path.with_suffix(".json")
-            path = Path.joinpath(Path("~/.config/qtile/layouts"), path).expanduser()
+
+            layouts_dir = os.path.expanduser(
+                os.path.join(getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "layouts")
+            )
+
+            path = Path.joinpath(Path(layouts_dir), path)
         else:
             path = path.expanduser()
 
         return path
 
-    def save_to(self, name):
-        path = self._resolve_path(name)
-
+    @staticmethod
+    def save_to(data: SerializedLayout, name: str):
+        """save this serialized layout to the specified layout file"""
+        path = LayoutSerDes.resolve_path(name)
         path.parent.mkdir(parents=True, exist_ok=True)
 
         with path.open("w") as f:
-            json.dump(self.data, f, indent=4)
+            json.dump(data, f, indent=4)
 
-    @classmethod
-    def load_from(cls, name, check_layout_name=None):
-        path = cls._resolve_path(name)
-
+    @staticmethod
+    def load_from(name: str, check_layout_name: Optional[str] = None) -> SerializedLayout:
+        """load a serialized layout from the specified layout file
+        raise RuntimeError if check_layout_name is given and it does not match with value in the layout file
+        """
+        path = LayoutSerDes.resolve_path(name)
         with path.open() as f:
             data = json.load(f)
 
         if check_layout_name is not None and data["name"] != check_layout_name:
-            logger.error(f"Loaded layout does not have expected name {check_layout_name}: {data}")
-            return None
+            raise RuntimeError(
+                f"Loaded layout does not have expected name {check_layout_name}: {data}"
+            )
 
-        serialized_layout = SerializedLayout(None)
-        serialized_layout.data = data
-        return serialized_layout
+        return data
 
 
-def serialize_window(window, is_focus: bool):
-    wm_class = window.get_wm_class()
-    if wm_class != None:
-        wm_class = None if len(wm_class) == 0 else wm_class[0]
+class SerializedWindow(TypedDict, total=False):
+    title: str
+    title_regex: str
+    wm_instance_class: str
+    wm_instance_class_regex: str
+    wm_class: str
+    wm_class_regex: str
+    role: str
+    role_regex: str
+    wm_type: str
+    wm_type_regex: str
+    net_wm_pid: int
+    focus: bool
 
-    serialized_window = {
-        "wm_name": window.name,
-        "wm_class": wm_class,
-        "wm_role": window.get_wm_role(),
-        "wm_type": window.get_wm_type(),
-    }
 
-    if is_focus:
-        serialized_window["focus"] = True
+class WindowSerDes:
+    @staticmethod
+    def serialize(window: WindowType, focus: Optional[bool] = None) -> SerializedWindow:
 
-    return serialized_window
+        serialized_window = SerializedWindow(title=window.name)
+
+        wm_role = window.get_wm_role()
+        if wm_role is not None:
+            serialized_window["role"] = wm_role
+
+        wm_type = window.get_wm_type()
+        if wm_type is not None:
+            serialized_window["wm_type"] = wm_type
+
+        wm_class = window.get_wm_class()
+        if wm_class is not None and len(wm_class) >= 1:
+            serialized_window["wm_instance_class"] = wm_class[0]
+
+        wm_class = window.get_wm_class()
+        if wm_class is not None and len(wm_class) >= 2:
+            serialized_window["wm_class"] = wm_class[1]
+
+        if isinstance(window, Window):
+            serialized_window["net_wm_pid"] = cast(Window, window).get_pid()
+
+        if focus:
+            serialized_window["focus"] = True
+
+        return serialized_window
+
+    @staticmethod
+    def _resolve_match_field_value(
+        serialized_window: SerializedWindow,
+        field_name: str,
+        regex_field_name: str,
+    ) -> Pattern | str | None:
+        """looks for the _regex field. if it is None then fall back to the non _regex field"""
+        if serialized_window.get(regex_field_name, None) is not None:
+            return re.compile(serialized_window[regex_field_name])  # type: ignore
+        else:
+            return serialized_window.get(field_name, None)  # type: ignore
+
+    @staticmethod
+    def to_match(data: SerializedWindow) -> Match:
+        return Match(
+            title=WindowSerDes._resolve_match_field_value(data, "title", "title_regex"),
+            wm_instance_class=WindowSerDes._resolve_match_field_value(
+                data, "wm_instance_class", "wm_instance_class_regex"
+            ),
+            wm_class=WindowSerDes._resolve_match_field_value(data, "wm_class", "wm_class_regex"),
+            role=WindowSerDes._resolve_match_field_value(data, "role", "role_regex"),
+            wm_type=WindowSerDes._resolve_match_field_value(data, "wm_type", "wm_type_regex"),
+            net_wm_pid=data.get("net_wm_pid", None),
+        )

--- a/test/layouts/test_serialize.py
+++ b/test/layouts/test_serialize.py
@@ -69,7 +69,7 @@ def test_save_serialized_layout(serialized_layout, name):
         LayoutSerDes.save_to(serialized_layout, name)
 
         saved_json = json.loads(
-            "\n".join([call.args[0] for call in mock_file().write.call_args_list])
+            "\n".join([call[0][0] for call in mock_file().write.call_args_list])
         )
         assert serialized_layout == saved_json
 
@@ -121,7 +121,7 @@ def test_serialized_window_to_match(mock_match):
 
     assert mock_match.call_count == 1
 
-    call_kwargs = mock_match.call_args.kwargs
+    call_kwargs = mock_match.call_args[1]
     assert call_kwargs["title"] == kwargs["title"]
     assert call_kwargs.get("wm_instance_class", None) is None
     assert call_kwargs["wm_class"] == re.compile(kwargs["wm_class_regex"])

--- a/test/layouts/test_serialize.py
+++ b/test/layouts/test_serialize.py
@@ -1,0 +1,131 @@
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import re
+from os.path import expanduser
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from libqtile.layout.serialize import (
+    LayoutSerDes,
+    SerializedLayout,
+    SerializedWindow,
+    WindowSerDes,
+)
+
+
+def test_resolve_to_absolute_path():
+    # layout name should resolve to an absolute path
+    path = LayoutSerDes.resolve_path("test")
+    assert path.is_absolute()
+    assert path.name == "test.json"
+    assert path.parent.name == "layouts"
+    assert path.parent.parent.name == "qtile"
+
+
+def test_resolve_given_absolute_path():
+    # absolute paths should be used as is
+    path = Path("/tmp/test.json")
+    resolved_path = LayoutSerDes.resolve_path(path)
+    assert path == resolved_path
+
+
+def test_resolve_expand_user_path():
+    # ~ should be expaned to user
+    path = Path("~/test.json")
+    resolved_path = LayoutSerDes.resolve_path(path)
+    assert str(resolved_path).startswith(expanduser("~"))
+
+
+@pytest.fixture
+def serialized_layout():
+    return SerializedLayout(name="test")
+
+
+layout_filenames = pytest.mark.parametrize("name", [("test"), ("/tmp/test.json")])
+
+
+@layout_filenames
+def test_save_serialized_layout(serialized_layout, name):
+    with patch("pathlib.Path.open", mock_open()) as mock_file:
+        LayoutSerDes.save_to(serialized_layout, name)
+
+        saved_json = json.loads(
+            "\n".join([call.args[0] for call in mock_file().write.call_args_list])
+        )
+        assert serialized_layout == saved_json
+
+
+@layout_filenames
+def test_load_serialized_layout(serialized_layout, name):
+    with patch("pathlib.Path.open", mock_open(read_data=json.dumps(serialized_layout))) as _:
+        loaded_json = LayoutSerDes.load_from(name)
+        assert serialized_layout == loaded_json
+
+
+@layout_filenames
+def test_load_serialized_layout_check_name_fail(serialized_layout, name):
+    with patch("pathlib.Path.open", mock_open(read_data=json.dumps(serialized_layout))) as _:
+        with pytest.raises(RuntimeError):
+            LayoutSerDes.load_from(name, check_layout_name=serialized_layout["name"][::-1])
+
+
+def test_serialized_window_no_fields():
+    # all fields should be optional
+    SerializedWindow()
+
+
+@pytest.fixture
+def serialized_window_all_kwargs():
+    fields = ["title", "wm_instance_class", "wm_class", "role", "wm_type"]
+    fields.extend([f"{field}_regex" for field in fields])
+
+    kwargs = {v: v for v in fields}
+    kwargs["net_wm_pid"] = 0
+    kwargs["focus"] = True
+
+    return kwargs
+
+
+def test_serialized_window_all_fields(serialized_window_all_kwargs):
+    serialized_window = SerializedWindow(**serialized_window_all_kwargs)
+
+    for key in serialized_window_all_kwargs:
+        assert serialized_window[key] == serialized_window_all_kwargs[key]
+
+
+@patch("libqtile.layout.serialize.Match")
+def test_serialized_window_to_match(mock_match):
+    kwargs = {v: v for v in ["title", "wm_class", "wm_class_regex"]}
+    kwargs["focus"] = True
+
+    WindowSerDes.to_match(SerializedWindow(**kwargs))
+
+    assert mock_match.call_count == 1
+
+    call_kwargs = mock_match.call_args.kwargs
+    assert call_kwargs["title"] == kwargs["title"]
+    assert call_kwargs.get("wm_instance_class", None) is None
+    assert call_kwargs["wm_class"] == re.compile(kwargs["wm_class_regex"])
+    assert call_kwargs.get("role", None) is None
+    assert call_kwargs.get("wm_type", None) is None
+    assert call_kwargs.get("net_wm_pid", None) is None
+    assert call_kwargs.get("focus", None) is None


### PR DESCRIPTION
Hi all!

### What is this?
I came from i3, and one of the features I used in i3 on a daily basis is [layout saving](https://i3wm.org/docs/layout-saving.html). It makes me a bit sad that qtile doesn't currently support it. That's why I decided it to implement something similar for the `Columns` layout.

This is a draft PR. Docs and unit tests are not included. Just want to know if this goes against any design philosophies, or if there's any major flaws in my implementation.

### Feature explanation

Two cmds are added for `Columns`: `cmd_save_layout` and `cmd_load_layout`.

`cmd_save_layout` will serialize some fields of current windows in the `Columns` object into a json file.

`cmd_load_layout` will read the json file and try to recreate the layout. Windows are matched using the `Match` object, created from rule definitions in the json file. Window position, column widths as well as window focus will be restored. Note this command does not create any of the windows, it performs layout only.

`serialize.py` is added to extract some common functionality for reuse, in case other layouts may want to implement save / load in the future.

Two utility methods are also added to the `Match` class.

### Example

```
# Saves current layout to ~/.config/qtile/layouts/test.json
qtile cmd-obj -o layout -f save_layout -a test

# Saves current layout to /tmp/test.json
qtile cmd-obj -o layout -f save_layout -a /tmp/test.json

# Saves group 1's layout to ~/.config/qtile/layouts/test.json
# not sure what is the best way to get a specific group
qtile cmd-obj -o group -f eval -a 'self.qtile.groups_map["1"].layout.cmd_save_layout("test")'
```

```
# load layout (note, assuming all the windows are created)

# load ~/.config/qtile/layouts/test.json to the current layout
qtile cmd-obj -o layout -f load_layout -a test

# load /tmp/test.json to the current layout
qtile cmd-obj -o layout -f load_layout -a /tmp/test.json

# load ~/.config/qtile/layouts/test.json to the group 1's layout:
qtile cmd-obj -o group -f eval -a 'self.qtile.groups_map["1"].layout.cmd_load_layout("test")'
```

Also closes https://github.com/qtile/qtile/issues/3256