### PR TITLE
x11: ignore pointer_motion_hint_mask for grabbed keys

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -155,7 +155,12 @@ class Core(base.Core):
 
         numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])[0]
         self._numlock_mask = xcbq.ModMasks.get(self.conn.get_modifier(numlock_code), 0)
-        self._valid_mask = ~(self._numlock_mask | xcbq.ModMasks["lock"] | xcbq.AllButtonsMask)
+        self._valid_mask = ~(
+            self._numlock_mask
+            | xcbq.ModMasks["lock"]
+            | xcbq.AllButtonsMask
+            | xcbq.PointerMotionHintMask
+        )
 
     @property
     def name(self):

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -86,6 +86,7 @@ ModMasks = {
 AllButtonsMask = 0b11111 << 8
 ButtonMotionMask = 1 << 13
 ButtonReleaseMask = 1 << 3
+PointerMotionHintMask = 1 << 7
 
 NormalHintsFlags = {
     "USPosition": 1,  # User-specified x, y


### PR DESCRIPTION
This mask shouldn't be used for keybindings so excluded it from key
events shouldn't cause any issues with existing configs. However doing
so seems to fix #3568 where the mask is appearing on an alternate
keyboard layout.

Fixes #3568