### PR TITLE
Fix Launchbar crash when no `progs`

### DIFF
--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -111,7 +111,7 @@ class LaunchBar(base._Widget):
                         "cmd": prog[1],
                         "comment": prog[2] if len(prog) > 2 else None,
                     }
-                    for prog in config["progs"]
+                    for prog in config.get("progs", list())
                 ]
             )
         )


### PR DESCRIPTION
Didn't rebase #3340 before merging. #3428 reveals that there's an issue in `Launchbar`'s init where no `progs` are passed (which
shouldn't happen as it defeats the point of the widget...).

Regardless, the test doesn't fail on CI because, due to missing dependencies, the test is skipped for `LaunchBar`.

This PR fixes that issue by providing an empty list as a fallback.