### PR TITLE
Accept lowercase keybinds

### DIFF
--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -96,7 +96,7 @@ def translate_masks(modifiers: list[str]) -> int:
     masks = []
     for i in modifiers:
         try:
-            masks.append(ModMasks[i])
+            masks.append(ModMasks[i.lower()])
         except KeyError as e:
             raise WlrQError("Unknown modifier: %s" % i) from e
     if masks:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -153,7 +153,7 @@ class Core(base.Core):
         self.qtile = None  # type: Qtile | None
         self._painter = None
 
-        numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["Num_Lock"])[0]
+        numlock_code = self.conn.keysym_to_keycode(xcbq.keysyms["num_lock"])[0]
         self._numlock_mask = xcbq.ModMasks.get(self.conn.get_modifier(numlock_code), 0)
         self._valid_mask = ~(
             self._numlock_mask
@@ -751,7 +751,7 @@ class Core(base.Core):
         """Simulates a keypress on the focused window."""
         # FIXME: This needs to be done with sendevent, once we have that fixed.
         modmasks = xcbq.translate_masks(modifiers)
-        keysym = xcbq.keysyms.get(key)
+        keysym = xcbq.keysyms.get(key.lower())
 
         class DummyEv:
             pass
@@ -851,4 +851,4 @@ class Core(base.Core):
 
     def keysym_from_name(self, name: str) -> int:
         """Get the keysym for a key from its name"""
-        return keysyms[name]
+        return keysyms[name.lower()]

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -62,15 +62,6 @@ class XCBQError(QtileError):
     pass
 
 
-def rdict(d):
-    r = {}
-    for k, v in d.items():
-        r.setdefault(v, []).append(k)
-    return r
-
-
-rkeysyms = rdict(keysyms)
-
 # Keyboard modifiers bitmask values from X Protocol
 ModMasks = {
     "shift": 1 << 0,
@@ -790,7 +781,7 @@ class Painter:
 
 
 def get_keysym(key: str) -> int:
-    keysym = keysyms.get(key)
+    keysym = keysyms.get(key.lower())
     if not keysym:
         raise XCBQError("Unknown key: %s" % key)
     return keysym
@@ -812,7 +803,7 @@ def translate_masks(modifiers: list[str]) -> int:
     masks = []
     for i in modifiers:
         try:
-            masks.append(ModMasks[i])
+            masks.append(ModMasks[i.lower()])
         except KeyError as e:
             raise XCBQError("Unknown modifier: %s" % i) from e
     if masks:

--- a/libqtile/backend/x11/xkeysyms.py
+++ b/libqtile/backend/x11/xkeysyms.py
@@ -2205,3 +2205,4 @@ keysyms = {
     "braille_dots_2345678": 0x10028FE,
     "braille_dots_12345678": 0x10028FF,
 }
+keysyms = {k.lower(): v for k, v in keysyms.items()}

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -139,12 +139,12 @@ class Config:
         # because they are dynamically resolved from the default_config. so we
         # need to ignore the errors here about missing attributes.
         for k in self.keys:
-            if k.key not in valid_keys:
+            if k.key.lower() not in valid_keys:
                 raise ConfigError("No such key: %s" % k.key)
             for m in k.modifiers:
-                if m not in valid_mods:
+                if m.lower() not in valid_mods:
                     raise ConfigError("No such modifier: %s" % m)
         for ms in self.mouse:
             for m in ms.modifiers:
-                if m not in valid_mods:
+                if m.lower() not in valid_mods:
                     raise ConfigError("No such modifier: %s" % m)


### PR DESCRIPTION
Currently, the wayland backend accepts lowercase keybinds, as it uses `case_insensitive=True` on all symbol lookups (see `grab_key()`). Both the X11 backend and the config validator only accept symbols as reported by X11. In reality, no two keys exist that share a name but have different capitalization, which is why `case_insensitive=True` even exists in wayland. Modifier keys on the other hand require all-lowercase in qtile. This PR fixes this inconsistent behavior across all backends, allowing any capitalization.