### PR TITLE
WL: don't wait until mapping to listen for fullscreen requests

### DIFF
--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -68,6 +68,7 @@ class XdgWindow(Window[XdgSurface]):
         self.add_listener(surface.new_popup_event, self._on_new_popup)
         self.add_listener(surface.surface.commit_event, self._on_commit)
         self.add_listener(surface.surface.new_subsurface_event, self._on_new_subsurface)
+        self.add_listener(surface.toplevel.request_fullscreen_event, self._on_request_fullscreen)
 
     def finalize(self) -> None:
         Window.finalize(self)
@@ -106,9 +107,6 @@ class XdgWindow(Window[XdgSurface]):
                 self.ftm_handle.set_app_id(self._wm_class or "")
 
             # Add the toplevel's listeners
-            self.add_listener(
-                surface.toplevel.request_fullscreen_event, self._on_request_fullscreen
-            )
             self.add_listener(surface.toplevel.set_title_event, self._on_set_title)
             self.add_listener(surface.toplevel.set_app_id_event, self._on_set_app_id)
             self.add_listener(


### PR DESCRIPTION
Sway does wait until mapping so I'm not sure why this is needed, but for me this lets mpv open up in a fullscreen state.

fixes #3902