### PR TITLE
Fix Window.center() bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add 'warp_pointer' option to `Drag` that when set will warp the pointer to the bottom right of
           the window when dragging begins.
     * bugfixes
+        - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
 
 Qtile 0.22.0, released 2022-09-22:
     !!! Config breakage !!!

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -544,8 +544,8 @@ class Window(_Window, metaclass=ABCMeta):
 
         screen = self.group.screen
 
-        x = (screen.width - self.width) // 2
-        y = (screen.height - self.height) // 2
+        x = screen.x + (screen.width - self.width) // 2
+        y = screen.y + (screen.height - self.height) // 2
 
         self.place(
             x,

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -1,6 +1,6 @@
 import pytest
 
-from test.conftest import BareConfig
+from test.conftest import BareConfig, dualmonitor
 from test.layouts.layout_utils import assert_focused
 from test.test_manager import ManagerConfig
 
@@ -200,6 +200,7 @@ def test_bring_front_click(manager, bring_front_click):
         assert wins.index(wids[0]) < wins.index(wids[1]) < wins.index(wids[2])
 
 
+@dualmonitor
 @bare_config
 def test_center_window(manager):
     """Check that floating windows are centered correctly."""
@@ -217,5 +218,17 @@ def test_center_window(manager):
     info = manager.c.window.info()
     assert info["x"] == (800 - 200) / 2  # (screen width - window width) / 2
     assert info["y"] == (600 - 100) / 2  # (screen height - window height) / 2
+    assert info["width"] == 200
+    assert info["height"] == 100
+
+    manager.c.window.togroup("b")  # Second screen
+    manager.c.to_screen(1)  # Focus screen
+    manager.c.group["b"].toscreen()  # Make sure group b is on that screen
+
+    # Second screen is 640x480 at offset (800, 0)
+    manager.c.window.center()
+    info = manager.c.window.info()
+    assert info["x"] == 800 + (640 - 200) / 2  # offset + (screen width - window width) / 2
+    assert info["y"] == (480 - 100) / 2  # (screen height - window height) / 2
     assert info["width"] == 200
     assert info["height"] == 100


### PR DESCRIPTION
Window.center() did not take account of screen offsets so windows would appear on the wrong screen when using multi-monitor setups.

Fixes #3912