### PR TITLE
WL: Don't use unknown variable when finding output for xdg_popup

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1698,9 +1698,13 @@ class XdgPopupWindow(HasListeners):
             box = xdg_popup.base.get_geometry()
             lx, ly = self.core.output_layout.closest_point(parent.x + box.x, parent.y + box.y)
             wlr_output = self.core.output_layout.output_at(lx, ly)
-            assert wlr_output and isinstance(wlr_output.data, Output)
-            self.output = wlr_output.data
-            box = Box(*self.output.get_geometry())
+            if wlr_output and wlr_output.data:
+                output = wlr_output.data
+            else:
+                logger.warning("Failed to find output at for xdg_popup. Please report.")
+                output = self.core.outputs[0]
+            self.output = output
+            box = Box(*output.get_geometry())
             box.x = round(box.x - lx)
             box.y = round(box.y - ly)
             self.output_box = box


### PR DESCRIPTION
The `Output` variable here is not imported at runtime, so a NameError is
always raised at this assertion. This wasn't caught because at testtime
it is loaded. Gah.

As of yet, backend exceptions are not caught and logged. This should be
fixed so that any exceptions raised in the wayland backend internal code
can be identified. That'll come later.