### PR TITLE
Make ffibuild script more user friendly

### DIFF
--- a/scripts/ffibuild
+++ b/scripts/ffibuild
@@ -1,9 +1,68 @@
-#!/bin/sh
-echo "building pango"
-python3 ./libqtile/pango_ffi_build.py
-echo "building xcursors"
-python3 ./libqtile/backend/x11/xcursors_ffi_build.py
-echo "building pulseaudio volume control"
-python3 ./libqtile/widget/pulseaudio_ffi.py
-echo "building Wayland libinput interface"
-python3 ./libqtile/backend/wayland/libinput_ffi_build.py
+#!/usr/bin/env python3
+"""
+Build script for libqtile's CFFI helpers.
+"""
+
+from __future__ import annotations
+
+import sys
+from subprocess import run
+from typing import NamedTuple
+
+
+class Builder(NamedTuple):
+    """
+    A build script. If 'features' is None, this script is required.
+    """
+
+    name: str
+    path: str
+    features: str | None
+
+
+scripts = [
+    Builder("Pango interface", "./libqtile/pango_ffi_build.py", None),
+    Builder(
+        "xcursors",
+        "./libqtile/backend/x11/xcursors_ffi_build.py",
+        "X11 backend",
+    ),
+    Builder("PulseAudio interface", "./libqtile/widget/pulseaudio_ffi.py", "PulseVolume widget"),
+    Builder(
+        "Wayland libinput interface",
+        "./libqtile/backend/wayland/libinput_ffi_build.py",
+        "Wayland backend input configurability",
+    ),
+]
+
+
+def build(builder: Builder, verbose: bool) -> bool:
+    print("Building", builder.name)
+
+    p = run(["python3", builder.path], capture_output=True)
+
+    if p.returncode:
+        print("    Failed!")
+        if builder.features:
+            print("    This is optional and is needed for:", builder.features)
+        else:
+            print("    This component is required.")
+
+        if verbose:
+            print(p.stderr.decode())
+
+        return True
+
+    return False
+
+
+if __name__ == "__main__":
+    verbose = "-v" in sys.argv
+    errors = False
+
+    for builder in scripts:
+        errors |= build(builder, verbose)
+
+    if errors and not verbose:
+        print("\nFailures for optional components can be ignored.")
+        print("Pass -v to print full stack traces.")


### PR DESCRIPTION
This build script outputs lots of errors if build fails, but some errors
can safely be ignored if dependants are not needed. This commit captures
the output and prints more useful messages in the case of errors.

see https://github.com/qtile/qtile/issues/3491

--

If a build script fails, this is the default output:
```
Building Pango interface
    Failed!
    This component is required.
Building xcursors
Building PulseAudio interface
Building Wayland libinput interface

Failures for optional components can be ignored.
Pass -v to print full stack traces.
```

Upon passing `-v`, this becomes:
```
Building Pango interface
    Failed!
    This component is required.
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 336, in _parse
    ast = _get_parser().parse(fullcsource)
  File "/usr/lib/python3.10/site-packages/pycparser/c_parser.py", line 147, in parse
    return self.cparser.parse(
  File "/usr/lib/python3.10/site-packages/pycparser/ply/yacc.py", line 331, in parse
    return self.parseopt_notrack(input, lexer, debug, tracking, tokenfunc)
  File "/usr/lib/python3.10/site-packages/pycparser/ply/yacc.py", line 1199, in parseopt_notrack
    tok = call_errorfunc(self.errorfunc, errtoken, self)
  File "/usr/lib/python3.10/site-packages/pycparser/ply/yacc.py", line 193, in call_errorfunc
    r = errorfunc(token)
  File "/usr/lib/python3.10/site-packages/pycparser/c_parser.py", line 1936, in p_error
    self._parse_error('At end of input', self.clex.filename)
  File "/usr/lib/python3.10/site-packages/pycparser/plyparser.py", line 67, in _parse_error
    raise ParseError("%s: %s" % (coord, msg))
pycparser.plyparser.ParseError: <cdef source string>: At end of input

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mcol/git/qtile/./libqtile/pango_ffi_build.py", line 32, in <module>
    pango_ffi.cdef(
  File "/usr/lib/python3.10/site-packages/cffi/api.py", line 112, in cdef
    self._cdef(csource, override=override, packed=packed, pack=pack)
  File "/usr/lib/python3.10/site-packages/cffi/api.py", line 126, in _cdef
    self._parser.parse(csource, override=override, **options)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 389, in parse
    self._internal_parse(csource)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 394, in _internal_parse
    ast, macros, csource = self._parse(csource)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 338, in _parse
    self.convert_pycparser_error(e, csource)
  File "/usr/lib/python3.10/site-packages/cffi/cparser.py", line 367, in convert_pycparser_error
    raise CDefError(msg)
cffi.CDefError: parse error
<cdef source string>: At end of input

Building xcursors
Building PulseAudio interface
Building Wayland libinput interface
```

Some failures are for optional components:
```
Building Pango interface
Building xcursors
Building PulseAudio interface
Building Wayland libinput interface
    Failed!
    This is optional and is needed for: Wayland backend input configurability

Failures for optional components can be ignored.
Pass -v to print full stack traces.
```

Upon success:
```
Building Pango interface
Building xcursors
Building PulseAudio interface
Building Wayland libinput interface
```