### PR TITLE
Avoid raising windows to the top of the stack.

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -486,6 +486,9 @@ class _Window:
         window.set_attribute(eventmask=self._window_mask)
         self._group = None
 
+        # Keep managed windows below override-redirect windows
+        qtile.core.raise_window(self.window)
+
         try:
             g = self.window.get_geometry()
             self._x = g.x
@@ -900,7 +903,8 @@ class _Window:
             height=height,
         )
         if above:
-            kwarg["stackmode"] = StackMode.Above
+            kwarg["stackmode"] = StackMode.Below
+            kwarg["sibling"] = self.qtile.core.stack_window.wid
 
         self.window.configure(**kwarg)
         self.paint_borders(bordercolor, borderwidth)
@@ -1260,7 +1264,7 @@ class Static(_Window, base.Static):
             self.update_strut()
 
     def cmd_bring_to_front(self):
-        self.window.configure(stackmode=StackMode.Above)
+        self.qtile.core.raise_window(self.window)
 
 
 class Window(_Window, base.Window):
@@ -1851,7 +1855,7 @@ class Window(_Window, base.Window):
 
     def cmd_bring_to_front(self):
         if self.floating:
-            self.window.configure(stackmode=StackMode.Above)
+            self.qtile.core.raise_window(self.window)
         else:
             self._reconfigure_floating()  # atomatically above
 

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -566,8 +566,13 @@ class Connection:
 
         assert len(q.keysyms) % q.keysyms_per_keycode == 0
         for i in range(len(q.keysyms) // q.keysyms_per_keycode):
+            # self.code_to_syms[first + i] = q.keysyms[
+            #     i * q.keysyms_per_keycode : (i + 1) * q.keysyms_per_keycode
+            # ]
+            # JDR: this prevents "b" and "n" being both reported as keysyms in a
+            # "dvorak," dual layout
             self.code_to_syms[first + i] = q.keysyms[
-                i * q.keysyms_per_keycode : (i + 1) * q.keysyms_per_keycode
+                i * q.keysyms_per_keycode : i * q.keysyms_per_keycode + 2
             ]
 
         sym_to_codes = {}


### PR DESCRIPTION
As discussed in [this email](https://www.mail-archive.com/qtile-dev@googlegroups.com/msg00629.html) from 2017, ordinarily window managers reorder managed windows amongst themselves (e.g. using XRestackWindows) but never bring them to the top of the X server's stack (above override-redirect windows) using e.g. XRaiseWindow.  qtile uses the xcb equivalent of XRaiseWindow (ConfigureWindow with StackMode.Above and no sibling), which causes undesirable effects:

- Long-lived notification popups (e.g. lxqt-notificationd) get covered by new windows.
- New windows can appear on top of a lock screen (#676).

It seems silly for a tiling window manager to keep its own window stack, so this PR has a simpler solution.  In backend.x11.core.Core.distribute_windows, an offscreen (but mapped) window called stacking_window is created and pushed to the bottom of the stack.  Then all instances of ConfigureWindow with StackMode.Above and no sibling are replaced by ConfigureWindow with StackMode.Below and sibling=stack_window.  In this way qtile can use the X server to keep track of stacking order directly (as it did before), but it ensures that managed windows stay below override-redirect windows, as is conventional.

This fixes #676.