### PR TITLE
WL: set keyboard settings for all configured Keyboards

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1003,7 +1003,8 @@ class Core(base.Core, wlrq.HasListeners):
         identical to those accepted by the env variables.
         """
         if self.keyboards:
-            self.keyboards[-1].set_keymap(layout, options, variant)
+            for keyboard in self.keyboards:
+                keyboard.set_keymap(layout, options, variant)
         else:
             logger.warning("Could not set keymap: no keyboards set up.")
 


### PR DESCRIPTION
Instead of applying new keyboard settings via `Core.cmd_set_keymap` to
only `Core.keyboards[-1]` -- the most recently added keyboard -- add the
settings to all keyboards.

Fixes #3425