### PR TITLE
WL: set default XWayland cursor image to left_ptr

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
           (which were ignored previously), remove them.
     * features
         - Add ability to draw borders and add margins to the `Max` layout.
+        - The default XWayland cursor is now set at startup to left_ptr, so an xsetroot call is not needed to
+          avoid the ugly X cursor.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -489,6 +489,20 @@ class Core(base.Core, wlrq.HasListeners):
         self._xwayland.set_seat(self.seat)
         self.xwayland_atoms: dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
 
+        # Set the default XWayland cursor
+        xcursor = self.cursor_manager.get_xcursor("left_ptr")
+        if xcursor:
+            image = next(xcursor.images, None)
+            if image:
+                self._xwayland.set_cursor(
+                    image._ptr.buffer,
+                    image._ptr.width * 4,
+                    image._ptr.width,
+                    image._ptr.height,
+                    image._ptr.hotspot_x,
+                    image._ptr.hotspot_y,
+                )
+
     def _on_xwayland_new_surface(self, _listener: Listener, surface: xwayland.Surface) -> None:
         logger.debug("Signal: xwayland new_surface")
         assert self.qtile is not None

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywlroots>=0.15.12,<0.16.0
+  pywlroots>=0.15.13,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install cairocffi
-    pip install pywlroots>=0.15.12,<0.16.0
+    pip install pywlroots>=0.15.13,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -93,7 +93,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
-    pip install pywlroots>=0.15.12,<0.16.0
+    pip install pywlroots>=0.15.13,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     pip install .


### PR DESCRIPTION
This is equivalent to running `xsetroot -cursor_name left_ptr` at
startup. The X11 backend does this via
`self._root.set_cursor("left_ptr")`. Here we set it too, otherwise the
default cursor that appears when the pointer is above XWayland clients
is an ugly cross.