### PR TITLE
fix: log python errors in config.py also on startup

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -109,6 +109,7 @@ class Qtile(CommandObject):
             self.config.load()
             self.config.validate()
         except Exception as e:
+            logger.exception("Configuration error:")
             send_notification("Configuration error", str(e))
 
         if hasattr(self.core, "wmname"):


### PR DESCRIPTION
Previously, any syntax errors in `config.py` were silently ignored on startup due to the exception of the module import being caught and converted into a simple notification message. This makes it hard to debug errors in the config file. On reload, this already is logged as expected, just not on the initial start.

This PR adds the exception log on startup to make the behavior consistent in both cases.