### PR TITLE
StatusNotifier bugfixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.x.x, released xxxx-xx-xx:
           to change this set `if_no_focused` to True.
         - Widget with duplicate names will be automatically renamed by appending numeric suffixes
         - Fix resizing of wallpaper when screen scale changes (X11)
+        - Two small bugfixes for `StatusNotifier` - better handling of Ayatana indicators
 
 Qtile 0.20.0, released 2022-01-24:
     * features

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -361,8 +361,11 @@ class StatusNotifierWatcher(ServiceInterface):  # noqa: E303
         if message.sender == message.body[0]:
             return False
 
-        self._items.append(message.sender)
-        self.on_item_added(message.sender, message.body[0])
+        if message.sender not in self._items:
+            self._items.append(message.sender)
+            if self.on_item_added is not None:
+                self.on_item_added(message.sender, message.body[0])
+            self.StatusNotifierItemRegistered(message.sender)
         return False
 
     async def _setup_listeners(self):
@@ -397,6 +400,8 @@ class StatusNotifierWatcher(ServiceInterface):  # noqa: E303
     def RegisterStatusNotifierItem(self, service: "s"):  # type: ignore  # noqa: F821, N802
         if service not in self._items:
             self._items.append(service)
+            if self.on_item_added is not None:
+                self.on_item_added(service)
             self.StatusNotifierItemRegistered(service)
 
     @method()
@@ -421,8 +426,6 @@ class StatusNotifierWatcher(ServiceInterface):  # noqa: E303
 
     @signal()
     def StatusNotifierItemRegistered(self, service) -> "s":  # type: ignore  # noqa: F821, N802
-        if self.on_item_added is not None:
-            self.on_item_added(service)
         return service
 
     @signal()

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -349,6 +349,9 @@ class StatusNotifierWatcher(ServiceInterface):  # noqa: E303
         Ayatana indicators seem to register themselves by passing their object
         path rather than the service providing that object. We therefore need
         to identify the sender of the message in order to register the service.
+
+        Returning False so senders receieve a reply (returning True prevents
+        reply being sent)
         """
         if message.member != "RegisterStatusNotifierItem":
             return False
@@ -360,7 +363,7 @@ class StatusNotifierWatcher(ServiceInterface):  # noqa: E303
 
         self._items.append(message.sender)
         self.on_item_added(message.sender, message.body[0])
-        return True
+        return False
 
     async def _setup_listeners(self):
         """


### PR DESCRIPTION
 Ayatana apps need to issue a signal when registered
 RegisterStatusNotifierItem does not return so libappindicator apps produce warning messages and may disconnect

Closes #3433 