### PR TITLE
WL: Check libinput support was built before accessing it

### DIFF
--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -329,7 +329,7 @@ def configure_device(device: InputDevice, configs: dict[str, InputConfig] | None
     identifier = "%d:%d:%s" % (device.vendor, device.product, name)
     type_key = "type:" + device.device_type.name.lower()
 
-    if type_key == "type:pointer":
+    if type_key == "type:pointer" and libinput:
         # This checks whether the pointer is a touchpad.
         handle = device.libinput_get_device_handle()
         if handle and libinput.libinput_device_config_tap_get_finger_count(handle) > 0:


### PR DESCRIPTION
This is mostly checked already, where `_configure_pointer` checks
libinput has been imported correctly, but there is another use of the
libinput module before this point which should also check. Without doing
so, confusing AttributeErrors appear because `libinput is None`.

https://github.com/qtile/qtile/issues/3534