### PR TITLE
Rewrite config.py docstrings, typing and docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build -E -W
+SPHINXBUILD   = sphinx-build -E -W --keep-going
 PAPER         =
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 
-# -- Options for HTML output --------fautod-------------------------------------------
+# -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/docs/manual/config/groups.rst
+++ b/docs/manual/config/groups.rst
@@ -5,9 +5,9 @@ Groups
 A group is a container for a bunch of windows, analogous to workspaces in other
 window managers. Each client window managed by the window manager belongs to
 exactly one group. The ``groups`` config file variable should be initialized to
-a list of :class:`~libqtile.dgroups.DGroup` objects.
+a list of :class:`~libqtile.config.Group` objects.
 
-:class:`~libqtile.dgroups.DGroup` objects provide several options for group
+:class:`~libqtile.config.Group` objects provide several options for group
 configuration. Groups can be configured to show and hide themselves when
 they're not empty, spawn applications for them when they start, automatically
 acquire certain groups, and various other options.
@@ -18,6 +18,7 @@ Example
 ::
 
     from libqtile.config import Group, Match
+
     groups = [
         Group("a"),
         Group("b"),
@@ -27,6 +28,7 @@ Example
     # allow mod3+1 through mod3+0 to bind to groups; if you bind your groups
     # by hand in your config, you don't need to do this.
     from libqtile.dgroups import simple_key_binder
+
     dgroups_key_binder = simple_key_binder("mod3")
 
 
@@ -53,16 +55,15 @@ ScratchPad and DropDown
 
 :class:`~libqtile.config.ScratchPad` is a special - by default invisible -
 group which acts as a container for :class:`~libqtile.config.DropDown`
-configurations. A `DropDown` can be configured to spawn a defined process and
-bind thats process' window to it. The associated window can then be shown and
-hidden by the lazy command ``dropdown_toggle()``
-(see :ref:`lazy`) from the ScratchPad group.
-Thus - for example - your favorite terminal emulator turns into a quake-like
-terminal by the control of Qtile.
+configurations. A :class:`~libqtile.config.DropDown` can be configured to spawn
+a defined process and bind thats process' window to it. The associated window
+can then be shown and hidden by the lazy command :meth:`dropdown_toggle` (see
+:ref:`lazy`) from the ScratchPad group.  Thus - for example - your favorite
+terminal emulator turns into a quake-like terminal by the control of Qtile.
 
 If the DropDown window turns visible it is placed as a floating window on top
-of the current group.
-If the DropDown is hidden, it is simply switched back to the ScratchPad group.
+of the current group. If the DropDown is hidden, it is simply switched back to
+the ScratchPad group.
 
 Example
 -------
@@ -70,7 +71,8 @@ Example
 ::
 
   from libqtile.config import Group, ScratchPad, DropDown, Key
-  from libqtile.command import lazy
+  from libqtile.lazy import lazy
+
   groups = [
       ScratchPad("scratchpad", [
           # define a drop down terminal.
@@ -97,8 +99,9 @@ visible.
 Some programs run in a server-like mode where the spawned process does not
 directly own the window that is created, which is instead created by a
 background process. In this case, the window may not be correctly caught in the
-scratchpad group. To work around this, you can pass a ``config.Match`` object
-to the corresponding ``Dropdown``. See below.
+scratchpad group. To work around this, you can pass a
+:class:`~libqtile.config.Match` object to the corresponding
+:class:`~libqtile.config.DropDown`. See below.
 
 Reference
 ---------

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -5,7 +5,7 @@ Keys
 ====
 
 The ``keys`` variable defines Qtile's key bindings. Individual key bindings are
-defined with :class:`libqtile.config.Key` as demonstrated in the following
+defined with :class:`~libqtile.config.Key` as demonstrated in the following
 example. Note that you may specify more than one callback functions.
 
 ::
@@ -24,7 +24,7 @@ example. Note that you may specify more than one callback functions.
    ]
 
 The above may also be written more concisely with the help of the
-:class:`libqtile.config.EzKey` helper class. The following example is
+:class:`~libqtile.config.EzKey` helper class. The following example is
 functionally equivalent to the above::
 
     from libqtile.config import EzKey as Key
@@ -35,8 +35,8 @@ functionally equivalent to the above::
        Key("M-A-<Tab>", callback, ...),
     ]
 
-The :class:`EzKey` modifier keys (i.e. ``MASC``) can be overwritten through the
-``EzKey.modifier_keys`` dictionary. The defaults are::
+The :class:`~libqtile.config.EzKey` modifier keys (i.e. ``MASC``) can be
+overwritten through the ``EzKey.modifier_keys`` dictionary. The defaults are::
 
     modifier_keys = {
        'M': 'mod4',
@@ -46,7 +46,8 @@ The :class:`EzKey` modifier keys (i.e. ``MASC``) can be overwritten through the
     }
 
 Callbacks can also be configured to work only under certain conditions by using
-the ``when()`` method. Currently, the following conditions are supported:
+the :meth:`~libqtile.lazy.LazyCall.when` method. Currently, the following
+conditions are supported:
 
 ::  
 
@@ -72,10 +73,9 @@ the ``when()`` method. Currently, the following conditions are supported:
 KeyChords
 =========
 
-Qtile also allows sequences of keys to trigger callbacks. In Qtile, these
-sequences are known as chords and are defined with
-:class:`libqtile.config.KeyChord`. Chords are added to the ``keys`` section of
-the config file.
+Qtile also allows sequences of keys to trigger callbacks. These sequences are
+known as chords and are defined with :class:`~libqtile.config.KeyChord`. Chords
+are added to the ``keys`` section of the config file.
 
 ::
 
@@ -122,7 +122,7 @@ shrink it etc. as many times as needed. To exit the mode, press <escape>.
 
 .. note::
     If using modes, users may also wish to use the Chord widget
-    (:class:`libqtile.widget.chord.Chord`) as this will display the name of the
+    (:class:`~libqtile.widget.Chord`) as this will display the name of the
     currently active mode on the bar.
 
 Chains
@@ -226,5 +226,5 @@ Reference
 .. qtile_class:: libqtile.config.KeyChord
    :no-commands:
 
-.. qtile_class:: libqtile.config.EzConfig
+.. qtile_class:: libqtile.config.EzKey
    :no-commands:

--- a/docs/manual/config/layouts.rst
+++ b/docs/manual/config/layouts.rst
@@ -21,6 +21,7 @@ Example
 ::
 
     from libqtile import layout
+
     layouts = [
         layout.Max(),
         layout.Stack(stacks=2)

--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -4,10 +4,10 @@
 Lazy objects
 ============
 
-The ``lazy.lazy`` object is a special helper object to specify a command for
-later execution. This object acts like the root of the object graph, which
-means that we can specify a key binding command with the same syntax used to
-call the command through a script or through :ref:`qtile-shell`.
+The :data:`lazy.lazy` object is a special helper object to specify a command
+for later execution. This object acts like the root of the object graph, which
+means that we can specify a command with the same syntax used to call the
+command through a script or through :ref:`qtile-shell`.
 
 Example
 -------
@@ -15,7 +15,7 @@ Example
 ::
 
     from libqtile.config import Key
-    from libqtile.command import lazy
+    from libqtile.lazy import lazy
 
     keys = [
         Key(
@@ -161,7 +161,7 @@ Examples
 ::
 
     from libqtile.config import Key
-    from libqtile.command import lazy
+    from libqtile.lazy import lazy
 
     @lazy.function
     def my_function(qtile):
@@ -183,7 +183,7 @@ Arguments can be added to the ``lazy.function`` call.
 ::
 
     from libqtile.config import Key
-    from libqtile.command import lazy
+    from libqtile.lazy import lazy
     from libqtile.log_utils import logger
 
     def multiply(qtile, value, multiplier=10):
@@ -203,7 +203,7 @@ Arguments can also be passed to the decorated function.
 ::
 
     from libqtile.config import Key
-    from libqtile.command import lazy
+    from libqtile.lazy import lazy
     from libqtile.log_utils import logger
 
     @lazy.function

--- a/docs/manual/config/mouse.rst
+++ b/docs/manual/config/mouse.rst
@@ -41,3 +41,6 @@ Reference
 
 .. qtile_class:: libqtile.config.Drag
    :no-commands:
+
+.. qtile_class:: libqtile.config.EzClick
+   :no-commands:

--- a/docs/manual/troubleshooting.rst
+++ b/docs/manual/troubleshooting.rst
@@ -71,7 +71,7 @@ Qtile, so that the debug logs printed by Qtile are only the server's.
 
 If you suspect a client may be responsible for a bug, it can be helpful to look
 at the issue trackers for other compositors, such as `sway
-<https://github.com/swaywm/sway/issues`_. Similarly if you're hacking on
+<https://github.com/swaywm/sway/issues>`_. Similarly if you're hacking on
 Qtile's internals and think you've found an unexpected quirk it may be helpful
 to search the issue tracker for `wlroots
 <https://gitlab.freedesktop.org/wlroots/wlroots/-/issues>`_.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -33,61 +33,70 @@ import sys
 from typing import TYPE_CHECKING
 
 from libqtile import configurable, hook, utils
-from libqtile.backend import base
 from libqtile.bar import Bar
 from libqtile.command.base import CommandObject
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from typing import Any, Callable, ContextManager, Iterable
 
+    from libqtile.backend import base
     from libqtile.bar import BarType
     from libqtile.command.base import ItemT
+    from libqtile.core.manager import Qtile
     from libqtile.group import _Group
+    from libqtile.lazy import LazyCall
 
 
 class Key:
-    """Defines a keybinding.
+    """
+    Defines a keybinding.
 
     Parameters
     ==========
     modifiers:
         A list of modifier specifications. Modifier specifications are one of:
-        "shift", "lock", "control", "mod1", "mod2", "mod3", "mod4", "mod5".
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
     key:
-        A key specification, e.g. "a", "Tab", "Return", "space".
+        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``.
     commands:
-        A list of lazy command objects generated with the lazy.lazy helper.
-        If multiple Call objects are specified, they are run in sequence.
+        A list :class:`LazyCall` objects to evaluate in sequence upon keypress.
     desc:
-        description to be added to the key binding
+        Description to be added to the key binding. (Optional)
+
     """
 
-    def __init__(self, modifiers: list[str], key: str, *commands, desc: str = ""):
+    def __init__(
+        self, modifiers: list[str], key: str, *commands: LazyCall, desc: str = ""
+    ) -> None:
         self.modifiers = modifiers
         self.key = key
         self.commands = commands
         self.desc = desc
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Key (%s, %s)>" % (self.modifiers, self.key)
 
 
 class KeyChord:
-    """Define a key chord aka vim like mode
+    """
+    Define a key chord aka Vim-like mode.
 
     Parameters
     ==========
     modifiers:
         A list of modifier specifications. Modifier specifications are one of:
-        "shift", "lock", "control", "mod1", "mod2", "mod3", "mod4", "mod5".
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
     key:
-        A key specification, e.g. "a", "Tab", "Return", "space".
+        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``.
     submappings:
-        A list of Key or KeyChord declarations to bind in this chord.
+        A list of :class:`Key` or :class:`KeyChord` declarations to bind in this chord.
     mode:
-        A string with vim like mode name. If it's set, the chord mode will
-        not be left after a keystroke (except for Esc which always leaves the
-        current chord/mode).
+        A string with Vim-like mode name. If set, the chord mode will not be left after
+        a keystroke (except for Esc which always leaves the current chord/mode).
+        (Optional)
+
     """
 
     def __init__(
@@ -96,7 +105,7 @@ class KeyChord:
         key: str,
         submappings: list[Key | KeyChord],
         mode: str = "",
-    ):
+    ) -> None:
         self.modifiers = modifiers
         self.key = key
 
@@ -104,47 +113,88 @@ class KeyChord:
         self.submappings = submappings
         self.mode = mode
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<KeyChord (%s, %s)>" % (self.modifiers, self.key)
 
 
 class Mouse:
-    def __init__(self, modifiers: list[str], button: str, *commands, **kwargs):
+    def __init__(self, modifiers: list[str], button: str, *commands: LazyCall) -> None:
         self.modifiers = modifiers
         self.button = button
         self.commands = commands
         self.button_code = int(self.button.replace("Button", ""))
-        for k, v in kwargs.items():
-            setattr(self, k, v)
         self.modmask: int = 0
 
 
 class Drag(Mouse):
-    """Defines binding of a mouse to some dragging action
+    """
+    Bind commands to a dragging action.
 
-    On each motion event command is executed with two extra parameters added x
-    and y offset from previous move.
+    On each motion event the bound commands are executed with two additional parameters
+    specifying the x and y offset from the previous position.
+
+    Parameters
+    ==========
+    modifiers:
+        A list of modifier specifications. Modifier specifications are one of:
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
+    button:
+        The button used to start dragging e.g. ``"Button1"``.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon drag.
+    start:
+        A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
+
     """
 
-    def __init__(self, *args, start=False, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        modifiers: list[str],
+        button: str,
+        *commands: LazyCall,
+        start: LazyCall | None = None,
+    ) -> None:
+        super().__init__(modifiers, button, *commands)
         self.start = start
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Drag (%s, %s)>" % (self.modifiers, self.button)
 
 
 class Click(Mouse):
-    """Defines binding of a mouse click"""
+    """
+    Bind commands to a clicking action.
 
-    def __repr__(self):
+    Parameters
+    ==========
+    modifiers:
+        A list of modifier specifications. Modifier specifications are one of:
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
+    button:
+        The button used to start dragging e.g. ``"Button1"``.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon drag.
+
+    """
+
+    def __repr__(self) -> str:
         return "<Click (%s, %s)>" % (self.modifiers, self.button)
 
 
 class EzConfig:
     """
-    Helper class for defining key and button bindings in an emacs-like format.
+    Helper class for defining key and button bindings in an Emacs-like format.
+
     Inspired by Xmonad's XMonad.Util.EZConfig.
+
+    Splits an emacs keydef into modifiers and keys. For example:
+
+          "m-s-a"     -> ['mod4', 'shift'], 'a'
+          "a-<minus>" -> ['mod1'], 'minus'
+          "C-<Tab>"   -> ['control'], 'Tab'
+
     """
 
     modifier_keys = {
@@ -154,15 +204,9 @@ class EzConfig:
         "C": "control",
     }
 
-    def parse(self, spec):
-        """
-        Splits an emacs keydef into modifiers and keys. For example:
-          "M-S-a"     -> ['mod4', 'shift'], 'a'
-          "A-<minus>" -> ['mod1'], 'minus'
-          "C-<Tab>"   -> ['control'], 'Tab'
-        """
+    def parse(self, spec: str) -> tuple[list[str], str]:
         mods = []
-        keys = []
+        keys: list[str] = []
 
         for key in spec.split("-"):
             if not key:
@@ -192,33 +236,73 @@ class EzConfig:
 
 
 class EzKey(EzConfig, Key):
-    def __init__(self, keydef, *commands, **kwargs):
+    """
+    Defines a keybinding using the Emacs-like format.
+
+    Parameters
+    ==========
+    keydef:
+        The Emacs-like key specification, e.g. ``"M-S-a"``.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon keypress.
+    desc:
+        Description to be added to the key binding. (Optional)
+
+    """
+
+    def __init__(self, keydef: str, *commands: LazyCall, desc: str = "") -> None:
         modkeys, key = self.parse(keydef)
-        super().__init__(modkeys, key, *commands, **kwargs)
+        super().__init__(modkeys, key, *commands, desc=desc)
 
 
 class EzClick(EzConfig, Click):
-    def __init__(self, btndef, *commands, **kwargs):
+    """
+    Bind commands to a clicking action using the Emacs-like format.
+
+    Parameters
+    ==========
+    btndef:
+        The Emacs-like button specification, e.g. ``"M-1"``.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon drag.
+
+    """
+
+    def __init__(self, btndef: str, *commands: LazyCall) -> None:
         modkeys, button = self.parse(btndef)
         button = "Button%s" % button
-        super().__init__(modkeys, button, *commands, **kwargs)
+        super().__init__(modkeys, button, *commands)
 
 
 class EzDrag(EzConfig, Drag):
-    def __init__(self, btndef, *commands, **kwargs):
+    """
+    Bind commands to a dragging action using the Emacs-like format.
+
+    Parameters
+    ==========
+    btndef:
+        The Emacs-like button specification, e.g. ``"M-1"``.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon drag.
+    start:
+        A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
+
+    """
+
+    def __init__(self, btndef: str, *commands: LazyCall, start: LazyCall | None = None) -> None:
         modkeys, button = self.parse(btndef)
         button = "Button%s" % button
-        super().__init__(modkeys, button, *commands, **kwargs)
+        super().__init__(modkeys, button, *commands, start=start)
 
 
 class ScreenRect:
-    def __init__(self, x, y, width, height):
+    def __init__(self, x: int, y: int, width: int, height: int) -> None:
         self.x = x
         self.y = y
         self.width = width
         self.height = height
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s %d,%d %d,%d>" % (
             self.__class__.__name__,
             self.x,
@@ -227,17 +311,15 @@ class ScreenRect:
             self.height,
         )
 
-    def hsplit(self, columnwidth):
-        assert columnwidth > 0
-        assert columnwidth < self.width
+    def hsplit(self, columnwidth: int) -> tuple[ScreenRect, ScreenRect]:
+        assert 0 < columnwidth < self.width
         return (
             self.__class__(self.x, self.y, columnwidth, self.height),
             self.__class__(self.x + columnwidth, self.y, self.width - columnwidth, self.height),
         )
 
-    def vsplit(self, rowheight):
-        assert rowheight > 0
-        assert rowheight < self.height
+    def vsplit(self, rowheight: int) -> tuple[ScreenRect, ScreenRect]:
+        assert 0 < rowheight < self.height
         return (
             self.__class__(self.x, self.y, self.width, rowheight),
             self.__class__(self.x, self.y + rowheight, self.width, self.height - rowheight),
@@ -245,20 +327,20 @@ class ScreenRect:
 
 
 class Screen(CommandObject):
-    """A physical screen, and its associated paraphernalia.
+    """
+    A physical screen, and its associated paraphernalia.
 
-    Define a screen with a given set of Bars of a specific geometry.  Note that
-    bar.Bar objects can only be placed at the top or the bottom of the screen
-    (bar.Gap objects can be placed anywhere).  Also, ``x``, ``y``, ``width``,
-    and ``height`` aren't specified usually unless you are using 'fake
-    screens'.
+    Define a screen with a given set of :class:`Bar`s of a specific geometry. Also,
+    ``x``, ``y``, ``width``, and ``height`` aren't specified usually unless you are
+    using 'fake screens'.
 
     The ``wallpaper`` parameter, if given, should be a path to an image file. How this
     image is painted to the screen is specified by the ``wallpaper_mode`` parameter. By
     default, the image will be placed at the screens origin and retain its own
-    dimensions. If the mode is 'fill', the image will be centred on the screen and
-    resized to fill it. If the mode is 'stretch', the image is stretched to fit all of
-    it into the screen.
+    dimensions. If the mode is ``"fill"``, the image will be centred on the screen and
+    resized to fill it. If the mode is ``"stretch"``, the image is stretched to fit all
+    of it into the screen.
+
     """
 
     group: _Group
@@ -277,7 +359,7 @@ class Screen(CommandObject):
         y: int | None = None,
         width: int | None = None,
         height: int | None = None,
-    ):
+    ) -> None:
 
         self.top = top
         self.bottom = bottom
@@ -285,7 +367,7 @@ class Screen(CommandObject):
         self.right = right
         self.wallpaper = wallpaper
         self.wallpaper_mode = wallpaper_mode
-        self.qtile = None
+        self.qtile: Qtile | None = None
         # x position of upper left corner can be > 0
         # if one screen is "right" of the other
         self.x = x if x is not None else 0
@@ -293,7 +375,17 @@ class Screen(CommandObject):
         self.width = width if width is not None else 0
         self.height = height if height is not None else 0
 
-    def _configure(self, qtile, index, x, y, width, height, group, reconfigure_gaps=False):
+    def _configure(
+        self,
+        qtile: Qtile,
+        index: int,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        group: _Group,
+        reconfigure_gaps: bool = False,
+    ) -> None:
         self.qtile = qtile
         self.index = index
         self.x = x
@@ -307,23 +399,24 @@ class Screen(CommandObject):
             self.wallpaper = os.path.expanduser(self.wallpaper)
             self.paint(self.wallpaper, self.wallpaper_mode)
 
-    def paint(self, path, mode=None):
-        self.qtile.paint_screen(self, path, mode)
+    def paint(self, path: str, mode: str | None = None) -> None:
+        if self.qtile:
+            self.qtile.paint_screen(self, path, mode)
 
     @property
-    def gaps(self):
+    def gaps(self) -> Iterable[BarType]:
         return (i for i in [self.top, self.bottom, self.left, self.right] if i)
 
     @property
-    def dx(self):
+    def dx(self) -> int:
         return self.x + self.left.size if self.left else self.x
 
     @property
-    def dy(self):
+    def dy(self) -> int:
         return self.y + self.top.size if self.top else self.y
 
     @property
-    def dwidth(self):
+    def dwidth(self) -> int:
         val = self.width
         if self.left:
             val -= self.left.size
@@ -332,7 +425,7 @@ class Screen(CommandObject):
         return val
 
     @property
-    def dheight(self):
+    def dheight(self) -> int:
         val = self.height
         if self.top:
             val -= self.top.size
@@ -340,10 +433,12 @@ class Screen(CommandObject):
             val -= self.bottom.size
         return val
 
-    def get_rect(self):
+    def get_rect(self) -> ScreenRect:
         return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
 
-    def set_group(self, new_group, save_prev=True, warp=True):
+    def set_group(
+        self, new_group: _Group | None, save_prev: bool = True, warp: bool = True
+    ) -> None:
         """Put group on this screen"""
         if new_group is None:
             return
@@ -371,7 +466,8 @@ class Screen(CommandObject):
         else:
             if hasattr(self, "group"):
                 old_group = self.group
-                ctx = self.qtile.core.masked()
+                assert self.qtile is not None
+                ctx: ContextManager = self.qtile.core.masked()
             else:
                 old_group = None
                 ctx = contextlib.nullcontext()
@@ -388,7 +484,7 @@ class Screen(CommandObject):
         hook.fire("focus_change")
         hook.fire("layout_change", self.group.layouts[self.group.current_layout], self.group)
 
-    def toggle_group(self, group=None, warp=True):
+    def toggle_group(self, group: _Group | None = None, warp: bool = True) -> None:
         """Switch to the selected group or to the previously active one"""
         if group in (self.group, None) and hasattr(self, "previous_group"):
             group = self.previous_group
@@ -402,16 +498,18 @@ class Screen(CommandObject):
         elif name == "bar":
             return False, [x.position for x in self.gaps]
         elif name == "widget":
-            return False, [w.name for g in self.gaps for w in g.widgets if isinstance(g, Bar)]
+            bars = (g for g in self.gaps if isinstance(g, Bar))
+            return False, [w.name for b in bars for w in b.widgets]
         elif name == "group":
             return True, [self.group.name]
         return None
 
-    def _select(self, name, sel):
+    def _select(self, name: str, sel: str | int | None) -> CommandObject | None:
         if name == "layout":
             if sel is None:
                 return self.group.layout
             else:
+                assert isinstance(sel, int)
                 return utils.lget(self.group.layouts, sel)
         elif name == "window":
             if sel is None:
@@ -421,6 +519,7 @@ class Screen(CommandObject):
                     if i.wid == sel:
                         return i
         elif name == "bar":
+            assert isinstance(sel, str)
             return getattr(self, sel)
         elif name == "widget":
             for gap in self.gaps:
@@ -434,8 +533,16 @@ class Screen(CommandObject):
                 return self.group
             else:
                 return self.group if sel == self.group.name else None
+        return None
 
-    def resize(self, x=None, y=None, w=None, h=None):
+    def resize(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        w: int | None = None,
+        h: int | None = None,
+    ) -> None:
+        assert self.qtile is not None
         if x is None:
             x = self.x
         if y is None:
@@ -450,88 +557,102 @@ class Screen(CommandObject):
                 bar.draw()
         self.qtile.call_soon(self.group.layout_all)
 
-    def cmd_info(self):
+    def cmd_info(self) -> dict[str, int]:
         """Returns a dictionary of info for this screen."""
         return dict(index=self.index, width=self.width, height=self.height, x=self.x, y=self.y)
 
-    def cmd_resize(self, x=None, y=None, w=None, h=None):
+    def cmd_resize(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        w: int | None = None,
+        h: int | None = None,
+    ) -> None:
         """Resize the screen"""
         self.resize(x, y, w, h)
 
-    def cmd_next_group(self, skip_empty=False, skip_managed=False):
+    def cmd_next_group(self, skip_empty: bool = False, skip_managed: bool = False) -> None:
         """Switch to the next group"""
         n = self.group.get_next_group(skip_empty, skip_managed)
         self.set_group(n)
         return n.name
 
-    def cmd_prev_group(self, skip_empty=False, skip_managed=False, warp=True):
+    def cmd_prev_group(
+        self, skip_empty: bool = False, skip_managed: bool = False, warp: bool = True
+    ) -> None:
         """Switch to the previous group"""
         n = self.group.get_previous_group(skip_empty, skip_managed)
         self.set_group(n, warp=warp)
         return n.name
 
-    def cmd_toggle_group(self, group_name=None, warp=True):
+    def cmd_toggle_group(self, group_name: str | None = None, warp: bool = True) -> None:
         """Switch to the selected group or to the previously active one"""
-        group = self.qtile.groups_map.get(group_name)
+        assert self.qtile is not None
+        group = self.qtile.groups_map.get(group_name if group_name else "")
         self.toggle_group(group, warp=warp)
 
-    def cmd_set_wallpaper(self, path, mode=None):
+    def cmd_set_wallpaper(self, path: str, mode: str | None = None) -> None:
         """Set the wallpaper to the given file."""
         self.paint(path, mode)
 
 
 class Group:
-    """Represents a "dynamic" group
+    """
+    Represents a "dynamic" group
 
-    These groups can spawn apps, only allow certain Matched windows to be on
-    them, hide when they're not in use, etc.
-    Groups are identified by their name.
+    These groups can spawn apps, only allow certain Matched windows to be on them, hide
+    when they're not in use, etc. Groups are identified by their name.
 
     Parameters
     ==========
-    name: string
-        the name of this group
-    matches: default ``None``
-        list of ``Match`` objects whose  windows will be assigned to this group
-    exclusive: boolean
-        when other apps are started in this group, should we allow them here or not?
-    spawn: string or list of strings
-        this will be ``exec()`` d when the group is created, you can pass
-        either a program name or a list of programs to ``exec()``
-    layout: string
-        the name of default layout for this group (e.g. 'max' or 'stack').
-        This is the name specified for a particular layout in config.py
-        or if not defined it defaults in general the class name in all lower case.
-    layouts: list
-        the group layouts list overriding global layouts.
-        Use this to define a separate list of layouts for this particular group.
-    persist: boolean
-        should this group stay alive with no member windows?
-    init: boolean
-        is this group alive when qtile starts?
-    position  int
-        group position
-    label: string
-        the display name of the group.
-        Use this to define a display name other than name of the group.
-        If set to None, the display name is set to the name.
+    name:
+        The name of this group.
+    matches:
+        List of :class:`Match` objects whose matched windows will be assigned to this
+        group.
+    exclusive:
+        When other apps are started in this group, should we allow them here or not?
+    spawn:
+        This will be ``exec()`` d when the group is created. Tou can pass either a
+        program name or a list of programs to ``exec()``
+    layout:
+        The name of default layout for this group (e.g. ``"max"``). This is the name
+        specified for a particular layout in ``config.py`` or if not defined it defaults
+        in general to the class name in all lower case.
+    layouts:
+        The group layouts list overriding global layouts. Use this to define a separate
+        list of layouts for this particular group.
+    persist:
+        Should this group stay alive when it has no member windows?
+    init:
+        Should this group be alive when Qtile starts?
+    layout_opts:
+        Options to pass to a layout.
+    screen_affinity:
+        Make a dynamic group prefer to start on a specific screen.
+    position:
+        The position of this group.
+    label:
+        The display name of the group. Use this to define a display name other than name
+        of the group. If set to ``None``, the display name is set to the name.
+
     """
 
     def __init__(
         self,
         name: str,
         matches: list[Match] | None = None,
-        exclusive=False,
+        exclusive: bool = False,
         spawn: str | list[str] | None = None,
         layout: str | None = None,
-        layouts: list | None = None,
-        persist=True,
-        init=True,
-        layout_opts=None,
-        screen_affinity=None,
-        position=sys.maxsize,
+        layouts: list[str] | None = None,
+        persist: bool = True,
+        init: bool = True,
+        layout_opts: dict[str, Any] | None = None,
+        screen_affinity: int | None = None,
+        position: int = sys.maxsize,
         label: str | None = None,
-    ):
+    ) -> None:
         self.name = name
         self.label = label
         self.exclusive = exclusive
@@ -546,7 +667,7 @@ class Group:
         self.screen_affinity = screen_affinity
         self.position = position
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         attrs = utils.describe_attributes(
             self,
             [
@@ -565,29 +686,37 @@ class Group:
 
 
 class ScratchPad(Group):
-    """Represents a "ScratchPad" group
+    """
+    Represents a "ScratchPad" group
 
-    ScratchPad adds a (by default) invisible group to qtile.
-    That group is used as a place for currently not visible windows spawned by a
-    ``DropDown`` configuration.
+    ScratchPad adds a (by default) invisible group to Qtile. That group is used as a
+    place for currently not visible windows spawned by a :class:`DropDown`
+    configuration.
 
     Parameters
     ==========
-    name: string
-        the name of this group
-    dropdowns: default ``None``
-        list of DropDown objects
-    position: int
-        group position
-    label: string
-        The display name of the ScratchPad group. Defaults to the empty string
-        such that the group is hidden in ``GroupList`` widget.
-    single : Boolean
-        Only one of the window among the specified dropdowns will be
-        visible at a time.
+    name:
+        The name of this group.
+    dropdowns:
+        :class:`DropDown` s available on the scratchpad.
+    position:
+        The position of this group.
+    label:
+        The display name of the :class:`ScratchPad` group. Defaults to the empty string
+        such that the group is hidden in :class:`~libqtile.widget.GroupBox` widget.
+    single:
+        If ``True``, only one of the dropdowns will be visible at a time.
+
     """
 
-    def __init__(self, name, dropdowns=None, position=sys.maxsize, label="", single=False):
+    def __init__(
+        self,
+        name: str,
+        dropdowns: list[DropDown] | None = None,
+        position: int = sys.maxsize,
+        label: str = "",
+        single: bool = False,
+    ) -> None:
         Group.__init__(
             self,
             name,
@@ -600,7 +729,7 @@ class ScratchPad(Group):
         self.dropdowns = dropdowns if dropdowns is not None else []
         self.single = single
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<config.ScratchPad %r (%s)>" % (
             self.name,
             ", ".join(dd.name for dd in self.dropdowns),
@@ -608,47 +737,49 @@ class ScratchPad(Group):
 
 
 class Match:
-    """Match for dynamic groups or auto-floating windows.
+    """
+    Match for dynamic groups or auto-floating windows.
 
-    It can match by title, wm_class, role, wm_type, wm_instance_class or
-    net_wm_pid.
+    It can match by title, wm_class, role, wm_type, wm_instance_class or net_wm_pid.
 
-    ``Match`` supports both regular expression objects (i.e. the result of
-    ``re.compile()``) or strings (match as an "include"-match). If a window
-    matches all specified values, it is considered a match.
+    :class:`Match` supports both regular expression objects (i.e. the result of
+    ``re.compile()``) or strings (match as an "include"-match). If a window matches all
+    specified values, it is considered a match.
 
     Parameters
     ==========
     title:
-        matches against the WM_NAME atom (X11) or title (Wayland)
+        Match against the WM_NAME atom (X11) or title (Wayland).
     wm_class:
-        matches against the second string in WM_CLASS atom (X11) or app ID (Wayland)
+        Match against the second string in WM_CLASS atom (X11) or app ID (Wayland).
     role:
-        matches against the WM_ROLE atom (X11 only)
+        Match against the WM_ROLE atom (X11 only).
     wm_type:
-        matches against the WM_TYPE atom (X11 only)
+        Match against the WM_TYPE atom (X11 only).
     wm_instance_class:
-        matches against the first string in WM_CLASS atom (X11) or app ID (Wayland)
+        Match against the first string in WM_CLASS atom (X11) or app ID (Wayland).
     net_wm_pid:
-        matches against the _NET_WM_PID atom (X11) or PID (Wayland) -
-        (only int allowed for this rule)
+        Match against the _NET_WM_PID atom (X11) or PID (Wayland).
     func:
-        delegate the match to the given function, which receives the tested
-        client as argument and must return True if it matches, False otherwise
+        Delegate the match to the given function, which receives the tested client as an
+        argument and must return ``True`` if it matches, ``False`` otherwise.
+    wid:
+        Match against the window ID.
+
     """
 
     def __init__(
         self,
-        title=None,
-        wm_class=None,
-        role=None,
-        wm_type=None,
-        wm_instance_class=None,
-        net_wm_pid=None,
-        func: Callable[[base.WindowType], bool] | None = None,
-        wid=None,
-    ):
-        self._rules = {}
+        title: str | None = None,
+        wm_class: str | None = None,
+        role: str | None = None,
+        wm_type: str | None = None,
+        wm_instance_class: str | None = None,
+        net_wm_pid: int | None = None,
+        func: Callable[[base.Window], bool] | None = None,
+        wid: int | None = None,
+    ) -> None:
+        self._rules: dict[str, Any] = {}
 
         if title is not None:
             self._rules["title"] = title
@@ -673,12 +804,12 @@ class Match:
             self._rules["wm_type"] = wm_type
 
     @staticmethod
-    def _get_property_predicate(name, value):
+    def _get_property_predicate(name: str, value: Any) -> Callable[..., bool]:
         if name == "net_wm_pid" or name == "wid":
             return lambda other: other == value
         elif name == "wm_class":
 
-            def predicate(other):
+            def predicate(other) -> bool:  # type: ignore
                 # match as an "include"-match on any of the received classes
                 match = getattr(other, "match", lambda v: v in other)
                 return value and any(match(v) for v in value)
@@ -686,14 +817,15 @@ class Match:
             return predicate
         else:
 
-            def predicate(other):
+            def predicate(other) -> bool:  # type: ignore
                 # match as an "include"-match
                 match = getattr(other, "match", lambda v: v in other)
                 return match(value)
 
             return predicate
 
-    def compare(self, client):
+    def compare(self, client: base.Window) -> bool:
+        value: Any
         for property_name, rule_value in self._rules.items():
             if property_name == "title":
                 value = client.name
@@ -728,35 +860,44 @@ class Match:
             return False
         return True
 
-    def map(self, callback, clients):
+    def map(self, callback: Callable[[base.Window], Any], clients: list[base.Window]) -> None:
         """Apply callback to each client that matches this Match"""
         for c in clients:
             if self.compare(c):
                 callback(c)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Match %s>" % self._rules
 
 
 class Rule:
-    """How to act on a match
+    """
+    How to act on a match.
 
-    A Rule contains a list of Match objects, and a specification about what to
-    do when any of them is matched.
+    A :class:`Rule` contains a list of :class:`Match` objects, and a specification about
+    what to do when any of them is matched.
 
     Parameters
     ==========
-    match :
-        ``Match`` object or a list of such associated with this ``Rule``
-    float :
-        auto float this window?
-    intrusive :
-        override the group's exclusive setting?
-    break_on_match :
+    match:
+        :class:`Match` object or a list of such associated with this rule.
+    float:
+        Should we auto float this window?
+    intrusive:
+        Should we override the group's exclusive setting?
+    break_on_match:
         Should we stop applying rules if this rule is matched?
+
     """
 
-    def __init__(self, match, group=None, float=False, intrusive=False, break_on_match=True):
+    def __init__(
+        self,
+        match: Match | list[Match],
+        group: _Group | None = None,
+        float: bool = False,
+        intrusive: bool = False,
+        break_on_match: bool = True,
+    ) -> None:
         if isinstance(match, Match):
             self.matchlist = [match]
         else:
@@ -766,10 +907,10 @@ class Rule:
         self.intrusive = intrusive
         self.break_on_match = break_on_match
 
-    def matches(self, w):
+    def matches(self, w: base.Window) -> bool:
         return any(w.match(m) for m in self.matchlist)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         actions = utils.describe_attributes(
             self, ["group", "float", "intrusive", "break_on_match"]
         )
@@ -778,9 +919,9 @@ class Rule:
 
 class DropDown(configurable.Configurable):
     """
-    Configure a specified command and its associated window for the ScratchPad.
-    That window can be shown and hidden using a configurable keystroke
-    or any other scripted trigger.
+    Configure a specified command and its associated window for the :class:`ScratchPad`.
+    That window can be shown and hidden using a configurable keystroke or any other
+    scripted trigger.
     """
 
     defaults = (
@@ -803,47 +944,46 @@ class DropDown(configurable.Configurable):
         (
             "on_focus_lost_hide",
             True,
-            "Shall the window be hidden if focus is lost? If so, the DropDown "
+            "Shall the window be hidden if focus is lost? If so, the :class:`DropDown` "
             "is hidden if window focus or the group is changed.",
         ),
         (
             "warp_pointer",
             True,
             "Shall pointer warp to center of window on activation? "
-            "This has only effect if any of the on_focus_lost_xxx "
-            "configurations is True",
+            "This only has effect if any of the ``on_focus_lost_xxx`` options are "
+            "``True``",
         ),
         (
             "match",
             None,
-            "Use a ``config.Match`` to identify the spawned window and move it to the "
+            "Use a :class:`Match` to identify the spawned window and move it to the "
             "scratchpad, instead of relying on the window's PID. This works around "
             "some programs that may not be caught by the window's PID if it does "
             "not match the PID of the spawned process.",
         ),
     )
 
-    def __init__(self, name, cmd, **config):
+    def __init__(self, name: str, cmd: str, **config: dict[str, Any]) -> None:
         """
-        Initialize DropDown window wrapper.
-        Define a command to spawn a process for the first time the DropDown
-        is shown.
+        Initialize :class:`DropDown` window wrapper.
+
+        Define a command to spawn a process for the first time the class:`DropDown` is
+        shown.
 
         Parameters
         ==========
-        name: string
-            The name of the DropDown configuration.
-        cmd: string
-            Command to spawn a process.
-        match : Match
-            A match object to identify the window instead of the pid.
+        name:
+            The name of the dropdown.
+        cmd:
+            Command to spawn a window to be captured by the dropdown.
         """
         configurable.Configurable.__init__(self, **config)
         self.name = name
         self.command = cmd
         self.add_defaults(self.defaults)
 
-    def info(self):
+    def info(self) -> dict[str, Any]:
         return dict(
             name=self.name,
             command=self.command,

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,6 +147,8 @@ ignore_missing_imports = True
 disallow_untyped_defs = True
 [mypy-libqtile.core.*]
 disallow_untyped_defs = True
+[mypy-libqtile.config]
+disallow_untyped_defs = True
 [mypy-libqtile.log_utils]
 disallow_untyped_defs = True
 [mypy-libqtile.utils]


### PR DESCRIPTION
This does a few things:
- Adds the --keep-going flag to sphinx-build so we can see all errors
  that would happen rather than it exiting when the first is hit.
- Rewrites all libqtile.config docstrings in a consistent format.
- Documents the Ez classes
- Makes all references in docstrings and the docs link to where they
  reference, improving navigability of the docs.
- Adds type hints to all of config.py and enforces this. They also
  improve the docs by showing valid arguments to class inits and
  methods.