### PR TITLE
Volume widget display change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add `force_update` command to `ThreadPoolText` widgets to simplify updating from key bindings
         - Add scrolling ability to `_TextBox`-based widgets.
         - Add player controls (via mouse callbacks) to `Mpris2` widget.
+        - Added ability to specify volume text when muted and umuted, and this applies for both `Volume` and `PulseVolume`.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -229,6 +229,7 @@ class PulseVolume(Volume):
             self.bar.draw()
 
     def get_volume(self):
+        self.mute = self.mute_text
         if self.default_sink:
             if self.default_sink["muted"]:
                 return -1
@@ -236,6 +237,7 @@ class PulseVolume(Volume):
             if not base:
                 return -1
             current = max(self.default_sink["values"])
+            self.mute = self.unmute_text
             return round(current * 100 / base)
         return -1
 

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -231,10 +231,10 @@ class PulseVolume(Volume):
             self.bar.draw()
 
     def get_volume(self):
-        self.mute = self.unmute_text
+        self.mute = False
         if self.default_sink:
             if self.default_sink["muted"]:
-                self.mute = self.mute_text
+                self.mute = True
                 return 0
             base = self.default_sink["base_volume"]
             if not base:

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -235,7 +235,6 @@ class PulseVolume(Volume):
         if self.default_sink:
             if self.default_sink["muted"]:
                 self.mute = True
-                return 0
             base = self.default_sink["base_volume"]
             if not base:
                 return -1

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -85,7 +85,7 @@ class Volume(base._TextBox):
         ),
         (
             "mute_format",
-            "{volume}% M",
+            "M",
             "Format of text to display when the volume is muted. Available fields: 'volume'",
         ),
     ]

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -32,11 +32,9 @@
 
 import re
 import subprocess
-from copy import deepcopy
 
 from libqtile import bar
 from libqtile.widget import base
