### PR TITLE
Allow 3 digit hex colour values

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -91,9 +91,13 @@ def rgb(x: ColorType) -> tuple[float, float, float, float]:
             alpha = float("0." + alpha_str)
         else:
             alpha = 1.0
-        if len(x) not in (6, 8):
-            raise ValueError("RGB specifier must be 6 or 8 characters long.")
-        vals = tuple(int(i, 16) for i in (x[0:2], x[2:4], x[4:6]))
+        if len(x) not in (3, 6, 8):
+            raise ValueError("RGB specifier must be 3, 6 or 8 characters long.")
+        if len(x) == 3:
+            # Multiplying by 17: 0xA * 17 = 0xAA etc.
+            vals = tuple(int(i, 16) * 17 for i in x)
+        else:
+            vals = tuple(int(i, 16) for i in (x[0:2], x[2:4], x[4:6]))
         if len(x) == 8:
             alpha = int(x[6:8], 16) / 255.0
         vals += (alpha,)  # type: ignore

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -63,6 +63,22 @@ def test_rgb_from_base10_tuple_with_alpha():
     assert utils.rgb([255, 255, 0, 0.5]) == (1, 1, 0, 0.5)
 
 
+def test_rgb_from_3_digit_hex_number():
+    assert utils.rgb("f0f") == (1, 0, 1, 1)
+
+
+def test_rgb_from_3_digit_hex_string():
+    assert utils.rgb("#f0f") == (1, 0, 1, 1)
+
+
+def test_rgb_from_3_digit_hex_number_with_alpha():
+    assert utils.rgb("f0f.5") == (1, 0, 1, 0.5)
+
+
+def test_rgb_from_3_digit_hex_string_with_alpha():
+    assert utils.rgb("#f0f.5") == (1, 0, 1, 0.5)
+
+
 def test_has_transparency():
     colours = [
         ("#00000000", True),


### PR DESCRIPTION
A common short-hand version for hex colours is to use `RGB` to represent `RRGGBB`.

This PR amends `libqtile.utils` to allow 3 digit hex values to be treated as valid colours.