### PR TITLE
Fix Systray inheritance order

### DIFF
--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -96,7 +96,9 @@ class Icon(window._Window):
     handle_UnmapNotify = handle_DestroyNotify  # noqa: N815
 
 
-class Systray(window._Window, base._Widget):
+# Mypy doesn't like the inheritance of height and width as _Widget's
+# properties are read only but _Window's have a getter and setter.
+class Systray(base._Widget, window._Window):  # type: ignore[misc]
     """
     A widget that manages system tray.
 


### PR DESCRIPTION
I'll be honest, I'm confused by this one!

Switching the inheritance order of the base classes fixes a bug where users using RectDecorations from qtile-extras have colours inverted (i.e. the decoration's fill colour is the widget background colour and the background colour is the widet's fill colour).