### PR TITLE
Remove dbus match rules on shutdown/restart/reload

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -55,7 +55,7 @@ from libqtile.log_utils import logger
 from libqtile.resources.sleep import inhibitor
 from libqtile.scratchpad import ScratchPad
 from libqtile.scripts.main import VERSION
-from libqtile.utils import cancel_tasks, get_cache_dir, lget, send_notification
+from libqtile.utils import cancel_tasks, get_cache_dir, lget, remove_dbus_rules, send_notification
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
@@ -298,6 +298,7 @@ class Qtile(CommandObject):
         self.groups_map.clear()
         self.groups.clear()
         self.screens.clear()
+        remove_dbus_rules()
         self.load_config()
 
     def _finalize_configurables(self) -> None:
@@ -324,6 +325,7 @@ class Qtile(CommandObject):
 
     def finalize(self) -> None:
         self._finalize_configurables()
+        remove_dbus_rules()
         inhibitor.stop()
         cancel_tasks()
         self.core.finalize()

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -52,6 +52,8 @@ except ImportError:
 
 from libqtile.log_utils import logger
 
+dbus_bus_connections = set()
+
 # Create a list to collect references to tasks so they're not garbage collected
 # before they've run
 TASKS: list[asyncio.Task[None]] = []
@@ -424,25 +426,32 @@ async def _send_dbus_message(
     signature: str,
     body: Any,
     negotiate_unix_fd: bool = False,
+    bus: MessageBus | None = None,
 ) -> tuple[MessageBus | None, Message | None]:
     """
     Private method to send messages to dbus via dbus_next.
 
+    An existing bus connection can be passed, if left empty, a new
+    bus connection will be created.
+
     Returns a tuple of the bus object and message response.
     """
-    if session_bus:
-        bus_type = BusType.SESSION
-    else:
-        bus_type = BusType.SYSTEM
+    if bus is None:
+        if session_bus:
+            bus_type = BusType.SESSION
+        else:
+            bus_type = BusType.SYSTEM
+
+        try:
+            bus = await MessageBus(
+                bus_type=bus_type, negotiate_unix_fd=negotiate_unix_fd
+            ).connect()
+        except (AuthError, Exception):
+            logger.warning("Unable to connect to dbus.")
+            return None, None
 
     if isinstance(body, str):
         body = [body]
-
-    try:
-        bus = await MessageBus(bus_type=bus_type, negotiate_unix_fd=negotiate_unix_fd).connect()
-    except (AuthError, Exception):
-        logger.warning("Unable to connect to dbus.")
-        return None, None
 
     # Ignore types here: dbus-next has default values of `None` for certain
     # parameters but the signature is `str` so passing `None` results in an
@@ -458,6 +467,11 @@ async def _send_dbus_message(
             body=body,
         )
     )
+
+    # Keep details of bus connections so we can close them on exit
+    # dbus_bus_connetions is a set so we don't need to worry about
+    # duplicates
+    dbus_bus_connections.add(bus)
 
     return bus, msg
 
