### PR TITLE
Use logger.error in loop exception handler

### DIFF
--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -60,7 +60,7 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
             # CancelledErrors happen when we simply cancel the main task during
             # a normal restart procedure
             if not isinstance(exc, asyncio.CancelledError):
-                logger.exception(exc)
+                logger.error(exc)
         else:
             logger.error("unhandled error in event loop: %s", context["msg"])
 


### PR DESCRIPTION
Using logger.exception results in `NoneType: None` messages being written to the log. This is because the method is not called from an exception handler. Using logger.error removes this issue.