### PR TITLE
Add scrolling to `_TextBox` widgets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `resume` hook when computer resumes from sleep/suspend/hibernate.
         - Add `text_only` option for `LaunchBar` widget.
         - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
+        - Add scrolling ability to `_TextBox`-based widgets.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `text_only` option for `LaunchBar` widget.
         - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
         - Add scrolling ability to `_TextBox`-based widgets.
+        - Add player controls (via mouse callbacks) to `Mpris2` widget.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message
@@ -21,6 +22,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Reduce error messages in `StatusNotifier` widget from certain apps.
         - Reset colours in `Chord` widget
         - Prevent crash in `LaunchBar` when using SVG icons
+        - Improve scrolling in `Mpris2` widget (options to repeat scrolling etc.)
 
 Qtile 0.21.0, released 2022-03-23:
     * features

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -353,10 +353,10 @@ def scan_files(dirpath: str, *names: str) -> defaultdict[str, list[str]]:
 async def _send_dbus_message(
     session_bus: bool,
     message_type: MessageType,
-    destination: str,
-    interface: str,
-    path: str,
-    member: str,
+    destination: str | None,
+    interface: str | None,
+    path: str | None,
+    member: str | None,
     signature: str,
     body: Any,
 ) -> tuple[MessageBus | None, Message | None]:
