### PR TITLE
Fix scratchpad spawn issue

### DIFF
--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -291,7 +291,6 @@ class ScratchPad(group._Group):
         name = None
         for name, dd in self.dropdowns.items():
             if dd.window is client:
-                dd.unsubscribe()
                 del self.dropdowns[name]
                 break
         self._check_unsubscribe()


### PR DESCRIPTION
0b028019 introduced a bug that, when you kill the dropdown, the `hide` method of the dropdown is being called before the `on_client_killed` method. This is an issue as `hide` unsubscribes some hooks (if `on_focus_lost_hide` is set to `True`) but `on_client_killed` also tries to unsubscribe these hooks and so raises an exception.