### PR TITLE
Add decorator to hide commands

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -86,6 +86,20 @@ def expose_command(name: Callable | str | list[str] | None = None) -> Callable:
     return wrapper
 
 
+def hide_command(func: Callable) -> Callable:
+    """
+    Decorator to hide a previously exposed command.
+
+    This should be used when an object inherits from an existing
+    CommandObject but does not implement certain methods.
+
+    The decorator should be used by creating a method with the same name
+    and decorating it with `@hide_command`.
+    """
+    setattr(func, "_hide_cmd", True)
+    return func
+
+
 class SelectError(Exception):
     """Error raised in resolving a command graph object"""
 
@@ -137,6 +151,10 @@ class CommandObject(metaclass=abc.ABCMeta):
                 method = getattr(c, method_name, None)
 
                 if method is None:
+                    continue
+
+                if hasattr(method, "_hide_cmd") and method_name in commands:
+                    del commands[method_name]
                     continue
 
                 # If the command has been exposed, add it to our dictionary

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -31,7 +31,7 @@ import libqtile.confreader
 import libqtile.layout
 import libqtile.log_utils
 import libqtile.widget
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.base import CommandObject, expose_command, hide_command
 from libqtile.command.interface import CommandError
 from libqtile.confreader import Config
 from libqtile.lazy import lazy
@@ -113,6 +113,12 @@ class FakeCommandObject(CommandObject):
         return None
 
 
+class HiddenCommandObject(FakeCommandObject):
+    @hide_command
+    def two(self):
+        pass
+
+
 def test_doc():
     c = FakeCommandObject()
     assert "one()" in c.doc("one")
@@ -130,6 +136,11 @@ def test_command():
     c = FakeCommandObject()
     assert c.command("one")
     assert not c.command("nonexistent")
+
+
+def test_hidden_commands():
+    c = HiddenCommandObject()
+    assert len(c.commands()) == 8
 
 
 class DecoratedTextBox(libqtile.widget.TextBox):


### PR DESCRIPTION
By default, when an object inherits from a CommandObject, any methods that were exposed on the command graph will also be exposed for the child, regardless of whether the method is explicitly decorated or not.

Sometimes, we may want methods to be hidden (e.g. when they are not appropriate for the child object). This PR adds a decorator that will hide methods from the graph.


@m-col the context for this is #4001 where the `grow_left/right` commands don't make sense for the `MonadWide` layout.

This is more of a "nice to have" so don't mind if you don't like it!