### PR TITLE
Enforce proper logging style

### DIFF
--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -113,8 +113,8 @@ class Painter:
         try:
             with open(image_path, "rb") as f:
                 image, _ = cairocffi.pixbuf.decode_to_image_surface(f.read())
-        except IOError as e:
-            logger.error("Wallpaper: %s", e)
+        except IOError:
+            logger.exception("Could not load wallpaper:")
             return
 
         surface = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, screen.width, screen.height)

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -694,8 +694,8 @@ class Painter:
         try:
             with open(image_path, "rb") as f:
                 image, _ = cairocffi.pixbuf.decode_to_image_surface(f.read())
-        except IOError as e:
-            logger.error("Wallpaper: %s", e)
+        except IOError:
+            logger.exception("Could not load wallpaper:")
             return
 
         # Querying the screen dimensions via the xcffib connection does not

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -347,9 +347,9 @@ class Bar(Gap, configurable.Configurable):
                 widget.offsetx = self.border_width[3]
 
             widget.configured = True
-        except Exception as e:
-            logger.error(
-                "%s widget crashed during _configure with error: %s", widget.__class__.__name__, e
+        except Exception:
+            logger.exception(
+                "%s widget crashed during _configure with error:", widget.__class__.__name__
             )
             self.crashed_widgets.append(widget)
             configured = False

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -258,7 +258,7 @@ class Qtile(CommandObject):
         try:
             self.config.load()
         except Exception as error:
-            logger.error("Configuration error: %s", error)
+            logger.exception("Configuration error:")
             send_notification("Configuration error", str(error))
             return
 
@@ -1111,7 +1111,7 @@ class Qtile(CommandObject):
         try:
             self.config.load()
         except Exception as error:
-            logger.error("Preventing restart because of a configuration error: %s", error)
+            logger.exception("Preventing restart because of a configuration error:")
             send_notification("Configuration error", str(error))
             return
         self.restart()
@@ -1460,8 +1460,8 @@ class Qtile(CommandObject):
                     return
                 try:
                     result = eval("c.{0:s}".format(cmd))
-                except (CommandError, CommandException, AttributeError) as err:
-                    logger.error(err)
+                except (CommandError, CommandException, AttributeError):
+                    logger.exception("Command errored:")
                     result = None
                 if result is not None:
                     from pprint import pformat

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -60,10 +60,8 @@ def make_qtile(options):
             )
             copyfile(default_config_path, options.configfile)
             logger.info("Copied default_config.py to %s", options.configfile)
-        except Exception as e:
-            logger.exception(
-                "Failed to copy default_config.py to %s: (%s)", options.configfile, e
-            )
+        except Exception:
+            logger.exception("Failed to copy default_config.py to %s:", options.configfile)
 
     config = confreader.Config(options.configfile)
 

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -180,8 +180,8 @@ def import_class(
     try:
         module = importlib.import_module(module_path, __package__)
         return getattr(module, class_name)
-    except ImportError as error:
-        logger.warning("Unmet dependencies for '%s.%s': %s", module_path, class_name, error)
+    except ImportError:
+        logger.exception("Unmet dependencies for '%s.%s':", module_path, class_name)
         if fallback:
             logger.debug("%s", traceback.format_exc())
             return fallback(module_path, class_name)

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -236,7 +236,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             with open(path, "r") as f:
                 return f.read().strip(), value_type
         except OSError as e:
-            logger.debug("Failed to read '%s': %s", path, e)
+            logger.exception("Failed to read '%s':", path)
             if isinstance(e, FileNotFoundError):
                 # Let's try another file if this one doesn't exist
                 return None

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -66,11 +66,11 @@ class _X11LayoutBackend(_BaseLayoutBackend):
         try:
             command = "setxkbmap -verbose 10 -query"
             setxkbmap_output = check_output(command.split(" ")).decode()
-        except CalledProcessError as e:
-            logger.error("Can not get the keyboard layout: %s", e)
+        except CalledProcessError:
+            logger.exception("Can not get the keyboard layout:")
             return "unknown"
-        except OSError as e:
-            logger.error("Please, check that xset is available: %s", e)
+        except OSError:
+            logger.exception("Please, check that xset is available:")
             return "unknown"
 
         match_layout = self.kb_layout_regex.search(setxkbmap_output)
@@ -90,10 +90,10 @@ class _X11LayoutBackend(_BaseLayoutBackend):
             command.extend(["-option", options])
         try:
             check_output(command)
-        except CalledProcessError as e:
-            logger.error("Can not change the keyboard layout: %s", e)
-        except OSError as e:
-            logger.error("Please, check that setxkbmap is available: %s", e)
+        except CalledProcessError:
+            logger.error("Can not change the keyboard layout:")
+        except OSError:
+            logger.error("Please, check that setxkbmap is available:")
 
 
 class _WaylandLayoutBackend(_BaseLayoutBackend):

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -163,5 +163,5 @@ class Net(base.ThreadPoolText):
                 )
 
             return " ".join(ret_stat)
-        except Exception as excp:
-            logger.error("%s: Caught Exception:\n%s", self.__class__.__name__, excp)
+        except Exception:
+            logger.exception("Net widget errored while polling:")

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ exclude = libqtile/_ffi*.py,libqtile/backend/x11/_ffi*.py
 max-line-length = 98
 ban-relative-imports = true
 ignore = E203,W503,E704,E123,E226,E121,E24,E126,W504,N818,E501
+enable-extensions = G
 
 [tool:pytest]
 python_files = test_*.py

--- a/tox.ini
+++ b/tox.ini
@@ -62,6 +62,7 @@ deps =
     flake8-black>=0.2.4
     flake8-isort
     flake8-tidy-imports
+    flake8-logging-format
     pep8-naming
 commands =
     flake8 {toxinidir}/libqtile {toxinidir}/bin/ {toxinidir}/test --exclude=test/configs/syntaxerr.py,**/_ffi*.py


### PR DESCRIPTION
This usess the flake8 plugin 'flake8-logging-format' to enforce proper
style of logging calls. The main misuse in libqtile is manually passing
exceptions, when the logging module gets exceptions and appends them to
'logging.exception' calls, and using 'logger.error' in place of
'logger.exception' when passing exceptions.