### PR TITLE
Fix `PulseVolume` `theme_path` bug

### DIFF
--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -246,8 +246,8 @@ class PulseVolume(Volume):
         return -1
 
     def timer_setup(self):
+        if self.theme_path:
+            self.setup_images()
         self.poll()
         if self.update_interval is not None:
             self.timeout_add(self.update_interval, self.timer_setup)
-        if self.theme_path:
-            self.setup_images()


### PR DESCRIPTION
Widget tried to draw the icons before loading the images from the provided `theme_path`.

This solves issue #4039

To make sure this change solves the issue, I modified file `/usr/lib/python3.10/site-packages/libqtile/widget/pulse_volume.py` with the changes in the PR and it works fine.

Screenshot after the changes:
![image](https://user-images.githubusercontent.com/5770755/205949957-f5283071-e7ef-4782-b824-c612d3139e3e.png)
