### PR TITLE
WL: wlr_export_dmabuf_v1 protocol initialized

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -36,6 +36,7 @@ from wlroots.wlr_types import (
     Cursor,
     DataControlManagerV1,
     DataDeviceManager,
+    ExportDmabufManagerV1,
     ForeignToplevelManagerV1,
     GammaControlManagerV1,
     OutputLayout,
@@ -175,6 +176,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(self.layer_shell.new_surface_event, self._on_new_layer_surface)
 
         # Add support for additional protocols
+        ExportDmabufManagerV1(self.display)
         XdgOutputManagerV1(self.display, self.output_layout)
         ScreencopyManagerV1(self.display)
         GammaControlManagerV1(self.display)

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ ipython =
   jupyter_console
 wayland =
   pywayland>=0.4.12
-  pywlroots>=0.15.15,<0.16.0
+  pywlroots>=0.15.17,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install cairocffi
-    pip install pywlroots>=0.15.15,<0.16.0
+    pip install pywlroots>=0.15.17,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476


### PR DESCRIPTION
* wlr_export_dmabuf_v1 is used by screenshots apps on the vulkan backend
  as shm based screenshots don't work on vulkan renderer.

* Bump pywlroots to `0.15.17`.

Signed-off-by: Shinyzenith <aakashsensharma@gmail.com>