@@ -379,13 +379,16 @@ async def _send_dbus_message(
         logger.warning("Unable to connect to dbus.")
         return None, None
 
+    # Ignore types here: dbus-next has default values of `None` for certain
+    # parameters but the signature is `str` so passing `None` results in an
+    # error in mypy.
     msg = await bus.call(
         Message(
             message_type=message_type,
-            destination=destination,
-            interface=interface,
-            path=path,
-            member=member,
+            destination=destination,  # type: ignore
+            interface=interface,  # type: ignore
+            path=path,  # type: ignore
+            member=member,  # type: ignore
             signature=signature,
             body=body,
         )

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -388,6 +388,29 @@ class _TextBox(_Widget):
         ("markup", True, "Whether or not to use pango markup"),
         ("fmt", "{}", "How to format the text"),
         ("max_chars", 0, "Maximum number of characters to display in widget."),
+        (
+            "scroll",
+            False,
+            "Whether text should be scrolled. When True, you must set the widget's ``width``.",
+        ),
+        (
+            "scroll_repeat",
+            True,
+            "Whether text should restart scrolling once the text has ended",
+        ),
+        (
+            "scroll_delay",
+            2,
+            "Number of seconds to pause before starting scrolling and restarting/clearing text at end",
+        ),
+        ("scroll_step", 1, "Number of pixels to scroll with each step"),
+        ("scroll_interval", 0.1, "Time in seconds before next scrolling step"),
+        (
+            "scroll_clear",
+            False,
+            "Whether text should scroll completely away (True) or stop when the end of the text is shown (False)",
+        ),
+        ("scroll_hide", False, "Whether the widget should hide when scrolling has finished"),
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -395,6 +418,12 @@ class _TextBox(_Widget):
         _Widget.__init__(self, width, **config)
         self.add_defaults(_TextBox.defaults)
         self.text = text
+        self._is_scrolling = False
+        self._should_scroll = False
+        self._scroll_offset = 0
+        self._scroll_queued = False
+        self._scroll_timer = None
+        self._scroll_width = width
 
     @property
     def text(self):
@@ -407,6 +436,9 @@ class _TextBox(_Widget):
         self._text = value
         if self.layout:
             self.layout.text = self.formatted_text
+            if self.scroll:
+                self.check_width()
+                self.reset_scroll()
 
     @property
     def formatted_text(self):
@@ -461,6 +493,26 @@ class _TextBox(_Widget):
             self.fontshadow,
             markup=self.markup,
         )
+        if not isinstance(self._scroll_width, int) and self.scroll:
+            logger.warning("%s: You must specify a width when enabling scrolling.", self.name)
+            self.scroll = False
+
+        if self.scroll:
+            self.check_width()
+
+    def check_width(self):
+        """
+        Check whether the widget needs to have calculated or fixed width
+        and whether the text should be scrolled.
+        """
+        if self.layout.width > self._scroll_width:
+            self.length_type = bar.STATIC
+            self.length = self._scroll_width
+            self._is_scrolling = True
+            self._should_scroll = True
+        else:
+            self.length_type = bar.CALCULATED
+            self._should_scroll = False
 
     def calculate_length(self):
         if self.text:
@@ -481,15 +533,11 @@ class _TextBox(_Widget):
         if not self.can_draw():
             return
         self.drawer.clear(self.background or self.bar.background)
-        if self.bar.horizontal:
-            self.layout.draw(
-                self.actual_padding or 0,
-                int(self.bar.height / 2.0 - self.layout.height / 2.0) + 1,
-            )
-        else:
-            # We need to do some transformations for vertical bars.
-            self.drawer.ctx.save()
 
+        # size = self.bar.height if self.bar.horizontal else self.bar.width
+        self.drawer.ctx.save()
+
+        if not self.bar.horizontal:
             # Left bar reads bottom to top
             if self.bar.screen.left is self.bar:
                 self.drawer.ctx.rotate(-90 * math.pi / 180.0)
@@ -500,12 +548,79 @@ class _TextBox(_Widget):
                 self.drawer.ctx.translate(self.bar.width, 0)
                 self.drawer.ctx.rotate(90 * math.pi / 180.0)
 
-            self.layout.draw(
-                self.actual_padding or 0, int(self.bar.width / 2.0 - self.layout.height / 2.0) + 1
+        # If we're scrolling, we clip the context to the scroll width less the padding
+        # Move the text layout position (and we only see the clipped portion)
+        if self._should_scroll:
+            self.drawer.ctx.rectangle(
+                self.actual_padding,
+                0,
+                self._scroll_width - 2 * self.actual_padding,
+                self.bar.size,
             )
-            self.drawer.ctx.restore()
+            self.drawer.ctx.clip()
 
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.width)
+        self.layout.draw(
+            (self.actual_padding or 0) - self._scroll_offset,
+            int(self.bar.size / 2.0 - self.layout.height / 2.0) + 1,
+        )
+        self.drawer.ctx.restore()
+
+        self.drawer.draw(
+            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
+        )
+
+        # We only want to scroll if:
+        # - User has asked us to scroll and the scroll width is smaller than the layout (should_scroll=True)
+        # - We are still scrolling (is_scrolling=True)
+        # - We haven't already queued the next scroll (scroll_queued=False)
+        if self._should_scroll and self._is_scrolling and not self._scroll_queued:
+            self._scroll_queued = True
+            if self._scroll_offset == 0:
+                interval = self.scroll_delay
+            else:
+                interval = self.scroll_interval
+            self._scroll_timer = self.timeout_add(interval, self.do_scroll)
+
+    def do_scroll(self):
+        # Allow the next scroll tick to be queued
+        self._scroll_queued = False
+
+        # If we're still scrolling, adjust the next offset
+        if self._is_scrolling:
+            self._scroll_offset += self.scroll_step
+
+        # Check whether we need to stop scrolling when:
+        # - we've scrolled all the text off the widget (scroll_clear = True)
+        # - the final pixel is visible (scroll_clear = False)
+        if (self.scroll_clear and self._scroll_offset > self.layout.width) or (
+            not self.scroll_clear
+            and (self.layout.width - self._scroll_offset)
+            < (self._scroll_width - 2 * self.actual_padding)
+        ):
+            self._is_scrolling = False
+
+        # We've reached the end of the scroll so what next?
+        if not self._is_scrolling:
+            if self.scroll_repeat:
+                # Pause and restart scrolling
+                self._scroll_timer = self.timeout_add(self.scroll_delay, self.reset_scroll)
+            elif self.scroll_hide:
+                # Clear the text
+                self._scroll_timer = self.timeout_add(self.scroll_delay, self.hide_scroll)
+            # If neither of these options then the text is no longer updated.
+
+        self.draw()
+
+    def reset_scroll(self):
+        self._scroll_offset = 0
+        self._is_scrolling = True
+        self._scroll_queued = False
+        if self._scroll_timer:
+            self._scroll_timer.cancel()
+        self.draw()
+
+    def hide_scroll(self):
+        self.update("")
 
     def cmd_set_font(self, font=UNSPECIFIED, fontsize=UNSPECIFIED, fontshadow=UNSPECIFIED):
         """
@@ -560,8 +675,8 @@ class InLoopPollText(_TextBox):
         ),
     ]  # type: list[tuple[str, Any, str]]
 
-    def __init__(self, default_text="N/A", width=bar.CALCULATED, **config):
-        _TextBox.__init__(self, default_text, width, **config)
+    def __init__(self, default_text="N/A", **config):
+        _TextBox.__init__(self, default_text, **config)
         self.add_defaults(InLoopPollText.defaults)
 
     def timer_setup(self):
@@ -616,7 +731,7 @@ class ThreadPoolText(_TextBox):
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text, **config):
-        super().__init__(text, width=bar.CALCULATED, **config)
+        super().__init__(text, **config)
         self.add_defaults(ThreadPoolText.defaults)
 
     def timer_setup(self):

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -34,7 +34,7 @@ import itertools
 from functools import partial
 from typing import Any
 
-from libqtile import bar, hook
+from libqtile import hook
 from libqtile.widget import base
 
 
@@ -45,7 +45,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
-        base._TextBox.__init__(self, width=bar.CALCULATED, **config)
+        base._TextBox.__init__(self, **config)
         self.add_defaults(_GroupBase.defaults)
         self.add_defaults(base.PaddingMixin.defaults)
         self.add_defaults(base.MarginMixin.defaults)

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -21,12 +21,25 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
+import asyncio
+from typing import TYPE_CHECKING
+
+from dbus_next import Message, Variant
 from dbus_next.constants import MessageType
 
 from libqtile.log_utils import logger
-from libqtile.utils import add_signal_receiver
+from libqtile.utils import _send_dbus_message, add_signal_receiver
 from libqtile.widget import base
+
+if TYPE_CHECKING:
+    from typing import Any
+
+MPRIS_PATH = "/org/mpris/MediaPlayer2"
+MPRIS_OBJECT = "org.mpris.MediaPlayer2"
+MPRIS_PLAYER = "org.mpris.MediaPlayer2.Player"
+PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 
 class Mpris2(base._TextBox):
@@ -35,6 +48,9 @@ class Mpris2(base._TextBox):
     A widget which displays the current track/artist of your favorite MPRIS
     player. This widget scrolls the text if neccessary and information that
     is displayed is configurable.
+
+    Basic mouse controls are also available: button 1 = play/pause,
+    scroll up = next track, scroll down = previous track.
 
     Widget requirements: dbus-next_.
 
@@ -45,11 +61,12 @@ class Mpris2(base._TextBox):
         ("name", "audacious", "Name of the MPRIS widget."),
         (
             "objname",
-            "org.mpris.MediaPlayer2.audacious",
+            None,
             "DBUS MPRIS 2 compatible player identifier"
             "- Find it out with dbus-monitor - "
             "Also see: http://specifications.freedesktop.org/"
-            "mpris-spec/latest/#Bus-Name-Policy",
+            "mpris-spec/latest/#Bus-Name-Policy. "
+            "``None`` will listen for notifications from all MPRIS2 compatible players.",
         ),
         (
             "display_metadata",
@@ -58,22 +75,64 @@ class Mpris2(base._TextBox):
             "See http://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#index5h3 "
             "for available values",
         ),
-        ("scroll_chars", 30, "How many chars at once to display."),
-        ("scroll_interval", 0.5, "Scroll delay interval."),
-        ("scroll_wait_intervals", 8, "Wait x scroll_interval before" "scrolling/removing text"),
-        ("stop_pause_text", None, "Optional text to display when in the stopped/paused state"),
+        ("scroll", True, "Whether text should scroll."),
+        ("playing_text", "{track}", "Text to show when playing"),
+        ("paused_text", "Paused: {track}", "Text to show when paused"),
+        ("stopped_text", "", "Text to show when stopped"),
+        (
+            "stop_pause_text",
+            None,
+            "(Deprecated) Optional text to display when in the stopped/paused state",
+        ),
+        (
+            "no_metadata_text",
+            "No metadata for current track",
+            "Text to show when track has no metadata",
+        ),
     ]
 
     def __init__(self, **config):
         base._TextBox.__init__(self, "", **config)
         self.add_defaults(Mpris2.defaults)
-
-        self.scrolltext = None
-        self.displaytext = ""
         self.is_playing = False
-        self.scroll_timer = None
-        self.scroll_counter = None
         self.count = 0
+        self.displaytext = ""
+        self.track_info = ""
+        self.status = "{track}"
+        self.add_callbacks(
+            {
+                "Button1": self.cmd_play_pause,
+                "Button4": self.cmd_next,
+                "Button5": self.cmd_previous,
+            }
+        )
+        paused = ""
+        stopped = ""
+        if "stop_pause_text" in config:
+            logger.warning(
+                "The use of 'stop_pause_text' is deprecated. Please use 'paused_text' and 'stopped_text' instead."
+            )
+            if "paused_text" not in config:
+                paused = self.stop_pause_text
+
+            if "stopped_text" not in config:
+                stopped = self.stop_pause_text
+
+        self.prefixes = {
+            "Playing": self.playing_text,
+            "Paused": paused or self.paused_text,
+            "Stopped": stopped or self.stopped_text,
+        }
+
+        self._current_player: str | None = None
+        self.player_names: dict[str, str] = {}
+
+    @property
+    def player(self) -> str:
+        if self._current_player is None:
+            return "None"
+        else:
+            return self.player_names.get(self._current_player, "Unknown")
 
     async def _config_async(self):
         subscribe = await add_signal_receiver(
@@ -86,97 +145,148 @@ class Mpris2(base._TextBox):
         )
 
         if not subscribe:
-            logger.warning("Unable to add signal receiver for %s.", self.objname)
+            logger.warning("Unable to add signal receiver for Mpris2 players")
 
     def message(self, message):
         if message.message_type != MessageType.SIGNAL:
             return
 
-        self.update(*message.body)
+        asyncio.create_task(self.process_message(message))
 
-    def update(self, interface_name, changed_properties, _invalidated_properties):
+    async def process_message(self, message):
+        current_player = message.sender
+
+        if current_player not in self.player_names:
+            self.player_names[current_player] = await self.get_player_name(current_player)
+
+        self._current_player = current_player
+
+        self.parse_message(*message.body)
+
+    async def get_player_name(self, player):
+        bus, message = await _send_dbus_message(
+            True,
+            MessageType.METHOD_CALL,
+            player,
+            PROPERTIES_INTERFACE,
+            MPRIS_PATH,
+            "Get",
+            "ss",
+            [MPRIS_OBJECT, "Identity"],
+        )
+
+        if bus:
+            bus.disconnect()
+
+        if message.message_type != MessageType.METHOD_RETURN:
+            logger.warning("Could not retrieve identity of player on %s.", player)
+            return ""
+
+        return message.body[0].value
+
+    def parse_message(
+        self,
+        _interface_name: str,
+        changed_properties: dict[str, Any],
+        _invalidated_properties: list[str],
+    ) -> None:
         """
         http://specifications.freedesktop.org/mpris-spec/latest/Track_List_Interface.html#Mapping:Metadata_Map
         """
         if not self.configured:
-            return True
-        olddisplaytext = self.displaytext
+            return
+
+        if "Metadata" not in changed_properties and "PlaybackStatus" not in changed_properties:
+            return
+
         self.displaytext = ""
 
         metadata = changed_properties.get("Metadata")
         if metadata:
-            metadata = metadata.value
-            self.is_playing = True
-
-            meta_list = []
-            for key in self.display_metadata:
-                val = getattr(metadata.get(key), "value", None)
-                if isinstance(val, str):
-                    meta_list.append(val)
-                elif isinstance(val, list):
-                    val = " - ".join((y for y in val if isinstance(y, str)))
-                    meta_list.append(val)
-
-            self.displaytext = " - ".join(meta_list)
-            self.displaytext.replace("\n", "")
+            self.track_info = self.get_track_info(metadata.value)
 
         playbackstatus = getattr(changed_properties.get("PlaybackStatus"), "value", None)
-        if playbackstatus == "Paused":
-            if self.stop_pause_text is not None:
-                self.is_playing = False
-                self.displaytext = self.stop_pause_text
-            elif self.displaytext:
-                self.is_playing = False
-                self.displaytext = "Paused: {}".format(self.displaytext)
-            else:
-                self.is_playing = False
-                self.displaytext = "Paused"
-        elif playbackstatus == "Playing":
-            if not self.displaytext and olddisplaytext:
-                self.is_playing = True
-                self.displaytext = olddisplaytext.replace("Paused: ", "")
-            elif not self.displaytext and not olddisplaytext:
-                self.is_playing = True
-                self.displaytext = "No metadata for current track"
-            elif self.displaytext:
-                # Players might send more than one "Playing" message.
-                pass
-        elif playbackstatus:
-            self.is_playing = False
-            self.displaytext = ""
+        if playbackstatus:
+            self.is_playing = playbackstatus == "Playing"
+            self.status = self.prefixes.get(playbackstatus, "{track}")
 
-        if self.scroll_chars and self.scroll_interval:
-            if self.scroll_timer:
-                self.scroll_timer.cancel()
-            self.scrolltext = self.displaytext
-            self.scroll_counter = self.scroll_wait_intervals
-            self.scroll_timer = self.timeout_add(self.scroll_interval, self.scroll_text)
-            return
+        if not self.track_info:
+            self.track_info = self.no_metadata_text
+
+        self.displaytext = self.status.format(track=self.track_info)
+
         if self.text != self.displaytext:
-            self.text = self.displaytext
-            self.bar.draw()
+            self.update(self.displaytext)
 
-    def scroll_text(self):
-        if self.text != self.scrolltext[: self.scroll_chars]:
-            self.text = self.scrolltext[: self.scroll_chars]
-            self.bar.draw()
-        if self.scroll_counter:
-            self.scroll_counter -= 1
-            if self.scroll_counter:
-                self.timeout_add(self.scroll_interval, self.scroll_text)
-                return
-        if len(self.scrolltext) >= self.scroll_chars:
-            self.scrolltext = self.scrolltext[1:]
-            if len(self.scrolltext) == self.scroll_chars:
-                self.scroll_counter += self.scroll_wait_intervals
-            self.timeout_add(self.scroll_interval, self.scroll_text)
+    def get_track_info(self, metadata: dict[str, Variant]) -> str:
+        meta_list = []
+        for key in self.display_metadata:
+            val = getattr(metadata.get(key), "value", None)
+            if isinstance(val, str):
+                meta_list.append(val)
+            elif isinstance(val, list):
+                val = " - ".join((y for y in val if isinstance(y, str)))
+                meta_list.append(val)
+
+        text = " - ".join(meta_list)
+        text.replace("\n", "")
+
+        return text
+
+    def cmd_info(self) -> dict[str, Any]:
+        info = base._TextBox.info(self)
+        info["isplaying"] = self.is_playing
+        info["player"] = self.player
+
+        return info
+
+    def _player_cmd(self, cmd: str) -> None:
+        if self._current_player is None:
             return
-        self.text = ""
-        self.bar.draw()
 
-    def cmd_info(self):
-        """What's the current state of the widget?"""
-        return dict(
-            displaytext=self.displaytext,
-            isplaying=self.is_playing,
+        task = asyncio.create_task(self._send_player_cmd(cmd))
+        task.add_done_callback(self._task_callback)
+
+    async def _send_player_cmd(self, cmd: str) -> Message | None:
+        bus, message = await _send_dbus_message(
+            True,
+            MessageType.METHOD_CALL,
+            self._current_player,
+            MPRIS_PLAYER,
+            MPRIS_PATH,
+            cmd,
+            "",
+            [],
         )
+
+        if bus:
+            bus.disconnect()
+
+        return message
+
+    def _task_callback(self, task: asyncio.Task) -> None:
+        message = task.result()
+
+        # This happens if we can't connect to dbus. Logger call is made
+        # elsewhere so we don't need to do any more here.
+        if message is None:
+            return
+
+        if message.message_type != MessageType.METHOD_RETURN:
+            logger.warning("Unable to send command to player.")
+
+    def cmd_play_pause(self) -> None:
+        """Toggle the playback status."""
+        self._player_cmd("PlayPause")
+
+    def cmd_next(self) -> None:
+        """Play the next track."""
+        self._player_cmd("Next")
+
+    def cmd_previous(self) -> None:
+        """Play the previous track."""
+        self._player_cmd("Previous")
+
+    def cmd_stop(self) -> None:
+        """Stop playback."""
+        self._player_cmd("Stop")

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -40,7 +40,7 @@ import pickle
 import string
 from collections import deque
 
-from libqtile import bar, hook, pangocffi, utils
+from libqtile import hook, pangocffi, utils
 from libqtile.command.base import CommandObject, SelectError
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import CommandError, QtileCommandInterface
@@ -354,7 +354,7 @@ class Prompt(base._TextBox):
     ]
 
     def __init__(self, **config) -> None:
-        base._TextBox.__init__(self, "", bar.CALCULATED, **config)
+        base._TextBox.__init__(self, "", **config)
         self.add_defaults(Prompt.defaults)
         self.active = False
         self.completer = None  # type: AbstractCompleter | None

--- a/libqtile/widget/quick_exit.py
+++ b/libqtile/widget/quick_exit.py
@@ -17,8 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from libqtile import bar
 from libqtile.widget import base
 
 
@@ -35,8 +33,8 @@ class QuickExit(base._TextBox):
         ("countdown_start", 5, "Time to accept the second pushing."),
     ]
 
