### PR TITLE
Move from pytest-cov to coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,12 @@
 [run]
 source = libqtile
+concurrency = multiprocessing
+parallel = true
+sigterm = true
 
 [report]
 omit =
     libqtile/interactive/*
     libqtile/scripts/*
     libqtile/ffi_build.py
+    test/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source = libqtile
 concurrency = multiprocessing
 parallel = true
 sigterm = true
+dynamic_context = test_function
 
 [report]
 omit =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ types-pytz
 types-pkg_resources
 pep8-naming
 psutil
-pytest-cov <= 3.0.0
+coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ tests_require =
   flake8
   pep8-naming
   psutil
-  pytest-cov <= 3.0.0
+  coverage
 
 [options.entry_points]
 console_scripts =
@@ -65,7 +65,7 @@ doc =
 test =
   flake8
   pep8-naming
-  pytest-cov <= 3.0.0
+  coverage
 ipython =
   ipykernel
   jupyter_console

--- a/test/widgets/test_memory.py
+++ b/test/widgets/test_memory.py
@@ -89,4 +89,5 @@ def test_memory_units(manager_nospawn, minimal_conf_noscreen, patched_memory, un
     config = minimal_conf_noscreen
     config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([widget], 10))]
     manager_nospawn.start(config)
+    manager_nospawn.c.widget["memory"].eval("self.update(self.poll())")
     assert manager_nospawn.c.widget["memory"].info()["text"] == expects

--- a/test/widgets/test_openweather.py
+++ b/test/widgets/test_openweather.py
@@ -97,6 +97,7 @@ def test_openweather_parse(
         libqtile.config.Screen(top=Bar([patch_openweather.OpenWeather(**params)], 10))
     ]
     manager_nospawn.start(config)
+    manager_nospawn.c.widget["openweather"].eval("self.update(self.poll())")
     info = manager_nospawn.c.widget["openweather"].info()["text"]
     assert info == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,8 @@ whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
     pytest >= 6.2.1
-    pytest-cov <= 3.0.0
+    ; pytest-cov <= 3.0.0
+    coverage
     setuptools >= 40.5.0
     bowler
     xkbcommon >= 0.3
@@ -48,9 +49,16 @@ commands =
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
 # pypy3 is very slow when running coverage reports so we skip it (coverage is reported on py37 to py310)
-    !py310-!pypy3: python3 -m pytest -W error --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
+    !py310-!pypy3: coverage run -m pytest -W error --backend=x11 --backend=wayland {posargs}
     pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland {posargs}
-    py310: python3 -m pytest --cov libqtile --cov-report term-missing --backend=x11 --backend=wayland {posargs}
+    py310: coverage run -m pytest --backend=x11 --backend=wayland {posargs}
+
+    # Coverage runs tests in parallel so we need to combine results into a single file
+    !pypy3: coverage combine -q
+    # Include a text summary in the build log
+    !pypy3: coverage report -m
+    # Create an xml summary to be submitted to coveralls.io
+    !pypy3: coverage xml
 
 [testenv:packaging]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
     pytest >= 6.2.1
-    ; pytest-cov <= 3.0.0
     coverage
     setuptools >= 40.5.0
     bowler
@@ -47,8 +46,8 @@ commands =
     pip install pywlroots>=0.15.21,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
-# py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
-# pypy3 is very slow when running coverage reports so we skip it (coverage is reported on py37 to py310)
+    # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
+    # pypy3 is very slow when running coverage reports so we skip it (coverage is reported on py37 to py310)
     !py310-!pypy3: coverage run -m pytest -W error --backend=x11 --backend=wayland {posargs}
     pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland {posargs}
     py310: coverage run -m pytest --backend=x11 --backend=wayland {posargs}


### PR DESCRIPTION
pytest-cov 4.0.0 dropped support for `multiprocessing` which massively impacts our coverage scores. Pinning to 3.0.0 would retain that support but is not a good long term solution.

pytest-cov recommends moving to coverage but I'm currently seeing a few drops in coverage on a small number of tests. Needs debugging.