### PR TITLE
Add welcome message to first PR submitted by user

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,0 +1,24 @@
+name: PR Greetings
+
+on: [pull_request_target]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: >+
+            Thank you for opening your first PR into Qtile!
+
+            If you have not heard from us in a while, please feel free to ping
+            one of the devs or anyone who has commented on the PR, as sometimes
+            things fall through the cracks.
+
+            You can also join the chat room for real-time discussion, see the
+            [community links](https://github.com/qtile/qtile#community).
+
+            For details on what PRs might need to be include please see [the
+            docs](http://docs.qtile.org/en/stable/manual/contributing.html#submit-a-pull-request).


### PR DESCRIPTION
This adds a github workflow that applies to when a github user submits their first Qtile PR. It posts a message welcoming them, inviting them to ping someone if needed, to join the chat, and points them to the PR docs.