### PR TITLE
Add option to specify custom log path

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+from pathlib import Path
 
 from libqtile.log_utils import get_default_log, init_log
 from libqtile.scripts import check, cmd_obj, migrate, run_cmd, shell, start, top
@@ -20,6 +21,14 @@ except ModuleNotFoundError:
         VERSION = "dev"
 
 
+def check_folder(value):
+    path = Path(value)
+    if not path.parent.is_dir():
+        raise argparse.ArgumentTypeError("Log path destination folder does not exist.")
+    # init_log expects a Path object so return `path` not `value`
+    return path
+
+
 def main():
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
@@ -31,7 +40,14 @@ def main():
         choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
         help="Set qtile log level",
     )
-
+    parent_parser.add_argument(
+        "-p",
+        "--log-path",
+        default=get_default_log(),
+        dest="log_path",
+        type=check_folder,
+        help="Set alternative qtile log path",
+    )
     main_parser = argparse.ArgumentParser(
         prog="qtile",
         description="A full-featured tiling window manager for X11 and Wayland.",
@@ -62,7 +78,7 @@ def main():
     options = main_parser.parse_args()
     if func := getattr(options, "func", None):
         log_level = getattr(logging, options.log_level)
-        init_log(log_level, log_path=get_default_log())
+        init_log(log_level, log_path=options.log_path)
         func(options)
     else:
         main_parser.print_usage()


### PR DESCRIPTION
This adds a new command line option ("-p", "--log-path") to define a custom path for the log file.

A bit niche but would be useful for my development work. I test development in a separate X session and have noticed some issues with my primary qtile session not writing to the log after the development session has written to that file. Writing to a separate file should solve that.