### PR TITLE
2 fixes for `LaunchBar`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           included in the logs.
         - Reduce error messages in `StatusNotifier` widget from certain apps.
         - Reset colours in `Chord` widget
+        - Prevent crash in `LaunchBar` when using SVG icons
 
 Qtile 0.21.0, released 2022-03-23:
     * features

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Wayland: primary clipboard should now behave same way as with X after selecting something it
           should be copied into clipboard
         - Add `resume` hook when computer resumes from sleep/suspend/hibernate.
+        - Add `text_only` option for `LaunchBar` widget.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -154,20 +154,20 @@ class LaunchBar(base._Widget):
                 continue
             else:
                 try:
-                    img = cairocffi.ImageSurface.create_from_png(iconfile)
+                    img = Img.from_path(iconfile)
                 except cairocffi.Error:
                     logger.exception(
                         'Error loading icon for application "%s" (%s)', img_name, iconfile
                     )
                     return
 
-            input_width = img.get_width()
-            input_height = img.get_height()
+            input_width = img.width
+            input_height = img.height
 
             sp = input_height / (self.bar.height - 4)
             width = int(input_width / sp)
 
-            imgpat = cairocffi.SurfacePattern(img)
+            imgpat = cairocffi.SurfacePattern(img.surface)
             scaler = cairocffi.Matrix()
             scaler.scale(sp, sp)
             scaler.translate(self.padding * -1, -2)

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -83,6 +83,7 @@ class LaunchBar(base._Widget):
             " [('thunderbird', 'thunderbird -safe-mode', 'launch thunderbird in safe mode'), "
             " ('logout', 'qshell:self.qtile.cmd_shutdown()', 'logout from qtile')]",
         ),
+        ("text_only", False, "Don't use any icons."),
     ]
 
     def __init__(
@@ -128,12 +129,14 @@ class LaunchBar(base._Widget):
     def setup_images(self):
         """Create image structures for each icon files."""
         for img_name, iconfile in self.icons_files.items():
-            if iconfile is None:
-                logger.warning(
-                    'No icon found for application "%s" (%s) switch to text mode',
-                    img_name,
-                    iconfile,
-                )
+            if iconfile is None or self.text_only:
+                # Only warn the user that there's no icon if they haven't set text only mode
+                if not self.text_only:
+                    logger.warning(
+                        'No icon found for application "%s" (%s) switch to text mode',
+                        img_name,
+                        iconfile,
+                    )
                 # if no icon is found and no default icon was set, we just
                 # print the name, based on a textbox.
                 textbox = base._TextBox()


### PR DESCRIPTION
1 - handle SVG icons

The `LaunchBar` widget currently expects icons to be in PNG format and crashes when a SVG icon is used.

This PR fixes the issue by using `libqtile.images.Img` to generate the surface used for icons.

Fixes #3476


2 - add `text_only` option

Adds a new `text_only` option to force text display even when icons are available.