### PR TITLE
Add command to do interactive mac-like sliding between groups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
           setting `border_focus_stack` and `border_normal_stack` variables.
         - New widget: GenPollCommand
+        - Add `Swipe` and `Pinch` actions, similar to `Drag`, but for touchpad gestures.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -87,6 +87,18 @@ class Core(CommandObject, metaclass=ABCMeta):
     def ungrab_pointer(self) -> None:
         """Release grabbed pointer events"""
 
+    def start_slide_into_group(
+        self,
+        screen: config.Screen,
+        next_group: _Group,
+        prev_group: _Group,
+        scale: float,
+    ) -> None:
+        """Start a slide between groups, if supported."""
+
+    def slide_to_group(self, dx: int, dy: int) -> None:
+        """Continue a slide between groups, if supported."""
+
     def on_config_load(self, initial: bool) -> None:
         """
         Respond to config loading. `initial` will be `True` if Qtile just started.

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1468,5 +1468,4 @@ class Core(base.Core, wlrq.HasListeners):
         # End sequence
         if self._current_output:
             self._current_output.slide_state = None
-            # self._current_output.damage()
         self._slide_state = None

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.window import WindowType
-    from libqtile.backend.wayland.wlrq import Dnd
+    from libqtile.backend.wayland.wlrq import Dnd, SlideState
     from libqtile.config import Screen
 
 no_transform = WlOutput.transform.normal
@@ -61,6 +61,7 @@ class Output(HasListeners):
         self._damage: OutputDamage = OutputDamage(wlr_output)
         self.wallpaper: Texture | None = None
         self.x, self.y = self.output_layout.output_coords(wlr_output)
+        self.slide_state: SlideState | None = None
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)
         self.add_listener(self._damage.frame_event, self._on_frame)
@@ -126,8 +127,33 @@ class Output(HasListeners):
                     if self.wallpaper:
                         width, height = wlr_output.effective_resolution()
                         box = Box(0, 0, int(width * scale), int(height * scale))
-                        matrix = Matrix.project_box(box, no_transform, 0, transform_matrix)
-                        renderer.render_texture_with_matrix(self.wallpaper, matrix, 1)
+                        if self.slide_state:
+                            # Slide wallpaper
+                            box.x += self.slide_state.dx
+                            renderer.render_texture_with_matrix(
+                                self.wallpaper,
+                                Matrix.project_box(box, no_transform, 0, transform_matrix),
+                                1,
+                            )
+                            box.x -= width
+                            renderer.render_texture_with_matrix(
+                                self.wallpaper,
+                                Matrix.project_box(box, no_transform, 0, transform_matrix),
+                                1,
+                            )
+                            box.x += width * 2
+                            renderer.render_texture_with_matrix(
+                                self.wallpaper,
+                                Matrix.project_box(box, no_transform, 0, transform_matrix),
+                                1,
+                            )
+                        else:
+                            renderer.render_texture_with_matrix(
+                                self.wallpaper,
+                                Matrix.project_box(box, no_transform, 0, transform_matrix),
+                                1,
+                            )
+
                     else:
                         renderer.clear([0, 0, 0, 1])
 

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.window import WindowType
-    from libqtile.backend.wayland.wlrq import Dnd, SlideState
+    from libqtile.backend.wayland.wlrq import Dnd, GroupSlide
     from libqtile.config import Screen
 
 no_transform = WlOutput.transform.normal
@@ -61,7 +61,7 @@ class Output(HasListeners):
         self._damage: OutputDamage = OutputDamage(wlr_output)
         self.wallpaper: Texture | None = None
         self.x, self.y = self.output_layout.output_coords(wlr_output)
-        self.slide_state: SlideState | None = None
+        self.slide_state: GroupSlide | None = None
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)
         self.add_listener(self._damage.frame_event, self._on_frame)
@@ -83,6 +83,10 @@ class Output(HasListeners):
     def finalize(self) -> None:
         self.finalize_listeners()
         self.core.remove_output(self)
+
+        if slide := self.slide_state:
+            if slide.future:
+                slide.future.cancel()
 
     @property
     def screen(self) -> Screen:

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -42,7 +42,9 @@ if TYPE_CHECKING:
 
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.output import Output
+    from libqtile.backend.wayland.window import Window
     from libqtile.config import Screen
+    from libqtile.group import _Group
 
 
 class WlrQError(QtileError):
@@ -272,3 +274,21 @@ class CursorState:
     surface: Surface | None = None
     hotspot: tuple[int, int] = (0, 0)
     hidden: bool = False
+
+
+@dataclass()
+class SlideState:
+    """
+    The state of an ongoing slide between groups. Used by the core when the
+    `screen.start_slide_into_group` command is used. At the end of a group slide,
+    `Core.ungrab_pointer` can consume this data and discard it.
+    """
+
+    screen: Screen
+    next_group: _Group
+    prev_group: _Group
+    width: int
+    scale: float = 1.0
+    dx: int = 0
+    result: _Group | None = None
+    target_dx: int = 0

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -34,6 +34,7 @@ from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
+    import asyncio
     from typing import Any, Callable
 
     from pywayland.server import Signal
@@ -280,15 +281,17 @@ class CursorState:
 class SlideState:
     """
     The state of an ongoing slide between groups. Used by the core when the
