### PR TITLE
Add graceful call to unbind keys in dgroups simple key binder

### DIFF
--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -37,11 +37,17 @@ from libqtile.log_utils import logger
 def simple_key_binder(mod, keynames=None):
     """Bind keys to mod+group position or to the keys specified as second argument"""
 
+    def _graceful_fail_call(func, param):
+        try:
+            func(param)
+        except KeyError:
+            logger.warning('Key not found in dgroup keys: "%s"', str(param))
+
     def func(dgroup):
         # unbind all
         for key in dgroup.keys[:]:
-            dgroup.qtile.ungrab_key(key)
-            dgroup.keys.remove(key)
+            _graceful_fail_call(dgroup.qtile.ungrab_key, key)
+            _graceful_fail_call(dgroup.keys.remove, key)
 
         if keynames:
             keys = keynames


### PR DESCRIPTION
Hi all,

I am a newbie user and have a weird behavior with DGroups keybindings. When I close emacs the Dgroups keybindings stop working until I restart Qtile.
Looking at the logs I got this:

![image](https://user-images.githubusercontent.com/1923786/174747402-0c5e8ed0-d545-4ef2-b35e-92fb531fa36d.png)

Not sure if this is useful for the community but it solved my issues. Please let me know if it doesn't make sense and close this PR.

Many thanks.

Cheers,