### PR TITLE
Make Cmus widget use filename as fallback

### DIFF
--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -99,6 +99,10 @@ class Cmus(base.ThreadPoolText):
             if self.local:
                 artist = info["artist"]
                 now_playing = "{0} - {1}".format(artist, title)
+                if now_playing == " - ":
+                    file_path = info["file"]
+                    file_path = file_path.split("/")[-1]
+                    now_playing = file_path
             else:
                 if info["stream"]:
                     now_playing = info["stream"]

--- a/test/widgets/test_cmus.py
+++ b/test/widgets/test_cmus.py
@@ -89,6 +89,12 @@ class MockCmusRemoteProcess:
                 "tag album Anjunabeats 14",
                 "tag title Always - Tinlicker Extended Mix",
             ],
+            [
+                "status playing",
+                "file /playing/file/always.mp3",
+                "duration 222",
+                "position 14",
+            ],
         ]
         cls.index = 0
         cls.is_error = False
@@ -228,3 +234,16 @@ def test_escape_text(fake_qtile, patched_cmus, fake_window):
 
     # It's stopped so colour should reflect this
     assert text == "♫ Above &amp; Beyond - Always - Tinlicker Extended Mix"
+
+
+def test_missing_metadata(fake_qtile, patched_cmus, fake_window):
+    widget = patched_cmus.Cmus()
+
+    # Set track to one that's missing Title and Artist metadata
+    MockCmusRemoteProcess.index = 4
+    fakebar = FakeBar([widget], window=fake_window)
+    widget._configure(fake_qtile, fakebar)
+    text = widget.poll()
+
+    # Displayed text should default to the name of the file
+    assert text == "♫ always.mp3"


### PR DESCRIPTION
Hi! I use Qtile, Cmus, and the Cmus widget inside Qtile. My music collection exists as local files. I noticed something that could be improved.

I've brought some screenshots to justify my changes.

If I'm playing music in the Cmus music player, then the Qtile widget will display its artist and title (seen bottom of screen in green).
![image](https://user-images.githubusercontent.com/59140312/178187719-9d906717-371d-414d-bbc8-020bd913d029.png)

This is done by getting the metadata from the music files. If there is no metadata though, we get empty strings, as seen below.
![image](https://user-images.githubusercontent.com/59140312/178187677-42668c8b-8f92-40e4-b80e-67671ab2f2ad.png)

Adding this code makes it so the widget uses the file's name as a fallback text to display instead of just " - ".
![image](https://user-images.githubusercontent.com/59140312/178187891-ab00441d-2596-49c2-b740-7bc4819d5c17.png)

Additional considerations:
- use fallback even if Artist is set but Title is not?
- remove file extension from fallback (.mp3 in this case)