### PR TITLE
Fix pep8 test failures

### DIFF
--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -95,13 +95,13 @@ class RunCommand(_Extension):
     `client <http://docs.qtile.org/en/latest/manual/commands/scripting.html>`_.
     """
 
-    defaults = [
+    defaults: list[tuple[str, Any, str]] = [
         # NOTE: Do not use a list as a default value, since it would be shared
         #       among all the objects inheriting this class, and if one of them
         #       modified it, all the other objects would see the modified list;
         #       use a string or a tuple instead, which are immutable
         ("command", None, "the command to be launched (string or list with arguments)"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, **config):
         _Extension.__init__(self, **config)

--- a/libqtile/extension/base.py
+++ b/libqtile/extension/base.py
@@ -21,7 +21,6 @@
 import re
 import shlex
 from subprocess import PIPE, Popen
-from typing import Any
 
 from libqtile import configurable
 from libqtile.log_utils import logger
@@ -95,7 +94,7 @@ class RunCommand(_Extension):
     `client <http://docs.qtile.org/en/latest/manual/commands/scripting.html>`_.
     """
 
-    defaults: list[tuple[str, Any, str]] = [
+    defaults = [
         # NOTE: Do not use a list as a default value, since it would be shared
         #       among all the objects inheriting this class, and if one of them
         #       modified it, all the other objects would see the modified list;

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
     """This class defines the API that should be exposed by all layouts"""
 
-    defaults = []  # type: list[tuple[str, Any, str]]
+    defaults: list[tuple[str, Any, str]] = []
 
     def __init__(self, **config):
         # name is a little odd; we can't resolve it until the class is defined

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -29,15 +29,13 @@ from libqtile import configurable
 from libqtile.command.base import CommandObject, expose_command
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from libqtile.command.base import ItemT
 
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
     """This class defines the API that should be exposed by all layouts"""
 
-    defaults: list[tuple[str, Any, str]] = []
+    defaults = []
 
     def __init__(self, **config):
         # name is a little odd; we can't resolve it until the class is defined

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -138,14 +138,14 @@ class _Widget(CommandObject, configurable.Configurable):
 
     offsetx: int = 0
     offsety: int = 0
-    defaults = [
+    defaults: list[tuple[str, Any, str]] = [
         ("background", None, "Widget background color"),
         (
             "mouse_callbacks",
             {},
             "Dict of mouse button press callback functions. Accepts functions and ``lazy`` calls.",
         ),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, length, **config):
         """

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -44,8 +44,6 @@ from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from libqtile.command.base import ItemT
 
 # Each widget class must define which bar orientation(s) it supports by setting
@@ -138,7 +136,7 @@ class _Widget(CommandObject, configurable.Configurable):
 
     offsetx: int = 0
     offsety: int = 0
-    defaults: list[tuple[str, Any, str]] = [
+    defaults = [
         ("background", None, "Widget background color"),
         (
             "mouse_callbacks",
@@ -452,7 +450,7 @@ class _TextBox(_Widget):
             "Whether text should scroll completely away (True) or stop when the end of the text is shown (False)",
         ),
         ("scroll_hide", False, "Whether the widget should hide when scrolling has finished"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         self.layout = None
@@ -719,7 +717,7 @@ class InLoopPollText(_TextBox):
             "Update interval in seconds, if none, the "
             "widget updates whenever the event loop is idle.",
         ),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, default_text="N/A", **config):
         _TextBox.__init__(self, default_text, **config)
@@ -774,7 +772,7 @@ class ThreadPoolText(_TextBox):
             600,
             "Update interval in seconds, if none, the " "widget updates whenever it's done.",
         ),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, text, **config):
         super().__init__(text, **config)
@@ -829,7 +827,7 @@ class PaddingMixin(configurable.Configurable):
         ("padding", 3, "Padding inside the box"),
         ("padding_x", None, "X Padding. Overrides 'padding' if set"),
         ("padding_y", None, "Y Padding. Overrides 'padding' if set"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     padding_x = configurable.ExtraFallback("padding_x", "padding")
     padding_y = configurable.ExtraFallback("padding_y", "padding")
@@ -847,7 +845,7 @@ class MarginMixin(configurable.Configurable):
         ("margin", 3, "Margin inside the box"),
         ("margin_x", None, "X Margin. Overrides 'margin' if set"),
         ("margin_y", None, "Y Margin. Overrides 'margin' if set"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     margin_x = configurable.ExtraFallback("margin_x", "margin")
     margin_y = configurable.ExtraFallback("margin_y", "margin")

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -48,8 +48,6 @@ from libqtile.utils import send_notification
 from libqtile.widget import base
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from libqtile.utils import ColorsType
 
 
@@ -456,7 +454,7 @@ class BatteryIcon(base._Widget):
         ("update_interval", 60, "Seconds between status updates"),
         ("theme_path", default_icon_path(), "Path of the icons"),
         ("scale", 1, "Scale factor relative to the bar height.  " "Defaults to 1"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     icon_names = (
         "battery-missing",
@@ -486,7 +484,7 @@ class BatteryIcon(base._Widget):
         self.length_type = bar.STATIC
         self.length = 0
         self.image_padding = 0
-        self.surfaces = {}  # type: dict[str, Img]
+        self.surfaces: dict[str, Img] = {}
         self.current_icon = "battery-missing"
 
         self._battery = self._load_battery(**config)

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -48,7 +47,7 @@ class GenPollUrl(base.ThreadPoolText):
         ("user_agent", "Qtile", "Set the user agent"),
         ("headers", {}, "Extra Headers"),
         ("xml", False, "Is XML?"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, **config):
         base.ThreadPoolText.__init__(self, "", **config)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -32,7 +32,6 @@
 
 import itertools
 from functools import partial
-from typing import Any
 
 from libqtile import hook
 from libqtile.widget import base
@@ -42,7 +41,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
     defaults = [
         ("borderwidth", 3, "Current group border width"),
         ("center_aligned", True, "center-aligned group box"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, **config):
         base._TextBox.__init__(self, **config)

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 import time
-from typing import Any
 from urllib.parse import urlencode
 
 from libqtile.widget.generic_poll_text import GenPollUrl
@@ -255,7 +254,7 @@ class OpenWeather(GenPollUrl):
             dict(),
             "Dictionary of weather symbols. Can be used to override default symbols.",
         ),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, **config):
         GenPollUrl.__init__(self, **config)

--- a/libqtile/widget/textbox.py
+++ b/libqtile/widget/textbox.py
@@ -22,9 +22,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from typing import Any
-
 from libqtile import bar
 from libqtile.command.base import expose_command
 from libqtile.widget import base
@@ -39,7 +36,7 @@ class TextBox(base._TextBox):
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
         ("padding", None, "Padding left and right. Calculated if None."),
         ("foreground", "#ffffff", "Foreground colour."),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, text=text, width=width, **config)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -19,15 +19,10 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from libqtile import bar
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
-
-if TYPE_CHECKING:
-    from typing import Any
 
 
 class WidgetBox(base._Widget):
@@ -68,7 +63,7 @@ class WidgetBox(base._Widget):
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
         ("widgets", list(), "A list of widgets to include in the box"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, _widgets: list[base._Widget] | None = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -33,7 +33,7 @@ class WindowCount(base._TextBox):
     current group of the screen on which the widget is.
     """
 
-    defaults = [
+    defaults: list[tuple[str, Any, str]] = [
         ("font", "sans", "Text font"),
         ("fontsize", None, "Font pixel size. Calculated if None."),
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),
@@ -41,7 +41,7 @@ class WindowCount(base._TextBox):
         ("foreground", "#ffffff", "Foreground colour."),
         ("text_format", "{num}", "Format for message"),
         ("show_zero", False, "Show window count when no windows"),
-    ]  # type: list[tuple[str, Any, str]]
+    ]
 
     def __init__(self, width=bar.CALCULATED, **config):
         base._TextBox.__init__(self, width=width, **config)

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -20,8 +20,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from libqtile import bar, hook
 from libqtile.command.base import expose_command
 from libqtile.widget import base
@@ -33,7 +31,7 @@ class WindowCount(base._TextBox):
     current group of the screen on which the widget is.
     """
 
-    defaults: list[tuple[str, Any, str]] = [
+    defaults = [
         ("font", "sans", "Text font"),
         ("fontsize", None, "Font pixel size. Calculated if None."),
         ("fontshadow", None, "font shadow color, default is None(no shadow)"),


### PR DESCRIPTION
flake8 and pyflakes have dropped support for type comments so we had a number of test failures as a result.

This PR addresses this by replacing the type comments with type annotations.

Fixes #4021


I'm expecting this to fail on mypy because there must have been a reason that we used type comments in the first place. However, I can't run `tox -e mypy` as I'm getting some wayland-related build errors! 