### PR TITLE
WL: refactor input device management, add command to get device info, update inputs when config is reloaded

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Wayland: input inhibitor protocol support added (pywayland>=0.4.14 & pywlroots>=0.15.19)
         - Add commands to control Pomodoro widget.
         - Add icon theme support to `TaskList` widget (available on X11 and Wayland backends).
+        - Wayland: Use `qtile cmd-obj -o core -f get_inputs` to get input device identifiers for
+          configuring inputs. Also input configs will be updated by config reloads (pywlroots>=0.15.21)
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -90,8 +90,10 @@ class Core(CommandObject, metaclass=ABCMeta):
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
 
-    def distribute_windows(self, initial: bool) -> None:
-        """Distribute windows to groups. `initial` will be `True` if Qtile just started."""
+    def on_config_load(self, initial: bool) -> None:
+        """
+        Respond to config loading. `initial` will be `True` if Qtile just started.
+        """
 
     def warp_pointer(self, x: int, y: int) -> None:
         """Warp the pointer to the given coordinates relative."""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -131,6 +131,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         # set up inputs
         self.keyboards: list[inputs.Keyboard] = []
+        self._pointers: list[inputs.Pointer] = []
         self.grabbed_keys: list[tuple[int, int]] = []
         self.grabbed_buttons: list[tuple[int, int]] = []
         DataDeviceManager(self.display)
@@ -145,7 +146,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(self.seat.start_drag_event, self._on_start_drag)
         self.add_listener(self.backend.new_input_event, self._on_new_input)
         # Some devices are added early, so we need to remember to configure them
-        self._pending_input_devices: list[input_device.InputDevice] = []
+        self._pending_input_devices: list[inputs._Device] = []
         hook.subscribe.startup_complete(self._configure_pending_inputs)
 
         self._input_inhibit_manager = InputInhibitManager(self.display)
@@ -247,6 +248,8 @@ class Core(base.Core, wlrq.HasListeners):
         self._poll()
         for kb in self.keyboards.copy():
             kb.finalize()
+        for pt in self._pointers.copy():
+            pt.finalize()
         for out in self.outputs.copy():
             out.finalize()
 
@@ -292,21 +295,27 @@ class Core(base.Core, wlrq.HasListeners):
         logger.debug("Signal: seat start_drag")
         self.live_dnd = wlrq.Dnd(self, event)
 
-    def _on_new_input(self, _listener: Listener, device: input_device.InputDevice) -> None:
+    def _on_new_input(self, _listener: Listener, wlr_device: input_device.InputDevice) -> None:
         logger.debug("Signal: backend new_input_event")
-        if device.device_type == input_device.InputDeviceType.POINTER:
-            self._add_new_pointer(device)
-        elif device.device_type == input_device.InputDeviceType.KEYBOARD:
-            self._add_new_keyboard(device)
+
+        device: inputs._Device
+        if wlr_device.device_type == input_device.InputDeviceType.POINTER:
+            device = self._add_new_pointer(wlr_device)
+        elif wlr_device.device_type == input_device.InputDeviceType.KEYBOARD:
+            device = self._add_new_keyboard(wlr_device)
+        else:
+            logger.info("New %s device", wlr_device.device_type.name)
+            return
 
         capabilities = WlSeat.capability.pointer
         if self.keyboards:
             capabilities |= WlSeat.capability.keyboard
         self.seat.set_capabilities(capabilities)
 
-        logger.info("New %s: %s", device.device_type.name, device.name)
+        logger.info("New device: %s %s", *device.get_info())
         if self.qtile:
-            inputs.configure_device(device, self.qtile.config.wl_input_rules)
+            if self.qtile.config.wl_input_rules:
+                device.configure(self.qtile.config.wl_input_rules)
         else:
             self._pending_input_devices.append(device)
 
@@ -469,7 +478,8 @@ class Core(base.Core, wlrq.HasListeners):
     def _on_new_virtual_pointer(
         self, _listener: Listener, new_pointer_event: vpointer.VirtualPointerV1NewPointerEvent
     ) -> None:
