### PR TITLE
WL: support for primary selection (clibpoard)

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -137,6 +137,7 @@ class Core(base.Core, wlrq.HasListeners):
         DataControlManagerV1(self.display)
         self.seat = seat.Seat(self.display, "seat0")
         self.add_listener(self.seat.request_set_selection_event, self._on_request_set_selection)
+        self.add_listener(self.seat.request_set_primary_selection_event, self._on_request_set_primary_selection)
         self.add_listener(self.seat.request_start_drag_event, self._on_request_start_drag)
         self.add_listener(self.seat.start_drag_event, self._on_start_drag)
         self.add_listener(self.backend.new_input_event, self._on_new_input)
@@ -248,6 +249,12 @@ class Core(base.Core, wlrq.HasListeners):
     ) -> None:
         self.seat.set_selection(event._ptr.source, event.serial)
         logger.debug("Signal: seat request_set_selection")
+
+    def _on_request_set_primary_selection(
+        self, _listener: Listener, event: seat.RequestSetPrimarySelectionEvent
+    ) -> None:
+        self.seat.set_primary_selection(event._ptr.source, event.serial)
+        logger.debug("Signal: seat request_set_primary_selection")
 
     def _on_request_start_drag(
         self, _listener: Listener, event: seat.RequestStartDragEvent


### PR DESCRIPTION
This adds proper support for primary selection so it works the same way as with X server.
It is dependant on https://github.com/flacjacket/pywlroots/pull/85