### PR TITLE
Add CommandClient for CommandObjects

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -63,6 +63,15 @@ class CommandObject(metaclass=abc.ABCMeta):
     A CommandObject should also implement `._items()` and `._select()` methods
     (c.f. docstring for `.items()` and `.select()`).
     """
+    @property
+    def c(self):  # type: ignore
+        """Expose an interactive command client for the current object."""
+        # TODO: Fix this!
+        # The imports are called here to prevent circular imports
+        from libqtile.command.client import InteractiveCommandClient
+        from libqtile.command.interface import QtileCommandInterface
+
+        return InteractiveCommandClient(QtileCommandInterface(self))
 
     def select(self, selectors: list[SelectorType]) -> CommandObject:
         """Return a selected object


### PR DESCRIPTION
This is draft for now so we can discuss (I posted a discusion in #3542 which got some upvotes but no actual feedback...)

The idea of this PR is to simplify users' ability to code their own python functions while still accessing the public API (i.e. exposed commands).

Every instance of a `CommandObject` gets a new property (called `c` here to match the manager in our test suite) which is an instance of an `InteractiveCommandClient` with the current node being the object instance.

This means users can write code like this:
``` python
@lazy.function
def my_lazy_function(qtile):
    qtile.c.reload_config()   # same as lazy.reload_config()

@lazy.widget["textbox"].function
def update_textbox_text(widget):
    new_text = "New message"
    widget.c.update(new_text)   # same as lazy.widget["textbox"].update("New message")

# Functions can then be attached to keybindings
```
Arguably this is redundant if we ever merge the decorators PR but it does feel quite neat (other than users needing to know to access the `c` property...)

Happy to can it if people don't like it.

I won't write any tests until I know whether it's worth the effort or not!