-        self._add_new_pointer(new_pointer_event.new_pointer.input_device)
+        device = self._add_new_pointer(new_pointer_event.new_pointer.input_device)
+        logger.info("New virtual pointer: %s %s", *device.get_info())
 
     def _on_new_idle_inhibitor(
         self, _listener: Listener, idle_inhibitor: IdleInhibitorV1
@@ -750,19 +760,26 @@ class Core(base.Core, wlrq.HasListeners):
 
         return handled
 
-    def _add_new_pointer(self, device: input_device.InputDevice) -> None:
-        self.cursor.attach_input_device(device)
+    def _add_new_pointer(self, wlr_device: input_device.InputDevice) -> inputs.Pointer:
+        device = inputs.Pointer(self, wlr_device)
+        self._pointers.append(device)
+        self.cursor.attach_input_device(wlr_device)
+        return device
 
-    def _add_new_keyboard(self, device: input_device.InputDevice) -> None:
-        self.keyboards.append(inputs.Keyboard(self, device))
-        self.seat.set_keyboard(device)
+    def _add_new_keyboard(self, wlr_device: input_device.InputDevice) -> inputs.Keyboard:
+        device = inputs.Keyboard(self, wlr_device)
+        self.keyboards.append(device)
+        self.seat.set_keyboard(wlr_device)
+        return device
 
     def _configure_pending_inputs(self) -> None:
         """Configure inputs that were detected before the config was loaded."""
-        if self.qtile:
+        assert self.qtile is not None
+
+        if self.qtile.config.wl_input_rules:
             for device in self._pending_input_devices:
-                inputs.configure_device(device, self.qtile.config.wl_input_rules)
-            self._pending_input_devices.clear()
+                device.configure(self.qtile.config.wl_input_rules)
+        self._pending_input_devices.clear()
 
     def setup_listener(self, qtile: Qtile) -> None:
         """Setup a listener for the given qtile instance"""
@@ -1128,3 +1145,26 @@ class Core(base.Core, wlrq.HasListeners):
                 self._cursor_state.hotspot,
             )
             self._cursor_state.hidden = False
+
+    def cmd_get_inputs(self) -> dict[str, list[dict[str, str]]]:
+        """Get information on all input devices."""
+        info = {}
+        device_lists: dict[str, list[inputs._Device]] = {
+            "type:keyboard": self.keyboards,  # type: ignore
+            "type:pointer": self._pointers,  # type: ignore
+        }
+
+        for type_key, devices in device_lists.items():
+            type_info = []
+
+            for dev in devices:
+                type_info.append(
+                    dict(
+                        name=dev.wlr_device.name,
+                        identifier=dev.get_info()[1],
+                    )
+                )
+
+            info[type_key] = type_info
+
+        return info

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -805,7 +805,7 @@ class Core(base.Core, wlrq.HasListeners):
             self.event_loop.dispatch(0)
             self.display.flush_clients()
 
-    def distribute_windows(self, initial: bool) -> None:
+    def on_config_load(self, initial: bool) -> None:
         if initial:
             # This backend does not support restarting
             return
@@ -840,6 +840,11 @@ class Core(base.Core, wlrq.HasListeners):
                 win.unhide()
             else:
                 win.hide()
+
+        # Apply input device configuration
+        if self.qtile.config.wl_input_rules:
+            for device in [*self.keyboards, *self._pointers]:
+                device.configure(self.qtile.config.wl_input_rules)
 
     def new_wid(self) -> int:
         """Get a new unique window ID"""

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -20,11 +20,11 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from pywayland.protocol.wayland import WlKeyboard
 from wlroots import ffi, lib
-from wlroots.wlr_types import input_device
 from xkbcommon import xkb
 
 from libqtile import configurable
@@ -76,6 +76,9 @@ class InputConfig(configurable.Configurable):
     When a input device is being configured, the most specific matching key in the
     dictionary is found and the corresponding settings are used to configure the device.
     Unique identifiers are chosen first, then ``"type:X"``, then ``"*"``.
+
+    The command ``qtile cmd-obj -o core -f get_inputs`` can be used to get information
+    about connected devices, including their identifiers.
 
     Options default to ``None``, leave a device's default settings intact. For
     information on what each option does, see the documenation for libinput:
@@ -146,13 +149,61 @@ if libinput:
     }
 
 
-class Keyboard(HasListeners):
-    def __init__(self, core: Core, device: InputDevice):
+class _Device(ABC, HasListeners):
+    def __init__(self, core: Core, wlr_device: InputDevice):
         self.core = core
