### PR TITLE
Misc wayland window fixes

### DIFF
--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -78,15 +78,12 @@ class Core(CommandObject, metaclass=ABCMeta):
     def grab_button(self, mouse: config.Mouse) -> int:
         """Configure the backend to grab the mouse event"""
 
-    @abstractmethod
     def ungrab_buttons(self) -> None:
         """Release the grabbed button events"""
 
-    @abstractmethod
     def grab_pointer(self) -> None:
         """Configure the backend to grab mouse events"""
 
-    @abstractmethod
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1000,8 +1000,10 @@ class Core(base.Core, wlrq.HasListeners):
             if not win.surface.current.keyboard_interactive:
                 return
 
-        if isinstance(win, (xwindow.XWindow, xwindow.XStatic)):
+        if isinstance(win, xwindow.XStatic):
             if win.surface.override_redirect and not win.surface.or_surface_wants_focus():
+                return
+            if win.surface.icccm_input_model() == xwayland.ICCCMInputModel.NONE:
                 return
 
         previous_surface = self.seat.keyboard_state.focused_surface

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -253,8 +253,14 @@ class Core(base.Core, wlrq.HasListeners):
         # Start
         self.backend.start()
 
-        # Place cursor
-        self.warp_pointer(0, 0)
+        # Place cursor in middle of centre output
+        x = y = 0
+        if box := self.output_layout.get_box():
+            if output := self.output_layout.output_at(box.width / 2, box.height / 2):
+                if box := self.output_layout.get_box(reference=output):
+                    x = box.x + box.width / 2
+                    y = box.y + box.height / 2
+        self.warp_pointer(x, y)
         self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
 
     @property

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -794,11 +794,10 @@ class Core(base.Core, wlrq.HasListeners):
                                     cx - self._hovered_window.x,
                                     cy - self._hovered_window.y,
                                 )
-                        else:
+                        elif self.seat.pointer_state.focused_surface:
                             # moved from a Window or Static to an Internal
-                            if self.seat.pointer_state.focused_surface:
-                                self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
-                                self.seat.pointer_notify_clear_focus()
+                            self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                            self.seat.pointer_notify_clear_focus()
                     win.process_pointer_enter(cx, cy)
                     self._hovered_window = win
                 return

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -138,7 +138,6 @@ class Core(base.Core, wlrq.HasListeners):
         self.keyboards: list[inputs.Keyboard] = []
         self._pointers: list[inputs.Pointer] = []
         self.grabbed_keys: list[tuple[int, int]] = []
-        self.grabbed_buttons: list[tuple[int, int]] = []
         DataDeviceManager(self.display)
         self.live_dnd: wlrq.Dnd | None = None
         DataControlManagerV1(self.display)
@@ -1151,20 +1150,7 @@ class Core(base.Core, wlrq.HasListeners):
 
     def grab_button(self, mouse: config.Mouse) -> int:
         """Configure the backend to grab the mouse event"""
