### PR TITLE
A bunch of improvements to logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
     !!! Config breakage !!!
         - lazy.qtile.display_kb() no longer receives any arguments. If you passed it any arguments
           (which were ignored previously), remove them.
+        - If you have a custom startup Python script that you use instead of `qtile start` and run init_log
+          manually, the signature has changed. Please check the source for the updated arguments.
     * features
         - Add ability to draw borders and add margins to the `Max` layout.
         - The default XWayland cursor is now set at startup to left_ptr, so an xsetroot call is not needed to

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -117,7 +117,7 @@ class Core(base.Core, wlrq.HasListeners):
         ) = wlroots_helper.build_compositor(self.display)
         self.socket = self.display.add_socket()
         os.environ["WAYLAND_DISPLAY"] = self.socket.decode()
-        logger.info("Starting core with WAYLAND_DISPLAY=" + self.socket.decode())
+        logger.info("Starting core with WAYLAND_DISPLAY=%s", self.socket.decode())
 
         # These windows have not been mapped yet; they'll get managed when mapped
         self.pending_windows: set[window.WindowType] = set()
@@ -209,7 +209,7 @@ class Core(base.Core, wlrq.HasListeners):
         self._xwayland = xwayland.XWayland(self.display, self.compositor, True)
         if self._xwayland:
             os.environ["DISPLAY"] = self._xwayland.display_name or ""
-            logger.info("Set up XWayland with DISPLAY=" + os.environ["DISPLAY"])
+            logger.info("Set up XWayland with DISPLAY=%s", os.environ["DISPLAY"])
             self.add_listener(self._xwayland.ready_event, self._on_xwayland_ready)
             self.add_listener(self._xwayland.new_surface_event, self._on_xwayland_new_surface)
         else:
@@ -277,7 +277,7 @@ class Core(base.Core, wlrq.HasListeners):
             capabilities |= WlSeat.capability.keyboard
         self.seat.set_capabilities(capabilities)
 
-        logger.info(f"New {device.device_type.name}: {device.name}")
+        logger.info("New %s: %s", device.device_type.name, device.name)
         if self.qtile:
             inputs.configure_device(device, self.qtile.config.wl_input_rules)
         else:
@@ -481,7 +481,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         wid = self.new_wid()
         win = window.LayerStatic(self, self.qtile, layer_surface, wid)
-        logger.info(f"Managing new layer_shell window with window ID: {wid}")
+        logger.info("Managing new layer_shell window with window ID: %s", wid)
         self.qtile.manage(win)
 
     def _on_new_toplevel_decoration(
@@ -996,5 +996,5 @@ class Core(base.Core, wlrq.HasListeners):
         """Change virtual terminal to that specified"""
         success = self.backend.get_session().change_vt(vt)
         if not success:
-            logger.warning(f"Could not change VT to: {vt}")
+            logger.warning("Could not change VT to: %s", vt)
         return success

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -241,7 +241,7 @@ def _configure_pointer(device: InputDevice, conf: InputConfig, name: str) -> Non
     """Applies ``InputConfig`` rules to a pointer device"""
     handle = device.libinput_get_device_handle()
     if handle is None:
-        logger.debug(f"Device not handled by libinput: {name}")
+        logger.debug("Device not handled by libinput: %s", name)
         return
 
     if libinput is None:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -657,7 +657,7 @@ class XdgWindow(Window[XdgSurface]):
         if self in self.core.pending_windows:
             self.core.pending_windows.remove(self)
             self._wid = self.core.new_wid()
-            logger.debug(f"Managing new top-level window with window ID: {self.wid}")
+            logger.debug("Managing new top-level window with window ID: %s", self._wid)
 
             # Save the client's desired geometry
             surface = self.surface
@@ -895,7 +895,7 @@ class XWindow(Window[xwayland.Surface]):
         if self in self.core.pending_windows:
             self.core.pending_windows.remove(self)
             self._wid = self.core.new_wid()
-            logger.debug(f"Managing new XWayland window with window ID: {self.wid}")
+            logger.debug("Managing new XWayland window with window ID: %s", self._wid)
 
             # Make it static if it isn't a regular window
             if self.surface.override_redirect:

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -114,7 +114,7 @@ class Painter:
             with open(image_path, "rb") as f:
                 image, _ = cairocffi.pixbuf.decode_to_image_surface(f.read())
         except IOError as e:
-            logger.error("Wallpaper: %s" % e)
+            logger.error("Wallpaper: %s", e)
             return
 
         surface = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, screen.width, screen.height)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -100,7 +100,7 @@ class Core(base.Core):
                 "_NET_WM_NAME", "UTF8_STRING", unpack=str
             )
             if existing_wmname:
-                logger.error("not starting; existing window manager {}".format(existing_wmname))
+                logger.error("not starting; existing window manager %s", existing_wmname)
                 raise ExistingWMException(existing_wmname)
 
         self.eventmask = (
@@ -298,7 +298,7 @@ class Core(base.Core):
                     event_type = event_type[:-5]
 
                 targets = self._get_target_chain(event_type, event)
-                logger.debug(f"X11 event: {event_type} (targets: {len(targets)})")
+                logger.debug("X11 event: %s (targets: %s)", event_type, targets)
                 for target in targets:
                     ret = target(event)
                     if not ret:
@@ -325,9 +325,9 @@ class Core(base.Core):
                 if error_code:
                     error_string = xcbq.XCB_CONN_ERRORS[error_code]
                     logger.exception(
-                        "Shutting down due to X connection error {error_string} ({error_code})".format(
-                            error_string=error_string, error_code=error_code
-                        )
+                        "Shutting down due to X connection error %s (%s)",
+                        error_string,
+                        error_code,
                     )
                     self.remove_listener()
                     self.qtile.stop()
@@ -455,7 +455,7 @@ class Core(base.Core):
 
         for code in codes:
             if code == 0:
-                logger.warning(f"Can't grab {key} (unknown keysym: {hex(keysym)})")
+                logger.warning("Can't grab %s (unknown keysym: %02x)", key, keysym)
                 continue
             for amask in self._auto_modmasks():
                 self.conn.conn.core.GrabKey(
@@ -602,7 +602,7 @@ class Core(base.Core):
             try:
                 self.qtile.groups[index].cmd_toscreen()
             except IndexError:
-                logger.debug("Invalid desktop index: %s" % index)
+                logger.debug("Invalid desktop index: %s", index)
 
     def handle_KeyPress(self, event) -> None:  # noqa: N802
         assert self.qtile is not None

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1711,7 +1711,7 @@ class Window(_Window, base.Window):
                     logger.debug("Ignoring focus request")
                 else:
                     logger.debug(
-                        "Invalid value for focus_on_window_activation: {}".format(focus_behavior)
+                        "Invalid value for focus_on_window_activation: %s", focus_behavior
                     )
         elif atoms["_NET_CLOSE_WINDOW"] == opcode:
             self.kill()

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -336,8 +336,9 @@ class Screen(_Wrapper):
             return desired_depth, self._visuals[desired_depth]
 
         logger.info(
-            f"{desired_depth} bit colour depth not available. "
-            f"Falling back to root depth: {self.root_depth}."
+            "%s bit colour depth not available. Falling back to root depth: %s.",
+            desired_depth,
+            self.root_depth,
         )
         return self.root_depth, self._visuals[self.root_depth]
 
@@ -351,7 +352,7 @@ class Screen(_Wrapper):
         """
         allowed = screen.allowed_depths
         if depth not in [x.depth for x in allowed]:
-            logger.warning(f"Unsupported colour depth: {depth}.")
+            logger.warning("Unsupported colour depth: %s", depth)
             return
 
         for i in allowed:
@@ -694,7 +695,7 @@ class Painter:
             with open(image_path, "rb") as f:
                 image, _ = cairocffi.pixbuf.decode_to_image_surface(f.read())
         except IOError as e:
-            logger.error("Wallpaper: %s" % e)
+            logger.error("Wallpaper: %s", e)
             return
 
         # Querying the screen dimensions via the xcffib connection does not

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -331,8 +331,9 @@ class Bar(Gap, configurable.Configurable):
 
         if widget.supported_backends and (self.qtile.core.name not in widget.supported_backends):
             logger.warning(
-                f"Widget removed: {widget.__class__.__name__} does not support "
-                f"{self.qtile.core.name}."
+                "Widget removed: %s does not support %s.",
+                widget.__class__.__name__,
+                self.qtile.core,
             )
             self.crashed_widgets.append(widget)
             return False
@@ -348,8 +349,7 @@ class Bar(Gap, configurable.Configurable):
             widget.configured = True
         except Exception as e:
             logger.error(
-                "{} widget crashed during _configure with "
-                "error: {}".format(widget.__class__.__name__, repr(e))
+                "%s widget crashed during _configure with error: %s", widget.__class__.__name__, e
             )
             self.crashed_widgets.append(widget)
             configured = False

--- a/libqtile/command_client.py
+++ b/libqtile/command_client.py
@@ -2,5 +2,5 @@ from libqtile.command.client import *  # noqa
 from libqtile.log_utils import logger
 
 logger.warning(
-    "libqtile.command_client is deprecated. " "It has been moved to libqtile.command.client"
+    "libqtile.command_client is deprecated. It has been moved to libqtile.command.client"
 )

--- a/libqtile/command_graph.py
+++ b/libqtile/command_graph.py
@@ -2,5 +2,5 @@ from libqtile.command.graph import *  # noqa
 from libqtile.log_utils import logger
 
 logger.warning(
-    "libqtile.command_graph is deprecated. " "It has been moved to libqtile.command.graph"
+    "libqtile.command_graph is deprecated. It has been moved to libqtile.command.graph"
 )

--- a/libqtile/command_interface.py
+++ b/libqtile/command_interface.py
@@ -2,5 +2,5 @@ from libqtile.command.interface import *  # noqa
 from libqtile.log_utils import logger
 
 logger.warning(
-    "libqtile.command_interface is deprecated. " "It has been moved to libqtile.command.interface"
+    "libqtile.command_interface is deprecated. It has been moved to libqtile.command.interface"
 )

--- a/libqtile/command_object.py
+++ b/libqtile/command_object.py
@@ -2,5 +2,5 @@ from libqtile.command.base import *  # noqa
 from libqtile.log_utils import logger
 
 logger.warning(
-    "libqtile.command_object is deprecated. " "It has been moved to libqtile.command.base."
+    "libqtile.command_object is deprecated. It has been moved to libqtile.command.base."
 )

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -62,7 +62,7 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
             if not isinstance(exc, asyncio.CancelledError):
                 logger.exception(exc)
         else:
-            logger.error(f'unhandled error in event loop: {context["msg"]}')
+            logger.error("unhandled error in event loop: %s", context["msg"])
 
 
 class QtileEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -258,7 +258,7 @@ class Qtile(CommandObject):
         try:
             self.config.load()
         except Exception as error:
-            logger.error("Configuration error: {}".format(error))
+            logger.error("Configuration error: %s", error)
             send_notification("Configuration error", str(error))
             return
 
@@ -331,7 +331,7 @@ class Qtile(CommandObject):
             if len(self.groups) < i + 1:
                 name = f"autogen_{i + 1}"
                 self.add_group(name)
-                logger.warning(f"Too few groups in config. Added group: {name}")
+                logger.warning("Too few groups in config. Added group: %s", name)
 
             if i < len(current_groups):
                 grp = current_groups[i]
@@ -376,9 +376,7 @@ class Qtile(CommandObject):
     def process_key_event(self, keysym: int, mask: int) -> None:
         key = self.keys_map.get((keysym, mask), None)
         if key is None:
-            logger.debug(
-                "Ignoring unknown keysym: {keysym}, mask: {mask}".format(keysym=keysym, mask=mask)
-            )
+            logger.debug("Ignoring unknown keysym: %s, mask: %s", keysym, mask)
             return
 
         if isinstance(key, KeyChord):
@@ -390,7 +388,7 @@ class Qtile(CommandObject):
                         (cmd.selectors, cmd.name, cmd.args, cmd.kwargs)
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
-                        logger.error("KB command error %s: %s" % (cmd.name, val))
+                        logger.error("KB command error %s: %s", cmd.name, val)
             if self.chord_stack and (self.chord_stack[-1].mode == "" or key.key == "Escape"):
                 self.cmd_ungrab_chord()
             return
@@ -462,7 +460,7 @@ class Qtile(CommandObject):
         try:
             button.modmask = self.core.grab_button(button)
         except utils.QtileError:
-            logger.warning(f"Unknown modifier(s): {button.modifiers}")
+            logger.warning("Unknown modifier(s): %s", button.modifiers)
             return
         if button.button_code not in self.mouse_map:
             self.mouse_map[button.button_code] = []
@@ -713,14 +711,14 @@ class Qtile(CommandObject):
                     if i.check(self):
                         status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs))
                         if status in (interface.ERROR, interface.EXCEPTION):
-                            logger.error("Mouse command error %s: %s" % (i.name, val))
+                            logger.error("Mouse command error %s: %s", i.name, val)
                         handled = True
             elif isinstance(m, Drag):
                 if m.start:
                     i = m.start
                     status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs))
                     if status in (interface.ERROR, interface.EXCEPTION):
-                        logger.error("Mouse command error %s: %s" % (i.name, val))
+                        logger.error("Mouse command error %s: %s", i.name, val)
                         continue
                 else:
                     val = (0, 0)
@@ -752,7 +750,7 @@ class Qtile(CommandObject):
                         (i.selectors, i.name, i.args + (rx + dx, ry + dy), i.kwargs)
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
-                        logger.error("Mouse command error %s: %s" % (i.name, val))
+                        logger.error("Mouse command error %s: %s", i.name, val)
 
     def warp_to_screen(self) -> None:
         if self.current_screen:
@@ -1113,7 +1111,7 @@ class Qtile(CommandObject):
         try:
             self.config.load()
         except Exception as error:
-            logger.error("Preventing restart because of a configuration error: {}".format(error))
+            logger.error("Preventing restart because of a configuration error: %s", error)
             send_notification("Configuration error", str(error))
             return
         self.restart()
@@ -1141,7 +1139,7 @@ class Qtile(CommandObject):
             args = ["/bin/sh", "-c", cmd]
 
         if shutil.which(to_lookup) is None:
-            logger.error("couldn't find `{}`".format(to_lookup))
+            logger.error("couldn't find `%s`", to_lookup)
             return -1
 
         r, w = os.pipe()
@@ -1301,7 +1299,7 @@ class Qtile(CommandObject):
         """
         mb = self.widgets_map.get(widget)
         if not mb:
-            logger.error("No widget named '{0:s}' present.".format(widget))
+            logger.error("No widget named '%s' present.", widget)
             return
 
         mb.start_input(prompt, self.find_window, "window", strict_completer=True)
@@ -1336,7 +1334,7 @@ class Qtile(CommandObject):
 
         mb = self.widgets_map.get(widget)
         if not mb:
-            logger.error("No widget named '{0:s}' present.".format(widget))
+            logger.error("No widget named '%s' present.", widget)
             return
 
         mb.start_input(prompt, self.move_to_group, "group", strict_completer=True)
@@ -1357,11 +1355,11 @@ class Qtile(CommandObject):
                 try:
                     self.groups_map[group].cmd_toscreen()
                 except KeyError:
-                    logger.warning("No group named '{0:s}' present.".format(group))
+                    logger.warning("No group named '%s' present.", group)
 
         mb = self.widgets_map.get(widget)
         if not mb:
-            logger.error("No widget named '{0:s}' present.".format(widget))
+            logger.error("No widget named '%s' present.", widget)
             return
 
         mb.start_input(prompt, f, "group", strict_completer=True)
@@ -1384,7 +1382,7 @@ class Qtile(CommandObject):
             mb = self.widgets_map[widget]
             mb.start_input(prompt, f, allow_empty_input=True)
         except KeyError:
-            logger.error("No widget named '{0:s}' present.".format(widget))
+            logger.error("No widget named '%s' present.", widget)
 
     def cmd_spawncmd(
         self,
@@ -1424,7 +1422,7 @@ class Qtile(CommandObject):
             mb = self.widgets_map[widget]
             mb.start_input(prompt, f, complete)
         except KeyError:
-            logger.error("No widget named '{0:s}' present.".format(widget))
+            logger.error("No widget named '%s' present.", widget)
 
     def cmd_qtilecmd(
         self,
@@ -1475,7 +1473,7 @@ class Qtile(CommandObject):
 
         mb = self.widgets_map[widget]
         if not mb:
-            logger.error("No widget named {0:s} present.".format(widget))
+            logger.error("No widget named %s present.", widget)
             return
         mb.start_input(prompt, f, "qshell")
 
@@ -1539,7 +1537,7 @@ class Qtile(CommandObject):
                 bar.show(not bar.is_show())
                 self.current_group.layout_all()
             else:
-                logger.warning("Not found bar in position '%s' for hide/show." % position)
+                logger.warning("Not found bar in position '%s' for hide/show.", position)
         elif position == "all":
             screen = self.current_screen
             is_show = None
@@ -1553,15 +1551,14 @@ class Qtile(CommandObject):
             else:
                 logger.warning("Not found bar for hide/show.")
         else:
-            logger.warning("Invalid position value:{0:s}".format(position))
+            logger.warning("Invalid position value:%s", position)
 
     def cmd_get_state(self) -> str:
         """Get pickled state for restarting qtile"""
         buf = io.BytesIO()
         self.dump_state(buf)
         state = buf.getvalue().decode(errors="backslashreplace")
-        logger.debug("State = ")
-        logger.debug("".join(state.split("\n")))
+        logger.debug("State = %s", state)
         return state
 
     def cmd_tracemalloc_toggle(self) -> None:

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -248,5 +248,5 @@ class DGroups:
                 self.sort_groups()
             del self.timeout[client]
 
-        logger.debug(f"Deleting {group} in {self.delay}s")
+        logger.debug("Deleting %s in %ss", group, self.delay)
         self.timeout[client] = self.qtile.call_later(self.delay, delete_client)

--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -64,7 +64,7 @@ class _Extension(configurable.Configurable):
 
             if not isinstance(col, str) or not RGB.match(col):
                 logger.warning(
-                    f"Invalid extension '{c}' color: {col}. " f"Must be #RGB or #RRGGBB string."
+                    "Invalid extension '%s' color: %s. Must be #RGB or #RRGGBB string.", c, col
                 )
                 setattr(self, c, None)
                 continue

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -125,7 +125,7 @@ class _Group(CommandObject):
                 hook.fire("layout_change", self.layouts[self.current_layout], self)
                 self.layout_all()
                 return
-        logger.error("No such layout: {}".format(layout))
+        logger.error("No such layout: %s", layout)
 
     def use_layout(self, index):
         assert -len(self.layouts) <= index < len(self.layouts), "layout index out of bounds"

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -123,7 +123,9 @@ class Spiral(_SimpleLayoutBase):
         self.initial_main_pane_ratio = self.main_pane_ratio
         self.main_pane = self.main_pane.lower()
         if self.main_pane not in ["top", "left", "bottom", "right"]:
-            logger.warning(f"Unknown main_pane location: {self.main_pane}. Defaulting to 'left'.")
+            logger.warning(
+                "Unknown main_pane location: %s. Defaulting to 'left'.", self.main_pane
+            )
             self.main_pane = "left"
 
         # Calculate the order of transformations required based on position of main pane
@@ -349,11 +351,13 @@ class Spiral(_SimpleLayoutBase):
             try:
                 value = float(value)
             except ValueError:
-                logger.error(f"Invalid ratio value: {value}")
+                logger.error("Invalid ratio value: %s", value)
                 return
 
         if not (0 <= value <= 1):
-            logger.warning(f"Invalid value for {prop}: {value}. Value must be between 0 and 1.")
+            logger.warning(
+                "Invalid value for %s: %s. Value must be between 0 and 1.", prop, value
+            )
             return
 
         setattr(self, prop, value)

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -75,7 +75,7 @@ def init_log(
     log_path=True,
     log_size=10000000,
     log_numbackups=1,
-    log_color=True,
+    log_color=False,
 ):
     for handler in logger.handlers:
         logger.removeHandler(handler)

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -96,6 +96,7 @@ def init_log(
     log_path: Path | None = None,
     log_size: int = 10000000,
     log_numbackups: int = 1,
+    logger=logger,
 ) -> None:
     for handler in logger.handlers:
         logger.removeHandler(handler)

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -33,7 +33,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 if typing.TYPE_CHECKING:
-    from logging import LogRecord
+    from logging import Logger, LogRecord
 
 logger = getLogger(__package__)
 
@@ -96,7 +96,7 @@ def init_log(
     log_path: Path | None = None,
     log_size: int = 10000000,
     log_numbackups: int = 1,
-    logger=logger,
+    logger: Logger = logger,
 ) -> None:
     for handler in logger.handlers:
         logger.removeHandler(handler)

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -73,7 +73,6 @@ class ColorFormatter(Formatter):
 def init_log(
     log_level=WARNING,
     log_path=True,
-    log_truncate=False,
     log_size=10000000,
     log_numbackups=1,
     log_color=True,
@@ -113,9 +112,6 @@ def init_log(
         except TypeError:  # Happens if log_path doesn't contain formatters.
             pass
         log_path = os.path.expanduser(log_path)
-        if log_truncate:
-            with open(log_path, "w"):
-                pass
         file_handler = RotatingFileHandler(
             log_path, maxBytes=log_size, backupCount=log_numbackups
         )

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2013-2014 Tao Sauvage
 # Copyright (c) 2014 Sean Vig
 # Copyright (c) 2014 roger
+# Copyright (c) 2022 Matt Colligan
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +22,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import os
 import sys
+import typing
 import warnings
 from logging import WARNING, Formatter, StreamHandler, captureWarnings, getLogger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    from logging import LogRecord
 
 logger = getLogger(__package__)
 
@@ -53,7 +60,7 @@ class ColorFormatter(Formatter):
     color_seq = "\033[%dm"
     bold_seq = "\033[1m"
 
-    def format(self, record):
+    def format(self, record: LogRecord) -> str:
         """Format the record with colors."""
         color = self.color_seq % (30 + self.colors[record.levelname])
         message = Formatter.format(self, record)
@@ -85,10 +92,10 @@ def get_default_log() -> Path:
 
 
 def init_log(
-    log_level=WARNING,
+    log_level: int = WARNING,
     log_path: Path | None = None,
-    log_size=10000000,
-    log_numbackups=1,
+    log_size: int = 10000000,
+    log_numbackups: int = 1,
 ) -> None:
     for handler in logger.handlers:
         logger.removeHandler(handler)
@@ -96,7 +103,7 @@ def init_log(
     if log_path is None or os.getenv("QTILE_XEPHYR"):
         # During tests or interactive xephyr development, log to stdout.
         handler = StreamHandler(sys.stdout)
-        formatter = ColorFormatter(
+        formatter: Formatter = ColorFormatter(
             "$RESET$COLOR%(asctime)s $BOLD$COLOR%(name)s "
             "%(filename)s:%(funcName)s():L%(lineno)d $RESET %(message)s"
         )

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -180,7 +180,7 @@ if has_dbus:
             reply = await self.bus.release_name(BUS_NAME)
 
             if reply != ReleaseNameReply.RELEASED:
-                logger.error(f"Could not release {BUS_NAME}.")
+                logger.error("Could not release %s", BUS_NAME)
                 return
 
             self._service = None
@@ -215,7 +215,7 @@ else:
     class FakeManager:
         def __init__(self):
             logger.warning(
-                "dbus-next is not installed. " "Notification service and widget are unavailable."
+                "dbus-next is not installed. Notification service and widget are unavailable."
             )
 
         async def register(self, *args, **kwargs):

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from libqtile.log_utils import init_log
+from libqtile.log_utils import get_default_log, init_log
 from libqtile.scripts import check, cmd_obj, migrate, run_cmd, shell, start, top
 
 try:
@@ -62,7 +62,7 @@ def main():
     options = main_parser.parse_args()
     try:
         log_level = getattr(logging, options.log_level)
-        init_log(log_level=log_level, log_color=sys.stdout.isatty())
+        init_log(log_level, log_path=get_default_log())
         options.func(options)
     except AttributeError:
         main_parser.print_usage()

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -274,7 +274,7 @@ async def _notify(
     )
 
     if msg and msg.message_type == MessageType.ERROR:
-        logger.warning("Unable to send notification. " "Is a notification server running?")
+        logger.warning("Unable to send notification. Is a notification server running?")
 
     # a new bus connection is made each time a notification is sent so
     # we disconnect when the notification is done
@@ -312,11 +312,11 @@ def guess_terminal(preference: str | Sequence | None = None) -> str | None:
     ]
 
     for terminal in test_terminals:
-        logger.debug("Guessing terminal: {}".format(terminal))
+        logger.debug("Guessing terminal: %s", terminal)
         if not which(terminal, os.X_OK):
             continue
 
-        logger.info("Terminal found: {}".format(terminal))
+        logger.info("Terminal found: %s", terminal)
         return terminal
 
     logger.error("Default terminal has not been found.")
@@ -399,7 +399,7 @@ async def add_signal_receiver(
     Returns True if subscription is successful.
     """
     if not has_dbus:
-        logger.warning("dbus-next is not installed. " "Unable to subscribe to signals")
+        logger.warning("dbus-next is not installed. Unable to subscribe to signals")
         return False
 
     match_args = {

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -119,7 +119,7 @@ class Backlight(base.InLoopPollText):
             with open(path, "r") as f:
                 return float(f.read().strip())
         except FileNotFoundError:
-            logger.debug("Failed to get %s" % path)
+            logger.debug("Failed to get %s", path)
             raise RuntimeError("Unable to read status for {}".format(os.path.basename(path)))
 
     def _get_info(self):
@@ -143,9 +143,7 @@ class Backlight(base.InLoopPollText):
                     f.write(str(round(value)))
             except PermissionError:
                 logger.warning(
-                    "Cannot set brightness: no write permission for {0}".format(
-                        self.brightness_file
-                    )
+                    "Cannot set brightness: no write permission for %s", self.brightness_file
                 )
         else:
             self.call_process(shlex.split(self.change_command.format(value)))

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -272,7 +272,7 @@ class _Widget(CommandObject, configurable.Configurable):
                         (cmd.selectors, cmd.name, cmd.args, cmd.kwargs)
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
-                        logger.error("Mouse callback command error %s: %s" % (cmd.name, val))
+                        logger.error("Mouse callback command error %s: %s", cmd.name, val)
             else:
                 cmd()
 

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -236,7 +236,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             with open(path, "r") as f:
                 return f.read().strip(), value_type
         except OSError as e:
-            logger.debug("Failed to read '{}': {}".format(path, e))
+            logger.debug("Failed to read '%s': %s", path, e)
             if isinstance(e, FileNotFoundError):
                 # Let's try another file if this one doesn't exist
                 return None

--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -98,11 +98,9 @@ class CheckUpdates(base.ThreadPoolText):
             except KeyError:
                 distros = sorted(self.cmd_dict.keys())
                 logger.error(
-                    self.distro
-                    + " is not a valid distro name. "
-                    + "Use one of the list: "
-                    + str(distros)
-                    + "."
+                    "%s is not a valid distro name. Use one of the list: %s.",
+                    self.distro,
+                    str(distros),
                 )
                 self.cmd = None
 

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -143,7 +143,7 @@ class CurrentLayoutIcon(base._TextBox):
             try:
                 surface = self.surfaces[self.current_layout]
             except KeyError:
-                logger.error("No icon for layout {}".format(self.current_layout))
+                logger.error("No icon for layout %s", self.current_layout)
             else:
                 self.drawer.clear(self.background or self.bar.background)
                 self.drawer.ctx.set_source(surface)
@@ -190,7 +190,7 @@ class CurrentLayoutIcon(base._TextBox):
         for layout_name in self._get_layout_names():
             icon_file_path = self.find_icon_file_path(layout_name)
             if icon_file_path is None:
-                logger.warning('No icon found for layout "{}"'.format(layout_name))
+                logger.warning('No icon found for layout "%s"', layout_name)
                 icon_file_path = self.find_icon_file_path("unknown")
 
             try:
@@ -201,8 +201,7 @@ class CurrentLayoutIcon(base._TextBox):
                 # an invalid image or is not readable.
                 self.icons_loaded = False
                 logger.exception(
-                    'Failed to load icon from file "{}", '
-                    "error was: {}".format(icon_file_path, e.message)
+                    'Failed to load icon from file "%s", error was: %s', icon_file_path, e.message
                 )
                 return
 

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -350,7 +350,7 @@ class NetGraph(_Graph):
                 self.interface = self.get_main_iface()
             except RuntimeError:
                 logger.warning(
-                    "NetGraph - Automatic interface detection failed, " "falling back to 'eth0'"
+                    "NetGraph - Automatic interface detection failed, falling back to 'eth0'"
                 )
                 self.interface = "eth0"
         if self.bandwidth_type != "down" and self.bandwidth_type != "up":

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -59,7 +59,7 @@ class Image(base._Widget, base.MarginMixin):
         self.filename = os.path.expanduser(self.filename)
 
         if not os.path.exists(self.filename):
-            logger.warning("Image does not exist: {}".format(self.filename))
+            logger.warning("Image does not exist: %s", self.filename)
             return
 
         img = Img.from_path(self.filename)

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -67,10 +67,10 @@ class _X11LayoutBackend(_BaseLayoutBackend):
             command = "setxkbmap -verbose 10 -query"
             setxkbmap_output = check_output(command.split(" ")).decode()
         except CalledProcessError as e:
-            logger.error("Can not get the keyboard layout: {0}".format(e))
+            logger.error("Can not get the keyboard layout: %s", e)
             return "unknown"
         except OSError as e:
-            logger.error("Please, check that xset is available: {0}".format(e))
+            logger.error("Please, check that xset is available: %s", e)
             return "unknown"
 
         match_layout = self.kb_layout_regex.search(setxkbmap_output)
@@ -91,9 +91,9 @@ class _X11LayoutBackend(_BaseLayoutBackend):
         try:
             check_output(command)
         except CalledProcessError as e:
-            logger.error("Can not change the keyboard layout: {0}".format(e))
+            logger.error("Can not change the keyboard layout: %s", e)
         except OSError as e:
-            logger.error("Please, check that setxkbmap is available: {0}".format(e))
+            logger.error("Please, check that setxkbmap is available: %s", e)
 
 
 class _WaylandLayoutBackend(_BaseLayoutBackend):

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -239,7 +239,7 @@ class Mpd2(base.ThreadPoolText):
                 err = err1.format(Class=type(context).__name__, attr=attr_name)
             else:
                 err = err2.format(Class=type(context).__name__, attr=attr_name)
-            logger.exception(err + " {}".format(e.args[0]))
+            logger.exception("%s %s", err, e.args[0])
 
     def toggle(self):
         """toggle play/pause."""

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -86,8 +86,7 @@ class Mpris2(base._TextBox):
         )
 
         if not subscribe:
-            msg = "Unable to add signal receiver for {}.".format(self.objname)
-            logger.warning(msg)
+            logger.warning("Unable to add signal receiver for %s.", self.objname)
 
     def message(self, message):
         if message.message_type != MessageType.SIGNAL:

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -110,7 +110,7 @@ class StatusNotifierItem:  # noqa: E303
                 # We'll pick it up via the message handler so we can ignore this.
                 return False
             except InvalidObjectPathError:
-                logger.info(f"Cannot find {self.path} path on {self.service}.")
+                logger.info("Cannot find %s path on %s.", self.path, self.service)
                 if self.path == STATUSNOTIFIER_PATH:
                     return False
 
@@ -136,7 +136,7 @@ class StatusNotifierItem:  # noqa: E303
                 continue
 
         if not interface_found:
-            logger.warning(f"Unable to find StatusNotifierItem" f"interface on {self.service}")
+            logger.warning("Unable to find StatusNotifierItem interface on %s", self.service)
             return False
 
         # Default to XDG icon:

--- a/libqtile/widget/thermal_zone.py
+++ b/libqtile/widget/thermal_zone.py
@@ -33,7 +33,7 @@ class ThermalZone(base.ThreadPoolText):
             with open(self.zone) as f:
                 value = round(int(f.read().rstrip()) / 1000)
         except OSError:
-            logger.exception("{} does not exist".format(self.zone))
+            logger.exception("%s does not exist", self.zone)
             return "err!"
 
         variables = dict()

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -85,8 +85,7 @@ class WidgetBox(base._Widget):
         self.close_button_location: str
         if self.close_button_location not in ["left", "right"]:
             val = self.close_button_location
-            msg = "Invalid value for 'close_button_location': {}".format(val)
-            logger.warning(msg)
+            logger.warning("Invalid value for 'close_button_location': %s", val)
             self.close_button_location = "left"
 
     def _configure(self, qtile, bar):

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,5 +145,7 @@ ignore_missing_imports = True
 disallow_untyped_defs = True
 [mypy-libqtile.core.*]
 disallow_untyped_defs = True
+[mypy-libqtile.log_utils]
+disallow_untyped_defs = True
 [mypy-libqtile.utils]
 disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
+  pywayland>=0.4.12
   pywlroots>=0.15.13,<0.16.0
   xkbcommon>=0.3
 

--- a/test/core/test_lifecycle.py
+++ b/test/core/test_lifecycle.py
@@ -42,7 +42,7 @@ def no_op(*args, **kwargs):
 
 @pytest.fixture
 def patched_lifecycle(monkeypatch):
-    init_log(logging.WARNING, log_path=None, log_color=False)
+    init_log(logging.WARNING, log_path=None)
     monkeypatch.setattr("libqtile.core.lifecycle.sys.executable", "python")
     monkeypatch.setattr("libqtile.core.lifecycle.sys.argv", ["arg1", "arg2"])
     monkeypatch.setattr("libqtile.core.lifecycle.atexit.register", no_op)

--- a/test/core/test_lifecycle.py
+++ b/test/core/test_lifecycle.py
@@ -42,7 +42,7 @@ def no_op(*args, **kwargs):
 
 @pytest.fixture
 def patched_lifecycle(monkeypatch):
-    init_log(logging.WARNING)
+    init_log()
     monkeypatch.setattr("libqtile.core.lifecycle.sys.executable", "python")
     monkeypatch.setattr("libqtile.core.lifecycle.sys.argv", ["arg1", "arg2"])
     monkeypatch.setattr("libqtile.core.lifecycle.atexit.register", no_op)

--- a/test/core/test_lifecycle.py
+++ b/test/core/test_lifecycle.py
@@ -17,8 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import logging
-
 import pytest
 
 from libqtile.core.lifecycle import Behavior, LifeCycle

--- a/test/core/test_lifecycle.py
+++ b/test/core/test_lifecycle.py
@@ -42,7 +42,7 @@ def no_op(*args, **kwargs):
 
 @pytest.fixture
 def patched_lifecycle(monkeypatch):
-    init_log(logging.WARNING, log_path=None)
+    init_log(logging.WARNING)
     monkeypatch.setattr("libqtile.core.lifecycle.sys.executable", "python")
     monkeypatch.setattr("libqtile.core.lifecycle.sys.argv", ["arg1", "arg2"])
     monkeypatch.setattr("libqtile.core.lifecycle.atexit.register", no_op)

--- a/test/extension/test_command_set.py
+++ b/test/extension/test_command_set.py
@@ -36,7 +36,7 @@ def fake_qtile():
 
 @pytest.fixture
 def log_extension_output(monkeypatch):
-    init_log(logging.WARNING)
+    init_log()
 
     def fake_popen(cmd, *args, **kwargs):
         class PopenObj:

--- a/test/extension/test_command_set.py
+++ b/test/extension/test_command_set.py
@@ -36,7 +36,7 @@ def fake_qtile():
 
 @pytest.fixture
 def log_extension_output(monkeypatch):
-    init_log(logging.WARNING, log_path=None)
+    init_log(logging.WARNING)
 
     def fake_popen(cmd, *args, **kwargs):
         class PopenObj:

--- a/test/extension/test_command_set.py
+++ b/test/extension/test_command_set.py
@@ -36,7 +36,7 @@ def fake_qtile():
 
 @pytest.fixture
 def log_extension_output(monkeypatch):
-    init_log(logging.WARNING, log_path=None, log_color=False)
+    init_log(logging.WARNING, log_path=None)
 
     def fake_popen(cmd, *args, **kwargs):
         class PopenObj:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -209,7 +209,7 @@ class TestManager:
         an error and the returned manager should not be started, otherwise this
         will likely block the thread.
         """
-        init_log(self.log_level, log_path=None)
+        init_log(self.log_level)
         kore = self.backend.create()
         config = config_class()
         for attr in dir(default_config):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -21,7 +21,7 @@ from libqtile import command, config, ipc, layout
 from libqtile.confreader import Config
 from libqtile.core.manager import Qtile
 from libqtile.lazy import lazy
-from libqtile.log_utils import init_log
+from libqtile.log_utils import init_log, logger
 from libqtile.resources import default_config
 
 # the sizes for outputs
@@ -174,7 +174,7 @@ class TestManager:
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
-                logger = init_log(self.log_level, log_path=None)
+                init_log(self.log_level)
                 if hasattr(self, "log_queue"):
                     logger.addHandler(logging.handlers.QueueHandler(self.log_queue))
                 Qtile(

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -174,7 +174,7 @@ class TestManager:
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
-                logger = init_log(self.log_level, log_path=None, log_color=False)
+                logger = init_log(self.log_level, log_path=None)
                 if hasattr(self, "log_queue"):
                     logger.addHandler(logging.handlers.QueueHandler(self.log_queue))
                 Qtile(
@@ -209,7 +209,7 @@ class TestManager:
         an error and the returned manager should not be started, otherwise this
         will likely block the thread.
         """
-        init_log(self.log_level, log_path=None, log_color=False)
+        init_log(self.log_level, log_path=None)
         kore = self.backend.create()
         config = config_class()
         for attr in dir(default_config):

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -416,7 +416,7 @@ def test_lazy_arguments(manager_nospawn):
 
 
 def test_deprecated_modules(caplog):
-    libqtile.log_utils.init_log(logging.WARNING)
+    libqtile.log_utils.init_log()
 
     from libqtile.command_client import InteractiveCommandClient  # noqa: F401
 

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -416,7 +416,7 @@ def test_lazy_arguments(manager_nospawn):
 
 
 def test_deprecated_modules(caplog):
-    libqtile.log_utils.init_log(logging.WARNING, log_path=None, log_color=False)
+    libqtile.log_utils.init_log(logging.WARNING, log_path=None)
 
     from libqtile.command_client import InteractiveCommandClient  # noqa: F401
 

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -416,7 +416,7 @@ def test_lazy_arguments(manager_nospawn):
 
 
 def test_deprecated_modules(caplog):
-    libqtile.log_utils.init_log(logging.WARNING, log_path=None)
+    libqtile.log_utils.init_log(logging.WARNING)
 
     from libqtile.command_client import InteractiveCommandClient  # noqa: F401
 

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -47,7 +47,7 @@ class Call:
 
 @pytest.fixture
 def hook_fixture():
-    libqtile.log_utils.init_log(logging.CRITICAL)
+    libqtile.log_utils.init_log()
 
     yield
 

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -22,7 +22,6 @@
 # SOFTWARE.
 
 import asyncio
-import logging
 from multiprocessing import Value
 
 import pytest

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -47,7 +47,7 @@ class Call:
 
 @pytest.fixture
 def hook_fixture():
-    libqtile.log_utils.init_log(logging.CRITICAL, log_path=None)
+    libqtile.log_utils.init_log(logging.CRITICAL)
 
     yield
 

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -47,7 +47,7 @@ class Call:
 
 @pytest.fixture
 def hook_fixture():
-    libqtile.log_utils.init_log(logging.CRITICAL, log_path=None, log_color=False)
+    libqtile.log_utils.init_log(logging.CRITICAL, log_path=None)
 
     yield
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     xcffib >= 0.10.1
     bowler
     xkbcommon >= 0.3
-    pywayland >= 0.4.4
+    pywayland >= 0.4.12
     dbus-next
     PyGObject
 # pywayland has to be installed before pywlroots
@@ -92,7 +92,7 @@ deps =
     types-pytz
     types-pkg_resources
 commands =
-    pip install -r requirements.txt pywayland>=0.4.4 xkbcommon>=0.3
+    pip install -r requirements.txt pywayland>=0.4.12 xkbcommon>=0.3
     pip install pywlroots>=0.15.13,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy


### PR DESCRIPTION
A few miscellaneous changes to logging:

- log_utils typing
- simplifying where logs go: either to file (regular runtime) or stdout (tests/xephyr) but not both
- remove some redundant code from init_log
- catch and log exceptions raised within wayland callbacks - currently requires https://github.com/flacjacket/pywayland/pull/38
- make all log calls the same format, i.e. don't do string interpolation at the call site, let the logger do it, to avoid unnecessary work