### PR TITLE
Fix focus on click after clicking on root window

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -888,6 +888,8 @@ class Core(base.Core):
             # clicked on root window
             screen = qtile.find_screen(e.root_x, e.root_y)
             if screen:
+                if qtile.current_window:
+                    qtile.current_window._grab_click()
                 qtile.focus_screen(screen.index, warp=False)
 
     def flush(self):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1986,12 +1986,7 @@ class Window(_Window, base.Window):
                 self.group.focus(self, False)
             if self.group.screen and self.qtile.current_screen != self.group.screen:
                 self.qtile.focus_screen(self.group.screen.index, False)
-        else:
-            self._grab_click()
         return True
-
-    def handle_LeaveNotify(self, e):  # noqa: N802
-        self._ungrab_click()
 
     def handle_ButtonPress(self, e):  # noqa: N802
         self.qtile.core.focus_by_click(e, window=self)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1986,7 +1986,12 @@ class Window(_Window, base.Window):
                 self.group.focus(self, False)
             if self.group.screen and self.qtile.current_screen != self.group.screen:
                 self.qtile.focus_screen(self.group.screen.index, False)
+        else:
+            self._grab_click()
         return True
+
+    def handle_LeaveNotify(self, e):  # noqa: N802
+        self._ungrab_click()
 
     def handle_ButtonPress(self, e):  # noqa: N802
         self.qtile.core.focus_by_click(e, window=self)

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -524,6 +524,8 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
         # If we're clicking on a bar that's not on the current screen, focus that screen
         if self.screen and self.screen is not self.qtile.current_screen:
+            if self.qtile.core.name == "x11" and self.qtile.current_window:
+                self.qtile.current_window._grab_click()
             index = self.qtile.screens.index(self.screen)
             self.qtile.focus_screen(index, warp=False)
 


### PR DESCRIPTION
Fixes a bug where opening a window on screen A, clicking on Screen B (with no windows) and clicking back on the window does not focus the window.

Fixes #3800


@m-col - I don't love this. It works, but I can't see why it's needed when there's only a single window open. The bug is not there when you have multiple windows open on the first screen and click on a different window.