-        self.device = device
+        self.wlr_device = wlr_device
+
+    def finalize(self) -> None:
+        self.finalize_listeners()
+
+    def get_info(self) -> tuple[str, str]:
+        """
+        Get the device type and identifier for this input device. These can be used be
+        used to assign ``InputConfig`` options to devices or types of devices.
+        """
+        device = self.wlr_device
+        name = device.name
+        if name == " " or not name.isprintable():
+            name = "_"
+        type_key = "type:" + device.device_type.name.lower()
+        identifier = "%d:%d:%s" % (device.vendor, device.product, name)
+
+        if type_key == "type:pointer" and libinput is not None:
+            # This checks whether the pointer is a touchpad, so that we can target those
+            # specifically.
+            handle = device.libinput_get_device_handle()
+            if handle and libinput.libinput_device_config_tap_get_finger_count(handle) > 0:
+                type_key = "type:touchpad"
+
+        return type_key, identifier
+
+    def _match_config(self, configs: dict[str, InputConfig]) -> InputConfig | None:
+        """Finds a matching ``InputConfig`` rule."""
+        type_key, identifier = self.get_info()
+
+        if identifier in configs:
+            conf = configs[identifier]
+        elif type_key in configs:
+            conf = configs[type_key]
+        elif "*" in configs:
+            conf = configs["*"]
+        else:
+            return None
+        return conf
+
+    @abstractmethod
+    def configure(self, configs: dict[str, InputConfig]) -> None:
+        """Applies ``InputConfig`` rules to this input device."""
+        pass
+
+
+class Keyboard(_Device):
+    def __init__(self, core: Core, wlr_device: InputDevice):
+        super().__init__(core, wlr_device)
         self.qtile = core.qtile
         self.seat = core.seat
-        self.keyboard = device.keyboard
+        self.keyboard = wlr_device.keyboard
         self.keyboard.data = self
         self.grabbed_keys = core.grabbed_keys
 
@@ -166,10 +217,10 @@ class Keyboard(HasListeners):
         self.add_listener(self.keyboard.destroy_event, self._on_destroy)
 
     def finalize(self) -> None:
-        self.finalize_listeners()
+        super().finalize()
         self.core.keyboards.remove(self)
         if self.core.keyboards and self.core.seat.keyboard.destroyed:
