### PR TITLE
Fix various mirror bugs

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -641,7 +641,7 @@ class Drawer:
         self.ctx: cairocffi.Context
         self._reset_surface()
 
-        self.mirrors: set[Drawer] = set()
+        self._has_mirrors = False
 
         self.current_rect = (0, 0, 0, 0)
         self.previous_rect = (-1, -1, -1, -1)
@@ -652,9 +652,16 @@ class Drawer:
         self.surface = None
         self.ctx = None
 
-    def add_mirror(self, mirror: Drawer):
-        """Keep details of other drawers that are mirroring this one."""
-        self.mirrors.add(mirror)
+    @property
+    def has_mirrors(self):
+        return self._has_mirrors
+
+    @has_mirrors.setter
+    def has_mirrors(self, value):
+        if value and not self._has_mirrors:
+            self._create_last_surface()
+
+        self._has_mirrors = value
 
     @property
     def width(self) -> int:
@@ -679,6 +686,10 @@ class Drawer:
             None,
         )
         self.ctx = self.new_ctx()
+
+    def _create_last_surface(self):
+        """Creates a separate RecordingSurface for mirrors to access."""
+        self.last_surface = cairocffi.RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, None)
 
     @property
     def needs_update(self) -> bool:
@@ -769,9 +780,8 @@ class Drawer:
         """
         if self._enabled:
             self._draw(offsetx, offsety, width, height)
-            if self.mirrors:
-                # mypy is tripping over CONTENT_COLOR_ALPHA here despite it working earlier in this file!
-                self.last_surface = cairocffi.RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, None)  # type: ignore
+            if self.has_mirrors:
+                self._create_last_surface()
                 ctx = cairocffi.Context(self.last_surface)
                 ctx.set_source_surface(self.surface)
                 ctx.paint()

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -383,6 +383,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
     def kill_window(self):
         """Kill the window when the bar's screen is no longer being used."""
+        for name, w in self.qtile.widgets_map.copy().items():
+            if w in self.widgets:
+                w.finalize()
+                del self.qtile.widgets_map[name]
         self.drawer.finalize()
         self.window.kill()
         self.window = None

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -56,13 +56,20 @@ class CurrentLayout(base._TextBox):
             }
         )
 
-    def setup_hooks(self):
-        def hook_response(layout, group):
-            if group.screen is not None and group.screen == self.bar.screen:
-                self.text = layout.name
-                self.bar.draw()
+    def hook_response(self, layout, group):
+        if group.screen is not None and group.screen == self.bar.screen:
+            self.text = layout.name
+            self.bar.draw()
 
-        hook.subscribe.layout_change(hook_response)
+    def setup_hooks(self):
+        hook.subscribe.layout_change(self.hook_response)
+
+    def remove_hooks(self):
+        hook.unsubscribe.layout_change(self.hook_response)
+
+    def finalize(self):
+        self.remove_hooks()
+        base._TextBox.finalize(self)
 
 
 class CurrentLayoutIcon(base._TextBox):
@@ -126,17 +133,22 @@ class CurrentLayoutIcon(base._TextBox):
             }
         )
 
+    def hook_response(self, layout, group):
+        if group.screen is not None and group.screen == self.bar.screen:
+            self.current_layout = layout.name
+            self.bar.draw()
+
     def _setup_hooks(self):
         """
         Listens for layout change and performs a redraw when it occurs.
         """
+        hook.subscribe.layout_change(self.hook_response)
 
-        def hook_response(layout, group):
-            if group.screen is not None and group.screen == self.bar.screen:
-                self.current_layout = layout.name
-                self.bar.draw()
-
-        hook.subscribe.layout_change(hook_response)
+    def _remove_hooks(self):
+        """
+        Listens for layout change and performs a redraw when it occurs.
+        """
+        hook.unsubscribe.layout_change(self.hook_response)
 
     def draw(self):
         if self.icons_loaded:
@@ -241,3 +253,7 @@ class CurrentLayoutIcon(base._TextBox):
             self.surfaces[layout_name] = imgpat
 
         self.icons_loaded = True
+
+    def finalize(self):
+        self._remove_hooks()
+        base._TextBox.finalize(self)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -68,17 +68,26 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
         )
         self.setup_hooks()
 
-    def setup_hooks(self):
-        def hook_response(*args, **kwargs):
-            self.bar.draw()
+    def _hook_response(self, *args, **kwargs):
+        self.bar.draw()
 
