### PR TITLE
Delete .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-source = libqtile
-
-[report]
-omit =
-    libqtile/interactive/*
-    libqtile/scripts/*
-    libqtile/ffi_build.py


### PR DESCRIPTION
We're using `coveralls` now so we can lose this.