### PR TITLE
Release `Drag` events when clicking on Bar

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1134,6 +1134,8 @@ class Internal(_Window, base.Internal):
 
     def handle_ButtonRelease(self, e):  # noqa: N802
         self.process_button_release(e.event_x, e.event_y, e.detail)
+        # return True to ensure Core also processes the release
+        return True
 
     def handle_EnterNotify(self, e):  # noqa: N802
         self.process_pointer_enter(e.event_x, e.event_y)


### PR DESCRIPTION
If a user clicks on the bar when pressing a mod key and has a matching `Drag` event in their config then the `qtile._drag` value is set with the bar's position.

While the `_drag` value is set, windows will not be added to a group as this would prevent dragging windows. However, when clicking on the bar, the button_release event is swallowed by the bar and never passed back to the server so the `_drag` value is never unset.

This causes undesirable behaviour where new windows are not added to the current group until the release event is triggered on the server.

This PR fixes the issue by making `Bar.process_button_release` call `qtile.process_button_release`.

Fixes #3144


I'll be honest, I'm not 100% certain why this is needed i.e. why is the `button_release` event being swallowed by the bar but the `button_click` event isn't?