### PR TITLE
Fix Notify `CloseNotification` bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - New widget: GenPollCommand
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
+        - Fix `Notify` bug when apps close notifications.
 
 Qtile 0.22.0, released 2022-09-22:
     !!! Config breakage !!!

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -200,11 +200,9 @@ if has_dbus:
             return (notif, self.add(notif))
 
         def close(self, nid):
-            notif = self.notifications[nid]
-
             for callback in self.close_callbacks:
                 try:
-                    callback(notif)
+                    callback(nid)
                 except Exception:
                     logger.exception("Exception in notifier close callback")
 


### PR DESCRIPTION
`CloseNotification` tried to look up the notifcation by the id received by the method. However, the id was not zero indexed and so sending the ID of the last notification resulted in an IndexError.

This lookup was also redundant as the callbacks require the notification ID rather than the notification itself.

Fixes #3867