-    def __init__(self, widget=bar.CALCULATED, **config):
-        base._TextBox.__init__(self, "", widget, **config)
+    def __init__(self, **config):
+        base._TextBox.__init__(self, "", **config)
         self.add_defaults(QuickExit.defaults)
 
         self.is_counting = False

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -81,7 +81,7 @@ class Volume(base._TextBox):
     ]
 
     def __init__(self, **config):
-        base._TextBox.__init__(self, "0", width=bar.CALCULATED, **config)
+        base._TextBox.__init__(self, "0", **config)
         self.add_defaults(Volume.defaults)
         self.surfaces = {}
         self.volume = None

--- a/libqtile/widget/wallpaper.py
+++ b/libqtile/widget/wallpaper.py
@@ -24,7 +24,6 @@ import os
 import random
 import subprocess
 
-from libqtile import bar
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -54,7 +53,7 @@ class Wallpaper(base._TextBox):
     ]
 
     def __init__(self, **config):
-        base._TextBox.__init__(self, "empty", width=bar.CALCULATED, **config)
+        base._TextBox.__init__(self, "empty", **config)
         self.add_defaults(Wallpaper.defaults)
         self.index = 0
         self.images = []

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -52,7 +52,8 @@ class WindowTabs(base._TextBox):
     ]
 
     def __init__(self, **config):
