### PR TITLE
Tidy up cairo FAQ in docs

### DIFF
--- a/docs/_static/split_code.css
+++ b/docs/_static/split_code.css
@@ -1,3 +1,3 @@
-.docutils code {
+code.literal {
     white-space: break-spaces;
 }

--- a/docs/manual/faq.rst
+++ b/docs/manual/faq.rst
@@ -137,7 +137,11 @@ Where are the log files for Qtile?
 
 The log files for qtile are at ``~/.local/share/qtile/qtile.log``.
 
-I get ``AttributeError: cffi library 'libcairo.so.2' has no function, constant or global variable named 'cairo_xcb_surface_create'``
-====================================================================================================================================
+Why do I get an ``AttributeError`` when building Qtile?
+=======================================================
 
-See :ref:`Cairo Error <cairo-errors>`
+If you see this message:
+``AttributeError: cffi library 'libcairo.so.2' has no function, constant or global variable named 'cairo_xcb_surface_create'``
+when building Qtile then your Cairo version lacks XCB support.
+
+See :ref:`Cairo Error <cairo-errors>` for further information.


### PR DESCRIPTION
This is in relation to #3825. Added some css to break `code` lines if they're too long.  I've also reformatted the FAQ to tidy it up a bit.

Looks like this on RTD:
![20220911_204645](https://user-images.githubusercontent.com/946265/189546518-09f705c3-2e92-45ad-87d9-65c7f80b8c00.png)