-        keysym = wlrq.buttons[mouse.button_code]
-        mask_key = wlrq.translate_masks(mouse.modifiers)
-        self.grabbed_buttons.append((keysym, mask_key))
-        return mask_key
-
-    def ungrab_buttons(self) -> None:
-        """Release the grabbed button events"""
-        self.grabbed_buttons.clear()
-
-    def grab_pointer(self) -> None:
-        """Configure the backend to grab mouse events"""
-
-    def ungrab_pointer(self) -> None:
-        """Release grabbed pointer events"""
+        return wlrq.translate_masks(mouse.modifiers)
 
     def warp_pointer(self, x: float, y: float) -> None:
         """Warp the pointer to the coordinates in relative to the output layout"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1001,7 +1001,7 @@ class Core(base.Core, wlrq.HasListeners):
                 return
 
         if isinstance(win, (xwindow.XWindow, xwindow.XStatic)):
-            if not win.surface.or_surface_wants_focus():
+            if win.surface.override_redirect and not win.surface.or_surface_wants_focus():
                 return
 
         previous_surface = self.seat.keyboard_state.focused_surface
@@ -1031,11 +1031,13 @@ class Core(base.Core, wlrq.HasListeners):
         logger.debug("Focusing new window")
         if surface.is_xdg_surface and isinstance(win.surface, XdgSurface):
             win.surface.set_activated(True)
-            win.ftm_handle.set_activated(True)
+            if win.ftm_handle:
+                win.ftm_handle.set_activated(True)
 
         elif surface.is_xwayland_surface and isinstance(win.surface, xwayland.Surface):
             win.surface.activate(True)
-            win.ftm_handle.set_activated(True)
+            if win.ftm_handle:
+                win.ftm_handle.set_activated(True)
 
         if enter and self.seat.keyboard._ptr:  # This pointer is NULL when headless
             self.seat.keyboard_notify_enter(surface, self.seat.keyboard)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -243,6 +243,10 @@ class Core(base.Core, wlrq.HasListeners):
         # Start
         self.backend.start()
 
+        # Place cursor
+        self.warp_pointer(0, 0)
+        self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+
     @property
     def name(self) -> str:
         return "wayland"

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -729,12 +729,20 @@ class Core(base.Core, wlrq.HasListeners):
                     self.seat.pointer_notify_clear_focus()
 
             if win is not self.qtile.current_window:
-                hook.fire("client_mouse_enter", win)
+                if isinstance(win, window.Static):
+                    if self._hovered_window is not win:
+                        # qtile.current_window will never be a static window, but we
+                        # still only want to fire client_mouse_enter once, so check
+                        # self._hovered_window.
+                        hook.fire("client_mouse_enter", win)
 
-                if self.qtile.config.follow_mouse_focus:
-                    if isinstance(win, window.Static):
-                        self.qtile.focus_screen(win.screen.index, False)
-                    else:
+                        if self.qtile.config.follow_mouse_focus:
+                            self.qtile.focus_screen(win.screen.index, False)
+
+                else:
+                    hook.fire("client_mouse_enter", win)
+
+                    if self.qtile.config.follow_mouse_focus:
                         if win.group and win.group.current_window != win:
                             win.group.focus(win, False)
                         if (

--- a/libqtile/backend/wayland/layer.py
+++ b/libqtile/backend/wayland/layer.py
@@ -152,9 +152,9 @@ class LayerStatic(Static[LayerSurfaceV1]):
     ) -> None:
         self.x = x
         self.y = y
-        self._width = int(width)
-        self._height = int(height)
-        self.surface.configure(self._width, self._height)
+        self._width = width
+        self._height = height
+        self.surface.configure(width, height)
         self.damage()
 
     @expose_command()

--- a/libqtile/backend/wayland/layer.py
+++ b/libqtile/backend/wayland/layer.py
@@ -87,17 +87,17 @@ class LayerStatic(Static[LayerSurfaceV1]):
         self._mapped = mapped
 
         self._layer = self.surface.pending.layer
-        layer = self.output.layers[self._layer]
         if mapped:
-            layer.append(self)
+            self.output.layers[self._layer].append(self)
+            self.core.stack_windows()
         else:
-            layer.remove(self)
+            self.output.layers[self._layer].remove(self)
+            self.core.stacked_windows.remove(self)
 
             if self.reserved_space:
                 self.qtile.free_reserved_space(self.reserved_space, self.screen)
-        self.output.organise_layers()
 
-        self.core.stack_windows()
+        self.output.organise_layers()
 
     def _on_map(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: layerstatic map")

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -320,8 +320,6 @@ class Output(HasListeners):
 
                 win.place(int(x + self.x), int(y + self.y), int(ww), int(wh), 0, None)
 
-        self.core.stack_windows()
-
     def contains(self, rect: WindowType | Dnd) -> bool:
         """Returns whether the given window is visible on this output."""
         if rect.x + rect.width < self.x:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -158,9 +158,10 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         self._mapped = mapped
         if mapped:
             self.core.mapped_windows.append(self)
+            self.core.stack_windows()
         else:
             self.core.mapped_windows.remove(self)
-        self.core.stack_windows()
+            self.core.stacked_windows.remove(self)
         if self._idle_inhibitors_count > 0:
             self.core.check_idle_inhibitor()
 
@@ -580,9 +581,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     @expose_command()
     def bring_to_front(self) -> None:
         if self.mapped:
-            self.core.mapped_windows.remove(self)
-            self.core.mapped_windows.append(self)
-            self.core.stack_windows()
+            self.core.stack_windows(restack=self)
 
     @expose_command()
     def static(
@@ -614,9 +613,9 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         win.mapped = True
         win.place(x, y, width, height, 0, None)
         self.qtile.windows_map[self.wid] = win
-        if self in self.core.mapped_windows:
+        if self.mapped:
             self.core.mapped_windows.remove(self)
-        self.core.stack_windows()
+            self.core.stacked_windows.remove(self)
 
     @expose_command()
     def is_visible(self) -> bool:
@@ -679,10 +678,10 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
 
         if mapped:
             self.core.mapped_windows.append(self)
+            self.core.stack_windows()
         else:
             self.core.mapped_windows.remove(self)
-
-        self.core.stack_windows()
+            self.core.stacked_windows.remove(self)
 
     def _find_outputs(self) -> None:
         self._outputs = set(o for o in self.core.outputs if o.contains(self))
@@ -776,9 +775,7 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
     @expose_command()
     def bring_to_front(self) -> None:
         if self.mapped:
-            self.core.mapped_windows.remove(self)
-            self.core.mapped_windows.append(self)
-            self.core.stack_windows()
+            self.core.stack_windows(restack=self)
             self.damage()
 
 
@@ -834,9 +831,10 @@ class Internal(_Base, base.Internal):
         self._mapped = mapped
         if mapped:
             self.core.mapped_windows.append(self)
+            self.core.stack_windows()
         else:
             self.core.mapped_windows.remove(self)
-        self.core.stack_windows()
+            self.core.stacked_windows.remove(self)
 
     def hide(self) -> None:
         self.mapped = False
@@ -876,9 +874,7 @@ class Internal(_Base, base.Internal):
         respect_hints: bool = False,
     ) -> None:
         if above and self._mapped:
-            self.core.mapped_windows.remove(self)
-            self.core.mapped_windows.append(self)
-            self.core.stack_windows()
+            self.core.stack_windows(restack=self)
 
         self.x = x
         self.y = y
@@ -906,9 +902,7 @@ class Internal(_Base, base.Internal):
     @expose_command()
     def bring_to_front(self) -> None:
         if self.mapped:
-            self.core.mapped_windows.remove(self)
-            self.core.mapped_windows.append(self)
-            self.core.stack_windows()
+            self.core.stack_windows(restack=self)
 
 
 WindowType = typing.Union[Window, Static, Internal]

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -450,6 +450,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             group=self.group.name if self.group else None,
             id=self.wid,
             wm_class=self.get_wm_class(),
+            shell="XDG" if self.__class__.__name__ == "XdgWindow" else "XWayland",
             float_info=float_info,
             floating=self._float_state != FloatStates.NOT_FLOATING,
             maximized=self._float_state == FloatStates.MAXIMIZED,
@@ -777,6 +778,19 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
         if self.mapped:
             self.core.stack_windows(restack=self)
             self.damage()
+
+    @expose_command()
+    def info(self) -> dict:
+        """Return a dictionary of info."""
+        info = base.Static.info(self)
+        cls_name = self.__class__.__name__
+        if cls_name == "XdgStatic":
+            info["shell"] = "XDG"
+        elif cls_name == "XStatic":
+            info["shell"] = "XWayland"
+        else:
+            info["shell"] = "layer"
+        return info
 
 
 class Internal(_Base, base.Internal):

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -240,8 +240,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
 
         if warp and self.qtile.config.cursor_warp:
             self.core.warp_pointer(
-                self.x + self.width / 2,
-                self.y + self.height / 2,
+                self.x + self._width / 2,
+                self.y + self._height / 2,
             )
 
         if self.group:
@@ -306,8 +306,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             if self.group and self.group.screen:
                 screen = self.group.screen
                 if not self._float_width:  # These might start as 0
-                    self._float_width = self.width
-                    self._float_height = self.height
+                    self._float_width = self._width
+                    self._float_height = self._height
                 self._reconfigure_floating(
                     screen.x + self.float_x,
                     screen.y + self.float_y,
@@ -321,8 +321,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             self._update_fullscreen(False)
             if self._float_state == FloatStates.FLOATING:
                 # store last size
-                self._float_width = self.width
-                self._float_height = self.height
+                self._float_width = self._width
+                self._float_height = self._height
             self._float_state = FloatStates.NOT_FLOATING
             if self.group:
                 self.group.mark_floating(self, False)
@@ -391,11 +391,11 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         y += dy
 
         if w is None:
-            w = self.width
+            w = self._width
         w += dw
 
         if h is None:
-            h = self.height
+            h = self._height
         h += dh
 
         if h < 0:
@@ -445,8 +445,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             name=self.name,
             x=self.x,
             y=self.y,
-            width=self.width,
-            height=self.height,
+            width=self._width,
+            height=self._height,
             group=self.group.name if self.group else None,
             id=self.wid,
             wm_class=self.get_wm_class(),
@@ -544,7 +544,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
 
     @expose_command()
     def get_size(self) -> tuple[int, int]:
-        return self.width, self.height
+        return self._width, self._height
 
     @expose_command()
     def toggle_floating(self) -> None:
@@ -602,9 +602,9 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         if y is None:
             y = self.y + self.borderwidth
         if width is None:
-            width = self.width
+            width = self._width
         if height is None:
-            height = self.height
+            height = self._height
 
         self.finalize_listeners()
         win = self._to_static()
@@ -695,8 +695,8 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
 
         if warp and self.qtile.config.cursor_warp:
             self.core.warp_pointer(
-                self.x + self.width / 2,
-                self.y + self.height / 2,
+                self.x + self._width / 2,
+                self.y + self._height / 2,
             )
 
         hook.fire("client_focus", self)
@@ -801,7 +801,7 @@ class Internal(_Base, base.Internal):
         self.hide()
 
     def _new_texture(self) -> Texture:
-        clear = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, self.width, self.height)
+        clear = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, self._width, self._height)
         with cairocffi.Context(clear) as context:
             context.set_source_rgba(0, 0, 0, 0)
             context.paint()
@@ -809,9 +809,9 @@ class Internal(_Base, base.Internal):
         return Texture.from_pixels(
             self.core.renderer,
             DRM_FORMAT_ARGB8888,
-            cairocffi.ImageSurface.format_stride_for_width(cairocffi.FORMAT_ARGB32, self.width),
-            self.width,
-            self.height,
+            cairocffi.ImageSurface.format_stride_for_width(cairocffi.FORMAT_ARGB32, self._width),
+            self._width,
+            self._height,
             cairocffi.cairo.cairo_image_surface_get_data(clear._pointer),
         )
 
@@ -878,7 +878,7 @@ class Internal(_Base, base.Internal):
 
         self.x = x
         self.y = y
-        needs_reset = width != self.width or height != self.height
+        needs_reset = width != self._width or height != self._height
         self._width = width
         self._height = height
 
@@ -894,8 +894,8 @@ class Internal(_Base, base.Internal):
         return dict(
             x=self.x,
             y=self.y,
-            width=self.width,
-            height=self.height,
+            width=self._width,
+            height=self._height,
             id=self.wid,
         )
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -126,12 +126,14 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         self._float_width: int = 0
         self._float_height: int = 0
         self._float_state = FloatStates.NOT_FLOATING
-
-        surface.data = self.ftm_handle = core.foreign_toplevel_manager_v1.create_handle()
+        self.ftm_handle: ftm.ForeignToplevelHandleV1 | None = None
 
     def finalize(self) -> None:
         self.finalize_listeners()
-        self.ftm_handle.destroy()
+        if self.ftm_handle:
+            self.ftm_handle.destroy()
+            self.ftm_handle = None
+            self.surface.data = None
         self.core.remove_pointer_constraints(self)
 
     @property
@@ -354,7 +356,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             if self._float_state == FloatStates.MAXIMIZED:
                 self.floating = False
 
-        self.ftm_handle.set_maximized(do_maximize)
+        if self.ftm_handle:
+            self.ftm_handle.set_maximized(do_maximize)
 
     @property
     def minimized(self) -> bool:
@@ -369,7 +372,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             if self._float_state == FloatStates.MINIMIZED:
                 self.floating = False
 
-        self.ftm_handle.set_minimized(do_minimize)
+        if self.ftm_handle:
+            self.ftm_handle.set_minimized(do_minimize)
 
     def _tweak_float(
         self,

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -27,6 +27,7 @@ from pywayland import lib as wllib
 from pywayland.server import Listener
 from wlroots import ffi
 from wlroots.util.box import Box
+from wlroots.util.clock import Timespec
 from wlroots.util.edges import Edges
 from wlroots.wlr_types.xdg_shell import XdgPopup, XdgSurface, XdgTopLevelSetFullscreenEvent
 
@@ -128,6 +129,10 @@ class XdgWindow(Window[XdgSurface]):
             self.add_listener(self.ftm_handle.request_close_event, self._on_foreign_request_close)
 
             self.qtile.manage(self)
+
+            # Send a frame done event to provide an opportunity to redraw even if we
+            # aren't going to map (i.e. because the window was opened on a hidden group)
+            surface.surface.send_frame_done(Timespec.get_monotonic_time())
 
         if self.group and self.group.screen:
             self.mapped = True

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -264,9 +264,9 @@ class XdgWindow(Window[XdgSurface]):
 
         self.x = x
         self.y = y
-        self._width = int(width)
-        self._height = int(height)
-        self.surface.set_size(self._width, self._height)
+        self._width = width
+        self._height = height
+        self.surface.set_size(width, height)
         self.paint_borders(bordercolor, borderwidth)
 
         if above:
@@ -364,7 +364,7 @@ class XdgStatic(Static[XdgSurface]):
         self.y = y
         self._width = width
         self._height = height
-        self.surface.set_size(self._width, self._height)
+        self.surface.set_size(width, height)
         self.paint_borders(bordercolor, borderwidth)
         self._find_outputs()
         self.damage()

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -283,9 +283,7 @@ class XWindow(Window[xwayland.Surface]):
     @expose_command()
     def bring_to_front(self) -> None:
         if self.mapped:
-            self.core.mapped_windows.remove(self)
-            self.core.mapped_windows.append(self)
-            self.core.stack_windows()
+            self.core.stack_windows(restack=self)
             self.surface.restack(None, 0)  # XCB_STACK_MODE_ABOVE
 
     @expose_command()

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import typing
 
-from pywayland.server import Listener
 from wlroots import xwayland
 
 from libqtile import hook
@@ -34,6 +33,9 @@ from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
     from typing import Any
+
+    import wlroots.wlr_types.foreign_toplevel_management_v1 as ftm
+    from pywayland.server import Listener
 
     from libqtile.backend.wayland.core import Core
     from libqtile.core.manager import Qtile
@@ -72,12 +74,11 @@ class XWindow(Window[xwayland.Surface]):
             self.core.pending_windows.remove(self)
             self._wid = self.core.new_wid()
             logger.debug("Managing new XWayland window with window ID: %s", self._wid)
+            surface = self.surface
 
             # Make it static if it isn't a regular window
-            if self.surface.override_redirect:
-                self.static(
-                    None, self.surface.x, self.surface.y, self.surface.width, self.surface.height
-                )
+            if surface.override_redirect:
+                self.static(None, surface.x, surface.y, surface.width, surface.height)
                 win = self.qtile.windows_map[self._wid]
                 assert isinstance(win, XStatic)
                 self.core.focus_window(win)
@@ -85,24 +86,25 @@ class XWindow(Window[xwayland.Surface]):
 
             # Save the client's desired geometry. xterm seems to have these set to 1, so
             # let's ignore 1 or below. The float sizes will be fetched when it is floated.
-            if self.surface.width > 1:
-                self._width = self._float_width = self.surface.width
+            if surface.width > 1:
+                self._width = self._float_width = surface.width
             if self.surface.height > 1:
-                self._height = self._float_height = self.surface.height
+                self._height = self._float_height = surface.height
 
+            surface.data = self.ftm_handle = self.core.foreign_toplevel_manager_v1.create_handle()
             # Get the client's name and class
-            title = self.surface.title
+            title = surface.title
             if title:
                 self.name = title
                 self.ftm_handle.set_title(self.name)
-            self._wm_class = self.surface.wm_class
+            self._wm_class = surface.wm_class
             self.ftm_handle.set_app_id(self._wm_class or "")
 
             # Add event listeners
-            self.add_listener(self.surface.surface.commit_event, self._on_commit)
-            self.add_listener(self.surface.request_fullscreen_event, self._on_request_fullscreen)
-            self.add_listener(self.surface.set_title_event, self._on_set_title)
-            self.add_listener(self.surface.set_class_event, self._on_set_class)
+            self.add_listener(surface.surface.commit_event, self._on_commit)
+            self.add_listener(surface.request_fullscreen_event, self._on_request_fullscreen)
+            self.add_listener(surface.set_title_event, self._on_set_title)
+            self.add_listener(surface.set_class_event, self._on_set_class)
             self.add_listener(
                 self.ftm_handle.request_maximize_event, self._on_foreign_request_maximize
             )
@@ -133,8 +135,15 @@ class XWindow(Window[xwayland.Surface]):
                 seat.keyboard_clear_focus()
 
         if not self._unmapping:
+            # Client unmapped X11 windows return to a pending state, where we don't
+            # manage them, but clients can re-use them.
             self.qtile.unmanage(self.wid)
             self.finalize()
+            self.add_listener(self.surface.map_event, self._on_map)
+            self.add_listener(self.surface.unmap_event, self._on_unmap)
+            self.add_listener(self.surface.destroy_event, self._on_destroy)
+            self.core.pending_windows.add(self)
+            self._wid = -1
 
         self._unmapping = False
 
@@ -148,13 +157,15 @@ class XWindow(Window[xwayland.Surface]):
         title = self.surface.title
         if title and title != self.name:
             self.name = title
-            self.ftm_handle.set_title(title)
+            if self.ftm_handle:
+                self.ftm_handle.set_title(title)
             hook.fire("client_name_updated", self)
 
     def _on_set_class(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: xwindow set_class")
         self._wm_class = self.surface.wm_class
-        self.ftm_handle.set_app_id(self._wm_class or "")
+        if self.ftm_handle:
+            self.ftm_handle.set_app_id(self._wm_class or "")
 
     def hide(self) -> None:
         if self.mapped:
@@ -203,7 +214,8 @@ class XWindow(Window[xwayland.Surface]):
     def _update_fullscreen(self, do_full: bool) -> None:
         if do_full != (self._float_state == FloatStates.FULLSCREEN):
             self.surface.set_fullscreen(do_full)
-            self.ftm_handle.set_fullscreen(do_full)
+            if self.ftm_handle:
+                self.ftm_handle.set_fullscreen(do_full)
 
     @property
     def fullscreen(self) -> bool:
@@ -227,7 +239,8 @@ class XWindow(Window[xwayland.Surface]):
         elif self._float_state == FloatStates.FULLSCREEN:
             self.floating = False
 
-        self.ftm_handle.set_fullscreen(do_full)
+        if self.ftm_handle:
+            self.ftm_handle.set_fullscreen(do_full)
 
     def place(
         self,
@@ -333,6 +346,8 @@ class XStatic(Static[xwayland.Surface]):
         if surface.override_redirect:
             self.add_listener(surface.set_geometry_event, self._on_set_geometry)
 
+        self.ftm_handle: ftm.ForeignToplevelHandleV1 | None = None
+
     @expose_command()
     def kill(self) -> None:
         self.surface.close()
@@ -371,13 +386,15 @@ class XStatic(Static[xwayland.Surface]):
         title = self.surface.title
         if title and title != self.name:
             self.name = title
-            self.ftm_handle.set_title(title)
+            if self.ftm_handle:
+                self.ftm_handle.set_title(title)
             hook.fire("client_name_updated", self)
 
     def _on_set_class(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: xstatic set_class")
         self._wm_class = self.surface.wm_class
-        self.ftm_handle.set_app_id(self._wm_class or "")
+        if self.ftm_handle:
+            self.ftm_handle.set_app_id(self._wm_class or "")
 
     def _on_set_geometry(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: xstatic set_geometry")

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -267,9 +267,9 @@ class XWindow(Window[xwayland.Surface]):
 
         self.x = x
         self.y = y
-        self._width = int(width)
-        self._height = int(height)
-        self.surface.configure(x, y, self._width, self._height)
+        self._width = width
+        self._height = height
+        self.surface.configure(x, y, width, height)
         self.paint_borders(bordercolor, borderwidth)
 
         if above:

--- a/test/backend/wayland/test_window.py
+++ b/test/backend/wayland/test_window.py
@@ -1,0 +1,42 @@
+import pytest
+
+from test.backend.wayland.conftest import new_layer_client, new_xdg_client
+from test.conftest import BareConfig
+
+try:
+    # Check to see if we should skip layer shell tests
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("GtkLayerShell", "0.1")
+    from gi.repository import GtkLayerShell  # noqa: F401
+
+    has_layer_shell = True
+except (ImportError, ValueError):
+    has_layer_shell = False
+
+pytestmark = pytest.mark.skipif(not has_layer_shell, reason="GtkLayerShell not available")
+
+bare_config = pytest.mark.parametrize("wmanager", [BareConfig], indirect=True)
+
+
+@bare_config
+def test_info(wmanager):
+    """
+    Check windows are providing some Wayland-specific info.
+    """
+    # Regular window via XDG shell
+    pid = new_xdg_client(wmanager)
+    assert wmanager.c.window.info()["shell"] == "XDG"
+
+    # Regular XDG shell window converted to Static
+    wmanager.c.window.static()
+    wid = wmanager.c.windows()[0]["id"]
+    assert wmanager.c.window[wid].info()["shell"] == "XDG"
+    wmanager.kill_window(pid)
+
+    # Static window via layer shell
+    pid = new_layer_client(wmanager)
+    wid = wmanager.c.windows()[0]["id"]
+    assert wmanager.c.window[wid].info()["shell"] == "layer"
+    wmanager.kill_window(pid)


### PR DESCRIPTION
This makes the wayland core track which window of any type is under the pointer, rather than just internal windows. This lets us detect when the pointer moves out of a Window/Static window, so we can reset the cursor image (to the default 'left_ptr' icon) when that happens. Previously the icon was set upon all cursor movements if no non-internal window was under the pointer, doing needless work.

This also prevents windows that don't have pointer focus from changing the icon (firefox does this), and improves handling of focus and icon when transitioning between windows and borders.

Editted - added a few more commits that improve windows