### PR TITLE
Do not spam logs when we have to try multiple files for battery info

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -236,7 +236,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             with open(path, "r") as f:
                 return f.read().strip(), value_type
         except OSError as e:
-            logger.exception("Failed to read '%s':", path)
+            logger.debug("Failed to read '%s':", path, exc_info=True)
             if isinstance(e, FileNotFoundError):
                 # Let's try another file if this one doesn't exist
                 return None


### PR DESCRIPTION
Here's what I've got otherwise:

```
022-06-06 20:50:45,564 ERROR libqtile battery.py:_load_file():L239 Failed to read '/sys/class/power_supply/BAT0/current_now':
Traceback (most recent call last):
  File "libqtile/widget/battery.py", line 237, in _load_file
    return f.read().strip(), value_type
OSError: [Errno 19] No such device
```

The code tries multiple files on purpose, let's not log an error when one of these can't be found.