### PR TITLE
WIP: Add a xwayland_ready hook.

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -581,6 +581,7 @@ class Core(base.Core, wlrq.HasListeners):
                     image._ptr.hotspot_x,
                     image._ptr.hotspot_y,
                 )
+        hook.fire("xwayland_ready")
 
     def _on_xwayland_new_surface(self, _listener: Listener, surface: xwayland.Surface) -> None:
         logger.debug("Signal: xwayland new_surface")

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -355,6 +355,18 @@ class Subscribe:
         """
         return self._subscribe("resume", func)
 
+    def xwayland_ready(self, func):
+        """
+        Called when xwayland is started and ready and "DISPLAY" is set in os.environ.
+
+        Note: only the wayland backend fires this.
+
+        **Arguments**
+
+        None
+        """
+        return self._subscribe("xwayland_ready", func)
+
 
 subscribe = Subscribe()
 


### PR DESCRIPTION
When run with the wayland backend, this will fire when `DISPLAY` becomes
available in the os.environ, such that X clients can be launched in the
config.py


I'm running qtile on a system with no X.org, by using lightdm with wayland greeter.
Starting my ssh-agent when `startup_once` is fired wasn't enough to support [`ssh-add -c`](https://spencerkrum.com/posts/ssh-askpass-wayland/) as `DISPLAY` wasn't set yet in the env where the agent is spun up. I tried a little async co-routine that would sleep until `DISPLAY` would become available, but haven't had any luck.With this new hook I can start it like this:

```python
@hook.subscribe.xwayland_ready
def ssh_agent():
    # start agent
    agent = subprocess.Popen(
        "ssh-agent",
        stdout=subprocess.PIPE,
        text=True,
    )
    # cleanup on shutdown
    hook.subscribe.shutdown(agent.kill)

    # set the env
    output, err = agent.communicate()
    for var, val in (ln.split("=") for ln in output.splitlines() if "=" in ln):
        os.environ[var] = val.split(";")[0].strip()
```

TODO:

- [ ] discussion
- [ ] test
- [ ] documentation