-        base._TextBox.__init__(self, width=bar.STRETCH, **config)
+        width = config.pop("width", bar.STRETCH)
+        base._TextBox.__init__(self, width=width, **config)
         self.add_defaults(WindowTabs.defaults)
         if not isinstance(self.selected, (tuple, list)):
             self.selected = (self.selected, self.selected)

--- a/test/widgets/docs_screenshots/ss_mpris2.py
+++ b/test/widgets/docs_screenshots/ss_mpris2.py
@@ -40,8 +40,7 @@ def widget(monkeypatch, patched_module):  # noqa: F811
 )
 def ss_mpris2(screenshot_manager):
     widget = screenshot_manager.c.widget["mpris2"]
-    widget.eval("self.message(self.PLAYING)")
-    widget.eval("self.scroll_text()")
+    widget.eval("self.parse_message(*self.PLAYING.body)")
     screenshot_manager.take_screenshot()
 
 
@@ -50,6 +49,5 @@ def ss_mpris2(screenshot_manager):
 )
 def ss_mpris2_paused(screenshot_manager):
     widget = screenshot_manager.c.widget["mpris2"]
-    widget.eval("self.message(self.PAUSED)")
-    widget.eval("self.scroll_text()")
+    widget.eval("self.parse_message(*self.PAUSED.body)")
     screenshot_manager.take_screenshot()

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -146,6 +146,12 @@ def test_widget_init_config_vertical_bar(
     assert i["widgets"][0]["name"] == widget.name
 
 
+@pytest.mark.parametrize("widget_class,kwargs", parameters)
+def test_widget_init_config_set_width(widget_class, kwargs):
+    widget = widget_class(width=50)
+    assert widget
+
+
 def test_incompatible_orientation(fake_qtile, fake_window):
     clk1 = Clock()
     clk1.orientations = ORIENTATION_VERTICAL


### PR DESCRIPTION
**Draft for now - testers wanted**

I've implemented scrolling in `_TextBox` widgets and would be keen for people to test.

The gif is a bit jerky (and loops in the wrong place) but you can see we're doing pixel scrolling.
![out](https://user-images.githubusercontent.com/946265/160248478-a9fbb2fd-8166-4333-82d5-24015ec1cb5d.gif)

Scrolling also works on vertical bars.

Things to do:
- [x] Testing (how?)
- [x] Replace scrolling in mpris2 widget with this
- [x] Fix bugs people find

Fixes #3445