### PR TITLE
Two StatusNotifier fixes

### DIFF
--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -326,7 +326,8 @@ class StatusNotifierItem:  # noqa: E303
         return icon
 
     def activate(self):
-        asyncio.create_task(self._activate())
+        if hasattr(self, "call_activate"):
+            asyncio.create_task(self._activate())
 
     async def _activate(self):
         # Call Activate method and pass window position hints

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -510,6 +510,9 @@ class StatusNotifierHost:  # noqa: E303
             self._on_icon_changed.append(on_icon_changed)
 
         if self.started:
+            if on_item_added:
+                for item in self.items:
+                    on_item_added(item)
             return
 
         self.bus = await MessageBus().connect()


### PR DESCRIPTION
These two fixes are needed to close the issue posted on qtile-extras: https://github.com/elParaguayo/qtile-extras/issues/130
* Fixes an edge case where, when a user switches from `libqtile.widget.StatusNotifier` to `qtile_extras.widget.StatusNotifier` via a `reload_config` call, menus are not available
* Some apps don't have an `Activate` method exposed on dbus resulting in an error message when the icon is clicked.

Closes: https://github.com/elParaguayo/qtile-extras/issues/130