### PR TITLE
Fix text positioning when Bar has margin

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -566,9 +566,11 @@ class _TextBox(_Widget):
             )
             self.drawer.ctx.clip()
 
+        size = self.bar.height if self.bar.horizontal else self.bar.width
+
         self.layout.draw(
             (self.actual_padding or 0) - self._scroll_offset,
-            int(self.bar.size / 2.0 - self.layout.height / 2.0) + 1,
+            int(size / 2.0 - self.layout.height / 2.0) + 1,
         )
         self.drawer.ctx.restore()
 


### PR DESCRIPTION
The scrolling text commit introduced a bug where text was positioned incorrectly if the Bar had a margin.

This PR removes that bug. Hopefully.