### PR TITLE
Changes to when_floating rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,9 @@ Qtile 0.22.0, released 2022-09-22:
         - `KeyChord`'s signature has changed. ``mode`` is now a boolean to indicate whether the mode should persist.
           The ``name`` parameter should be used to name the chord (e.g. for the ``Chord`` widget).
     * features
+        - lazy.<object>.when(when_floating=X) now behaves differently: the lazy call will be executed
+          independently of the current window's float state by default, and can be limited to when it
+          is floating or tiled by passing when_floating as True or False respectively.
         - Add ability to draw borders and add margins to the `Max` layout.
         - The default XWayland cursor is now set at startup to left_ptr, so an xsetroot call is not needed to
           avoid the ugly X cursor.

--- a/docs/manual/config/keys.rst
+++ b/docs/manual/config/keys.rst
@@ -97,8 +97,11 @@ conditions are supported:
             lazy.layout.grow_down().when(layout='columns')
         ),
 
-        # Limit action to when the current window is not floating (default True)
+        # Limit action to when the current window is not floating
         Key([mod], "f", lazy.window.toggle_fullscreen().when(when_floating=False))
+
+        # Limit action to when the current window is floating
+        Key([mod], "f", lazy.window.toggle_fullscreen().when(when_floating=True))
 
         # Also matches are supported on the current window
         # For example to match on the wm_class for fullscreen do the following

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -52,7 +52,7 @@ class LazyCall:
         self._focused: Match | None = None
         self._if_no_focused: bool = False
         self._layouts: set[str] = set()
-        self._when_floating = True
+        self._when_floating: bool | None = None
 
     def __call__(self, *args, **kwargs):
         """Convenience method to allow users to pass arguments to
@@ -96,7 +96,7 @@ class LazyCall:
         focused: Match | None = None,
         if_no_focused: bool = False,
         layout: Iterable[str] | str | None = None,
-        when_floating: bool = True,
+        when_floating: bool | None = None,
     ) -> "LazyCall":
         """Enable call only for given layout(s) and floating state
 
@@ -138,7 +138,10 @@ class LazyCall:
             if not q.current_window and not self._if_no_focused:
                 return False
 
-        if cur_win_floating and not self._when_floating:
+        if cur_win_floating and self._when_floating is False:
+            return False
+
+        if not cur_win_floating and self._when_floating:
             return False
 
         if self._layouts and q.current_layout.name not in self._layouts:


### PR DESCRIPTION
when_floating is None by default
when set to True, apply lazy call to floating windows only
when set to False, apply lazy call to tiled windows only

Mention when_floating change in CHANGELOG

Add example of new when_floating usage.

---

This is a redo of PR #2900 (see also issue #2846). The previous PR was closed because I couldn't get to some formatting issues with the CHANGELOG in time.

The idea is to enable commands to trigger under any of these conditions:
- _only_ for floating windows,
- _only_ for tiled windows, and
-  for _all_ windows irrespecitve of floating state.

Example:

``` python
    Key([mod, mod3], "h",
        lazy.layout.shuffle_left().when(when_floating=False),
        lazy.window.move_floating(-32, 0).when(when_floating=True),
        desc="Move window to the left"),
    Key([mod, mod3], "l",
        lazy.layout.shuffle_right().when(when_floating=False),
        lazy.window.move_floating(32, 0).when(when_floating=True),
        desc="Move window to the right"),
    Key([mod, mod3], "j",
        lazy.layout.shuffle_down().when(when_floating=False),
        lazy.window.move_floating(0, 32).when(when_floating=True),
        desc="Move window down"),
    Key([mod, mod3], "k",
        lazy.layout.shuffle_up().when(when_floating=False),
        lazy.window.move_floating(0, -32).when(when_floating=True),
        desc="Move window up"),
```

So you can do more with the same keys.