### PR TITLE
WL: restack xwayland clients to top of Z axis upon activation

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -775,6 +775,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         elif surface.is_xwayland_surface and isinstance(win.surface, xwayland.Surface):
             win.surface.activate(True)
+            win.surface.restack(None, 0)  # XCB_STACK_MODE_ABOVE
             win.ftm_handle.set_activated(True)
 
         if enter and self.seat.keyboard._ptr:  # This pointer is NULL when headless

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.15.7,<0.16.0
+  pywlroots>=0.15.12,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install cairocffi
-    pip install pywlroots>=0.15.7,<0.16.0
+    pip install pywlroots>=0.15.12,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -93,7 +93,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.15.7,<0.16.0
+    pip install pywlroots>=0.15.12,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     pip install .


### PR DESCRIPTION
This Z axis management is 'below' the Qtile level, and pertains to how
they are seen from the POV of XWayland. While we may not have XWayland
clients mapped at the same time, the XWayland considers them to be, so
an unmapped window can actually obscure a mapped one and soak up the
input.

This requires the next release of pywlroots.

Fixes #3280