### PR TITLE
Drop deprecated license_file from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 name = qtile
 url = https://qtile.org
 license = MIT
-license_file = LICENSE
 description = A pure-Python tiling window manager.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
From setuptools 56.0.0 (Apr 2021) license_file is deprecated. Instead we could use license_files, but by default it finds LICENSE so it's redundant. This just removes it.