### PR TITLE
Add `resume` hook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           avoid the ugly X cursor.
         - Wayland: primary clipboard should now behave same way as with X after selecting something it
           should be copied into clipboard
+        - Add `resume` hook when computer resumes from sleep/suspend/hibernate.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -50,7 +50,7 @@ from libqtile.extension.base import _Extension
 from libqtile.group import _Group
 from libqtile.log_utils import logger
 from libqtile.scratchpad import ScratchPad
-from libqtile.utils import get_cache_dir, lget, send_notification
+from libqtile.utils import get_cache_dir, lget, send_notification, subscribe_for_resume_events
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
@@ -173,6 +173,10 @@ class Qtile(CommandObject):
 
         if self.config.reconfigure_screens:
             hook.subscribe.screen_change(self.cmd_reconfigure_screens)
+
+        # If user wants resume hooks we need to add a dbus rule
+        if "resume" in hook.subscriptions:
+            subscribe_for_resume_events()
 
         if initial:
             hook.fire("startup_complete")

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -340,6 +340,21 @@ class Subscribe:
         """
         return self._subscribe("leave_chord", func)
 
+    def resume(self, func):
+        """
+        Called when system wakes up from sleep, suspend or hibernate.
+
+        Relies on systemd's inhibitor dbus interface, via the dbus-next package.
+
+        Note: the hook is not fired when resuming from shutdown/reboot events.
+        Use the "startup" hooks for those scenarios.
+
+        **Arguments**
+
+        None
+        """
+        return self._subscribe("resume", func)
+
 
 subscribe = Subscribe()
 
@@ -356,7 +371,7 @@ class Unsubscribe(Subscribe):
             lst.remove(func)
         except ValueError:
             raise utils.QtileError(
-                "Tried to unsubscribe a hook that was not" " currently subscribed"
+                "Tried to unsubscribe a hook that was not currently subscribed"
             )
 
 

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     T = TypeVar("T")
 
 try:
-    from dbus_next import Message, Variant
+    from dbus_next import AuthError, Message, Variant
     from dbus_next.aio import MessageBus
     from dbus_next.constants import BusType, MessageType
 
@@ -278,7 +278,8 @@ async def _notify(
 
     # a new bus connection is made each time a notification is sent so
     # we disconnect when the notification is done
-    bus.disconnect()
+    if bus:
+        bus.disconnect()
 
 
 def guess_terminal(preference: str | Sequence | None = None) -> str | None:
@@ -353,7 +354,7 @@ async def _send_dbus_message(
     member: str,
     signature: str,
     body: Any,
-) -> tuple[MessageBus, Message | None]:
+) -> tuple[MessageBus | None, Message | None]:
     """
     Private method to send messages to dbus via dbus_next.
 
@@ -367,7 +368,11 @@ async def _send_dbus_message(
     if isinstance(body, str):
         body = [body]
 
-    bus = await MessageBus(bus_type=bus_type).connect()
+    try:
+        bus = await MessageBus(bus_type=bus_type).connect()
+    except (AuthError, Exception):
+        logger.warning("Unable to connect to dbus.")
+        return None, None
 
     msg = await bus.call(
         Message(
@@ -391,16 +396,29 @@ async def add_signal_receiver(
     dbus_interface: str | None = None,
     bus_name: str | None = None,
     path: str | None = None,
+    check_service: bool = False,
 ) -> bool:
     """
     Helper function which aims to recreate python-dbus's add_signal_receiver
     method in dbus_next with asyncio calls.
+
+    If check_service is `True` the method will raise a wanrning and return False
+    if the service is not visible on the bus. If the `bus_name` is None, no
+    check will be performed.
 
     Returns True if subscription is successful.
     """
     if not has_dbus:
         logger.warning("dbus-next is not installed. Unable to subscribe to signals")
         return False
+
+    if bus_name and check_service:
+        found = await find_dbus_service(bus_name, session_bus)
+        if not found:
+            logger.warning(
+                "The %s name was not found on the bus. No callback will be attached.", bus_name
+            )
+            return False
 
     match_args = {
         "type": "signal",
@@ -424,9 +442,37 @@ async def add_signal_receiver(
     )
 
     # Check if message sent successfully
-    if msg and msg.message_type == MessageType.METHOD_RETURN:
+    if bus and msg and msg.message_type == MessageType.METHOD_RETURN:
         bus.add_message_handler(callback)
         return True
 
     else:
         return False
+
+
+async def find_dbus_service(service: str, session_bus: bool) -> bool:
+    """Looks up service name to see if it is currently available on dbus."""
+
+    # We're using low level interface here to reduce unnecessary calls for
+    # introspection etc.
+    bus, msg = await _send_dbus_message(
+        session_bus,
+        MessageType.METHOD_CALL,
+        "org.freedesktop.DBus",
+        "org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "ListNames",
+        "",
+        [],
+    )
+
+    if bus is None or msg is None or (msg and msg.message_type != MessageType.METHOD_RETURN):
+        logger.warning("Unable to send lookup call to dbus.")
+        return False
+
+    bus.disconnect()
+    del bus
+
+    names = msg.body[0]
+
+    return service in names

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -44,6 +44,11 @@ class Call:
         self.val = val
 
 
+class NoArgCall(Call):
+    def __call__(self):
+        self.val += 1
+
+
 @pytest.fixture
 def hook_fixture():
     libqtile.log_utils.init_log()
@@ -184,3 +189,11 @@ def test_can_call_by_selection_notify(manager):
     hook.subscribe.selection_notify(test)
     hook.fire("selection_notify", "hello")
     assert test.val == "hello"
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_resume_hook(manager):
+    test = NoArgCall(0)
+    hook.subscribe.resume(test)
+    hook.fire("resume")
+    assert test.val == 1


### PR DESCRIPTION
Adds a new hook that is fired when the system wakes from suspend or sleep. The hook relies on systemd's inhibit dbus interface.

The hook can be used to trigger re-polling of widgets etc in users' configs.