-from libqtile.log_utils import logger
 
 __all__ = [
     "Volume",
@@ -92,10 +90,10 @@ class Volume(base._TextBox):
         self.mutedtext = "[off]"
         self.unmutedtext = "[on]"
 
-        if "muteicon" in config:
+        if "mutetext" in config:
             self.mutedtext = config["mutetext"]
 
-        if "unmuteicon" in config:
+        if "unmutetext" in config:
             self.unmutedtext = config["unmutetext"]
 
 
@@ -137,11 +135,11 @@ class Volume(base._TextBox):
 
     def update(self):
         vol = self.get_volume()
-        prevMute = deepcopy(self.mute)
-    
-        self.check_mute()
-        if vol != self.volume or self.mute != prevMute:
+        nMute = self.get_mute()
+
+        if vol != self.volume or self.mute != nMute:
             self.volume = vol
+            self.mute = nMute
             # Update the underlying canvas size before actually attempting
             # to figure out how big it is and draw it.
             self._update_drawer()
@@ -209,8 +207,8 @@ class Volume(base._TextBox):
             # this shouldn't happen
             return -1
 
-    def check_mute(self):
-        self.mute = self.mutedtext if "[off]" in self.mixer_out else self.unmutedtext
+    def get_mute(self):
+        return self.mutedtext if "[off]" in self.mixer_out else self.unmutedtext
 
     def draw(self):
         if self.theme_path:

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -79,8 +79,8 @@ class Volume(base._TextBox):
 			"Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
 		),
 		("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
-	 ("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
-	 ("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
+		("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
+		("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
 	]
 
 	def __init__(self, **config):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -143,7 +143,7 @@ class Volume(base._TextBox):
     def _update_drawer(self):
         if self.theme_path:
             self.drawer.clear(self.background or self.bar.background)
-            if self.volume <= 0:
+            if self.volume <= 0 or self.mute == self.mute_text:
                 img_name = "audio-volume-muted"
             elif self.volume <= 30:
                 img_name = "audio-volume-low"
@@ -155,7 +155,7 @@ class Volume(base._TextBox):
             self.drawer.ctx.set_source(self.surfaces[img_name])
             self.drawer.ctx.paint()
         elif self.emoji:
-            if self.volume <= 0:
+            if self.volume <= 0 or self.mute == self.mute_text:
                 self.text = "\U0001f507"
             elif self.volume <= 30:
                 self.text = "\U0001f508"

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -37,199 +37,199 @@ from libqtile import bar
 from libqtile.widget import base
 
 __all__ = [
-	"Volume",
+    "Volume",
 ]
 
 re_vol = re.compile(r"\[(\d?\d?\d?)%\]")
 
 
 class Volume(base._TextBox):
-	"""Widget that display and change volume
+    """Widget that display and change volume
 
-	By default, this widget uses ``amixer`` to get and set the volume so users
-	will need to make sure this is installed. Alternatively, users may set the
-	relevant parameters for the widget to use a different application.
+    By default, this widget uses ``amixer`` to get and set the volume so users
+    will need to make sure this is installed. Alternatively, users may set the
+    relevant parameters for the widget to use a different application.
 
-	If theme_path is set it draw widget as icons.
-	"""
+    If theme_path is set it draw widget as icons.
+    """
 
-	orientations = base.ORIENTATION_HORIZONTAL
-	defaults = [
-		("cardid", None, "Card Id"),
-		("device", "default", "Device Name"),
-		("channel", "Master", "Channel"),
-		("padding", 3, "Padding left and right. Calculated if None."),
-		("update_interval", 0.2, "Update time in seconds."),
-		("theme_path", None, "Path of the icons"),
-		(
-			"emoji",
-			False,
-			"Use emoji to display volume states, only if ``theme_path`` is not set."
-			"The specified font needs to contain the correct unicode characters.",
-		),
-		("mute_command", None, "Mute command"),
-		("volume_app", None, "App to control volume"),
-		("volume_up_command", None, "Volume up command"),
-		("volume_down_command", None, "Volume down command"),
-		("get_volume_command", None, "Command to get the current volume"),
-		(
-			"step",
-			2,
-			"Volume change for up an down commands in percentage."
-			"Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
-		),
-		("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
-		("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
-		("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
-	]
+    orientations = base.ORIENTATION_HORIZONTAL
+    defaults = [
+        ("cardid", None, "Card Id"),
+        ("device", "default", "Device Name"),
+        ("channel", "Master", "Channel"),
+        ("padding", 3, "Padding left and right. Calculated if None."),
+        ("update_interval", 0.2, "Update time in seconds."),
+        ("theme_path", None, "Path of the icons"),
+        (
+            "emoji",
+            False,
+            "Use emoji to display volume states, only if ``theme_path`` is not set."
+            "The specified font needs to contain the correct unicode characters.",
+        ),
+        ("mute_command", None, "Mute command"),
+        ("volume_app", None, "App to control volume"),
+        ("volume_up_command", None, "Volume up command"),
+        ("volume_down_command", None, "Volume down command"),
+        ("get_volume_command", None, "Command to get the current volume"),
+        (
+            "step",
+            2,
+            "Volume change for up an down commands in percentage."
+            "Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
+        ),
+        ("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
+        ("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
+        ("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
+    ]
 
-	def __init__(self, **config):
-		base._TextBox.__init__(self, "0", **config)
-		self.add_defaults(Volume.defaults)
-		self.surfaces = {}
-		self.volume = None
-		self.mute = ""
-		self.mixer_out = ""
+    def __init__(self, **config):
+        base._TextBox.__init__(self, "0", **config)
+        self.add_defaults(Volume.defaults)
+        self.surfaces = {}
+        self.volume = None
+        self.mute = ""
+        self.mixer_out = ""
 
-		self.add_callbacks(
-			{
-				"Button1": self.cmd_mute,
-				"Button3": self.cmd_run_app,
-				"Button4": self.cmd_increase_vol,
-				"Button5": self.cmd_decrease_vol,
-			}
-		)
+        self.add_callbacks(
+            {
+                "Button1": self.cmd_mute,
+                "Button3": self.cmd_run_app,
+                "Button4": self.cmd_increase_vol,
+                "Button5": self.cmd_decrease_vol,
+            }
+        )
 
-	def _configure(self, qtile, parent_bar):
-		if self.theme_path:
-			self.length_type = bar.STATIC
-			self.length = 0
-		base._TextBox._configure(self, qtile, parent_bar)
+    def _configure(self, qtile, parent_bar):
+        if self.theme_path:
+            self.length_type = bar.STATIC
+            self.length = 0
+        base._TextBox._configure(self, qtile, parent_bar)
 
-	def timer_setup(self):
-		self.timeout_add(self.update_interval, self.update)
-		if self.theme_path:
-			self.setup_images()
+    def timer_setup(self):
+        self.timeout_add(self.update_interval, self.update)
+        if self.theme_path:
+            self.setup_images()
 
-	def create_amixer_command(self, *args):
-		cmd = ["amixer"]
+    def create_amixer_command(self, *args):
+        cmd = ["amixer"]
 
-		if self.cardid is not None:
-			cmd.extend(["-c", str(self.cardid)])
+        if self.cardid is not None:
+            cmd.extend(["-c", str(self.cardid)])
 
-		if self.device is not None:
-			cmd.extend(["-D", str(self.device)])
+        if self.device is not None:
+            cmd.extend(["-D", str(self.device)])
 
-		cmd.extend([x for x in args])
-		return cmd
+        cmd.extend([x for x in args])
+        return cmd
 
-	def button_press(self, x, y, button):
-		base._TextBox.button_press(self, x, y, button)
-		self.draw()
+    def button_press(self, x, y, button):
+        base._TextBox.button_press(self, x, y, button)
+        self.draw()
 
-	def update(self):
-		vol = self.get_volume()
-		next_mute = self.mute_text if "[off]" in self.mixer_out else self.unmute_text
+    def update(self):
+        vol = self.get_volume()
+        next_mute = self.mute_text if "[off]" in self.mixer_out else self.unmute_text
 
-		if vol != self.volume or self.mute != next_mute:
-			self.volume = vol
-			self.mute = next_mute
-			# Update the underlying canvas size before actually attempting
-			# to figure out how big it is and draw it.
-			self._update_drawer()
-			self.bar.draw()
-		self.timeout_add(self.update_interval, self.update)
+        if vol != self.volume or self.mute != next_mute:
+            self.volume = vol
+            self.mute = next_mute
+            # Update the underlying canvas size before actually attempting
+            # to figure out how big it is and draw it.
+            self._update_drawer()
+            self.bar.draw()
+        self.timeout_add(self.update_interval, self.update)
 
-	def _update_drawer(self):
-		if self.theme_path:
-			self.drawer.clear(self.background or self.bar.background)
-			if self.volume <= 0 or self.mute == self.mute_text:
-				img_name = "audio-volume-muted"
-			elif self.volume <= 30:
-				img_name = "audio-volume-low"
-			elif self.volume < 80:
-				img_name = "audio-volume-medium"
-			else:  # self.volume >= 80:
-				img_name = "audio-volume-high"
+    def _update_drawer(self):
+        if self.theme_path:
+            self.drawer.clear(self.background or self.bar.background)
+            if self.volume <= 0 or self.mute == self.mute_text:
+                img_name = "audio-volume-muted"
+            elif self.volume <= 30:
+                img_name = "audio-volume-low"
+            elif self.volume < 80:
+                img_name = "audio-volume-medium"
+            else:  # self.volume >= 80:
+                img_name = "audio-volume-high"
 
-			self.drawer.ctx.set_source(self.surfaces[img_name])
-			self.drawer.ctx.paint()
-		elif self.emoji:
-			if self.volume <= 0 or self.mute == self.mute_text:
-				self.text = "\U0001f507"
-			elif self.volume <= 30:
-				self.text = "\U0001f508"
-			elif self.volume < 80:
-				self.text = "\U0001f509"
-			elif self.volume >= 80:
-				self.text = "\U0001f50a"
-		else:
-			self.text = self.format.format(volume=self.volume, mute=self.mute)
+            self.drawer.ctx.set_source(self.surfaces[img_name])
+            self.drawer.ctx.paint()
+        elif self.emoji:
+            if self.volume <= 0 or self.mute == self.mute_text:
+                self.text = "\U0001f507"
+            elif self.volume <= 30:
+                self.text = "\U0001f508"
+            elif self.volume < 80:
+                self.text = "\U0001f509"
+            elif self.volume >= 80:
+                self.text = "\U0001f50a"
+        else:
+            self.text = self.format.format(volume=self.volume, mute=self.mute)
 
-	def setup_images(self):
-		from libqtile import images
+    def setup_images(self):
+        from libqtile import images
 
-		names = (
-			"audio-volume-high",
-			"audio-volume-low",
-			"audio-volume-medium",
-			"audio-volume-muted",
-		)
-		d_images = images.Loader(self.theme_path)(*names)
-		for name, img in d_images.items():
-			new_height = self.bar.height - 1
-			img.resize(height=new_height)
-			if img.width > self.length:
-				self.length = img.width + self.actual_padding * 2
-			self.surfaces[name] = img.pattern
+        names = (
+            "audio-volume-high",
+            "audio-volume-low",
+            "audio-volume-medium",
+            "audio-volume-muted",
+        )
+        d_images = images.Loader(self.theme_path)(*names)
+        for name, img in d_images.items():
+            new_height = self.bar.height - 1
+            img.resize(height=new_height)
+            if img.width > self.length:
+                self.length = img.width + self.actual_padding * 2
+            self.surfaces[name] = img.pattern
 
-	def get_volume(self):
-		try:
-			get_volume_cmd = self.create_amixer_command("sget", self.channel)
+    def get_volume(self):
+        try:
+            get_volume_cmd = self.create_amixer_command("sget", self.channel)
 
-			if self.get_volume_command:
-				get_volume_cmd = self.get_volume_command
+            if self.get_volume_command:
+                get_volume_cmd = self.get_volume_command
 
-			self.mixer_out = self.call_process(get_volume_cmd)
-		except subprocess.CalledProcessError:
-			return -1
+            self.mixer_out = self.call_process(get_volume_cmd)
+        except subprocess.CalledProcessError:
+            return -1
 
-		volgroups = re_vol.search(self.mixer_out)
+        volgroups = re_vol.search(self.mixer_out)
 
-		if volgroups:
-			return int(volgroups.groups()[0])
-		else:
-			# this shouldn't happen
-			return -1
+        if volgroups:
+            return int(volgroups.groups()[0])
+        else:
+            # this shouldn't happen
+            return -1
 
-	def draw(self):
-		if self.theme_path:
-			self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
-		else:
-			base._TextBox.draw(self)
+    def draw(self):
+        if self.theme_path:
+            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        else:
+            base._TextBox.draw(self)
 
-	def cmd_increase_vol(self):
-		if self.volume_up_command is not None:
-			subprocess.call(self.volume_up_command, shell=True)
-		else:
-			subprocess.call(
-				self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
-			)
+    def cmd_increase_vol(self):
+        if self.volume_up_command is not None:
+            subprocess.call(self.volume_up_command, shell=True)
+        else:
+            subprocess.call(
+                self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
+            )
 
-	def cmd_decrease_vol(self):
-		if self.volume_down_command is not None:
-			subprocess.call(self.volume_down_command, shell=True)
-		else:
-			subprocess.call(
-				self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
-			)
+    def cmd_decrease_vol(self):
+        if self.volume_down_command is not None:
+            subprocess.call(self.volume_down_command, shell=True)
+        else:
+            subprocess.call(
+                self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
+            )
 
-	def cmd_mute(self):
-		if self.mute_command is not None:
-			subprocess.call(self.mute_command, shell=True)
-		else:
-			subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
+    def cmd_mute(self):
+        if self.mute_command is not None:
+            subprocess.call(self.mute_command, shell=True)
+        else:
+            subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
 
-	def cmd_run_app(self):
-		if self.volume_app is not None:
-			subprocess.Popen(self.volume_app, shell=True)
+    def cmd_run_app(self):
+        if self.volume_app is not None:
+            subprocess.Popen(self.volume_app, shell=True)

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -78,6 +78,8 @@ class Volume(base._TextBox):
             "Volume change for up an down commands in percentage."
             "Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
         ),
+        ("unmute_text", "[on]", "Text displayed when the volume is unmuted"),
+        ("mute_text", "[off]", "Text displayed when the volume is muted"),
     ]
 
     def __init__(self, **config):
@@ -87,15 +89,6 @@ class Volume(base._TextBox):
         self.volume = None
         self.mute = ""
         self.mixer_out = ""
-        self.mutedtext = "[off]"
-        self.unmutedtext = "[on]"
-
-        if "mutetext" in config:
-            self.mutedtext = config["mutetext"]
-
-        if "unmutetext" in config:
-            self.unmutedtext = config["unmutetext"]
-
 
         self.add_callbacks(
             {
@@ -135,11 +128,11 @@ class Volume(base._TextBox):
 
     def update(self):
         vol = self.get_volume()
-        nMute = self.get_mute()
+        next_mute = self.get_mute()
 
-        if vol != self.volume or self.mute != nMute:
+        if vol != self.volume or self.mute != next_mute:
             self.volume = vol
-            self.mute = nMute
+            self.mute = next_mute
             # Update the underlying canvas size before actually attempting
             # to figure out how big it is and draw it.
             self._update_drawer()
@@ -208,7 +201,7 @@ class Volume(base._TextBox):
             return -1
 
     def get_mute(self):
-        return self.mutedtext if "[off]" in self.mixer_out else self.unmutedtext
+        return self.mute_text if "[off]" in self.mixer_out else self.unmute_text
 
     def draw(self):
         if self.theme_path:

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -78,9 +78,21 @@ class Volume(base._TextBox):
             "Volume change for up an down commands in percentage."
             "Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
         ),
-        ("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
-        ("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
-        ("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
+        (
+            "unmute_text",
+            "[on]",
+            "Text displayed when the volume is unmuted and 'mute' field is included in ``format``",
+        ),
+        (
+            "mute_text",
+            "[off]",
+            "Text displayed when the volume is muted and 'mute' field is included in ``format``",
+        ),
+        (
+            "format",
+            "{volume}%",
+            "Format of text to display. Available fields: 'volume' and 'mute'",
+        ),
     ]
 
     def __init__(self, **config):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -37,199 +37,199 @@ from libqtile import bar
 from libqtile.widget import base
 
 __all__ = [
-    "Volume",
+	"Volume",
 ]
 
 re_vol = re.compile(r"\[(\d?\d?\d?)%\]")
 
 
 class Volume(base._TextBox):
-    """Widget that display and change volume
+	"""Widget that display and change volume
 
-    By default, this widget uses ``amixer`` to get and set the volume so users
-    will need to make sure this is installed. Alternatively, users may set the
-    relevant parameters for the widget to use a different application.
+	By default, this widget uses ``amixer`` to get and set the volume so users
+	will need to make sure this is installed. Alternatively, users may set the
+	relevant parameters for the widget to use a different application.
 
-    If theme_path is set it draw widget as icons.
-    """
+	If theme_path is set it draw widget as icons.
+	"""
 
-    orientations = base.ORIENTATION_HORIZONTAL
-    defaults = [
-        ("cardid", None, "Card Id"),
-        ("device", "default", "Device Name"),
-        ("channel", "Master", "Channel"),
-        ("padding", 3, "Padding left and right. Calculated if None."),
-        ("update_interval", 0.2, "Update time in seconds."),
-        ("theme_path", None, "Path of the icons"),
-        (
-            "emoji",
-            False,
-            "Use emoji to display volume states, only if ``theme_path`` is not set."
-            "The specified font needs to contain the correct unicode characters.",
-        ),
-        ("mute_command", None, "Mute command"),
-        ("volume_app", None, "App to control volume"),
-        ("volume_up_command", None, "Volume up command"),
-        ("volume_down_command", None, "Volume down command"),
-        ("get_volume_command", None, "Command to get the current volume"),
-        (
-            "step",
-            2,
-            "Volume change for up an down commands in percentage."
-            "Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
-        ),
-        ("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
-	    ("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
-	    ("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
-    ]
+	orientations = base.ORIENTATION_HORIZONTAL
+	defaults = [
+		("cardid", None, "Card Id"),
+		("device", "default", "Device Name"),
+		("channel", "Master", "Channel"),
+		("padding", 3, "Padding left and right. Calculated if None."),
+		("update_interval", 0.2, "Update time in seconds."),
+		("theme_path", None, "Path of the icons"),
+		(
+			"emoji",
+			False,
+			"Use emoji to display volume states, only if ``theme_path`` is not set."
+			"The specified font needs to contain the correct unicode characters.",
+		),
+		("mute_command", None, "Mute command"),
+		("volume_app", None, "App to control volume"),
+		("volume_up_command", None, "Volume up command"),
+		("volume_down_command", None, "Volume down command"),
+		("get_volume_command", None, "Command to get the current volume"),
+		(
+			"step",
+			2,
+			"Volume change for up an down commands in percentage."
+			"Only used if ``volume_up_command`` and ``volume_down_command`` are not set.",
+		),
+		("unmute_text", "[on]", "Text displayed when the volume is unmuted and 'mute' field is included in ``format``"),
+	 ("mute_text", "[off]", "Text displayed when the volume is muted and 'mute' field is included in ``format``"),
+	 ("format", "{volume}%", "Format of text to display. Available fields: 'volume' and 'mute'"),
+	]
 
-    def __init__(self, **config):
-        base._TextBox.__init__(self, "0", **config)
-        self.add_defaults(Volume.defaults)
-        self.surfaces = {}
-        self.volume = None
-        self.mute = ""
-        self.mixer_out = ""
+	def __init__(self, **config):
+		base._TextBox.__init__(self, "0", **config)
+		self.add_defaults(Volume.defaults)
+		self.surfaces = {}
+		self.volume = None
+		self.mute = ""
+		self.mixer_out = ""
 
-        self.add_callbacks(
-            {
-                "Button1": self.cmd_mute,
-                "Button3": self.cmd_run_app,
-                "Button4": self.cmd_increase_vol,
-                "Button5": self.cmd_decrease_vol,
-            }
-        )
+		self.add_callbacks(
+			{
+				"Button1": self.cmd_mute,
+				"Button3": self.cmd_run_app,
+				"Button4": self.cmd_increase_vol,
+				"Button5": self.cmd_decrease_vol,
+			}
+		)
 
-    def _configure(self, qtile, parent_bar):
-        if self.theme_path:
-            self.length_type = bar.STATIC
-            self.length = 0
-        base._TextBox._configure(self, qtile, parent_bar)
+	def _configure(self, qtile, parent_bar):
+		if self.theme_path:
+			self.length_type = bar.STATIC
+			self.length = 0
+		base._TextBox._configure(self, qtile, parent_bar)
 
-    def timer_setup(self):
-        self.timeout_add(self.update_interval, self.update)
-        if self.theme_path:
-            self.setup_images()
+	def timer_setup(self):
+		self.timeout_add(self.update_interval, self.update)
+		if self.theme_path:
+			self.setup_images()
 
-    def create_amixer_command(self, *args):
-        cmd = ["amixer"]
+	def create_amixer_command(self, *args):
+		cmd = ["amixer"]
 
-        if self.cardid is not None:
-            cmd.extend(["-c", str(self.cardid)])
+		if self.cardid is not None:
+			cmd.extend(["-c", str(self.cardid)])
 
-        if self.device is not None:
-            cmd.extend(["-D", str(self.device)])
+		if self.device is not None:
+			cmd.extend(["-D", str(self.device)])
 
-        cmd.extend([x for x in args])
-        return cmd
+		cmd.extend([x for x in args])
+		return cmd
 
-    def button_press(self, x, y, button):
-        base._TextBox.button_press(self, x, y, button)
-        self.draw()
+	def button_press(self, x, y, button):
+		base._TextBox.button_press(self, x, y, button)
+		self.draw()
 
-    def update(self):
-        vol = self.get_volume()
-        next_mute = self.mute_text if "[off]" in self.mixer_out else self.unmute_text
+	def update(self):
+		vol = self.get_volume()
+		next_mute = self.mute_text if "[off]" in self.mixer_out else self.unmute_text
 
-        if vol != self.volume or self.mute != next_mute:
-            self.volume = vol
-            self.mute = next_mute
-            # Update the underlying canvas size before actually attempting
-            # to figure out how big it is and draw it.
-            self._update_drawer()
-            self.bar.draw()
-        self.timeout_add(self.update_interval, self.update)
+		if vol != self.volume or self.mute != next_mute:
+			self.volume = vol
+			self.mute = next_mute
+			# Update the underlying canvas size before actually attempting
+			# to figure out how big it is and draw it.
+			self._update_drawer()
+			self.bar.draw()
+		self.timeout_add(self.update_interval, self.update)
 
-    def _update_drawer(self):
-        if self.theme_path:
-            self.drawer.clear(self.background or self.bar.background)
-            if self.volume <= 0 or self.mute == self.mute_text:
-                img_name = "audio-volume-muted"
-            elif self.volume <= 30:
-                img_name = "audio-volume-low"
-            elif self.volume < 80:
-                img_name = "audio-volume-medium"
-            else:  # self.volume >= 80:
-                img_name = "audio-volume-high"
+	def _update_drawer(self):
+		if self.theme_path:
+			self.drawer.clear(self.background or self.bar.background)
+			if self.volume <= 0 or self.mute == self.mute_text:
+				img_name = "audio-volume-muted"
+			elif self.volume <= 30:
+				img_name = "audio-volume-low"
+			elif self.volume < 80:
+				img_name = "audio-volume-medium"
+			else:  # self.volume >= 80:
+				img_name = "audio-volume-high"
 
-            self.drawer.ctx.set_source(self.surfaces[img_name])
-            self.drawer.ctx.paint()
-        elif self.emoji:
-            if self.volume <= 0 or self.mute == self.mute_text:
-                self.text = "\U0001f507"
-            elif self.volume <= 30:
-                self.text = "\U0001f508"
-            elif self.volume < 80:
-                self.text = "\U0001f509"
-            elif self.volume >= 80:
-                self.text = "\U0001f50a"
-        else:
-            self.text = self.format.format(volume=self.volume, mute=self.mute)
+			self.drawer.ctx.set_source(self.surfaces[img_name])
+			self.drawer.ctx.paint()
+		elif self.emoji:
+			if self.volume <= 0 or self.mute == self.mute_text:
+				self.text = "\U0001f507"
+			elif self.volume <= 30:
+				self.text = "\U0001f508"
+			elif self.volume < 80:
+				self.text = "\U0001f509"
+			elif self.volume >= 80:
+				self.text = "\U0001f50a"
+		else:
+			self.text = self.format.format(volume=self.volume, mute=self.mute)
 
-    def setup_images(self):
-        from libqtile import images
+	def setup_images(self):
+		from libqtile import images
 
-        names = (
-            "audio-volume-high",
-            "audio-volume-low",
-            "audio-volume-medium",
-            "audio-volume-muted",
-        )
-        d_images = images.Loader(self.theme_path)(*names)
-        for name, img in d_images.items():
-            new_height = self.bar.height - 1
-            img.resize(height=new_height)
-            if img.width > self.length:
-                self.length = img.width + self.actual_padding * 2
-            self.surfaces[name] = img.pattern
-    
-    def get_volume(self):
-        try:
-            get_volume_cmd = self.create_amixer_command("sget", self.channel)
+		names = (
+			"audio-volume-high",
+			"audio-volume-low",
+			"audio-volume-medium",
+			"audio-volume-muted",
+		)
+		d_images = images.Loader(self.theme_path)(*names)
+		for name, img in d_images.items():
+			new_height = self.bar.height - 1
+			img.resize(height=new_height)
+			if img.width > self.length:
+				self.length = img.width + self.actual_padding * 2
+			self.surfaces[name] = img.pattern
 
-            if self.get_volume_command:
-                get_volume_cmd = self.get_volume_command
+	def get_volume(self):
+		try:
+			get_volume_cmd = self.create_amixer_command("sget", self.channel)
 
-            self.mixer_out = self.call_process(get_volume_cmd)
-        except subprocess.CalledProcessError:
-            return -1
+			if self.get_volume_command:
+				get_volume_cmd = self.get_volume_command
 
-        volgroups = re_vol.search(self.mixer_out)
+			self.mixer_out = self.call_process(get_volume_cmd)
+		except subprocess.CalledProcessError:
+			return -1
 
-        if volgroups:
-            return int(volgroups.groups()[0])
-        else:
-            # this shouldn't happen
-            return -1
+		volgroups = re_vol.search(self.mixer_out)
 
-    def draw(self):
-        if self.theme_path:
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
-        else:
-            base._TextBox.draw(self)
+		if volgroups:
+			return int(volgroups.groups()[0])
+		else:
+			# this shouldn't happen
+			return -1
 
-    def cmd_increase_vol(self):
-        if self.volume_up_command is not None:
-            subprocess.call(self.volume_up_command, shell=True)
-        else:
-            subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
-            )
+	def draw(self):
+		if self.theme_path:
+			self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+		else:
+			base._TextBox.draw(self)
 
-    def cmd_decrease_vol(self):
-        if self.volume_down_command is not None:
-            subprocess.call(self.volume_down_command, shell=True)
-        else:
-            subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
-            )
+	def cmd_increase_vol(self):
+		if self.volume_up_command is not None:
+			subprocess.call(self.volume_up_command, shell=True)
+		else:
+			subprocess.call(
+				self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
+			)
 
-    def cmd_mute(self):
-        if self.mute_command is not None:
-            subprocess.call(self.mute_command, shell=True)
-        else:
-            subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
+	def cmd_decrease_vol(self):
+		if self.volume_down_command is not None:
+			subprocess.call(self.volume_down_command, shell=True)
+		else:
+			subprocess.call(
+				self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
+			)
 
-    def cmd_run_app(self):
-        if self.volume_app is not None:
-            subprocess.Popen(self.volume_app, shell=True)
+	def cmd_mute(self):
+		if self.mute_command is not None:
+			subprocess.call(self.mute_command, shell=True)
+		else:
+			subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
+
+	def cmd_run_app(self):
+		if self.volume_app is not None:
+			subprocess.Popen(self.volume_app, shell=True)

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -51,10 +51,6 @@ def test_emoji():
     vol._update_drawer()
     assert vol.text == "\U0001f50a"
 
-    vol.mute = "[off]"
-    vol._update_drawer()
-    assert vol.text == "\U0001f507"
-
 
 def test_text():
     fmt = "Volume: {}"
@@ -64,10 +60,14 @@ def test_text():
     assert vol.text == "80%"
 
 
-def test_format():
-    format = "Volume: {volume}% {mute}"
-    vol = Volume(format=format)
+def test_formats():
+    format = "Volume: {volume}%"
+    mute_format = "Volume: M"
+    vol = Volume(unmute_format=format, mute_format=mute_format)
     vol.volume = 50
-    vol.mute = "[on]"
     vol._update_drawer()
-    assert vol.text == "Volume: 50% [on]"
+    assert vol.text == "Volume: 50%"
+
+    vol.mute = True
+    vol._update_drawer()
+    assert vol.text == "Volume: M"

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -51,6 +51,10 @@ def test_emoji():
     vol._update_drawer()
     assert vol.text == "\U0001f50a"
 
+    vol.mute = "[off]"
+    vol._update_drawer()
+    assert vol.text == "\U0001f507"
+
 
 def test_text():
     fmt = "Volume: {}"

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -55,10 +55,13 @@ def test_emoji():
 def test_text():
     fmt = "Volume: {}"
     vol = Volume(fmt=fmt)
-    vol.volume = -1
+    vol.volume = 80
     vol._update_drawer()
-    assert vol.text == "M"
+    assert vol.text == "80%"
 
+    format = "Volume: {volume}% {mute}"
+    vol = Volume(format=format)
     vol.volume = 50
+    vol.mute = "[on]"
     vol._update_drawer()
-    assert vol.text == "50%"
+    assert vol.text == "Volume: 50% [on]"

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -63,6 +63,8 @@ def test_text():
     vol._update_drawer()
     assert vol.text == "80%"
 
+
+def test_format():
     format = "Volume: {volume}% {mute}"
     vol = Volume(format=format)
     vol.volume = 50


### PR DESCRIPTION
this is a minor change, where u'd see both the volume and if it's muted or not as (volume [on] or [off]) instead of the current behavior. [on] or [off] can also be changed by supplying values to unmutetext and mutetext in widgets. any changes to variable names or the default on off would make it better I think, but I cannot come up with other names.