### PR TITLE
Add `force_update` to `ThreadPoolText` widgets

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           should be copied into clipboard
         - Add `resume` hook when computer resumes from sleep/suspend/hibernate.
         - Add `text_only` option for `LaunchBar` widget.
+        - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -647,6 +647,10 @@ class ThreadPoolText(_TextBox):
     def poll(self):
         pass
 
+    def cmd_force_update(self):
+        """Immediately poll the widget. Existing timers are unaffected."""
+        self.update(self.poll())
+
 
 # these two classes below look SUSPICIOUSLY similar
 


### PR DESCRIPTION
This is a convenience command to help users trigger updates of polling widgets from key bindings, hooks etc.

This gets requested fairly often and we often end up telling people to do something like:
``` python
lazy.widget["some_polling_widget].eval("self.update(self.poll())")
```

This would be replaced by
``` python
lazy.widget["some_polling_widget"].force_update()
```