### PR TITLE
Reset colours in Chord widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message
           included in the logs.
         - Reduce error messages in `StatusNotifier` widget from certain apps.
+        - Reset colours in `Chord` widget
 
 Qtile 0.21.0, released 2022-03-23:
     * features

--- a/libqtile/widget/chord.py
+++ b/libqtile/widget/chord.py
@@ -29,7 +29,13 @@ class Chord(base._TextBox):
     """Display current key chord"""
 
     defaults = [
-        ("chords_colors", {}, "colors per chord in form of tuple ('bg', 'fg')."),
+        (
+            "chords_colors",
+            {},
+            "colors per chord in form of tuple {'chord_name': ('bg', 'fg')}. "
+            "Where a chord name is not in the dictionary, the default ``background`` and ``foreground``"
+            " values will be used.",
+        ),
         (
             "name_transform",
             lambda txt: txt,
@@ -43,6 +49,8 @@ class Chord(base._TextBox):
 
     def _configure(self, qtile, bar):
         base._TextBox._configure(self, qtile, bar)
+        self.default_background = self.background
+        self.default_foreground = self.foreground
         self.text = ""
         self._setup_hooks()
 
@@ -50,17 +58,25 @@ class Chord(base._TextBox):
         def hook_enter_chord(chord_name):
             if chord_name is True:
                 self.text = ""
+                self.reset_colours()
                 return
 
             self.text = self.name_transform(chord_name)
             if chord_name in self.chords_colors:
                 (self.background, self.foreground) = self.chords_colors.get(chord_name)
+            else:
+                self.reset_colours()
 
             self.bar.draw()
 
         hook.subscribe.enter_chord(hook_enter_chord)
         hook.subscribe.leave_chord(self.clear)
 
+    def reset_colours(self):
+        self.background = self.default_background
+        self.foreground = self.default_foreground
+
     def clear(self, *args):
+        self.reset_colours()
         self.text = ""
         self.bar.draw()

--- a/test/widgets/test_chord.py
+++ b/test/widgets/test_chord.py
@@ -1,5 +1,6 @@
 from libqtile import hook
 from libqtile.widget import Chord, base
+from test.widgets.conftest import FakeBar
 
 RED = "#FF0000"
 BLUE = "#00FF00"
@@ -9,19 +10,45 @@ BASE_BACKGROUND = textbox.background
 BASE_FOREGROUND = textbox.foreground
 
 
-def test_chord_widget(fake_bar):
+def test_chord_widget(fake_window, fake_qtile):
     chord = Chord(chords_colors={"testcolor": (RED, BLUE)})
-    chord.bar = fake_bar
-    chord._setup_hooks()
+    fakebar = FakeBar([chord], window=fake_window)
+    chord._configure(fake_qtile, fakebar)
+
+    # Text is blank at start
     assert chord.text == ""
+
+    # Fire hook for testcolor chord
+    hook.fire("enter_chord", "testcolor")
+
+    # Chord is in chords_colors so check colours
+    assert chord.background == RED
+    assert chord.foreground == BLUE
+    assert chord.text == "testcolor"
+
+    # New chord, not in dictionary so should be default colours
     hook.fire("enter_chord", "test")
     assert chord.text == "test"
     assert chord.background == BASE_BACKGROUND
     assert chord.foreground == BASE_FOREGROUND
+
+    # Unnamed chord so no text
     hook.fire("enter_chord", True)
     assert chord.text == ""
-    hook.fire("leave_chord")
-    assert chord.text == ""
+    assert chord.background == BASE_BACKGROUND
+    assert chord.foreground == BASE_FOREGROUND
+
+    # Back into testcolor and custom colours
     hook.fire("enter_chord", "testcolor")
     assert chord.background == RED
     assert chord.foreground == BLUE
+    assert chord.text == "testcolor"
+
+    # Colours shoud reset when leaving chord
+    hook.fire("leave_chord")
+    assert chord.text == ""
+    assert chord.background == BASE_BACKGROUND
+    assert chord.foreground == BASE_FOREGROUND
+
+    # Finalize the widget to prevent segfault
+    chord.finalize()


### PR DESCRIPTION
Chord widget sets colours based on entry in `chord_colors` dict. If the chord is not in the dict then the colours are not changed. This can lead to undesirable location if the widget needs to occupy a fixed space in the bar but have a default colour when not showing a chord name.

This PR resets the chord's background and foreground colours when a chord is left or when a chord is not in the `chord_colors` dict.

Fixes #3461