### PR TITLE
Fix drift in placement of static windows

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1205,8 +1205,8 @@ class Static(_Window, base.Static):
             self.height = e.height
 
         self.place(
-            self.screen.x + self.x,
-            self.screen.y + self.y,
+            self.x,
+            self.y,
             self.width,
             self.height,
             self.borderwidth,


### PR DESCRIPTION
Just noticed that static windows are broken for me yet again. A dual monitor setup might cause Qtile to position the bar wrongly.
Consider this setup:
```
+-----+------------+
|  1  |      2     |
|     +------------+
+-----+
```
Where an external bar should be placed at the top edge of monitor 2. However it will keep a distance from monitor 1 by the width of said monitor. In the following example, there will be a drift in the direction of `y` aswell: 
```
+-----+
|     +------------+
|  1  |      2     |
|     +------------+
+-----+
```

I suppose this should be fixed by not adding `screen.height` and `screen.width` to the position as the properties should already be set relative to the logical screen, not the physical monitor. 