### PR TITLE
Handle custom layout names in CurrentLayoutIcon

### DIFF
--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -156,9 +156,12 @@ class CurrentLayoutIcon(base._TextBox):
 
     def _get_layout_names(self):
         """
-        Returns the list of lowercased strings for each available layout name.
+        Returns a list of tuples of lowercased layout name and class name strings for each available layout.
         """
-        return [layout.__class__.__name__.lower() for layout in self.qtile.config.layouts]
+        return [
+            (layout.name, layout.__class__.__name__.lower())
+            for layout in self.qtile.config.layouts
+        ]
 
     def _update_icon_paths(self):
         self.icon_paths = []
@@ -187,9 +190,18 @@ class CurrentLayoutIcon(base._TextBox):
         """
         Loads layout icons.
         """
-        for layout_name in self._get_layout_names():
-            icon_file_path = self.find_icon_file_path(layout_name)
-            if icon_file_path is None:
+        for names in self._get_layout_names():
+            layout_name = names[0]
+            # Python doesn't have an ordered set but we can use a dictionary instead
+            # First key is the layout's name (which may have been set by the user),
+            # the second is the class name. If these are the same (i.e. the user hasn't
+            # set a name) then there is only one key in the dictionary.
+            layouts = dict.fromkeys(names)
+            for layout in layouts.keys():
+                icon_file_path = self.find_icon_file_path(layout)
+                if icon_file_path:
+                    break
+            else:
                 logger.warning('No icon found for layout "%s"', layout_name)
                 icon_file_path = self.find_icon_file_path("unknown")
 


### PR DESCRIPTION
Users may specify custom names for layouts in their configs. This can cause the `CurrentLayoutIcon` to fail as it's looking for an icon called `layout-custom-name` which may not exist.

This PR addresses the issue by enabling the widget to look for an icon for the underlying layout class name.

Fixes #3656