### PR TITLE
Removed hardcoded formatting in the Net widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
       - `Window.getsize` has been renamed `Window.get_size` (i.e. merged with the get_size command).
       - `Window.getposition` has been renamed `Window.get_position` (i.e. merged with the get_position command).
       - The `StockTicker` widget `function` option is being deprecated: rename it to `func`.
+      - The formatting of `NetWidget` has changed, if you use the `format` parameter in your config include 
+        `up_suffix`, `total_suffix` and `down_suffix` to display the respective units.
     * features
         - Add ability to set icon size in `LaunchBar` widget.
         - Add 'warp_pointer' option to `Drag` that when set will warp the pointer to the bottom right of
@@ -31,6 +33,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to spawn the `WidgetBox` widget opened.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
+        - Made the `NetWidget` text formattable.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -41,7 +41,7 @@ class Net(base.ThreadPoolText):
     defaults = [
         (
             "format",
-            "{interface}: {down} \u2193\u2191 {up}",
+            "{interface}: {down:6.2f}{down_suffix:<2}\u2193\u2191{up:6.2f}{up_suffix:<2}",
             "Display format of down/upload/total speed of given interfaces",
         ),
         (
@@ -123,15 +123,6 @@ class Net(base.ThreadPoolText):
                 }
             return interfaces
 
-    def _format(self, down, down_letter, up, up_letter, total, total_letter):
-        max_len_down = 7 - len(down_letter)
-        max_len_up = 7 - len(up_letter)
-        max_len_total = 7 - len(total_letter)
-        down = "{val:{max_len}.2f}".format(val=down, max_len=max_len_down)
-        up = "{val:{max_len}.2f}".format(val=up, max_len=max_len_up)
-        total = "{val:{max_len}.2f}".format(val=total, max_len=max_len_total)
-        return down[:max_len_down], up[:max_len_up], total[:max_len_total]
-
     def poll(self):
         ret_stat = []
         try:
@@ -144,21 +135,19 @@ class Net(base.ThreadPoolText):
                 down = down / self.update_interval
                 up = up / self.update_interval
                 total = total / self.update_interval
-                down, down_letter = self.convert_b(down)
-                up, up_letter = self.convert_b(up)
-                total, total_letter = self.convert_b(total)
-                down, up, total = self._format(
-                    down, down_letter, up, up_letter, total, total_letter
-                )
+                down, down_suffix = self.convert_b(down)
+                up, up_suffix = self.convert_b(up)
+                total, total_suffix = self.convert_b(total)
                 self.stats[intf] = new_stats[intf]
                 ret_stat.append(
                     self.format.format(
-                        **{
-                            "interface": intf,
-                            "down": down + down_letter,
-                            "up": up + up_letter,
-                            "total": total + total_letter,
-                        }
+                        interface=intf,
+                        down=down,
+                        down_suffix=down_suffix,
+                        up=up,
+                        up_suffix=up_suffix,
+                        total=total,
+                        total_suffix=total_suffix,
                     )
                 )
 

--- a/test/widgets/docs_screenshots/ss_net.py
+++ b/test/widgets/docs_screenshots/ss_net.py
@@ -39,6 +39,10 @@ def widget(monkeypatch):
     [
         {},
         {"format": "{interface}: U {up} D {down} T {total}"},
+        {
+            "format": "{interface}: U {up}{up_suffix} D {down}{down_suffix} T {total}{total_suffix}"
+        },
+        {"format": "{down:.0f}{down_suffix} \u2193\u2191 {up:.0f}{up_suffix}"},
         {"interface": "wlp58s0"},
         {"prefix": "M"},
     ],

--- a/test/widgets/test_net.py
+++ b/test/widgets/test_net.py
@@ -61,7 +61,10 @@ def patch_net(fake_qtile, monkeypatch, fake_window):
 
         # Reload fixes cases where psutil may have been imported previously
         reload(net)
-        widget = net.Net(format="{interface}: U {up} D {down} T {total}", **kwargs)
+        widget = net.Net(
+            format="{interface}: U {up}{up_suffix} D {down}{down_suffix} T {total}{total_suffix}",
+            **kwargs
+        )
         fakebar = FakeBar([widget], window=fake_window)
         widget._configure(fake_qtile, fakebar)
 
@@ -73,21 +76,19 @@ def patch_net(fake_qtile, monkeypatch, fake_window):
 def test_net_defaults(patch_net):
     """Default: widget shows `all` interfaces"""
     net1 = patch_net()
-    assert net1.poll() == "all: U 40.00kB D  1.20MB T  1.24MB"
+    assert net1.poll() == "all: U 40.0kB D 1.2MB T 1.24MB"
 
 
 def test_net_single_interface(patch_net):
     """Display single named interface"""
     net2 = patch_net(interface="wlp58s0")
-    assert net2.poll() == "wlp58s0: U 40.00kB D  1.20MB T  1.24MB"
+    assert net2.poll() == "wlp58s0: U 40.0kB D 1.2MB T 1.24MB"
 
 
 def test_net_list_interface(patch_net):
     """Display multiple named interfaces"""
     net2 = patch_net(interface=["wlp58s0", "lo"])
-    assert (
-        net2.poll() == "wlp58s0: U 40.00kB D  1.20MB T  1.24MB lo: U 40.00kB D  1.20MB T  1.24MB"
-    )
+    assert net2.poll() == "wlp58s0: U 40.0kB D 1.2MB T 1.24MB lo: U 40.0kB D 1.2MB T 1.24MB"
 
 
 def test_net_invalid_interface(patch_net):
@@ -99,7 +100,7 @@ def test_net_invalid_interface(patch_net):
 def test_net_use_bits(patch_net):
     """Display all interfaces in bits rather than bytes"""
     net4 = patch_net(use_bits=True)
-    assert net4.poll() == "all: U 320.0kb D  9.60Mb T  9.92Mb"
+    assert net4.poll() == "all: U 320.0kb D 9.6Mb T 9.92Mb"
 
 
 def test_net_convert_zero_b(patch_net):
@@ -111,7 +112,7 @@ def test_net_convert_zero_b(patch_net):
 def test_net_use_prefix(patch_net):
     """Tests `prefix` configurable option"""
     net6 = patch_net(prefix="M")
-    assert net6.poll() == "all: U  0.04MB D  1.20MB T  1.24MB"
+    assert net6.poll() == "all: U 0.04MB D 1.2MB T 1.24MB"
 
 
 # Untested: 128-129 - generic exception catching


### PR DESCRIPTION
Fix for  #3486
        The formatting for the speeds in the Net widget is hard coded.
        This PR fixes that.
        `down`, which was previously a string (eg:'123B'), is split into
        `down` and `down_suffix` (same for `up`).