### PR TITLE
Fix Bluetooth widget name bug

### DIFF
--- a/libqtile/widget/bluetooth.py
+++ b/libqtile/widget/bluetooth.py
@@ -72,7 +72,7 @@ class Bluetooth(base._TextBox):
 
         powered = await iface.get_powered()
         # subscribe receiver to property changed
-        props.on_properties_changed(self._signal_received)
+        props.on_properties_changed(self._adapter_signal_received)
         return powered
 
     async def _init_device(self):
@@ -86,15 +86,20 @@ class Bluetooth(base._TextBox):
         connected = await iface.get_connected()
         name = await iface.get_name()
         # subscribe receiver to property changed
-        props.on_properties_changed(self._signal_received)
+        props.on_properties_changed(self._device_signal_received)
         return connected, name
 
-    def _signal_received(self, interface_name, changed_properties, _invalidated_properties):
+    def _adapter_signal_received(
+        self, interface_name, changed_properties, _invalidated_properties
+    ):
         powered = changed_properties.get("Powered", None)
         if powered is not None:
             self.powered = powered.value
             self.update_text()
 
+    def _device_signal_received(
+        self, interface_name, changed_properties, _invalidated_properties
+    ):
         connected = changed_properties.get("Connected", None)
         if connected is not None:
             self.connected = connected.value

--- a/test/widgets/test_bluetooth.py
+++ b/test/widgets/test_bluetooth.py
@@ -93,11 +93,15 @@ def test_signal_handling(monkeypatch):
     widget.update_text()
     assert widget.text == "Mock Bluetooth Device"
 
-    widget._signal_received(None, {"Name": Variant("s", "New Device Name")}, None)
+    widget._device_signal_received(None, {"Name": Variant("s", "New Device Name")}, None)
     assert widget.text == "New Device Name"
 
-    widget._signal_received(None, {"Connected": Variant("b", False)}, None)
+    # Ignore Name change on the adapter
+    widget._adapter_signal_received(None, {"Name": Variant("s", "New Adapter Name")}, None)
+    assert widget.text == "New Device Name"
+
+    widget._device_signal_received(None, {"Connected": Variant("b", False)}, None)
     assert widget.text == "on"
 
-    widget._signal_received(None, {"Powered": Variant("b", False)}, None)
+    widget._adapter_signal_received(None, {"Powered": Variant("b", False)}, None)
     assert widget.text == "off"


### PR DESCRIPTION
Fixes an edge case where, if the bluetooth adapter emits a PropertiesChanged signal with the name of the adapter, the widget displays the adapter name rather than the connected device name. This is achieved by having separate handlers for the device and adapter signals.

Fixes #3816