### PR TITLE
WL: Print useful message when backend deps are missing

### DIFF
--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -1,14 +1,45 @@
+from __future__ import annotations
+
 import importlib
+import importlib.util
+from typing import TYPE_CHECKING
 
 from libqtile.utils import QtileError
 
-CORES = [
-    "wayland",
-    "x11",
-]
+if TYPE_CHECKING:
+    from typing import Any
+
+    from libqtile.backend.base import Core
 
 
-def get_core(backend, *args):
+CORES = {
+    "wayland": ("wlroots",),
+    "x11": ("xcffib",),
+}
+
+
+def has_deps(backend: str) -> list[str]:
+    """
+    Check if the backend has all its dependencies installed.
+
+    Args:
+        backend: The backend to check.
+
+    Returns:
+        A list of missing dependencies. If this is empty, we can use this backend.
+    """
+    if backend not in CORES:
+        raise QtileError(f"Backend {backend} does not exist")
+
+    not_found = []
+    for dep in CORES[backend]:
+        if not importlib.util.find_spec(dep):
+            not_found.append(dep)
+
+    return not_found
+
+
+def get_core(backend: str, *args: Any) -> Core:
     if backend not in CORES:
         raise QtileError(f"Backend {backend} does not exist")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-libqtile.backend.wayland.*]
 disallow_untyped_defs = True
+[mypy-libqtile.backend]
+disallow_untyped_defs = True
 [mypy-libqtile.bar]
 disallow_untyped_defs = True
 [mypy-libqtile.core.*]


### PR DESCRIPTION
If pywayland or pywlroots is missing, `qtile start -b wayland` will
output this message:

"Backend dependencies not found. Please install pywayland and pywlroots."

Rather than printing a traceback mentioning 'wlroots' (can be confused
with the main C library).

See #3601