### PR TITLE
Ensure Screens always have an Group associated group

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -267,7 +267,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             group = self.qtile.groups_map[group_name]
 
         if self.group is group:
-            if toggle and hasattr(self.group.screen, "previous_group"):
+            if toggle and self.group.screen.previous_group:
                 group = self.group.screen.previous_group
             else:
                 return

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1555,7 +1555,7 @@ class Window(_Window, base.Window):
                 raise CommandError("No such group: %s" % group_name)
 
         if self.group is group:
-            if toggle and hasattr(self.group.screen, "previous_group"):
+            if toggle and self.group.screen.previous_group:
                 group = self.group.screen.previous_group
             else:
                 return

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -27,7 +27,6 @@
 #
 from __future__ import annotations
 
-import contextlib
 import os.path
 import sys
 from typing import TYPE_CHECKING
@@ -38,7 +37,7 @@ from libqtile.command.base import CommandObject
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, ContextManager, Iterable
+    from typing import Any, Callable, Iterable
 
     from libqtile.backend import base
     from libqtile.bar import BarType
@@ -359,7 +358,6 @@ class Screen(CommandObject):
     """
 
     group: _Group
-    previous_group: _Group
     index: int
 
     def __init__(
@@ -389,6 +387,7 @@ class Screen(CommandObject):
         self.y = y if y is not None else 0
         self.width = width if width is not None else 0
         self.height = height if height is not None else 0
+        self.previous_group: _Group | None = None
 
     def _configure(
         self,
@@ -407,6 +406,7 @@ class Screen(CommandObject):
         self.y = y
         self.width = width
         self.height = height
+
         self.set_group(group)
         for i in self.gaps:
             i._configure(qtile, self, reconfigure=reconfigure_gaps)
@@ -461,7 +461,9 @@ class Screen(CommandObject):
         if new_group.screen == self:
             return
 
-        if save_prev and hasattr(self, "group"):
+        if save_prev and new_group is not self.group:
+            # new_group can be self.group only if the screen is getting configured for
+            # the first time
             self.previous_group = self.group
 
         if new_group.screen:
@@ -479,20 +481,17 @@ class Screen(CommandObject):
             s1.group = g2
             g2.set_screen(s1, warp)
         else:
-            if hasattr(self, "group"):
-                old_group = self.group
-                assert self.qtile is not None
-                ctx: ContextManager = self.qtile.core.masked()
-            else:
-                old_group = None
-                ctx = contextlib.nullcontext()
+            assert self.qtile is not None
+            old_group = self.group
             self.group = new_group
-            with ctx:
+            with self.qtile.core.masked():
                 # display clients of the new group and then hide from old group
                 # to remove the screen flickering
                 new_group.set_screen(self, warp)
 
-                if old_group is not None:
+                # Can be the same group only if the screen just got configured for the
+                # first time - see `Qtile._process_screens`.
+                if old_group is not new_group:
                     old_group.set_screen(None, warp)
 
         hook.fire("setgroup")
@@ -501,7 +500,7 @@ class Screen(CommandObject):
 
     def toggle_group(self, group: _Group | None = None, warp: bool = True) -> None:
         """Switch to the selected group or to the previously active one"""
-        if group in (self.group, None) and hasattr(self, "previous_group"):
+        if group in (self.group, None) and self.previous_group:
             group = self.previous_group
         self.set_group(group, warp=warp)
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -41,6 +41,7 @@ from libqtile.command.client import SelectError
 from libqtile.command.interface import CommandError, CommandException
 from libqtile.config import Match
 from libqtile.confreader import Config
+from libqtile.group import _Group
 from libqtile.lazy import lazy
 from test.conftest import dualmonitor, multimonitor
 from test.helpers import BareConfig, Retry, assert_window_died
@@ -1013,6 +1014,8 @@ def test_unmap_noscreen(manager):
 
 
 class TScreen(libqtile.config.Screen):
+    group = _Group("")
+
     def set_group(self, x, save_prev=True):
         pass
 


### PR DESCRIPTION
Currently sometimes AttributeErrors are raised:

```
AttributeError: 'Screen' object has no attribute 'group'
```

This avoids that by ensuring `Screen`s get a group the first time they are configured, and this removes any `hasattr` tests and instead checks things directly.

Possibly related: https://github.com/qtile/qtile/issues/3440