### PR TITLE
Replace subprocess.run with subprocess.Popen in docs

### DIFF
--- a/docs/manual/config/hooks.rst
+++ b/docs/manual/config/hooks.rst
@@ -64,7 +64,7 @@ We can then subscribe to ``startup_once`` to run this script:
     @hook.subscribe.startup_once
     def autostart():
         home = os.path.expanduser('~/.config/qtile/autostart.sh')
-        subprocess.run([home])
+        subprocess.Popen([home])
 
 Accessing the qtile object
 --------------------------


### PR DESCRIPTION
`subprocess.run` is blocking, so in case the script has errors or a missing `&`, the window manager will be stuck on a black screen. `subprocess.Popen` is not blocking, so it is a better choice to recommend to new users for autostarting applications.