### PR TITLE
ThermalSensor: make text formattable

### DIFF
--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -43,8 +43,8 @@ class ThermalSensor(base.InLoopPollText):
     """
 
     defaults = [
+        ("format", "{temp:.1f}{unit}", "Display string formatting"),
         ("metric", True, "True to use metric/C, False to use imperial/F"),
-        ("show_tag", False, "Show tag sensor"),
         ("update_interval", 2, "Update interval in seconds"),
         ("tag_sensor", None, 'Tag of the temperature sensor. For example: "temp1" or "Core 0"'),
         (
@@ -79,7 +79,6 @@ class ThermalSensor(base.InLoopPollText):
 
         temperature_list = {}
         temps = psutil.sensors_temperatures(fahrenheit=not self.metric)
-        unit = "°C" if self.metric else "°F"
         empty_index = 0
         for kernel_module in temps:
             for sensor in temps[kernel_module]:
@@ -89,7 +88,7 @@ class ThermalSensor(base.InLoopPollText):
                         kernel_module if kernel_module else "UNKNOWN", str(empty_index)
                     )
                     empty_index += 1
-                temperature_list[label] = (str(round(sensor.current, 1)), unit)
+                temperature_list[label] = sensor.current
 
         return temperature_list
 
@@ -97,13 +96,16 @@ class ThermalSensor(base.InLoopPollText):
         temp_values = self.get_temp_sensors()
         if temp_values is None:
             return False
-        text = ""
-        if self.show_tag and self.tag_sensor is not None:
-            text = self.tag_sensor + ": "
-        text += "".join(temp_values.get(self.tag_sensor, ["N/A"]))
-        temp_value = float(temp_values.get(self.tag_sensor, [0])[0])
+        temp_value = temp_values.get(self.tag_sensor, float("nan"))
         if temp_value > self.threshold:
             self.layout.colour = self.foreground_alert
         else:
             self.layout.colour = self.foreground_normal
-        return text
+        unit = "°C" if self.metric else "°F"
+
+        val = dict(
+            temp=temp_value,
+            tag=self.tag_sensor,
+            unit=unit
+        )
+        return self.format.format(**val)

--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -105,7 +105,7 @@ class ThermalSensor(base.InLoopPollText):
 
     def poll(self):
         temp_values = self.get_temp_sensors()
-        
+
         # Temperature not available
         if (temp_values is None) or (self.tag_sensor not in temp_values):
             return "N/A"
@@ -116,9 +116,5 @@ class ThermalSensor(base.InLoopPollText):
         else:
             self.layout.colour = self.foreground_normal
 
-        val = dict(
-            temp=temp_value,
-            tag=self.tag_sensor,
-            unit=self.unit
-        )
+        val = dict(temp=temp_value, tag=self.tag_sensor, unit=self.unit)
         return self.format.format(**val)

--- a/test/widgets/docs_screenshots/ss_sensors.py
+++ b/test/widgets/docs_screenshots/ss_sensors.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import sys
+from importlib import reload
+
+import pytest
+
+from test.widgets.test_sensors import MockPsutil
+
+
+@pytest.fixture
+def widget(monkeypatch):
+    monkeypatch.setitem(sys.modules, "psutil", MockPsutil("psutil"))
+    from libqtile.widget import sensors
+
+    reload(sensors)
+    yield sensors.ThermalSensor
+
+
+@pytest.mark.parametrize(
+    "screenshot_manager",
+    [{}, {"tag_sensor": "NVME"}, {"format": "{tag}: {temp:.0f}{unit}"}, {"threshold": 30.0}],
+    indirect=True,
+)
+def ss_thermal_sensor(screenshot_manager):
+    screenshot_manager.take_screenshot()

--- a/test/widgets/test_sensors.py
+++ b/test/widgets/test_sensors.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2022 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import sys
+from importlib import reload
+from types import ModuleType
+
+import pytest
+
+import libqtile.config
+import libqtile.widget
+from libqtile.bar import Bar
+
+
+class Temp:
+    def __init__(self, label, temp, fahrenheit=False):
+        self.label = label
+        self.current = temp
+        if fahrenheit:
+            self.current = (self.current * 9 / 5) + 32
+
+
+class MockPsutil(ModuleType):
+    @classmethod
+    def sensors_temperatures(cls, fahrenheit=False):
+        return {"core": [Temp("CPU", 45.0, fahrenheit)], "nvme": [Temp("NVME", 56.3, fahrenheit)]}
+
+
+@pytest.fixture
+def sensors_manager(monkeypatch, manager_nospawn, minimal_conf_noscreen, request):
+    monkeypatch.setitem(sys.modules, "psutil", MockPsutil("psutil"))
+    from libqtile.widget import sensors
+
+    reload(sensors)
+
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=Bar([sensors.ThermalSensor(**getattr(request, "param", dict()))], 10)
+        )
+    ]
+
+    manager_nospawn.start(config)
+    yield manager_nospawn
+
+
+def test_thermal_sensor_metric(sensors_manager):
+    assert sensors_manager.c.widget["thermalsensor"].info()["text"] == "45.0°C"
+
+
+@pytest.mark.parametrize("sensors_manager", [{"metric": False}], indirect=True)
+def test_thermal_sensor_imperial(sensors_manager):
+    assert sensors_manager.c.widget["thermalsensor"].info()["text"] == "113.0°F"
+
+
+@pytest.mark.parametrize("sensors_manager", [{"tag_sensor": "NVME"}], indirect=True)
+def test_thermal_sensor_tagged_sensor(sensors_manager):
+    assert sensors_manager.c.widget["thermalsensor"].info()["text"] == "56.3°C"
+
+
+@pytest.mark.parametrize("sensors_manager", [{"tag_sensor": "does_not_exist"}], indirect=True)
+def test_thermal_sensor_unknown_sensor(sensors_manager):
+    assert sensors_manager.c.widget["thermalsensor"].info()["text"] == "N/A"
+
+
+@pytest.mark.parametrize(
+    "sensors_manager", [{"format": "{tag}: {temp:.0f}{unit}"}], indirect=True
+)
+def test_thermal_sensor_format(sensors_manager):
+    assert sensors_manager.c.widget["thermalsensor"].info()["text"] == "CPU: 45°C"
+
+
+def test_thermal_sensor_colour_normal(sensors_manager):
+    _, temp = sensors_manager.c.widget["thermalsensor"].eval("self.layout.colour")
+    assert temp == "ffffff"
+
+
+@pytest.mark.parametrize("sensors_manager", [{"threshold": 30}], indirect=True)
+def test_thermal_sensor_colour_alert(sensors_manager):
+    _, temp = sensors_manager.c.widget["thermalsensor"].eval("self.layout.colour")
+    assert temp == "ff0000"


### PR DESCRIPTION
Currently, the text for the ThermalSensor widget is hardcoded. This PR adds formattable text and fixes this problem.

Now three variables are available in the format string: `temp`, `tag`, and `unit`.