### PR TITLE
Better logging of errors in eventloop

### DIFF
--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -54,13 +54,12 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
         loop: asyncio.AbstractEventLoop,
         context: dict,
     ) -> None:
-        # message is always present, but we'd prefer the exception if available
         if "exception" in context:
             exc = context["exception"]
             # CancelledErrors happen when we simply cancel the main task during
             # a normal restart procedure
             if not isinstance(exc, asyncio.CancelledError):
-                logger.error(exc)
+                logger.exception("Exception in event loop:")
         else:
             logger.error("unhandled error in event loop: %s", context["msg"])
 


### PR DESCRIPTION
The current exception handler just prints the exception but this does not include any reference to the function that raised the error.

Adding the `message` provides some additional information.

As an example:

Before the change:
`2022-11-27 17:52:06,647 libqtile loop.py:_handle_exception():L63  Expecting value: line 1 column 1 (char 0).`

No idea which object is causing this, or what type of error it is.

After the change:
`2022-11-27 18:00:09,051 libqtile loop.py:_handle_exception():L62  Expecting value: line 1 column 1 (char 0). Exception in callback TVHWidget._read_data(<Future finis... 1 (char 0)')>).`

However, we've still lost the fact that this is a `JSONDecodeError` which is annoying as the handler's `context` contains this:
```{'message': "Exception in callback TVHWidget._read_data(<Future finis... 1 (char 0)')>)", 'exception': JSONDecodeError('Expecting value: line 1 column 1 (char 0)'), 'handle': <Handle TVHWidget._read_data(<Future finis... 1 (char 0)')>)>}```