### PR TITLE
repr Window objects using the name of their class

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -266,7 +266,7 @@ class Window(_Window, metaclass=ABCMeta):
     float_y: int | None
 
     def __repr__(self):
-        return "Window(name=%r, wid=%i)" % (self.name, self.wid)
+        return "%s(name=%r, wid=%i)" % (self.__class__.__name__, self.name, self.wid)
 
     @property
     @abstractmethod
@@ -597,7 +597,7 @@ class Static(_Window, metaclass=ABCMeta):
     height: Any
 
     def __repr__(self):
-        return "Static(name=%r, wid=%s)" % (self.name, self.wid)
+        return "%s(name=%r, wid=%i)" % (self.__class__.__name__, self.name, self.wid)
 
     def info(self) -> dict:
         """Return a dictionary of info."""


### PR DESCRIPTION
There should be no noticable changes in x11 because there is only 1 `Window` and `Static` class, but in wayland we have one of each for all of xwayland, xdg shell and layer shell.

This is more helpful for debugging than anything else, e.g.:
```
>>> qtile cmd-obj -o cmd -f eval -a "self.windows_map"
(True,
 "{16: XdgWindow(name='[tmux] zsh:~', wid=16), 17: Internal(wid=17), 18: "
 "XdgWindow(name='zsh:.../libqtile/backend', wid=18), 19: XdgWindow(name='vim "
 "[1] ~/git/qtile/.git/COMMIT_EDITMSG', wid=19)}")
 ```
More informative debugging info 😄