### PR TITLE
Fix missing screenshots bug in docs build

### DIFF
--- a/docs/sphinx_qtile.py
+++ b/docs/sphinx_qtile.py
@@ -163,7 +163,7 @@ class QtileClass(SimpleDirectiveMixin, Directive):
             try:
                 with open(index, "r") as f:
                     shots = json.load(f)
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, FileNotFoundError):
                 shots = {}
 
             widget_shots = shots.get(class_name.lower(), dict())


### PR DESCRIPTION
When building the docs, our sphinx code looks for a json file which indexes the available screenshots.

The only avaiable error handling was for a decode error but the build would crash if no json file was found at all.

Fixes #3964