### PR TITLE
Add option to build docs without screenshots

### DIFF
--- a/docs/manual/hacking.rst
+++ b/docs/manual/hacking.rst
@@ -77,6 +77,16 @@ Build the documentation with ``make html``.
 
 Check the result by opening ``_build/html/index.html`` in your browser.
 
+.. note::
+
+  To speed up local testing, screenshots are not generated each time the documentation
+  is built.
+
+  You can enable screenshots by setting the ``QTILE_BUILD_SCREENSHOTS`` environmental
+  variable at build time e.g. ``QTILE_BUILD_SCREENSHOTS=1 make html``. You can also
+  export the variable so it will apply to all local builds ``export QTILE_BUILD_SCREENSHOTS=1``
+  (but remember to unset it if you want to skip building screenshots).
+
 Development and testing
 =======================
 

--- a/docs/manual/troubleshooting.rst
+++ b/docs/manual/troubleshooting.rst
@@ -71,7 +71,7 @@ Qtile, so that the debug logs printed by Qtile are only the server's.
 
 If you suspect a client may be responsible for a bug, it can be helpful to look
 at the issue trackers for other compositors, such as `sway
-<https://github.com/swaywm/sway/issues`_. Similarly if you're hacking on
+<https://github.com/swaywm/sway/issues>`_. Similarly if you're hacking on
 Qtile's internals and think you've found an unexpected quirk it may be helpful
 to search the issue tracker for `wlroots
 <https://gitlab.freedesktop.org/wlroots/wlroots/-/issues>`_.

--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -256,7 +256,12 @@ def generate_widget_screenshots():
 
 def setup(app):
     generate_keybinding_images()
-    generate_widget_screenshots()
+    # screenshots will be skipped unless QTILE_BUILD_SCREENSHOTS environment variable is set
+    # Variable is set for ReadTheDocs at https://readthedocs.org/dashboard/qtile/environmentvariables/
+    if os.getenv("QTILE_BUILD_SCREENSHOTS", False):
+        generate_widget_screenshots()
+    else:
+        print("Skipping screenshot builds...")
     app.add_directive('qtile_class', QtileClass)
     app.add_directive('qtile_hooks', QtileHooks)
     app.add_directive('qtile_module', QtileModule)


### PR DESCRIPTION
Added a `make quick` target to build docs without screenshots.

Speeds up build times which is useful when debugging docs locally.