### PR TITLE
Fix KeyChord stack bug

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -473,7 +473,7 @@ class Qtile(CommandObject):
         # Find another named mode or load the root keybindings:
         while self.chord_stack:
             chord = self.chord_stack.pop()
-            if chord.mode != "":
+            if chord.mode:
                 self.grab_chord(chord)
                 break
         else:


### PR DESCRIPTION
Changing `KeyChord.mode` to a boolean broke some functionality when using a stack of chords where non-modal chords were not exited on a keypress.

Fixes #3937