### PR TITLE
Add option to `Drag` for warping the cursor at the start of dragging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
       - The `StockTicker` widget `function` option is being deprecated: rename it to `func`.
     * features
         - Add ability to set icon size in `LaunchBar` widget.
+        - Add 'warp_cursor' option to `Drag` that when set will warp the cursor to the bottom right of
+          the window when dragging begins.
     * bugfixes
 
 Qtile 0.22.0, released 2022-09-22:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,7 +20,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
       - The `StockTicker` widget `function` option is being deprecated: rename it to `func`.
     * features
         - Add ability to set icon size in `LaunchBar` widget.
-        - Add 'warp_cursor' option to `Drag` that when set will warp the cursor to the bottom right of
+        - Add 'warp_pointer' option to `Drag` that when set will warp the pointer to the bottom right of
           the window when dragging begins.
     * bugfixes
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -160,8 +160,8 @@ class Drag(Mouse):
         A list :class:`LazyCall` objects to evaluate in sequence upon drag.
     start:
         A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
-    warp_cursor:
-        A :class:`bool` indicating if the cursor should be warped to the bottom right of the window
+    warp_pointer:
+        A :class:`bool` indicating if the pointer should be warped to the bottom right of the window
         at the start of dragging. (Default: `False`)
 
     """
@@ -172,11 +172,11 @@ class Drag(Mouse):
         button: str,
         *commands: LazyCall,
         start: LazyCall | None = None,
-        warp_cursor: bool = False,
+        warp_pointer: bool = False,
     ) -> None:
         super().__init__(modifiers, button, *commands)
         self.start = start
-        self.warp_cursor = warp_cursor
+        self.warp_pointer = warp_pointer
 
     def __repr__(self) -> str:
         return "<Drag (%s, %s)>" % (self.modifiers, self.button)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -160,6 +160,9 @@ class Drag(Mouse):
         A list :class:`LazyCall` objects to evaluate in sequence upon drag.
     start:
         A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
+    warp_cursor:
+        A :class:`bool` indicating if the cursor should be warped to the bottom right of the window
+        at the start of dragging. (Default: `False`)
 
     """
 
@@ -169,9 +172,11 @@ class Drag(Mouse):
         button: str,
         *commands: LazyCall,
         start: LazyCall | None = None,
+        warp_cursor: bool = False,
     ) -> None:
         super().__init__(modifiers, button, *commands)
         self.start = start
+        self.warp_cursor = warp_cursor
 
     def __repr__(self) -> str:
         return "<Drag (%s, %s)>" % (self.modifiers, self.button)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -757,7 +757,7 @@ class Qtile(CommandObject):
                 else:
                     val = (0, 0)
 
-                if m.warp_cursor:
+                if m.warp_pointer:
                     win_size = self.current_window.cmd_get_size()
                     win_pos = self.current_window.cmd_get_position()
                     x = win_size[0] + win_pos[0]

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -756,6 +756,14 @@ class Qtile(CommandObject):
                         continue
                 else:
                     val = (0, 0)
+
+                if m.warp_cursor:
+                    win_size = self.current_window.cmd_get_size()
+                    win_pos = self.current_window.cmd_get_position()
+                    x = win_size[0] + win_pos[0]
+                    y = win_size[1] + win_pos[1]
+                    self.core.warp_pointer(x, y)
+
                 self._drag = (x, y, val[0], val[1], m.commands)
                 self.core.grab_pointer()
                 handled = True

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -757,7 +757,7 @@ class Qtile(CommandObject):
                 else:
                     val = (0, 0)
 
-                if m.warp_pointer:
+                if m.warp_pointer and self.current_window is not None:
                     win_size = self.current_window.cmd_get_size()
                     win_pos = self.current_window.cmd_get_position()
                     x = win_size[0] + win_pos[0]


### PR DESCRIPTION
This PR adds an extra argument to `Drag` which allows the user to set a point where the cursor should be warped at when the dragging begins.

This allows the user to (for example) warp the cursor to the bottom right of the window when resizing very easily in the config:
```py
# In config.py
@lazy.function
def calc_bottom_right(qtile):
    w = qtile.current_window
    pos = w.cmd_get_position()
    size = w.cmd_get_size()
    x = pos[0] + size[0]
    y = pos[1] + size[1]
    return x, y


# Drag floating layouts.
mouse = [
    Drag(
        [mod], "Button3", lazy.window.set_size_floating(), start=lazy.window.get_size(), warp_pointer=calc_bottom_right()
    ),
]
```

### NOTE: In xephyr this doesn't actually warp the cursor. I don't know why, I've had the same issue when working on my own WM, but when you actually run Qtile it works as it should.
