### PR TITLE
Battery widget show as full when `Not charging`

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -190,6 +190,12 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             None,
             "Name of file with the current power draw in /sys/class/power_supply/battery_name",
         ),
+        (
+            "full_not_charging",
+            False,
+            "Some batteries report their status as 'Not charging' when full, rather than 'Full'. "
+            "If the widget reports an unknown state when full, try changing this to 'True'.",
+        ),
     ]
 
     filenames = {}  # type: dict
@@ -269,7 +275,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
     def update_status(self) -> BatteryStatus:
         stat = self._get_param("status_file")[0]
 
-        if stat == "Full":
+        if stat == "Full" or (self.full_not_charging and stat == "Not charging"):
             state = BatteryState.FULL
         elif stat == "Charging":
             state = BatteryState.CHARGING
@@ -331,6 +337,12 @@ class Battery(base.ThreadPoolText):
         ("battery", 0, "Which battery should be monitored (battery number or name)"),
         ("notify_below", None, "Send a notification below this battery level."),
         ("notification_timeout", 10, "Time in seconds to display notification. 0 for no expiry."),
+        (
+            "full_not_charging",
+            False,
+            "Some batteries report their status as 'Not charging' when full, rather than 'Full'. "
+            "If the widget reports an unknown state when full, try changing this to 'True'.",
+        ),
     ]
 
     def __init__(self, **config) -> None:


### PR DESCRIPTION
As per #3411, some batteries report their state as `Not charging` when they are full. The widget doesn't recognise this and shows the battery being in an "unknown" state.

While the issue can be solved by using the `unknown_char` parameter, that's undesirable in case a different, unknown state were to arise.

This PR adds a config parameter `full_not_charging` which, when set, will mark the battery as full when the state is `Not charging`.

Fixes #3411


The obvious alternative is to not have a parameter and just check for either wording but I wasn't sure if the `Not charging` status might arise at other times on systems where a full battery is reported as 'Full'.


I'd also like the poster in #3411 to check this (hence draft for now).