### PR TITLE
WL: implement input inhibitor protocol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
         - Add scrolling ability to `_TextBox`-based widgets.
         - Add player controls (via mouse callbacks) to `Mpris2` widget.
+        - Wayland: input inhibitor protocol support added (pywayland>=0.4.14 & pywlroots>=0.15.19)
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -200,7 +200,7 @@ class Keyboard(HasListeners):
 
         self.core.idle.notify_activity(self.seat)
 
-        if event.state == KEY_PRESSED:
+        if event.state == KEY_PRESSED and not self.core.exclusive_client:
             # translate libinput keycode -> xkbcommon
             keycode = event.keycode + 8
             layout_index = lib.xkb_state_key_get_layout(self.keyboard._ptr.xkb_state, keycode)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -26,7 +26,7 @@ import typing
 
 import cairocffi
 import wlroots.wlr_types.foreign_toplevel_management_v1 as ftm
-from pywayland.server import Listener
+from pywayland.server import Client, Listener
 from wlroots import PtrHasData, ffi
 from wlroots.util.box import Box
 from wlroots.wlr_types import Texture
@@ -225,6 +225,9 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         if self._wm_class:
             return [self._wm_class]
         return None
+
+    def belongs_to_client(self, other: Client) -> bool:
+        return other == Client.from_resource(self.surface.surface._ptr.resource)  # type: ignore
 
     def focus(self, warp: bool) -> None:
         self.core.focus_window(self)
@@ -759,6 +762,9 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
     @property
     def is_idle_inhibited(self) -> bool:
         return self._idle_inhibitors_count > 0
+
+    def belongs_to_client(self, other: Client) -> bool:
+        return other == Client.from_resource(self.surface.surface._ptr.resource)  # type: ignore
 
     def cmd_bring_to_front(self) -> None:
         if self.mapped:

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,8 +70,8 @@ ipython =
   ipykernel
   jupyter_console
 wayland =
-  pywayland>=0.4.12
-  pywlroots>=0.15.17,<0.16.0
+  pywayland>=0.4.14
+  pywlroots>=0.15.19,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     setuptools >= 40.5.0
     bowler
     xkbcommon >= 0.3
-    pywayland >= 0.4.12
+    pywayland >= 0.4.14
     dbus-next
     PyGObject
 # pywayland has to be installed before pywlroots
@@ -43,7 +43,7 @@ commands =
     pypy3: pip install cffi==1.15.0
     pip install xcffib>=0.10.1
     pip install cairocffi
-    pip install pywlroots>=0.15.17,<0.16.0
+    pip install pywlroots>=0.15.19,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -99,8 +99,8 @@ deps =
     types-pytz
     types-pkg_resources
 commands =
-    pip install -r requirements.txt pywayland>=0.4.12 xkbcommon>=0.3
-    pip install pywlroots>=0.15.15,<0.16.0
+    pip install -r requirements.txt pywayland>=0.4.14 xkbcommon>=0.3
+    pip install pywlroots>=0.15.19,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     pip install .


### PR DESCRIPTION
This is an attempt at implementing the input inhibitor protocol, built
upon the work done by @Graeme22 in #2852 (thanks @Graeme22!).

The main additional step made by this draft over #2852 is blocking
pointer and keyboard focus from going to surfaces that belong to other
clients, while still (in theory) allowing focus to move to other
surfaces belonging to the same client. All bindings (button/scroll/key)
become disabled.

One outstanding issue that prevents this from being a complete and
precise implementation of the protocol is that qtile commands executed
in the background proceed as normal. E.g. you can change group from a
script if you start the script, then start the input inhibitor, and then
the script changes group. On the plus side, input _is_ inhibited, so
this doesn't do much. In the case where a screenlocker is used via the
layer shell protocol, it covers the screen anyway, and so
layer_shell+input_inhibit screen locking seems usable. Unless a sneaky
process ran `qtile cmd-obj -o window -f kill` in the background, killing
it.