### PR TITLE
Remove confusion in Key documentation

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -62,7 +62,8 @@ class Key:
     key:
         A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``.
     commands:
-        A list :class:`LazyCall` objects to evaluate in sequence upon keypress.
+        One or more :class:`LazyCall` objects to evaluate in sequence upon keypress. Multiple
+        commands should be separated by commas.
     desc:
         Description to be added to the key binding. (Optional)
 


### PR DESCRIPTION
Previously, the `commands` argument said users could provide a list of commands. This is incorrect and providing a list will result in an error.