### PR TITLE
Updated installation notes for Debian 11

### DIFF
--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -40,4 +40,3 @@ repository can be used, see :ref:`installing-from-source`:
 .. code-block:: bash
 
    pip install qtile
-

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -19,3 +19,25 @@ dependencies are available via:
 .. code-block:: bash
 
     sudo apt-get install python3-xcffib python3-cairocffi
+
+
+Debian 11 (bullseye)
+--------------------
+
+Debian 11 comes with the necessary packages for installing Qtile. Starting 
+from a minimal Debian installation, the following packages are required:
+
+.. code-block:: bash
+
+   sudo apt install xserver-xorg xinit
+   sudo apt install libpangocairo-1.0-0
+   sudo apt install python3-pip python3-xcffib python3-cairocffi
+
+
+Either Qtile can then be downloaded from the package index or the Github 
+repository can be used, see :ref:`installing-from-source`:
+
+.. code-block:: bash
+
+   pip install qtile
+


### PR DESCRIPTION
Added details which packages are necessary for installing Qtile for Debian 11. Should work with Ubuntu as well, but the instructions are tested for Debian, only