-    `screen.start_slide_into_group` command is used. At the end of a group slide,
+    `screen.start_group_slide` command is used. At the end of a group slide,
     `Core.ungrab_pointer` can consume this data and discard it.
     """
 
     screen: Screen
-    next_group: _Group
-    prev_group: _Group
+    groups: list[_Group]
+    active_groups: tuple[_Group, _Group, _Group]
     width: int
-    scale: float = 1.0
+    index: int
+    scale: float
     dx: int = 0
     result: _Group | None = None
     target_dx: int = 0
+    future: asyncio.TimerHandle | None = None

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -39,7 +39,9 @@ from __future__ import annotations
 
 import functools
 import operator
+from dataclasses import dataclass
 from itertools import chain, repeat
+from typing import TYPE_CHECKING
 
 import cairocffi
 import cairocffi.pixbuf
@@ -56,6 +58,9 @@ from libqtile.backend.x11.xcursors import Cursors
 from libqtile.backend.x11.xkeysyms import keysyms
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError, hex
+
+if TYPE_CHECKING:
+    from libqtile.group import _Group
 
 
 class XCBQError(QtileError):
@@ -819,3 +824,21 @@ def translate_masks(modifiers: list[str]) -> int:
         return functools.reduce(operator.or_, masks)
     else:
         return 0
+
+
+@dataclass()
+class SlideState:
+    """
+    The state of an ongoing slide between groups. Used by the core when the
+    `screen.start_slide_into_group` command is used. At the end of a group slide,
+    `Core.ungrab_pointer` can consume this data and discard it.
+    """
+
+    screen: config.Screen
+    next_group: _Group
+    prev_group: _Group
+    width: int
+    scale: float = 1.0
+    dx: int = 0
+    result: _Group | None = None
+    target_dx: int = 0

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -780,9 +780,12 @@ class Screen(CommandObject):
         return (0, 0)
 
     @expose_command()
-    def slide_to_group(self, dx: int, dy: int) -> None:
+    def slide_to_group(self, dx: int, dy: int, invert: bool = False) -> None:
         """Used during interactive use of ``slide_to_group``."""
         assert self.qtile is not None
+        if invert:
+            dx = - dx
+            dy = - dy
         self.qtile.core.slide_to_group(dx, dy)
 
     @expose_command()

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -769,11 +769,12 @@ class Screen(CommandObject):
         # the slide, which must `group.set_screen(None, warp=False)` on these 2 groups
         # to undo this state. Then, it can do `screen.set_group(target_group)` on
         # whichever group is the desired end state.
-        next_group.set_screen(self, warp=False)
-        prev_group.set_screen(self, warp=False)
+        with self.qtile.core.masked():
+            next_group.set_screen(self, warp=False)
+            prev_group.set_screen(self, warp=False)
 
-        # Inform the backend so that it can prepare
-        self.qtile.core.start_slide_into_group(self, next_group, prev_group, scale)
+            # Inform the backend so that it can prepare
+            self.qtile.core.start_slide_into_group(self, next_group, prev_group, scale)
 
         # For use by drags, we just return some 0s which will be modified and passed to
         # `slide_to_group` below.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -169,8 +169,8 @@ class Drag(Mouse):
     start:
         A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
     warp_pointer:
-        A :class:`bool` indicating if the pointer should be warped to the bottom right of the window
-        at the start of dragging. (Default: `False`)
+        A :class:`bool` indicating if the pointer should be warped to the bottom right
+        of the current window at the start of dragging. (Default: `False`)
 
     """
 
@@ -209,6 +209,81 @@ class Click(Mouse):
 
     def __repr__(self) -> str:
         return "<Click (%s, %s)>" % (self.modifiers, self.button)