-            self.seat.set_keyboard(self.core.keyboards[-1].device)
+            self.seat.set_keyboard(self.core.keyboards[-1].wlr_device)
 
     def set_keymap(self, layout: str | None, options: str | None, variant: str | None) -> None:
         """
@@ -189,7 +240,7 @@ class Keyboard(HasListeners):
         self.finalize()
 
     def _on_modifier(self, _listener: Listener, _data: Any) -> None:
-        self.seat.set_keyboard(self.device)
+        self.seat.set_keyboard(self.wlr_device)
         self.seat.keyboard_notify_modifiers(self.keyboard.modifiers)
 
     def _on_key(self, _listener: Listener, event: KeyboardKeyEvent) -> None:
@@ -224,129 +275,111 @@ class Keyboard(HasListeners):
 
         self.seat.keyboard_notify_key(event)
 
+    def configure(self, configs: dict[str, InputConfig]) -> None:
+        """Applies ``InputConfig`` rules to this keyboard device."""
+        config = self._match_config(configs)
 
-def _configure_keyboard(device: InputDevice, conf: InputConfig) -> None:
-    """Applies ``InputConfig`` rules to a keyboard device"""
-    device.keyboard.set_repeat_info(conf.kb_repeat_rate, conf.kb_repeat_delay)
-    if isinstance(device.keyboard.data, Keyboard):
-        device.keyboard.data.set_keymap(conf.kb_layout, conf.kb_options, conf.kb_variant)
-    else:
-        logger.error("Couldn't configure keyboard. Please report this.")
-
-
-_logged_unsupported = False
+        if config:
+            self.keyboard.set_repeat_info(config.kb_repeat_rate, config.kb_repeat_delay)
+            self.set_keymap(config.kb_layout, config.kb_options, config.kb_variant)
 
 
-def _configure_pointer(device: InputDevice, conf: InputConfig, name: str) -> None:
-    """Applies ``InputConfig`` rules to a pointer device"""
-    handle = device.libinput_get_device_handle()
-    if handle is None:
-        logger.debug("Device not handled by libinput: %s", name)
-        return
+class Pointer(_Device):
+    _logged_unsupported = False
 
-    if libinput is None:
-        global _logged_unsupported
+    def __init__(self, core: Core, wlr_device: InputDevice):
+        super().__init__(core, wlr_device)
 
-        if not _logged_unsupported:
-            logger.error(
-                "Qtile was not built with libinput configuration support. "
-                "For support, pywlroots must be installed at build time."
-            )
-            _logged_unsupported = True
-        return
+        self.add_listener(wlr_device.destroy_event, self._on_destroy)
 
-    if libinput.libinput_device_config_accel_is_available(handle):
-        if ACCEL_PROFILES.get(conf.accel_profile):
-            libinput.libinput_device_config_accel_set_profile(
-                handle, ACCEL_PROFILES.get(conf.accel_profile)
-            )
-        if conf.pointer_accel is not None:
-            libinput.libinput_device_config_accel_set_speed(handle, conf.pointer_accel)
+    def finalize(self) -> None:
+        super().finalize()
+        self.core._pointers.remove(self)
 
-    if CLICK_METHODS.get(conf.click_method):
-        libinput.libinput_device_config_click_set_method(
-            handle, CLICK_METHODS.get(conf.click_method)
-        )
+    def _on_destroy(self, _listener: Listener, _data: Any) -> None:
+        logger.debug("Signal: pointer destroy")
+        self.finalize()
 
-    if conf.drag is not None:
-        libinput.libinput_device_config_tap_set_drag_enabled(handle, int(conf.drag))
+    def configure(self, configs: dict[str, InputConfig]) -> None:
+        """Applies ``InputConfig`` rules to this pointer device."""
+        config = self._match_config(configs)
+        if config is None:
+            return
 
-    if conf.drag_lock is not None:
-        libinput.libinput_device_config_tap_set_drag_lock_enabled(handle, int(conf.drag_lock))
+        handle = self.wlr_device.libinput_get_device_handle()
+        if handle is None:
+            logger.debug("Device not handled by libinput: %s", self.wlr_device.name)
+            return
 
-    if conf.dwt is not None:
-        if libinput.libinput_device_config_dwt_is_available(handle):
-            libinput.libinput_device_config_dwt_set_enabled(handle, int(conf.dwt))
+        if libinput is None:
+            if not Pointer._logged_unsupported:
+                logger.error(
+                    "Qtile was not built with libinput configuration support. "
+                    "For support, pywlroots must be installed at build time."
+                )
+                Pointer._logged_unsupported = True
+            return
 
-    if conf.left_handed is not None:
-        if libinput.libinput_device_config_left_handed_is_available(handle):
-            libinput.libinput_device_config_left_handed_set(handle, int(conf.left_handed))
+        if libinput.libinput_device_config_accel_is_available(handle):
+            if ACCEL_PROFILES.get(config.accel_profile):
+                libinput.libinput_device_config_accel_set_profile(
+                    handle, ACCEL_PROFILES.get(config.accel_profile)
+                )
+            if config.pointer_accel is not None:
+                libinput.libinput_device_config_accel_set_speed(handle, config.pointer_accel)
 
-    if conf.middle_emulation is not None:
-        libinput.libinput_device_config_middle_emulation_set_enabled(
-            handle, int(conf.middle_emulation)
-        )
-
-    if conf.natural_scroll is not None:
-        if libinput.libinput_device_config_scroll_has_natural_scroll(handle):
-            libinput.libinput_device_config_scroll_set_natural_scroll_enabled(
-                handle, int(conf.natural_scroll)
+        if CLICK_METHODS.get(config.click_method):
+            libinput.libinput_device_config_click_set_method(
+                handle, CLICK_METHODS.get(config.click_method)
             )
 
-    if SCROLL_METHODS.get(conf.scroll_method):
-        libinput.libinput_device_config_scroll_set_method(
-            handle, SCROLL_METHODS.get(conf.scroll_method)
-        )
-        if conf.scroll_method == "on_button_down":
-            if isinstance(conf.scroll_button, str):
-                if conf.scroll_button == "disable":
-                    button = 0
-                else:  # e.g. Button1
-                    button = buttons[int(conf.scroll_button[-1]) - 1]
-            else:
-                button = conf.scroll_button
-            libinput.libinput_device_config_scroll_set_button(handle, button)
+        if config.drag is not None:
+            libinput.libinput_device_config_tap_set_drag_enabled(handle, int(config.drag))
 
-    if libinput.libinput_device_config_tap_get_finger_count(handle) > 1:
-        if conf.tap is not None:
-            libinput.libinput_device_config_tap_set_enabled(handle, int(conf.tap))
+        if config.drag_lock is not None:
+            libinput.libinput_device_config_tap_set_drag_lock_enabled(
+                handle, int(config.drag_lock)
+            )
 
-        if conf.tap_button_map is not None:
-            if TAP_MAPS.get(conf.tap_button_map):
-                libinput.libinput_device_config_tap_set_button_map(
-                    handle, TAP_MAPS.get(conf.tap_button_map)
+        if config.dwt is not None:
+            if libinput.libinput_device_config_dwt_is_available(handle):
+                libinput.libinput_device_config_dwt_set_enabled(handle, int(config.dwt))
+
+        if config.left_handed is not None:
+            if libinput.libinput_device_config_left_handed_is_available(handle):
+                libinput.libinput_device_config_left_handed_set(handle, int(config.left_handed))
+
+        if config.middle_emulation is not None:
+            libinput.libinput_device_config_middle_emulation_set_enabled(
+                handle, int(config.middle_emulation)
+            )
+
+        if config.natural_scroll is not None:
+            if libinput.libinput_device_config_scroll_has_natural_scroll(handle):
+                libinput.libinput_device_config_scroll_set_natural_scroll_enabled(
+                    handle, int(config.natural_scroll)
                 )
 
+        if SCROLL_METHODS.get(config.scroll_method):
+            libinput.libinput_device_config_scroll_set_method(
+                handle, SCROLL_METHODS.get(config.scroll_method)
+            )
+            if config.scroll_method == "on_button_down":
+                if isinstance(config.scroll_button, str):
+                    if config.scroll_button == "disable":
+                        button = 0
+                    else:  # e.g. Button1
+                        button = buttons[int(config.scroll_button[-1]) - 1]
+                else:
+                    button = config.scroll_button
+                libinput.libinput_device_config_scroll_set_button(handle, button)
 
-def configure_device(device: InputDevice, configs: dict[str, InputConfig] | None) -> None:
-    if not configs:
-        return
+        if libinput.libinput_device_config_tap_get_finger_count(handle) > 1:
+            if config.tap is not None:
+                libinput.libinput_device_config_tap_set_enabled(handle, int(config.tap))
 
-    # Find a matching InputConfig
-    name = device.name
-    if name == " " or not name.isprintable():
-        name = "_"
-    identifier = "%d:%d:%s" % (device.vendor, device.product, name)
-    type_key = "type:" + device.device_type.name.lower()
-
-    if type_key == "type:pointer" and libinput:
-        # This checks whether the pointer is a touchpad.
-        handle = device.libinput_get_device_handle()
-        if handle and libinput.libinput_device_config_tap_get_finger_count(handle) > 0:
-            type_key = "type:touchpad"
-
-    if identifier in configs:
-        conf = configs[identifier]
-    elif type_key in configs:
-        conf = configs[type_key]
-    elif "*" in configs:
-        conf = configs["*"]
-    else:
-        return
-
-    if device.device_type == input_device.InputDeviceType.POINTER:
-        _configure_pointer(device, conf, name)
-    elif device.device_type == input_device.InputDeviceType.KEYBOARD:
-        _configure_keyboard(device, conf)
-    else:
-        logger.warning("Device not configured. Type '%s' not recognised.", device.device_type)
+            if config.tap_button_map is not None:
+                if TAP_MAPS.get(config.tap_button_map):
+                    libinput.libinput_device_config_tap_set_button_map(
+                        handle, TAP_MAPS.get(config.tap_button_map)
+                    )

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -222,7 +222,7 @@ class Core(base.Core):
             loop.remove_reader(self.fd)
             self.fd = None
 
-    def distribute_windows(self, initial) -> None:
+    def on_config_load(self, initial) -> None:
         """Assign windows to groups"""
         assert self.qtile is not None
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -162,7 +162,7 @@ class Qtile(CommandObject):
             else:
                 self._state.apply(self)
 
-        self.core.distribute_windows(initial)
+        self.core.on_config_load(initial)
 
         if self._state:
             for screen in self.screens:


### PR DESCRIPTION
These changes:

- refactor input devices and functions related to their configuration
- add command to the core to get information on all devices, helping in setting input configurations by providing device identifiers
- respond to config reloads, applying any changes to input configuration options

Requires https://github.com/flacjacket/pywlroots/pull/101