### PR TITLE
Add layout screenshots

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,6 +21,9 @@ build:
     - xvfb
     - dbus-x11
     - libnotify-bin
+    - scrot
+    - imagemagick
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -169,8 +169,7 @@ genkeyimg:
 	@echo "Keybinding images have been generated."
 
 genwidgetscreenshots:
-	rm -rf screenshots/widgets
-	@echo "Generating screenshots for widgets using pytest fixtures."
+	@echo "Generating screenshots for widgets and layouts using pytest fixtures."
 	pytest -o python_files="ss_*.py" -o python_functions="ss_*" --backend x11 ../test
 	@echo
-	@echo "Generated widget screenshots"
+	@echo "Generated widget and layout screenshots"

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -317,7 +317,9 @@ class TestManager:
         if not success():
             raise AssertionError("Window could not be killed...")
 
-    def test_window(self, name, floating=False, wm_type="normal", export_sni=False):
+    def test_window(
+        self, name, floating=False, wm_type="normal", export_sni=False, extra_args=None
+    ):
         """
         Create a simple window in X or Wayland. If `floating` is True then the wmclass
         is set to "dialog", which triggers auto-floating based on `default_float_rules`.
@@ -336,6 +338,9 @@ class TestManager:
         args = [python, path, "--name", wmclass, name, wm_type]
         if export_sni:
             args.append("export_sni_interface")
+        if extra_args:
+            args.extend(extra_args)
+
         return self._spawn_window(*args)
 
     def test_notification(self, name="notification"):

--- a/test/layouts/docs_screenshots/conftest.py
+++ b/test/layouts/docs_screenshots/conftest.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import glob
+import json
+import os
+import shutil
+from functools import partial
+from pathlib import Path
+from subprocess import run
+from types import MethodType
+
+import pytest
+
+from libqtile.config import Screen
+from test.helpers import BareConfig
+
+
+@pytest.fixture(scope="session")
+def target():
+    folder = Path(__file__).parent / "screenshots"
+    docs_folder = (
+        Path(__file__).parent
+        / ".."
+        / ".."
+        / ".."
+        / "docs"
+        / "_static"
+        / "screenshots"
+        / "layouts"
+    )
+    log = os.path.join(docs_folder, "shots.json")
+    if folder.is_dir():
+        shutil.rmtree(folder)
+    folder.mkdir()
+    key = {}
+
+    class LayoutAnimator:
+        def __init__(self, name, config):
+            self.temp_frames = list()
+            self.layout_name = name
+            self.config = config
+
+            # Define the target folder and check it exists
+            self.shots_dir = os.path.join(folder, self.layout_name)
+            if not os.path.isdir(self.shots_dir):
+                os.mkdir(self.shots_dir)
+
+            self.widcards = os.path.join(self.shots_dir, "shot_*.png")
+
+            self.index = 0
+
+        def get_temp_file_name(self):
+            """Returns a path for the screenshot."""
+            self.index += 1
+            return os.path.join(self.shots_dir, f"shot_{self.index}.png")
+
+        def animate(self):
+            """Converts all the frames into an animated gif and removes frames."""
+            nonlocal key
+
+            # Convert config into a string of key=value
+            entry = ", ".join(f"{k}={repr(v)}" for k, v in self.config.items())
+
+            # Check if widget is in the key dict
+            if self.layout_name not in key:
+                key[self.layout_name] = {}
+
+            # Increment the index number
+            indexes = [int(x) for x in key[self.layout_name]]
+            index = max(indexes) + 1 if indexes else 1
+
+            output = os.path.join(self.shots_dir, f"{index}.gif")
+
+            run(["convert", "-delay", "75", self.widcards, "-resize", "300x225", output])
+
+            # Delete frames
+            for f in glob.glob(self.widcards):
+                os.remove(f)
+
+            # Record the config
+            key[self.layout_name][index] = entry
+
+    yield LayoutAnimator
+
+    # We copy the screenshots from the test folder to the docs folder at the end
+    # This prevents pytest deleting the files itself
+
+    # Remove old screenshots
+    if os.path.isdir(docs_folder):
+        shutil.rmtree(docs_folder)
+
+    # Copy to the docs folder
+    shutil.copytree(folder, docs_folder)
+    with open(log, "w") as f:
+        json.dump(key, f)
+
+    # Clear up the tests folder
+    shutil.rmtree(folder)
+
+
+@pytest.fixture
+def screenshot_manager(layout, request, manager_nospawn, target):
+    """
+    Create a manager instance for the screenshots. Individual "tests" should only call
+    `screenshot_manager.take_screenshot()`. At the end of the test, the screenshots will
+    be combined into a single animated gif.
+
+    Layouts should create their own `layout` fixture in the relevant file. Configs can then
+    be passed by parametrizing "screenshot_manager".
+    """
+    # Partials can be used to hide some aspects of the config from being displayed in the
+    # docs. We need to split these out into their constituent parts.
+    if type(layout) is partial:
+        layout_class = layout.func
+        layout_config = layout.keywords
+    else:
+        layout_class = layout
+        layout_config = {}
+
+    # Get the layout config from the parameterisation
+    config = getattr(request, "param", dict())
+
+    # We need to embed the screenshot call in a CommandObject
+    # Calling directly from manager_nospawns captures the mouse pointer
+    # Adding the command to the layout causes issues with Slice as commands
+    # are rooted to the fallback layout
+    class ShootScreen(Screen):
+        def cmd_take_screenshot(self, filepath):
+            run(["scrot", "-o", filepath])
+
+    # Define a config containing our layout
+    class ScreenShotConfig(BareConfig):
+        layouts = [layout_class(**{**layout_config, **config})]
+        screens = [ShootScreen()]
+
+    # Define a new method to spawn a window with an incremental index number displayed
+    def add_window(self):
+        self.test_window(
+            str(self._window_index), extra_args=["layout_screenshot", str(self._window_index)]
+        )
+        self._window_index += 1
+
+    # Attach the new method to the manager instance
+    manager_nospawn._window_index = 1
+    manager_nospawn.add_window = MethodType(add_window, manager_nospawn)
+
+    # Start the manager
+    manager_nospawn.start(ScreenShotConfig)
+
+    # Create the animator object
+    animator = target(ScreenShotConfig.layouts[0].name, config)
+
+    # Define function to take a screenshot of the layout
+    def take_screenshot(self):
+        self.c.screen.take_screenshot(animator.get_temp_file_name())
+
+    # Attach it to the manager
+    manager_nospawn.take_screenshot = MethodType(take_screenshot, manager_nospawn)
+
+    yield manager_nospawn
+
+    # Take one more screenshot so we get a longer pause at the end of the loop
+    manager_nospawn.take_screenshot()
+
+    # Convert the frames into an animated gif
+    animator.animate()

--- a/test/layouts/docs_screenshots/ss_bsp.py
+++ b/test/layouts/docs_screenshots/ss_bsp.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Bsp
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"margin": 10},
+    ],
+    indirect=True,
+)
+def ss_bsp(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_columns.py
+++ b/test/layouts/docs_screenshots/ss_columns.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Columns
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"insert_position": 1},
+        {"num_columns": 3},
+        {"margin": 10},
+    ],
+    indirect=True,
+)
+def ss_columns(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_floating.py
+++ b/test/layouts/docs_screenshots/ss_floating.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from time import sleep
+
+import pytest
+
+import libqtile.layout
+
+# We need a shor delay after resizing windows to allow the display to render the window
+# correctly
+REFRESH_DELAY = 0.1
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Floating
+
+
+def ss_floating(screenshot_manager):
+    def _wnd(name):
+        return screenshot_manager.c.window[
+            {w["name"]: w["id"] for w in screenshot_manager.c.windows()}[name]
+        ]
+
+    screenshot_manager.add_window()
+    screenshot_manager.c.window.set_size_floating(400, 300)
+    screenshot_manager.c.window.set_position_floating(100, 100)
+    sleep(REFRESH_DELAY)
+    screenshot_manager.take_screenshot()
+
+    screenshot_manager.add_window()
+    screenshot_manager.c.window.set_size_floating(400, 300)
+    screenshot_manager.c.window.set_position_floating(300, 200)
+    sleep(REFRESH_DELAY)
+    screenshot_manager.take_screenshot()
+
+    screenshot_manager.add_window()
+    screenshot_manager.c.window.set_size_floating(300, 200)
+    screenshot_manager.c.window.set_position_floating(200, 250)
+    sleep(REFRESH_DELAY)
+    screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_matrix.py
+++ b/test/layouts/docs_screenshots/ss_matrix.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Matrix
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"columns": 3},
+        {"margin": 10},
+    ],
+    indirect=True,
+)
+def ss_matrix(screenshot_manager):
+    for _ in range(6):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_max.py
+++ b/test/layouts/docs_screenshots/ss_max.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Max
+
+
+def ss_max(screenshot_manager):
+    for _ in range(3):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_monad.py
+++ b/test/layouts/docs_screenshots/ss_monad.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        libqtile.layout.MonadTall,
+        libqtile.layout.MonadWide,
+        libqtile.layout.MonadThreeCol,
+    ],
+)
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"new_client_position": "bottom"},
+        {"margin": 10},
+    ],
+    indirect=True,
+)
+def ss_monad(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_ratiotile.py
+++ b/test/layouts/docs_screenshots/ss_ratiotile.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.RatioTile
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"ratio": 0.5},
+        {"margin": 10},
+    ],
+    indirect=True,
+)
+def ss_ratiotile(screenshot_manager):
+    for _ in range(6):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_slice.py
+++ b/test/layouts/docs_screenshots/ss_slice.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+from libqtile.config import Match
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Slice
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"match": Match(title="2"), "width": 400},
+        {"match": Match(title="2"), "width": 400, "fallback": libqtile.layout.Bsp()},
+    ],
+    indirect=True,
+)
+def ss_slice(screenshot_manager):
+    for _ in range(4):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_spiral.py
+++ b/test/layouts/docs_screenshots/ss_spiral.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Spiral
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"new_client_position": "bottom"},
+        {"ratio": 0.5, "main_pane": "top"},
+        {"ratio": 0.5, "margin": 10, "clockwise": False},
+    ],
+    indirect=True,
+)
+def ss_spiral(screenshot_manager):
+    for _ in range(6):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_stack.py
+++ b/test/layouts/docs_screenshots/ss_stack.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Stack
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [{}, {"fair": True}, {"autosplit": True}, {"num_stacks": 3}],
+    indirect=True,
+)
+def ss_stack(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_tile.py
+++ b/test/layouts/docs_screenshots/ss_tile.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+from libqtile.config import Match
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Tile
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+        {"master_match": [Match(title="2"), Match(title="4")]},
+        {"master_match": [Match(title="2"), Match(title="4")], "master_length": 2},
+    ],
+    indirect=True,
+)
+def ss_tile(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_treetab.py
+++ b/test/layouts/docs_screenshots/ss_treetab.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.TreeTab
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [{}, {"place_right": True}],
+    indirect=True,
+)
+def ss_treetab(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_verticaltile.py
+++ b/test/layouts/docs_screenshots/ss_verticaltile.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from time import sleep
+
+import pytest
+
+import libqtile.layout
+
+# We need a shor delay after resizing windows to allow the display to render the window
+# correctly
+REFRESH_DELAY = 0.1
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.VerticalTile
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+    ],
+    indirect=True,
+)
+def ss_verticaltile(screenshot_manager):
+    screenshot_manager.add_window()
+    screenshot_manager.take_screenshot()
+    screenshot_manager.add_window()
+    screenshot_manager.take_screenshot()
+    screenshot_manager.c.layout.maximize()
+    sleep(REFRESH_DELAY)
+    screenshot_manager.take_screenshot()
+    screenshot_manager.add_window()
+    screenshot_manager.take_screenshot()

--- a/test/layouts/docs_screenshots/ss_zoomy.py
+++ b/test/layouts/docs_screenshots/ss_zoomy.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+import libqtile.layout
+
+
+@pytest.fixture
+def layout():
+    yield libqtile.layout.Zoomy
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [
+        {},
+    ],
+    indirect=True,
+)
+def ss_zoomy(screenshot_manager):
+    for _ in range(5):
+        screenshot_manager.add_window()
+        screenshot_manager.take_screenshot()

--- a/test/scripts/window.py
+++ b/test/scripts/window.py
@@ -120,6 +120,15 @@ if __name__ == "__main__":
     # Check if we want to export a StatusNotifierItem interface
     sni = "export_sni_interface" in sys.argv
 
+    win_number = 0
+
+    if "layout_screenshot" in sys.argv:
+        try:
+            win_number = int(sys.argv[sys.argv.index("layout_screenshot") + 1])
+        except ValueError:
+            print("PASSED")
+            pass
+
     win = Gtk.Window(title=title)
     win.connect("destroy", Gtk.main_quit)
     win.connect("key-press-event", Gtk.main_quit)
@@ -163,6 +172,33 @@ if __name__ == "__main__":
                 body=[bus.unique_name],
             )
         )
+
+    # This is to make the windows more beautiful for our layout screenshots
+    if win_number:
+
+        # Gtk windows are styled with CSS
+        style = Gtk.CssProvider()
+        style.load_from_data(
+            b"""
+        /* ReadTheDocs blue! */
+        .rtd {
+            background-color: #2980b9;
+            color: #ffffff;
+            font-size: 100px;
+            font-style: italic;
+        }
+        """
+        )
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(), style, Gtk.STYLE_PROVIDER_PRIORITY_USER
+        )
+
+        # Create a label with the window number and style it
+        label = Gtk.Label(label=f"{win_number}")
+        label.get_style_context().add_class("rtd")
+
+        # Place the label (fills the window)
+        win.add(label)
 
     win.show_all()
     Gtk.main()


### PR DESCRIPTION
Similar to the widget screenshots, this PR adds (animated) screenshots for our layouts. It also adds a very simple framework for generating more screenshots for new layouts and configuration examples.

Draft for now as there are some bugs that need ironing out (and I need to see if it builds on ReadTheDocs!).

Here's an example of the `MonadThreeCol` layout:
![3](https://user-images.githubusercontent.com/946265/160669781-d1809a27-aaa0-4db1-917e-875d1440405c.gif)

There's also #1423 which was merged but we never really used.

This PR (currently) focuses on the layouts rather than the impacts of their associated commands.

Would it be useful to include animations showing the impact of commands (maybe displaying the command on the screen)? I'm conscious that we could end up with too many images which is probably not ideal.