+
+
+class Swipe(Drag):
+    """
+    Bind commands to a touchpad swiping action (Wayland only).
+
+    On each motion event the bound commands are executed with two additional parameters
+    specifying the x and y offset from the previous position.
+
+    Parameters
+    ==========
+    modifiers:
+        A list of modifier specifications. Modifier specifications are one of:
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
+    fingers:
+        The number of fingers used in the swipe.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon movement.
+    start:
+        A :class:`LazyCall` object to be evaluated when swiping begins. (Optional)
+    warp_pointer:
+        A :class:`bool` indicating if the pointer should be warped to the bottom right
+        of the current window at the start of swiping. (Default: `False`)
+
+    """
+
+    def __init__(
+        self,
+        modifiers: list[str],
+        fingers: int,
+        *commands: LazyCall,
+        start: LazyCall | None = None,
+        warp_pointer: bool = False,
+    ) -> None:
+        self.modifiers = modifiers
+        self.fingers = fingers
+        self.commands = commands
+        self.start = start
+        self.warp_pointer = warp_pointer
+        self.button_code: int = 0  # So we can use the same `Qtile` handlers as `Mouse`
+        self.modmask: int = 0
+
+    def __repr__(self) -> str:
+        return "<Swipe (%s, %s)>" % (self.modifiers, self.fingers)
+
+
+class Pinch(Swipe):
+    """
+    Bind commands to a touchpad pinching action (Wayland only).
+
+    On each motion event the bound commands are executed with four additional
+    parameters: the x and y offset from the previous position, and the scale and
+    rotation relative to the start of the pinch.
+
+    Parameters
+    ==========
+    modifiers:
+        A list of modifier specifications. Modifier specifications are one of:
+        ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
+        ``"mod4"``, ``"mod5"``.
+    fingers:
+        The number of fingers used in the pinch.
+    commands:
+        A list :class:`LazyCall` objects to evaluate in sequence upon movement.
+    start:
+        A :class:`LazyCall` object to be evaluated when pinching begins. (Optional)
+    warp_pointer:
+        A :class:`bool` indicating if the pointer should be warped to the bottom right
+        of the current window at the start of pinching. (Default: `False`)
+
+    """
+
+    def __repr__(self) -> str:
+        return "<Pinch (%s, %s)>" % (self.modifiers, self.fingers)
 
 
 class EzConfig:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -744,11 +744,17 @@ class Screen(CommandObject):
         """
         assert self.qtile is not None
 
+        # TODO: deal with this circular import
+        from libqtile.scratchpad import ScratchPad
+
         if not groups:
             groups = self.qtile.groups
 
         # Remove groups visible on other screens
-        groups = list(filter(lambda g: g.screen in (None, self), groups))
+        groups = filter(lambda g: g.screen in (None, self), groups)
+
+        # Remove any scratchpads (which may be present in self.qtile.groups)
+        groups = list(filter(lambda g: not isinstance(g, ScratchPad), groups))
 
         # How this works:
         # 1. Set the two potential target groups to use this screen. This creates an

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -266,20 +266,15 @@ class GroupBox(_GroupBase):
         their label. Groups with an empty string as label are never contained.
         Groups that are not named in visible_groups are not returned.
         """
+        groups = filter(lambda g: g.label, self.qtile.groups)
+
         if self.hide_unused:
-            if self.visible_groups:
-                return [
-                    g
-                    for g in self.qtile.groups
-                    if g.label and (g.windows or g.screen) and g.name in self.visible_groups
-                ]
-            else:
-                return [g for g in self.qtile.groups if g.label and (g.windows or g.screen)]
-        else:
-            if self.visible_groups:
-                return [g for g in self.qtile.groups if g.label and g.name in self.visible_groups]
-            else:
-                return [g for g in self.qtile.groups if g.label]
+            groups = filter(lambda g: g.windows or g.screen, groups)
+
+        if self.visible_groups:
+            groups = filter(lambda g: g.name in self.visible_groups, groups)
+
+        return list(groups)
 
     def get_clicked_group(self):
         group = None

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -269,7 +269,7 @@ class GroupBox(_GroupBase):
         groups = filter(lambda g: g.label, self.qtile.groups)
 
         if self.hide_unused:
-            groups = filter(lambda g: g.windows or g.screen, groups)
+            groups = filter(lambda g: g.windows or (g.screen and g.screen.group is g), groups)
 
         if self.visible_groups:
             groups = filter(lambda g: g.name in self.visible_groups, groups)
@@ -361,7 +361,7 @@ class GroupBox(_GroupBase):
             else:
                 text_color = self.inactive
 
-            if g.screen:
+            if g.screen and g.screen.group is g:
                 if self.highlight_method == "text":
                     border = None
                     text_color = self.this_current_screen_border


### PR DESCRIPTION
Submitting to start discussion and get feedback and any eager testers :)

Note: the first 13 commits are from PR https://github.com/qtile/qtile/pull/3862 as the changes in this feature are based on that git history. That PR is mostly bug fixes and is ready for merge, but this one may need more discussion or work before merging, so I've kept them separate.

The remaining commits (starting from 89724d3728a31a3e278c4ff67b682acb5b202f08) do:

- add `Swipe` and `Pinch` configurables, subclasses of `Drag`, that similarly can be used for interactive actions. Unfortunately these are Wayland-exclusive. I don't know how they could be implemented in the X backend without a good amount of libinput wrapping C, which would essentially write `libinput-gestures` into our own codebase. The key difference between something like `libinput-gestures` and this feature is the maintained interactivity.
    - I'm unsure whether pinch bindings should be included, or just included yet. Swiping is essentially just a coordinate translation, like dragging, so shares much of the same code within the `Qtile` class. Pinching OTOH has a scaling component which would likely need to be relayed to any bound commands.
- Adds a command (with corresponding `start` command) to `Screen` that can be bound to `Drag` or `Swipe` to start the sequence.
- Adds an implementation for both X11 and Wayland backends.

See commit messages and in-code comments and the command docstrings for more info. If anyone tests this out and finds issues or has comments please feel free to post!