### PR TITLE
WL: Always raise menu-like windows to top of xwayland Z stack

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -756,6 +756,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         if isinstance(win, (window.XWindow, window.XStatic)):
             if not win.surface.or_surface_wants_focus():
+                win.surface.restack(None, 0)  # XCB_STACK_MODE_ABOVE
                 return
 
         previous_surface = self.seat.keyboard_state.focused_surface


### PR DESCRIPTION
Currently XWayland windows are only raised to the top of the Z stack if
they are normal windows (non override-redirect) or appear to want focus.
wlroots uses an estimate to determine which OR windows want focus. Some
windows (e.g. Ardour menu windows) seem to fall through the cracks of
this estimate, appearing like normal windows but are labelled as OR. If
that happens we should still raise them to the top for expected
functionality.