### PR TITLE
Fix libffi version issue in CI

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,5 +32,7 @@ formats:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
+  # This first requirements file installs a pinned version of cffi as latest version causes crashes
+  - requirements: docs/requirements-rtd.txt
   - requirements: docs/requirements.txt
   - requirements: requirements.txt

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,0 +1,5 @@
+# ReadTheDocs currently builds on Ubuntu 20.04 which
+# seems to have some mismatch of the libffi library
+# and the latest release of cffi.
+# We can pin the version here for the docs build.
+cffi<=1.15.0

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ deps =
     pytest >= 6.2.1
     pytest-cov >= 2.10.1
     setuptools >= 40.5.0
-    xcffib >= 0.10.1
     bowler
     xkbcommon >= 0.3
     pywayland >= 0.4.12
@@ -36,6 +35,13 @@ deps =
     PyGObject
 # pywayland has to be installed before pywlroots
 commands =
+    # cffi's binary wheel is incompatible with some libffi libraries so we force build here
+    # See: https://github.com/Kozea/cairocffi/issues/202
+    !pypy3: pip install --force-reinstall --no-binary :all: cffi
+    # However, rebuilding on pypy doesn't work so we'll pin the version instead
+    # See: https://github.com/tych0/xcffib/issues/134
+    pypy3: pip install cffi==1.15.0
+    pip install xcffib>=0.10.1
     pip install cairocffi
     pip install pywlroots>=0.15.17,<0.16.0
     python3 setup.py -q install


### PR DESCRIPTION
New release of `cffi` (1.15.1) seems to break cairocffi so pin at version 1.15.0 for now.