-        hook.subscribe.client_managed(hook_response)
-        hook.subscribe.client_urgent_hint_changed(hook_response)
-        hook.subscribe.client_killed(hook_response)
-        hook.subscribe.setgroup(hook_response)
-        hook.subscribe.group_window_add(hook_response)
-        hook.subscribe.current_screen_change(hook_response)
-        hook.subscribe.changegroup(hook_response)
+    def setup_hooks(self):
+        hook.subscribe.client_managed(self._hook_response)
+        hook.subscribe.client_urgent_hint_changed(self._hook_response)
+        hook.subscribe.client_killed(self._hook_response)
+        hook.subscribe.setgroup(self._hook_response)
+        hook.subscribe.group_window_add(self._hook_response)
+        hook.subscribe.current_screen_change(self._hook_response)
+        hook.subscribe.changegroup(self._hook_response)
+
+    def remove_hooks(self):
+        hook.unsubscribe.client_managed(self._hook_response)
+        hook.unsubscribe.client_urgent_hint_changed(self._hook_response)
+        hook.unsubscribe.client_killed(self._hook_response)
+        hook.unsubscribe.setgroup(self._hook_response)
+        hook.unsubscribe.group_window_add(self._hook_response)
+        hook.unsubscribe.current_screen_change(self._hook_response)
+        hook.unsubscribe.changegroup(self._hook_response)
 
     def drawbox(
         self,
@@ -130,6 +139,10 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
             framed.draw_line(offset, y, highlighted)
         else:
             framed.draw(offset, y, rounded)
+
+    def finalize(self):
+        self.remove_hooks()
+        base._TextBox.finalize(self)
 
 
 class AGroupBox(_GroupBase):

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -177,11 +177,14 @@ class Mpd2(base.ThreadPoolText):
         super().__init__("", **config)
 
         self.add_defaults(Mpd2.defaults)
+        if self.color_progress:
+            self.color_progress = utils.hex(self.color_progress)
+
+    def _configure(self, qtile, bar):
+        super()._configure(qtile, bar)
         self.client = MPDClient()
         self.client.timeout = self.timeout
         self.client.idletimeout = self.idletimeout
-        if self.color_progress:
-            self.color_progress = utils.hex(self.color_progress)
 
     @property
     def connected(self):

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -51,6 +51,8 @@ class PulseVolume(Volume):
         self.handle = ffi.new_handle(self)
         self.client_name = ffi.new("char[]", b"Qtile-pulse")
 
+    def _configure(self, qtile, bar):
+        Volume._configure(self, qtile, bar)
         self.connect()
 
     def finalize(self):

--- a/libqtile/widget/windowname.py
+++ b/libqtile/widget/windowname.py
@@ -63,11 +63,13 @@ class WindowName(base._TextBox):
         hook.subscribe.client_name_updated(self.hook_response)
         hook.subscribe.focus_change(self.hook_response)
         hook.subscribe.float_change(self.hook_response)
+        hook.subscribe.current_screen_change(self.hook_response_current_screen)
 
-        @hook.subscribe.current_screen_change
-        def on_screen_changed():
-            if self.for_current_screen:
-                self.hook_response()
+    def remove_hooks(self):
+        hook.unsubscribe.client_name_updated(self.hook_response)
+        hook.unsubscribe.focus_change(self.hook_response)
+        hook.unsubscribe.float_change(self.hook_response)
+        hook.unsubscribe.current_screen_change(self.hook_response_current_screen)
 
     def hook_response(self, *args):
         if self.for_current_screen:
@@ -96,3 +98,11 @@ class WindowName(base._TextBox):
         else:
             unescaped = self.empty_group_string
         self.update(pangocffi.markup_escape_text(unescaped))
+
+    def hook_response_current_screen(self, *args):
+        if self.for_current_screen:
+            self.hook_response()
+
+    def finalize(self):
+        self.remove_hooks()
+        base._TextBox.finalize(self)


### PR DESCRIPTION
There are a few issues where mirrors don't tidy themselves up if they're removed from a running session (e.g. they're on a bar on a screen that is disabled).

This PR fixes this by:
- Introducing better handling of mirrors through the reflected widget rather than directly in the `Drawer` object
- Ensuring mirrors finalize themselves
- Removing dead widgets from `qtile.widgets_map`
- Unsetting hooks in various widgets so `bar.draw()` is not called on dead screens.