### PR TITLE
Evaluate cmd_eval code with globals of command object's module

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import abc
 import inspect
+import sys
 import traceback
 from typing import TYPE_CHECKING
 
@@ -189,17 +190,18 @@ class CommandObject(metaclass=abc.ABCMeta):
         return str(signature)
 
     def cmd_eval(self, code: str) -> tuple[bool, str | None]:
-        """Evaluates code in the same context as this function
+        """Evaluates code in the module namespace of the command object
 
         Return value is tuple `(success, result)`, success being a boolean and
         result being a string representing the return value of eval, or None if
         exec was used instead.
         """
         try:
+            globals_ = vars(sys.modules[self.__module__])
             try:
-                return True, str(eval(code))
+                return True, str(eval(code, globals_, locals()))
             except SyntaxError:
-                exec(code)
+                exec(code, globals_, locals())
                 return True, None
         except Exception:
             error = traceback.format_exc().strip().split("\n")[-1]

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -173,6 +173,11 @@ def test_cmd_commands(manager):
 
 
 @server_config
+def test_cmd_eval_namespace(manager):
+    assert manager.c.eval("__name__") == (True, "libqtile.core.manager")
+
+
+@server_config
 def test_call_unknown(manager):
     with pytest.raises(libqtile.command.client.SelectError, match="Not valid child or command"):
         manager.c.nonexistent

--- a/test/widgets/docs_screenshots/ss_chord.py
+++ b/test/widgets/docs_screenshots/ss_chord.py
@@ -33,5 +33,5 @@ def widget():
     indirect=True,
 )
 def ss_chord(screenshot_manager):
-    screenshot_manager.c.eval("from libqtile import hook;hook.fire('enter_chord', 'vim mode')")
+    screenshot_manager.c.eval("hook.fire('enter_chord', 'vim mode')")
     screenshot_manager.take_screenshot()


### PR DESCRIPTION
Currently code executed with `cmd_eval` calls is called within the definition of `cmd_eval` i.e. inside `libqtile.command.base`. Sometimes when I'm debugging stuff from the command line with evals I wish they were evaluated within the namespace of the module that defined the command object. So, this PR does just that!