### PR TITLE
WL: don't segfault when clients don't provide drag icons

### DIFF
--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -227,8 +227,8 @@ class Output(HasListeners):
         self, dnd: Dnd, now: Timespec, scale: float, transform_matrix: Matrix
     ) -> None:
         """Render the drag-n-drop icon if there is one."""
-        icon = dnd.wlr_drag.icon
-        if icon.mapped:
+        icon = dnd.icon
+        if icon is not None and icon.mapped:
             texture = icon.surface.get_texture()
             if texture:
                 box = Box(

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -191,10 +191,12 @@ class Dnd(HasListeners):
         self.height: int = 0
 
         self.add_listener(wlr_drag.destroy_event, self._on_destroy)
-        self.add_listener(wlr_drag.icon.map_event, self._on_icon_map)
-        self.add_listener(wlr_drag.icon.unmap_event, self._on_icon_unmap)
-        self.add_listener(wlr_drag.icon.destroy_event, self._on_icon_destroy)
-        self.add_listener(wlr_drag.icon.surface.commit_event, self._on_icon_commit)
+        self.icon = icon = wlr_drag.icon
+        if icon is not None:
+            self.add_listener(icon.map_event, self._on_icon_map)
+            self.add_listener(icon.unmap_event, self._on_icon_unmap)
+            self.add_listener(icon.destroy_event, self._on_icon_destroy)
+            self.add_listener(icon.surface.commit_event, self._on_icon_commit)
 
     def finalize(self) -> None:
         self.finalize_listeners()
@@ -218,9 +220,10 @@ class Dnd(HasListeners):
         logger.debug("Signal: wlr_drag_icon destroy")
 
     def _on_icon_commit(self, _listener: Listener, _event: Any) -> None:
-        self.width = self.wlr_drag.icon.surface.current.width
-        self.height = self.wlr_drag.icon.surface.current.height
-        self.position(self.core.cursor.x, self.core.cursor.y)
+        if self.icon is not None:
+            self.width = self.icon.surface.current.width
+            self.height = self.icon.surface.current.height
+            self.position(self.core.cursor.x, self.core.cursor.y)
 
     def position(self, cx: float, cy: float) -> None:
         self.x = cx

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ipython =
   jupyter_console
 wayland =
   pywayland>=0.4.14
-  pywlroots>=0.15.21,<0.16.0
+  pywlroots>=0.15.24,<0.16.0
   xkbcommon>=0.3
 
 [options.package_data]

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     pypy3: pip install cffi==1.15.0
     pip install xcffib>=0.10.1
     pip install cairocffi
-    pip install pywlroots>=0.15.21,<0.16.0
+    pip install pywlroots>=0.15.24,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
     # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
@@ -107,7 +107,7 @@ deps =
     types-pkg_resources
 commands =
     pip install -r requirements.txt pywayland>=0.4.14 xkbcommon>=0.3
-    pip install pywlroots>=0.15.21,<0.16.0
+    pip install pywlroots>=0.15.24,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
     pip install .


### PR DESCRIPTION
Sometimes they don't provide icons when dragging (e.g. chrome when dragging tabs). Thus `wlr_drag.icon` can be `None`.

Requires https://github.com/flacjacket/pywlroots/pull/107

Fixes #3894