### PR TITLE
Remove `Gap` objects from Command Graph

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
     from libqtile.widget.base import _Widget
 
 
-class Gap(CommandObject):
+class Gap:
     """A gap placed along one of the edges of the screen
 
     If a gap has been defined, Qtile will avoid covering it with windows. The
@@ -108,29 +108,11 @@ class Gap(CommandObject):
     def geometry(self):
         return (self.x, self.y, self.width, self.height)
 
-    def _items(self, name: str) -> ItemT:
-        if name == "screen" and self.screen is not None:
-            return True, []
-        return None
-
-    def _select(self, name, sel):
-        if name == "screen":
-            return self.screen
-
     @property
     def position(self):
         for i in ["top", "bottom", "left", "right"]:
             if getattr(self.screen, i) is self:
                 return i
-
-    def info(self):
-        return dict(position=self.position)
-
-    def cmd_info(self):
-        """
-        Info for this object.
-        """
-        return self.info()
 
 
 class Obj:
@@ -149,7 +131,7 @@ CALCULATED = Obj("CALCULATED")
 STATIC = Obj("STATIC")
 
 
-class Bar(Gap, configurable.Configurable):
+class Bar(Gap, configurable.Configurable, CommandObject):
     """A bar, which can contain widgets
 
     Parameters
@@ -680,6 +662,12 @@ class Bar(Gap, configurable.Configurable):
         :position One of "top", "bottom", "left", or "right"
         """
         self.process_button_click(x, y, button)
+
+    def cmd_info(self):
+        """
+        Info for this object.
+        """
+        return self.info()
 
 
 BarType = typing.Union[Bar, Gap]

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -496,7 +496,7 @@ class Screen(CommandObject):
         elif name == "window" and self.group is not None:
             return True, [i.wid for i in self.group.windows]
         elif name == "bar":
-            return False, [x.position for x in self.gaps]
+            return False, [x.position for x in self.gaps if isinstance(x, Bar)]
         elif name == "widget":
             bars = (g for g in self.gaps if isinstance(g, Bar))
             return False, [w.name for b in bars for w in b.widgets]
@@ -520,7 +520,10 @@ class Screen(CommandObject):
                         return i
         elif name == "bar":
             assert isinstance(sel, str)
-            return getattr(self, sel)
+            bar = getattr(self, sel)
+            if isinstance(bar, Bar):
+                return bar
+
         elif name == "widget":
             for gap in self.gaps:
                 if not isinstance(gap, Bar):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -790,7 +790,7 @@ class Qtile(CommandObject):
         elif name == "widget":
             return False, list(self.widgets_map.keys())
         elif name == "bar":
-            return False, [x.position for x in self.current_screen.gaps]
+            return False, [x.position for x in self.current_screen.gaps if isinstance(x, bar.Bar)]
         elif name == "window":
             windows: list[str | int]
             windows = [
@@ -819,7 +819,9 @@ class Qtile(CommandObject):
         elif name == "widget":
             return self.widgets_map.get(sel)  # type: ignore
         elif name == "bar":
-            return getattr(self.current_screen, sel)  # type: ignore
+            gap = getattr(self.current_screen, sel)  # type: ignore
+            if isinstance(gap, bar.Bar):
+                return gap
         elif name == "window":
             if sel is None:
                 return self.current_window


### PR DESCRIPTION
`Gap` objects have no real use on the graph and can cause issues in `qtile shell` as they don't expose the same commands as bars.

Fixes #3668