### PR TITLE
Add `single_border_width` and `single_margin` to VerticalTile layout

### DIFF
--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -136,10 +136,7 @@ class VerticalTile(_SimpleLayoutBase):
                 border_color = self.border_normal
 
             # width
-            if n > 1:
-                width = screen_rect.width - self.border_width * 2
-            else:
-                width = screen_rect.width
+            width = screen_rect.width - border_width * 2
 
             # height
             if n > 1:
@@ -158,7 +155,7 @@ class VerticalTile(_SimpleLayoutBase):
                 else:
                     height = normal_pane_height
             else:
-                height = screen_rect.height
+                height = screen_rect.height - border_width * 2
 
             # y
             y = screen_rect.y

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -88,6 +88,8 @@ class VerticalTile(_SimpleLayoutBase):
         ("border_normal", "#FFFFFF", "Border color(s) for un-focused windows."),
         ("border_width", 1, "Border width."),
         ("margin", 0, "Border margin (int or list of ints [N E S W])."),
+        ("single_border_width", 0, "Border width for single window"),
+        ("single_margin", None, "Margin size for single window"),
     ]
 
     ratio = 0.75
@@ -120,7 +122,13 @@ class VerticalTile(_SimpleLayoutBase):
             if n > 1:
                 border_width = self.border_width
             else:
-                border_width = 0
+                border_width = self.single_border_width
+
+            # margin
+            if n == 1 and self.single_margin is not None:
+                margin = self.single_margin
+            else:
+                margin = self.margin
 
             if window.has_focus:
                 border_color = self.border_focus
@@ -166,7 +174,7 @@ class VerticalTile(_SimpleLayoutBase):
                         y = y - sec_pane_height + main_pane_height
 
             window.place(
-                screen_rect.x, y, width, height, border_width, border_color, margin=self.margin
+                screen_rect.x, y, width, height, border_width, border_color, margin=margin
             )
             window.unhide()
         else:

--- a/test/layouts/test_verticaltile.py
+++ b/test/layouts/test_verticaltile.py
@@ -50,6 +50,16 @@ class VerticalTileConfig(Config):
 
 verticaltile_config = pytest.mark.parametrize("manager", [VerticalTileConfig], indirect=True)
 
+class VerticalTileMarginsConfig(VerticalTileConfig):
+    layouts = [layout.VerticalTile(), layout.VerticalTile(single_margin=10)]
+
+verticaltile_margins_config = pytest.mark.parametrize("manager", [VerticalTileMarginsConfig], indirect=True)
+
+class VerticalTileBordersConfig(VerticalTileConfig):
+    layouts = [layout.VerticalTile(), layout.VerticalTile(single_border_width=10)]
+
+verticaltile_borders_config = pytest.mark.parametrize("manager", [VerticalTileBordersConfig], indirect=True)
+
 
 @verticaltile_config
 def test_verticaltile_simple(manager):
@@ -90,3 +100,39 @@ def test_verticaltile_window_focus_cycle(manager):
 
     # assert window focus cycle, according to order in layout
     assert_focus_path(manager, "float1", "float2", "one", "two", "three")
+
+@verticaltile_margins_config
+def test_verticaltile_single_margin(manager):
+    manager.test_window("one")
+
+    info = manager.c.window.info()
+    assert info["x"] == 0
+    assert info["y"] == 0
+
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info["x"] == 10
+    assert info["y"] == 10
+
+    manager.test_window("two")
+    # No longer single window so margin reverts to "margin" which is 0
+    info = manager.c.window.info()
+    assert info["x"] == 0
+
+@verticaltile_borders_config
+def test_verticaltile_single_border(manager):
+    manager.test_window("one")
+
+    info = manager.c.window.info()
+    assert info["width"] == 800
+    assert info["height"] == 600
+
+    manager.c.next_layout()
+    info = manager.c.window.info()
+    assert info["width"] == 780
+    assert info["height"] == 580
+
+    manager.test_window("two")
+    info = manager.c.window.info()
+    assert info["width"] == 798
+    assert info["height"] == 298


### PR DESCRIPTION
Add `single_border_width` and `single_margin` to the `VerticalTile` layout to be used when there is only one window.