### PR TITLE
Pin pytest-cov to 3.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ types-pytz
 types-pkg_resources
 pep8-naming
 psutil
-pytest-cov
+pytest-cov <= 3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ tests_require =
   flake8
   pep8-naming
   psutil
-  pytest-cov
+  pytest-cov <= 3.0.0
 
 [options.entry_points]
 console_scripts =
@@ -65,7 +65,7 @@ doc =
 test =
   flake8
   pep8-naming
-  pytest-cov
+  pytest-cov <= 3.0.0
 ipython =
   ipykernel
   jupyter_console

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
     pytest >= 6.2.1
-    pytest-cov >= 2.10.1
+    pytest-cov <= 3.0.0
     setuptools >= 40.5.0
     bowler
     xkbcommon >= 0.3


### PR DESCRIPTION
pytest-cov 4.0.0 dropped multiprocessing support which makes all our `manager` tests report as uncovered.

This PR pins pytest-cov to 3.0.0. This is a temporary fix while we look for a better solution in #3870.