### PR TITLE
Update clone url in docs

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -95,7 +95,7 @@ With the dependencies in place, you can now install qtile:
 
 .. code-block:: bash
 
-    git clone git://github.com/qtile/qtile.git
+    git clone https://github.com/qtile/qtile.git
     cd qtile
     pip install .
 


### PR DESCRIPTION
Seems that due to recent changes by Github, cloning as described in the docs (with `git clone git://github.com/qtile/qtile.git`) doesn't work anymore. It produces this output:
```
Cloning into 'qtile'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

I updated the docs to to reflect a possible solution. 
I hope this is an acceptable contribution :)