### PR TITLE
Expose Pomodoro widget toggle break/active methods as commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add scrolling ability to `_TextBox`-based widgets.
         - Add player controls (via mouse callbacks) to `Mpris2` widget.
         - Wayland: input inhibitor protocol support added (pywayland>=0.4.14 & pywlroots>=0.15.19)
+        - Add commands to control Pomodoro widget.
     * bugfixes
         - Widgets that are incompatible with a backend (e.g. Systray on Wayland) will no longer show 
           as a ConfigError in the bar. Instead the widget is silently removed from the bar and a message

--- a/libqtile/widget/pomodoro.py
+++ b/libqtile/widget/pomodoro.py
@@ -76,8 +76,8 @@ class Pomodoro(base.ThreadPoolText):
 
         self.add_callbacks(
             {
-                "Button1": self._toggle_break,
-                "Button3": self._toggle_active,
+                "Button1": self.cmd_toggle_break,
+                "Button3": self.cmd_toggle_active,
             }
         )
 
@@ -146,7 +146,7 @@ class Pomodoro(base.ThreadPoolText):
         )
         return self.prefix[self.status] + time_string
 
-    def _toggle_break(self):
+    def cmd_toggle_break(self):
         if self.status == self.STATUS_INACTIVE:
             self.status = self.STATUS_START
             return
@@ -173,7 +173,7 @@ class Pomodoro(base.ThreadPoolText):
                     + self.end_time.strftime("%H:%M"),
                 )
 
-    def _toggle_active(self):
+    def cmd_toggle_active(self):
         if self.status != self.STATUS_INACTIVE:
             self.status = self.STATUS_INACTIVE
             if self.notification_on:

--- a/test/widgets/test_pomodoro.py
+++ b/test/widgets/test_pomodoro.py
@@ -79,16 +79,16 @@ def test_pomodoro(fake_qtile, fake_window):
     assert widget.layout.colour == COLOR_INACTIVE
 
     # Left clicking toggles state
-    widget._toggle_break()
+    widget.cmd_toggle_break()
     assert widget.poll() == f"{PREFIX_ACTIVE}0:15:0"
     assert widget.layout.colour == COLOR_ACTIVE
 
     # Another left click should pause
-    widget._toggle_break()
+    widget.cmd_toggle_break()
     assert widget.poll() == PREFIX_PAUSED
     assert widget.layout.colour == COLOR_INACTIVE
 
-    widget._toggle_break()
+    widget.cmd_toggle_break()
     # Add 5 mins should take 5 mins off our timer
     MockDatetime._adjustment += timedelta(minutes=5)
     assert widget.poll() == f"{PREFIX_ACTIVE}0:10:0"
@@ -120,9 +120,9 @@ def test_pomodoro(fake_qtile, fake_window):
     assert widget.poll() == f"{PREFIX_ACTIVE}0:5:0"
 
     # Right-click toggles active state
-    widget._toggle_active()
+    widget.cmd_toggle_active()
     assert widget.poll() == PREFIX_INACTIVE
 
     # Right-click again resets status
-    widget._toggle_active()
+    widget.cmd_toggle_active()
     assert widget.poll() == f"{PREFIX_ACTIVE}0:15:0"


### PR DESCRIPTION
They are already used for mouse callbacks but this lets them be controlled by keybindings/IPC etc