### PR TITLE
Two fixes for Mpris2 widget

### DIFF
--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -386,7 +386,7 @@ def _fire_async_event(co):
     if loop is None:
         asyncio.run(co)
     else:
-        asyncio.ensure_future(co)
+        asyncio.create_task(co)
 
 
 def fire(event, *args, **kwargs):

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -350,7 +350,12 @@ class _Widget(CommandObject, configurable.Configurable):
     def _wrapper(self, method, *method_args):
         self._remove_dead_timers()
         try:
-            method(*method_args)
+            if asyncio.iscoroutinefunction(method):
+                asyncio.create_task(method(*method_args))
+            elif asyncio.iscoroutine(method):
+                asyncio.create_task(method)
+            else:
+                method(*method_args)
         except:  # noqa: E722
             logger.exception("got exception from widget timer")
 


### PR DESCRIPTION
Adds two fixes to the MPRIS2 widget:
- Do an initial poll of the player when the widget starts (this ensures that text is presented after a `lazy.reload_config()` call).
- Do a background poll of the current player. This is useful if the player doesn't provide consistent signals when metatada/playing state changes.

Also adds a commit that allows coroutines to be passed to `_Widget.timeout_add` so that these are wrapped in an `asyncio.create_task` call.