### PR TITLE
StatusNotifier: better handling of Ayatana

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message
           included in the logs.
+        - Reduce error messages in `StatusNotifier` widget from certain apps.
 
 Qtile 0.21.0, released 2022-03-23:
     * features


### PR DESCRIPTION
Ayatana indicators don't provide their service when registering an item. Instead they provide their object path. The SNI widget deals with this by emplying a message handler to listen for register messages and identifies the service that sent the request. However, the invalid call is still also logged by the widget.

This PR fixes this by checking for InvalidBusName exceptions that are caused when trying to introspect the object path rather than the service and, where this happens, removing the invalid item from the watcher.

This has no impact on the operation of the widget but will reduce error messages in the log.