### PR TITLE
WL: don't warp cursor when sending keyboard focus to layer surfaces

### DIFF
--- a/libqtile/backend/wayland/layer.py
+++ b/libqtile/backend/wayland/layer.py
@@ -103,7 +103,7 @@ class LayerStatic(Static[LayerSurfaceV1]):
         logger.debug("Signal: layerstatic map")
         self.mapped = True
         self.output.organise_layers()
-        self.focus(True)
+        self.focus(False)
 
     def _on_unmap(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: layerstatic unmap")


### PR DESCRIPTION
These windows are like notifications and bars etc so it doesn't make sense to warp the cursor to them.