### PR TITLE
WL: Don't error when an xwayland window has an unknown wm_type

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -1014,9 +1014,9 @@ class XWindow(Window[xwayland.Surface]):
         return self.surface.pid
 
     def get_wm_type(self) -> str | None:
-        wm_type = self.surface.window_type
-        if wm_type:
-            return self.core.xwayland_atoms[wm_type[0]]
+        for wm_type in self.surface.window_type:
+            if wm_type in self.core.xwayland_atoms:
+                return self.core.xwayland_atoms[wm_type]
         return None
 
     def get_wm_role(self) -> str | None:


### PR DESCRIPTION
...and check all provided atoms in case any are valid.

As per the spec, window types are provided in order of preference,
usually non-standard extensions first, so let's check the whole list
until one is recognised. Failing that, we can just return None and
execution can continue, rather than erroring.

Fixes #3611