### PR TITLE
Border color for stacked windows in stack layout

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add 'warp_pointer' option to `Drag` that when set will warp the pointer to the bottom right of
           the window when dragging begins.
         - Add ability to disable group toggling in `GroupBox` widget
+        - Add ability to have different border color when windows are stacked in Stack layout. Requires 
+        setting `border_focus_stack` and `border_normal_stack` variables.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           the window when dragging begins.
         - Add ability to disable group toggling in `GroupBox` widget
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
-        setting `border_focus_stack` and `border_normal_stack` variables.
+          setting `border_focus_stack` and `border_normal_stack` variables.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
 

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -55,6 +55,10 @@ class Stack(Layout):
     defaults = [
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
+        ("border_focus_stack", "#881111",
+         "Border colour(s) for the focused stacked window."),
+        ("border_normal_stack", "#220000",
+         "Border colour(s) for un-focused stacked windows."),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),
@@ -206,9 +210,9 @@ class Stack(Layout):
             return
 
         if client.has_focus:
-            px = self.border_focus
+            px = self.border_focus if s.split else self.border_focus_stack
         else:
-            px = self.border_normal
+            px = self.border_normal if s.split else self.border_normal_stack
 
         column_width = int(screen_rect.width / len(self.stacks))
         xoffset = screen_rect.x + i * column_width

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -58,9 +58,11 @@ class Stack(Layout):
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_focus_stack", None,
-         "Border colour(s) for the focused stacked window. If 'None' will default to border_focus."),
+         "Border colour(s) for the focused stacked window. If 'None' will \
+         default to border_focus."),
         ("border_normal_stack", None,
-         "Border colour(s) for un-focused stacked windows. If 'None' will default to border_normal."),
+         "Border colour(s) for un-focused stacked windows. If 'None' will \
+         default to border_normal."),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -212,13 +212,19 @@ class Stack(Layout):
             return
 
         if client.has_focus:
-            if s.split and self.border_focus_stack:
-                px = self.border_focus_stack
+            if self.border_focus_stack:
+                if s.split:
+                    px = self.border_focus
+                else:
+                    px = self.border_focus_stack
             else:
                 px = self.border_focus
         else:
-            if s.split and self.border_normal_stack:
-                px = self.border_normal_stack 
+            if self.border_normal_stack:
+                if s.split:
+                    px = self.border_normal
+                else:
+                    px = self.border_normal_stack 
             else:
                 px = self.border_normal
 

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -210,7 +210,10 @@ class Stack(Layout):
             return
 
         if client.has_focus:
-            px = self.border_focus if s.split else self.border_focus_stack
+            if s.split and self.border_focus_stack:
+                px = self.border_focus_stack
+            else:
+                px = self.border_focus
         else:
             px = self.border_normal if s.split else self.border_normal_stack
 

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -57,12 +57,18 @@ class Stack(Layout):
     defaults = [
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
-        ("border_focus_stack", None,
-         "Border colour(s) for the focused stacked window. If 'None' will \
-         default to border_focus."),
-        ("border_normal_stack", None,
-         "Border colour(s) for un-focused stacked windows. If 'None' will \
-         default to border_normal."),
+        (
+            "border_focus_stack",
+            None,
+            "Border colour(s) for the focused stacked window. If 'None' will \
+         default to border_focus.",
+        ),
+        (
+            "border_normal_stack",
+            None,
+            "Border colour(s) for un-focused stacked windows. If 'None' will \
+         default to border_normal.",
+        ),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -56,9 +56,9 @@ class Stack(Layout):
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
         ("border_focus_stack", None,
-         "Border colour(s) for the focused stacked window."),
+         "Border colour(s) for the focused stacked window. If 'None' will default to border_focus."),
         ("border_normal_stack", None,
-         "Border colour(s) for un-focused stacked windows."),
+         "Border colour(s) for un-focused stacked windows. If 'None' will default to border_normal."),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),
         ("num_stacks", 2, "Number of stacks."),
@@ -215,7 +215,10 @@ class Stack(Layout):
             else:
                 px = self.border_focus
         else:
-            px = self.border_normal if s.split else self.border_normal_stack
+            if s.split and self.border_normal_stack:
+                px = self.border_normal_stack 
+            else:
+                px = self.border_normal
 
         column_width = int(screen_rect.width / len(self.stacks))
         xoffset = screen_rect.x + i * column_width

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -55,9 +55,9 @@ class Stack(Layout):
     defaults = [
         ("border_focus", "#0000ff", "Border colour(s) for the focused window."),
         ("border_normal", "#000000", "Border colour(s) for un-focused windows."),
-        ("border_focus_stack", "#881111",
+        ("border_focus_stack", None,
          "Border colour(s) for the focused stacked window."),
-        ("border_normal_stack", "#220000",
+        ("border_normal_stack", None,
          "Border colour(s) for un-focused stacked windows."),
         ("border_width", 1, "Border width."),
         ("autosplit", False, "Auto split all new stacks."),

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -224,7 +224,7 @@ class Stack(Layout):
                 if s.split:
                     px = self.border_normal
                 else:
-                    px = self.border_normal_stack 
+                    px = self.border_normal_stack
             else:
                 px = self.border_normal
 


### PR DESCRIPTION
This adds a new feature in **stack layout**. Now it is possible to change border color if the windows are in 'split' or 'stacked' state. This feature is present in column layout and is very useful to quickly see if there are windows "hiding" below. The feature will be as useful in stack layout.