### PR TITLE
WL: Let pointer constraints be compatible with XWayland windows

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -967,6 +967,11 @@ class Core(base.Core, wlrq.HasListeners):
             self._current_output = self.outputs[0] if self.outputs else None
             self.stack_windows()
 
+    def remove_pointer_constraints(self, window: window.Window | window.Static) -> None:
+        for pc in self.pointer_constraints.copy():
+            if pc.window is window:
+                pc.finalize()
+
     def keysym_from_name(self, name: str) -> int:
         """Get the keysym for a key from its name"""
         return xkb.keysym_from_name(name, case_insensitive=True)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -135,6 +135,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     def finalize(self) -> None:
         self.finalize_listeners()
         self.ftm_handle.destroy()
+        self.core.remove_pointer_constraints(self)
 
     @property
     def wid(self) -> int:
@@ -647,10 +648,6 @@ class XdgWindow(Window[XdgSurface]):
         for subsurface in self.subsurfaces:
             subsurface.finalize()
 
-        for pc in self.core.pointer_constraints.copy():
-            if pc.window is self:
-                pc.finalize()
-
     def _on_map(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: xdgwindow map")
 
@@ -866,7 +863,6 @@ class XdgWindow(Window[XdgSurface]):
         for pc in self.core.pointer_constraints.copy():
             if pc.window is self:
                 pc.window = win
-                break
 
         hook.fire("client_managed", win)
 
@@ -1151,6 +1147,7 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
 
     def finalize(self) -> None:
         self.finalize_listeners()
+        self.core.remove_pointer_constraints(self)
 
     @property
     def wid(self) -> int:
@@ -1299,10 +1296,6 @@ class XdgStatic(Static[XdgSurface]):
         Static.finalize(self)
         for subsurface in self.subsurfaces:
             subsurface.finalize()
-
-        for pc in self.core.pointer_constraints.copy():
-            if pc.window is self:
-                pc.finalize()
 
     def kill(self) -> None:
         self.surface.send_close()
@@ -1457,10 +1450,6 @@ class LayerStatic(Static[LayerSurfaceV1]):
         Static.finalize(self)
         for subsurface in self.subsurfaces:
             subsurface.finalize()
-
-        for pc in self.core.pointer_constraints.copy():
-            if pc.window is self:
-                pc.finalize()
 
     @property
     def mapped(self) -> bool:
@@ -1781,23 +1770,23 @@ class PointerConstraint(HasListeners):
         self._warp_target: tuple[float, float] = (0, 0)
         self._needs_warp: bool = False
 
-        self.add_listener(wlr_constraint.set_region_event, self._on_set_region)
-        self.add_listener(wlr_constraint.destroy_event, self._on_destroy)
-
+        assert core.qtile is not None
         owner = None
 
-        if core.qtile and core.qtile.windows_map:
-            for win in core.qtile.windows_map.values():
-                if isinstance(win, (XdgWindow, XdgStatic)):
-                    if win.surface.surface == self.wlr_constraint.surface:
-                        owner = win
-                        break
+        for win in core.qtile.windows_map.values():
+            if isinstance(win, (Window | Static)):
+                if win.surface.surface == self.wlr_constraint.surface:
+                    owner = win
+                    break
 
         if owner is None:
             logger.error("No window found for pointer constraints. Please report.")
             raise RuntimeError
 
-        self.window: XdgWindow | XdgStatic = owner
+        self.window: Window | Static = owner
+
+        self.add_listener(wlr_constraint.set_region_event, self._on_set_region)
+        self.add_listener(wlr_constraint.destroy_event, self._on_destroy)
 
     def finalize(self) -> None:
         if self.core.active_pointer_constraint is self:


### PR DESCRIPTION
Currently pointer constraints only work with XDG protocol windows, but
XWayland clients can also request pointer constraints the same way as
XDG windows, so let's make those compatible.

Fixes #3575