### PR TITLE
 Add GenPollCommand() widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to disable group toggling in `GroupBox` widget
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
           setting `border_focus_stack` and `border_normal_stack` variables.
+        - New widget: GenPollCommand
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
 

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -46,6 +46,7 @@ widgets = {
     "DF": "df",
     "GenPollText": "generic_poll_text",
     "GenPollUrl": "generic_poll_text",
+    "GenPollCommand": "generic_poll_text",
     "GmailChecker": "gmail_checker",
     "GroupBox": "groupbox",
     "HDDBusyGraph": "graph",

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -106,7 +106,7 @@ class GenPollCommand(base.ThreadPoolText):
 
     def __init__(self, **config):
         base.ThreadPoolText.__init__(self, "", **config)
-        self.add_defaults(Output.defaults)
+        self.add_defaults(GenPollCommand.defaults)
 
     def _configure(self, qtile, bar):
         base.ThreadPoolText._configure(self, qtile, bar)

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -92,3 +92,47 @@ class GenPollUrl(base.ThreadPoolText):
             text = "Can't parse"
 
         return text
+
+    
+class GenPollCommand(base.ThreadPoolText):
+    """A generic text widget to display output from scripts or shell commands"""
+
+    defaults = [
+        ("update_interval", 60,"update time in seconds"),
+        ("cmd", "date", "command line as a string or list of arguments to execute"),
+        ("shell", True, "run command through a shell to enable piping and shell expansion"),
+        ("text_before", "", "additional text to display before command output"),
+        ("text_after", "", "additional text to display after command output"),
+    ]
+
+    def __init__(self, **config):
+        base.ThreadPoolText.__init__(self, "", **config)
+        self.add_defaults(Output.defaults)
+
+    def _configure(self, qtile, bar):
+        base.ThreadPoolText._configure(self, qtile, bar)
+
+        self.text_before = str(self.text_before)
+        self.text_after = str(self.text_after)
+
+        self.add_callbacks({
+            "Button1": self.cmd_force_update,
+        })
+
+    def poll(self):
+        self.run_process()
+        return self.get_output()
+
+    def run_process(self):
+        self.completed_process = subprocess.run(
+            self.cmd,
+            capture_output=True,
+            text=True,
+            shell=self.shell,
+        )
+        return self.completed_process
+
+    def get_output(self):
+        output = self.completed_process.stdout.strip()
+        output = self.text_before + output + self.text_after
+        return str(output)

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
@@ -93,16 +94,14 @@ class GenPollUrl(base.ThreadPoolText):
 
         return text
 
-    
+
 class GenPollCommand(base.ThreadPoolText):
     """A generic text widget to display output from scripts or shell commands"""
 
     defaults = [
-        ("update_interval", 60,"update time in seconds"),
-        ("cmd", "date", "command line as a string or list of arguments to execute"),
-        ("shell", True, "run command through a shell to enable piping and shell expansion"),
-        ("text_before", "", "additional text to display before command output"),
-        ("text_after", "", "additional text to display after command output"),
+        ("update_interval", 60, "update time in seconds"),
+        ("cmd", None, "command line as a string or list of arguments to execute"),
+        ("shell", False, "run command through shell to enable piping and shell expansion"),
     ]
 
     def __init__(self, **config):
@@ -112,16 +111,12 @@ class GenPollCommand(base.ThreadPoolText):
     def _configure(self, qtile, bar):
         base.ThreadPoolText._configure(self, qtile, bar)
 
-        self.text_before = str(self.text_before)
-        self.text_after = str(self.text_after)
-
         self.add_callbacks({
-            "Button1": self.cmd_force_update,
+            "Button1": self.force_update,
         })
 
     def poll(self):
-        self.run_process()
-        return self.get_output()
+        return self.run_process().stdout.strip()
 
     def run_process(self):
         self.completed_process = subprocess.run(
@@ -131,8 +126,3 @@ class GenPollCommand(base.ThreadPoolText):
             shell=self.shell,
         )
         return self.completed_process
-
-    def get_output(self):
-        output = self.completed_process.stdout.strip()
-        output = self.text_before + output + self.text_after
-        return str(output)

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -110,19 +110,13 @@ class GenPollCommand(base.ThreadPoolText):
 
     def _configure(self, qtile, bar):
         base.ThreadPoolText._configure(self, qtile, bar)
-
-        self.add_callbacks({
-            "Button1": self.force_update,
-        })
+        self.add_callbacks({"Button1": self.force_update})
 
     def poll(self):
-        return self.run_process().stdout.strip()
-
-    def run_process(self):
-        self.completed_process = subprocess.run(
+        process = subprocess.run(
             self.cmd,
             capture_output=True,
             text=True,
             shell=self.shell,
         )
-        return self.completed_process
+        return process.stdout.strip()


### PR DESCRIPTION
Configuring GenPollText() to output scripts and shell command output can be tricky for new users. This new widget should make this task more easy and straight forward.