### PR TITLE
Fix `next` and `previous` commands for Bsp layout

### DIFF
--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -163,6 +163,11 @@ class Bsp(Layout):
         ("grow_amount", 10, "Amount by which to grow a window/column."),
         ("lower_right", True, "New client occupies lower or right subspace."),
         ("fair", True, "New clients are inserted in the shortest branch."),
+        (
+            "wrap_clients",
+            False,
+            "Whether client list should be wrapped when using ``next`` and ``previous`` commands.",
+        ),
     ]
 
     def __init__(self, **config):
@@ -242,25 +247,31 @@ class Bsp(Layout):
         clients = list(self.root.clients())
         return clients[-1] if len(clients) else None
 
-    def focus_next(self, client):
+    def focus_next(self, client, wrap=False):
         clients = list(self.root.clients())
         if client in clients:
             idx = clients.index(client)
-            return clients[(idx + 1) % len(clients)]
+            if not wrap and idx + 1 < len(clients):
+                return clients[(idx + 1)]
+            elif wrap:
+                return clients[(idx + 1) % len(clients)]
 
-    def focus_previous(self, client):
+    def focus_previous(self, client, wrap=False):
         clients = list(self.root.clients())
         if client in clients:
             idx = clients.index(client)
-            return clients[(idx - 1) % len(clients)]
+            if not wrap and idx > 0:
+                return clients[(idx - 1)]
+            elif wrap:
+                return clients[(idx - 1) % len(clients)]
 
     def cmd_next(self):
-        client = self.focus_next(self.current.client)
+        client = self.focus_next(self.current.client, wrap=self.wrap_clients)
         if client:
             self.group.focus(client, True)
 
     def cmd_previous(self):
-        client = self.focus_previous(self.current.client)
+        client = self.focus_previous(self.current.client, wrap=self.wrap_clients)
         if client:
             self.group.focus(client, True)
 

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -246,23 +246,21 @@ class Bsp(Layout):
         clients = list(self.root.clients())
         if client in clients:
             idx = clients.index(client)
-            if idx + 1 < len(clients):
-                return clients[idx + 1]
+            return clients[(idx + 1) % len(clients)]
 
     def focus_previous(self, client):
         clients = list(self.root.clients())
         if client in clients:
             idx = clients.index(client)
-            if idx > 0:
-                return clients[idx - 1]
+            return clients[(idx - 1) % len(clients)]
 
     def cmd_next(self):
-        client = self.focus_next(self.current)
+        client = self.focus_next(self.current.client)
         if client:
             self.group.focus(client, True)
 
     def cmd_previous(self):
-        client = self.focus_previous(self.current)
+        client = self.focus_previous(self.current.client)
         if client:
             self.group.focus(client, True)
 

--- a/test/layouts/test_bsp.py
+++ b/test/layouts/test_bsp.py
@@ -33,7 +33,7 @@ class BspConfig(Config):
         libqtile.config.Group("c"),
         libqtile.config.Group("d"),
     ]
-    layouts = [layout.Bsp(), layout.Bsp(margin_on_single=10)]
+    layouts = [layout.Bsp(), layout.Bsp(margin_on_single=10), layout.Bsp(wrap_clients=True)]
     floating_layout = libqtile.resources.default_config.floating_layout
     keys = []
     mouse = []
@@ -83,3 +83,32 @@ def test_bsp_margin_on_single(manager):
     # No longer single window so margin reverts to "margin" which is 0
     info = manager.c.window.info()
     assert info["x"] == 0
+
+
+@bsp_config
+def test_bsp_wrap_clients(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+
+    # Default has no wrapping
+    assert_focused(manager, "two")
+    manager.c.layout.next()
+    assert_focused(manager, "two")
+    manager.c.layout.previous()
+    assert_focused(manager, "one")
+    manager.c.layout.previous()
+    assert_focused(manager, "one")
+
+    # Switch to layout with wrapping enabled
+    manager.c.next_layout()
+    manager.c.next_layout()
+
+    assert_focused(manager, "one")
+    manager.c.layout.next()
+    assert_focused(manager, "two")
+    # Layout should wrap here
+    manager.c.layout.next()
+    assert_focused(manager, "one")
+    # and here
+    manager.c.layout.previous()
+    assert_focused(manager, "two")


### PR DESCRIPTION
The `next` and `previous` commands were broken as the layout looks for `self.current` in the client list. However, `self.current` is a Node, not a client and so there is never a match.

This PR fixes this by looking up the current node's `client` value.

I've also added looping so, when you call `next()` on the last client, you move to the first one.