### PR TITLE
clipboard widget: escape text

### DIFF
--- a/libqtile/widget/clipboard.py
+++ b/libqtile/widget/clipboard.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import bar, hook
+from libqtile import bar, hook, pangocffi
 from libqtile.backend.x11 import xcbq
 from libqtile.widget import base
 
@@ -92,7 +92,7 @@ class Clipboard(base._TextBox):
                 if self.max_width is not None and len(text) > self.max_width:
                     text = text[: self.max_width] + "..."
 
-            self.text = text
+            self.text = pangocffi.markup_escape_text(text)
 
             if self.timeout_id:
                 self.timeout_id.cancel()


### PR DESCRIPTION
If we don't, text with markup in it can generate:

2022-05-19 07:13:46,651 ERROR libqtile hook.py:fire():L391 Error in hook selection_change
Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/hook.py", line 389, in fire
    i(*args, **kwargs)
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/widget/clipboard.py", line 95, in hook_change
    self.text = text
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/widget/base.py", line 409, in text
    self.layout.text = self.formatted_text
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/drawer.py", line 72, in text
    attrlist, value, accel_char = pangocffi.parse_markup(value)
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/pangocffi.py", line 186, in parse_markup
    raise Exception("parse_markup() failed for %s" % value)

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>