### PR TITLE
StatusNotifier - update icon on NewIcon signal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7 and pypy 3.7 are not longer supported.
+        - Fix bug where `StatusNotifier` does not update icons
 
 Qtile 0.22.0, released 2022-09-22:
     !!! Config breakage !!!


### PR DESCRIPTION
It appears the `NewIcon` signal is also emitted when the item should update the locally stored image. This PR adds a signal handler for this scenario.

Fixes #3952