### PR TITLE
Fix CI failures

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -135,8 +135,6 @@ def has_transparency(colour: ColorsType):
     elif isinstance(colour, list):
         return any([has_transparency(c) for c in colour])
 
-    return False
-
 
 def remove_transparency(colour: ColorsType):
     """
@@ -152,8 +150,6 @@ def remove_transparency(colour: ColorsType):
 
     elif isinstance(colour, list):
         return [remove_transparency(c) for c in colour]
-
-    return (0, 0, 0)
 
 
 def scrub_to_utf8(text):

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
+    pip install cairocffi
     pip install pywlroots>=0.15.7,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
@@ -95,7 +96,8 @@ commands =
     pip install pywlroots>=0.15.7,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
-    python3 setup.py -q install
+    pip install .
+    {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
     python3 -m pytest -- test/test_check.py test/test_migrate.py
 


### PR DESCRIPTION
EDIT: CI tests are now passing. Updated commit message:

CI is failing with 2 errors:
1) cairocffi is not found
2) mypy errors

It looks like this might be related to an update to setuptools.

While we could pin setuptools, it seems we have been using deprecated methods (e.g. `python setup.py install`) so I prefer to fix the issues.

This PR fixes the CI failures by:
1) Adding cairocffi installation to tox.ini
2) Installing qtile via `pip install .` in tox mypy environment
3) Fixing 2 mypy errors (unreachable code in utils.py)