### PR TITLE
Disable stalebot action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,8 @@ jobs:
         exempt-issue-labels: 'task,bug,enhancement'
         stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
         stale-pr-label: 'stale'
-        days-before-stale: 90
+        exempt-all-pr-assignees: true
+        days-before-stale: 180
         days-before-close: 30
     - uses: actions/stale@v2.0.0
       with:
@@ -24,6 +25,7 @@ jobs:
         stale-issue-label: 'stale'
         stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
         stale-pr-label: 'stale'
+        exempt-all-pr-assignees: true
         only-labels: 'unconfirmed'
-        days-before-stale: 90
+        days-before-stale: 180
         days-before-close: 30


### PR DESCRIPTION
This was useful in the past but at this stage we've removed a lot of
truly stale issues and we're left with important issues getting made
stale. Coupled with slightly less dev activity the past few months, this
has become troublesome. In the future when we are up to top speed again
we can re-enable it if we find it useful!