### PR TITLE
groupbox: add `invert_line` parameter

### DIFF
--- a/libqtile/drawer.py
+++ b/libqtile/drawer.py
@@ -156,7 +156,7 @@ class TextFrame:
         else:
             self.pad_top = self.pad_bottom = pad_y
 
-    def draw(self, x, y, rounded=True, fill=False, line=False, highlight=False):
+    def draw(self, x, y, rounded=True, fill=False, line=False, invert=False, highlight=False):
         self.drawer.set_source_rgb(self.border_color)
         opts = [
             x,
@@ -171,8 +171,9 @@ class TextFrame:
                 self.drawer.fillrect(*opts)
                 self.drawer.set_source_rgb(self.border_color)
 
-            # change to only fill in bottom line
-            opts[1] = self.height - self.border_width  # y
+            if not invert:
+                # change to only fill in bottom line
+                opts[1] = self.height - self.border_width  # y
             opts[3] = self.border_width  # height
 
             self.drawer.fillrect(*opts)
@@ -192,8 +193,8 @@ class TextFrame:
     def draw_fill(self, x, y, rounded=True):
         self.draw(x, y, rounded=rounded, fill=True)
 
-    def draw_line(self, x, y, highlighted):
-        self.draw(x, y, line=True, highlight=highlighted)
+    def draw_line(self, x, y, invert, highlighted):
+        self.draw(x, y, line=True, invert=invert, highlight=highlighted)
 
     @property
     def height(self):

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -91,6 +91,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
         rounded=False,
         block=False,
         line=False,
+        invert_line=False,
         highlighted=False,
     ):
         self.layout.text = self.fmt.format(text)
@@ -104,6 +105,8 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
                 (self.bar.height - self.layout.height - self.borderwidth) / 2,
                 (self.bar.height - self.layout.height + self.borderwidth) / 2,
             ]
+            if highlighted:
+                invert_line = False
         else:
             pad_y = self.padding_y
 
@@ -127,7 +130,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
         if block and bordercolor is not None:
             framed.draw_fill(offset, y, rounded)
         elif line:
-            framed.draw_line(offset, y, highlighted)
+            framed.draw_line(offset, y, invert_line, highlighted)
         else:
             framed.draw(offset, y, rounded)
 
@@ -224,6 +227,7 @@ class GroupBox(_GroupBase):
             "Hide groups that have no windows and that are not displayed on any screen.",
         ),
         ("spacing", None, "Spacing between groups" "(if set to None, will be equal to margin_x)"),
+        ("invert_line", False, "Invert visibility when 'line' highlight method is not highlighted."),
     ]
 
     def __init__(self, **config):
@@ -365,6 +369,7 @@ class GroupBox(_GroupBase):
                             to_highlight = True
                         else:
                             border = self.this_screen_border
+                            to_highlight = True
                     else:
                         if self.qtile.current_screen == g.screen:
                             border = self.other_current_screen_border
@@ -393,6 +398,7 @@ class GroupBox(_GroupBase):
                 rounded=self.rounded,
                 block=is_block,
                 line=is_line,
+                invert_line=self.invert_line,
                 highlighted=to_highlight,
             )
             offset += bw + self.spacing


### PR DESCRIPTION
**Description:**
This PR allows the "line" highlight method to toggle up/down when it's highlighted.

**Example:** *Tested with Xephyr simulating two monitors.*

```python
widget.GroupBox(
    highlight_method = 'line',
    invert_line = False,
)
```
![image](https://user-images.githubusercontent.com/78786202/170593591-75fa1a85-0613-4687-98db-8499be78527f.png)

```python
widget.GroupBox(
    highlight_method = 'line',
    invert_line = True,
)
```
![image](https://user-images.githubusercontent.com/78786202/170593711-6f475a5d-864f-4ac7-9e1f-93db59b13913.png)

**Video:**

https://user-images.githubusercontent.com/78786202/170595021-1d87b3f8-6c65-491d-a408-1a06668ef0a5.mp4

