### PR TITLE
Makefile: fix 'lint' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ check: ## Run the test suite
 
 .PHONY: lint
 lint: ## Check the source code
-	TOXENV=format,pep8,vulture,mypy tox
+	TOXENV=codestyle,pep8,vulture,mypy tox
 
 .PHONY: clean
 clean: ## Clean generated files


### PR DESCRIPTION
The "format" toxenv no longer exists, and seems like it has mostly migrated
to the "codestyle" env. Let's update the lint target to reflect that.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>