### PR TITLE
Add tidy_groups command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
         - Add scrolling ability to `_TextBox`-based widgets.
         - Add player controls (via mouse callbacks) to `Mpris2` widget.
+        - Add `tidy_groups` command to move windows to leftmost groups.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1600,3 +1600,76 @@ class Qtile(CommandObject):
     def cmd_run_extension(self, extension: _Extension) -> None:
         """Run extensions"""
         extension.run()
+
+    def cmd_tidy_groups(self, follow_focus: bool = True, match_layout: bool = True) -> None:
+        """
+        Move windows to the leftmost empty groups.
+
+        For example, if you have windows on groups 2, 4 and 6,
+        running this command will move windows to groups 1, 2 and 3.
+
+        If follow_focus is True (default) the current window will remain focused
+        and the the group containing that window will be focused.
+
+        If match_layout is True (default) the layout in the destination will be changed
+        to match the layout of the group being moved but only if that layout is available
+        in the group. NB this only matches layouts by name so different configurations of
+        the same layout may not be matched.
+
+        Scratchpad windows are not moved.
+        """
+
+        def match_layout_name(current: _Group, destination: _Group) -> str | None:
+            layouts = [
+                layout.name
+                for layout in destination.layouts
+                if layout.name == current.layout.name
+            ]
+            if layouts:
+                return layouts[0]
+            return None
+
+        win = self.current_window
+        empty = []
+
+        for group in self.groups:
+
+            # We need to skip scratchpads
+            if hasattr(group, "dropdowns"):
+                continue
+
+            # If the group is empty, add it to the list of empty groups
+            # and then move on to the next group
+            if not group.windows:
+                empty.append(group)
+                continue
+
+            # If we have an empty group available and the current group has
+            # windows then we can start moving windows.
+            if empty and group.windows:
+
+                # Get the first available empty group
+                destination = empty.pop(0)
+
+                if match_layout:
+                    # Let's see if we can match the current layout in the destination
+                    layout = match_layout_name(group, destination)
+
+                    if layout is not None and layout != destination.layout.name:
+                        destination.cmd_setlayout(layout)
+
+                # We iterate over a copy of the windows list as we're modifying the original
+                for window in group.windows.copy():
+                    if group is self.current_group:
+                        window.hide()
+                    group.remove(window)
+                    destination.add(window)
+
+                # This group is now empty so we can add it to the list of empty groups
+                empty.append(group)
+
+        # Set focus to group containing the previously focused window
+        if follow_focus and win is not None:
+            assert win.group
+            win.group.cmd_toscreen()
+            win.focus(False)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1285,3 +1285,52 @@ def test_widget_duplicate_warnings(logger, manager):
 
     # Check this message level was info
     assert all([r.levelno == logging.INFO for r in records])
+
+
+@manager_config
+def test_tidy_groups_defaults(manager):
+    """Moves windows to leftmost group. Preserves focus and layouts."""
+    manager.c.group["b"].toscreen()
+    manager.test_window("one")
+    manager.c.group.setlayout("max")
+    manager.c.group["d"].toscreen()
+    manager.test_window("two")
+    manager.c.group.setlayout("tile")
+
+    manager.c.tidy_groups()
+
+    info_a = manager.c.group["a"].info()
+    info_b = manager.c.group["b"].info()
+
+    assert info_a["windows"] == ["one"]
+    assert info_a["layout"] == "max"
+
+    assert info_b["windows"] == ["two"]
+    assert info_b["layout"] == "tile"
+
+    assert manager.c.group.info()["name"] == "b"
+
+
+@manager_config
+def test_tidy_groups_no_defaults(manager):
+    """Moves window to leftmost groups. Don't preserve focus or layouts."""
+    assert manager.c.group["a"].info()["layout"] == "stack"
+    manager.c.group["b"].toscreen()
+    manager.test_window("one")
+    manager.c.group.setlayout("max")
+    manager.c.group["d"].toscreen()
+    manager.test_window("two")
+    manager.c.group.setlayout("tile")
+
+    manager.c.tidy_groups(False, False)
+
+    info_a = manager.c.group["a"].info()
+    info_b = manager.c.group["b"].info()
+
+    assert info_a["windows"] == ["one"]
+    assert info_a["layout"] == "stack"
+
+    assert info_b["windows"] == ["two"]
+    assert info_b["layout"] == "max"
+
+    assert manager.c.group.info()["name"] == "d"


### PR DESCRIPTION
Moves windows to the leftmost available groups. Layouts and focus can be preserved.