### PR TITLE
Fix `has_keyboard` AttributeError

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -179,6 +179,7 @@ class Bar(Gap, configurable.Configurable):
         self.window = None
         self.size_calculated = 0
         self._configured = False
+        self.has_keyboard: _Widget | None = None
 
         if isinstance(self.margin, int):
             self.margin = [self.margin] * 4


### PR DESCRIPTION
`Bar` has no default value for `has_keyboard` so, if `Bar.process_key_press` is called, an AttributeError may be raised.

This PR adds a default value which should prevent this error.