### PR TITLE
Add Ability to Add Group at a specified index

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
           setting `border_focus_stack` and `border_normal_stack` variables.
         - New widget: GenPollCommand
+        - Add ability to add a group at a specified index
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -519,10 +519,15 @@ class Qtile(CommandObject):
         layout: str | None = None,
         layouts: list[Layout] | None = None,
         label: str | None = None,
+        index: int | None = None,
     ) -> bool:
         if name not in self.groups_map.keys():
             g = _Group(name, layout, label=label)
-            self.groups.append(g)
+            if index is None:
+                self.groups.append(g)
+            else:
+                self.groups.insert(index, g)
+
             if not layouts:
                 layouts = self.config.layouts
             g._configure(layouts, self.config.floating_layout, self)
@@ -1564,9 +1569,12 @@ class Qtile(CommandObject):
         label: str | None = None,
         layout: str | None = None,
         layouts: list[Layout] | None = None,
+        index: int | None = None,
     ) -> bool:
         """Add a group with the given name"""
-        return self.add_group(name=group, layout=layout, layouts=layouts, label=label)
+        return self.add_group(
+            name=group, layout=layout, layouts=layouts, label=label, index=index
+        )
 
     @expose_command()
     def delgroup(self, group: str) -> None:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -520,6 +520,16 @@ def test_adddelgroup(manager):
 
 
 @manager_config
+def test_addgroupat(manager):
+    manager.test_window("one")
+    group_count = len(manager.c.get_groups())
+    manager.c.addgroup("aa", index=1)
+
+    assert len(manager.c.get_groups()) == group_count + 1
+    assert list(manager.c.get_groups())[1] == "aa"
+
+
+@manager_config
 def test_delgroup(manager):
     manager.test_window("one")
     for i in ["a", "d", "c"]:


### PR DESCRIPTION
My use case necessitated the ability to add a group at a specific position in order for the GroupBox widget to update correctly.