### PR TITLE
Fix pyxdg refs in docs

### DIFF
--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -59,9 +59,7 @@ class LaunchBar(base._Widget):
 
     Text will displayed when no icon is found.
 
-    Widget requirements: pyxdg_.
-
-    .. _pyxdg: https://freedesktop.org/wiki/Software/pyxdg/
+    Widget requirements: `pyxdg <https://pypi.org/project/pyxdg/>`__.
     """
 
     orientations = base.ORIENTATION_HORIZONTAL

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -554,8 +554,8 @@ class StatusNotifier(base._Widget):
     As per the specification, app icons are first retrieved from the
     user's current theme. If this is not available then the app may
     provide its own icon. In order to use this functionality, users
-    are recommended to install the `pyxdg`_ module to support retrieving
-    icons from the selected theme.
+    are recommended to install the `pyxdg <https://pypi.org/project/pyxdg/>`__
+    module to support retrieving icons from the selected theme.
 
     Letf-clicking an icon will trigger an activate event.
 
@@ -565,8 +565,6 @@ class StatusNotifier(base._Widget):
         However, a modded version of the widget which provides basic menu
         support is available from elParaguayo's `qtile-extras
         <https://github.com/elParaguayo/qtile-extras>`_ repo.
-
-    .. _pyxdg: https://pypi.org/project/pyxdg/
     """
 
     orientations = base.ORIENTATION_BOTH


### PR DESCRIPTION
LaunchBar and StatusNotifier docs both reference pyxdg dependency but rst gets confused when you have links with the same name.

One fix is to anonymise the links by using a double trailing underscore.