### PR TITLE
Fire client_killed hook after client is removed from group

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -658,15 +658,20 @@ class Qtile(CommandObject):
     def unmanage(self, wid: int) -> None:
         c = self.windows_map.get(wid)
         if c:
-            hook.fire("client_killed", c)
+            group = None
             if isinstance(c, base.Static):
                 if c.reserved_space:
                     self.free_reserved_space(c.reserved_space, c.screen)
             elif isinstance(c, base.Window):
                 if c.group:
+                    group = c.group
                     c.group.remove(c)
             del self.windows_map[wid]
             self.core.update_client_list(self.windows_map)
+            if isinstance(c, base.Window):
+                # Put the group back on the window so hooked functions can access it.
+                c.group = group
+            hook.fire("client_killed", c)
 
     def find_screen(self, x: int, y: int) -> Screen | None:
         """Find a screen based on the x and y offset"""

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -70,8 +70,6 @@ class WindowCount(base._TextBox):
     def _win_killed(self, window):
         try:
             self._count = len(self.bar.screen.group.windows)
-            if window.group == self.bar.screen.group:
-                self._count -= 1
         except AttributeError:
             self._count = 0
 


### PR DESCRIPTION
I'm not sure why this isn't the case already but let's keep an eye out for issues that arise due to this. We want a killed window to be removed from its group so that hooked functions that cause the group to lay out and configure windows don't cause errors (e.g. a wlroots assertion is raised when configuring a killed window). However we want `c.group` to still point to the group because it's useful for hooked functions, and code already exists that use it so this stops that from breaking.

fixes #3513