@@ -503,6 +517,8 @@ async def add_signal_receiver(
 
     rule = ",".join("{}='{}'".format(k, v) for k, v in match_args.items() if v)
 
+    logger.debug("Adding dbus match rule: %s", rule)
+
     bus, msg = await _send_dbus_message(
         session_bus,
         MessageType.METHOD_CALL,
@@ -511,7 +527,7 @@ async def add_signal_receiver(
         "/org/freedesktop/DBus",
         "AddMatch",
         "s",
-        rule,
+        [rule],
     )
 
     # Check if message sent successfully
@@ -548,3 +564,18 @@ async def find_dbus_service(service: str, session_bus: bool) -> bool:
     names = msg.body[0]
 
     return service in names
+
+
+def remove_dbus_rules() -> None:
+    # Disconnecting the bus connections is enough to remove the match rules.
+    while dbus_bus_connections:
+        bus = dbus_bus_connections.pop()
+        try:
+            bus.disconnect()
+        except OSError:
+            # Socket has already shut down
+            pass
+
+        # We need to manually close the socket until https://github.com/altdesktop/python-dbus-next/pull/148
+        # gets merged. There's no error on multiple calls to 'close()'.
+        bus._sock.close()

--- a/libqtile/widget/bluetooth.py
+++ b/libqtile/widget/bluetooth.py
@@ -677,3 +677,20 @@ class Bluetooth(base._TextBox, base.MarginMixin):
         self._line_index = 0
         self.show_adapter = False
         self.refresh()
+
+    def finalize(self):
+        """Remove dbus signal handlers before finalising."""
+        # Clearing dicts will call the __del__ method on the stored objects
+        # which has been defined to remove signal handlers
+        self.devices.clear()
+        self.adapters.clear()
+
+        # Remove object manager's handlers
+        self.object_manager.off_interfaces_added(self._interface_added)
+        self.object_manager.off_interfaces_removed(self._interface_removed)
+
+        # Disconnect the bus connection
+        self.bus.disconnect()
+        self.bus = None
+
+        base._TextBox.finalize(self)

--- a/libqtile/widget/keyboardkbdd.py
+++ b/libqtile/widget/keyboardkbdd.py
@@ -22,8 +22,6 @@
 
 import re
 
-from dbus_next.constants import MessageType
-
 from libqtile.log_utils import logger
 from libqtile.utils import add_signal_receiver
 from libqtile.widget import base
@@ -90,9 +88,6 @@ class KeyboardKbdd(base.ThreadPoolText):
             logger.warning("Could not subscribe to kbdd signal.")
 
     def _signal_received(self, message):
-        if message.message_type != MessageType.SIGNAL:
-            return
-
         self._layout_changed(*message.body)
 
     def _layout_changed(self, layout_changed):

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -29,6 +29,7 @@ import string
 from typing import TYPE_CHECKING
 
 from dbus_next import Message, Variant
+from dbus_next.aio import MessageBus
 from dbus_next.constants import MessageType
 
 from libqtile.command.base import expose_command
@@ -197,6 +198,7 @@ class Mpris2(base._TextBox):
         self._current_player: str | None = None
         self.player_names: dict[str, str] = {}
         self._background_poll: asyncio.TimerHandle | None = None
+        self.bus: MessageBus | None = None
 
     @property
     def player(self) -> str:
@@ -206,6 +208,10 @@ class Mpris2(base._TextBox):
             return self.player_names.get(self._current_player, "Unknown")
 
     async def _config_async(self):
+        # These two listeners create separate bus connections. Each connection only has one
+        # callback so we don't need any logic to identify the message and the appropriate
+        # handler in this code.
+
         # Set up a listener for NameOwner changes so we can remove players when they close
         await add_signal_receiver(
             self._name_owner_changed,
@@ -261,14 +267,31 @@ class Mpris2(base._TextBox):
 
         self.parse_message(*message.body)
 
+    async def _send_message(self, destination, interface, path, member, signature, body):
+        bus, message = await _send_dbus_message(
+            session_bus=True,
+            message_type=MessageType.METHOD_CALL,
+            destination=destination,
+            interface=interface,
+            path=path,
+            member=member,
+            signature=signature,
+            body=body,
+            bus=self.bus,
+        )
+
+        # We should reuse the same bus connection for repeated calls.
+        if self.bus is None:
+            self.bus = bus
+
+        return message
+
     async def _check_player(self):
         """Check for player at startup and retrieve metadata."""
         if not (self.objname or self._current_player):
             return
 
-        bus, message = await _send_dbus_message(
-            True,
-            MessageType.METHOD_CALL,
+        message = await self._send_message(
             self.objname if self.objname else self._current_player,
             PROPERTIES_INTERFACE,
             MPRIS_PATH,
@@ -276,9 +299,6 @@ class Mpris2(base._TextBox):
             "s",
             [MPRIS_PLAYER],
         )
-
-        if bus:
-            bus.disconnect()
 
         # If we get an error here it will be because the player object doesn't exist
         if message.message_type != MessageType.METHOD_RETURN:
@@ -298,9 +318,7 @@ class Mpris2(base._TextBox):
             self._background_poll = self.timeout_add(self.poll_interval, self._check_player)
 
     async def get_player_name(self, player):
-        bus, message = await _send_dbus_message(
-            True,
-            MessageType.METHOD_CALL,
+        message = await self._send_message(
             player,
             PROPERTIES_INTERFACE,
             MPRIS_PATH,
@@ -308,9 +326,6 @@ class Mpris2(base._TextBox):
             "ss",
             [MPRIS_OBJECT, "Identity"],
         )
-
-        if bus:
-            bus.disconnect()
 
         if message.message_type != MessageType.METHOD_RETURN:
             logger.warning("Could not retrieve identity of player on %s.", player)
@@ -378,9 +393,7 @@ class Mpris2(base._TextBox):
         task.add_done_callback(self._task_callback)
 
     async def _send_player_cmd(self, cmd: str) -> Message | None:
-        bus, message = await _send_dbus_message(
-            True,
-            MessageType.METHOD_CALL,
+        message = await self._send_message(
             self._current_player,
             MPRIS_PLAYER,
             MPRIS_PATH,
@@ -388,9 +401,6 @@ class Mpris2(base._TextBox):
             "",
             [],
         )
-
-        if bus:
-            bus.disconnect()
 
         return message
 

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -252,9 +252,6 @@ class Mpris2(base._TextBox):
             self._set_background_poll(False)
 
     def message(self, message):
-        if message.message_type != MessageType.SIGNAL:
-            return
-
         create_task(self.process_message(message))
 
     async def process_message(self, message):

--- a/test/widgets/docs_screenshots/ss_keyboardkbdd.py
+++ b/test/widgets/docs_screenshots/ss_keyboardkbdd.py
@@ -17,21 +17,18 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import sys
 from importlib import reload
 
 import pytest
 
-from test.widgets.test_keyboardkbdd import Mockconstants, MockSpawn, mock_signal_receiver
+from test.widgets.test_keyboardkbdd import MockSpawn, mock_signal_receiver
 
 
 @pytest.fixture
 def widget(monkeypatch):
-    monkeypatch.setitem(sys.modules, "dbus_next.constants", Mockconstants("dbus_next.constants"))
     from libqtile.widget import keyboardkbdd
 
     reload(keyboardkbdd)
-    monkeypatch.setattr("libqtile.widget.keyboardkbdd.MessageType", Mockconstants.MessageType)
     monkeypatch.setattr(
         "libqtile.widget.keyboardkbdd.KeyboardKbdd.call_process", MockSpawn.call_process
     )

--- a/test/widgets/test_keyboardkbdd.py
+++ b/test/widgets/test_keyboardkbdd.py
@@ -25,9 +25,7 @@
 
 # This test file covers the remaining widget code
 
-import sys
 from importlib import reload
-from types import ModuleType
 
 import pytest
 
@@ -36,11 +34,6 @@ from test.widgets.conftest import FakeBar
 
 async def mock_signal_receiver(*args, **kwargs):
     return True
-
-
-class Mockconstants(ModuleType):
-    class MessageType:
-        SIGNAL = 1
 
 
 class MockSpawn:
@@ -62,13 +55,11 @@ class MockMessage:
 
 @pytest.fixture
 def patched_widget(monkeypatch):
-    monkeypatch.setitem(sys.modules, "dbus_next.constants", Mockconstants("dbus_next.constants"))
     from libqtile.widget import keyboardkbdd
 
     reload(keyboardkbdd)
 
     # The next line shouldn't be necessary but I got occasional failures without it when testing locally
-    monkeypatch.setattr("libqtile.widget.keyboardkbdd.MessageType", Mockconstants.MessageType)
     monkeypatch.setattr(
         "libqtile.widget.keyboardkbdd.KeyboardKbdd.call_process", MockSpawn.call_process
     )
@@ -86,11 +77,6 @@ def test_keyboardkbdd_process_running(fake_qtile, patched_widget, fake_window):
 
     # Create a message with the index of the active keyboard
     message = MockMessage(body=1)
-    kbd._signal_received(message)
-    assert kbd.keyboard == "us"
-
-    # Test non-"signal" message
-    message = MockMessage(body=0, is_signal=False)
     kbd._signal_received(message)
     assert kbd.keyboard == "us"
 


### PR DESCRIPTION
Various object create match rules on the dbus server (e.g. SNI and Mpris2 widgets). These rules should be removed when qtile shuts down, restarts or reloads the config to eliminate redundant messages being sent by the dbus server.