### PR TITLE
Warn when config duplicates Key mod+key spec

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -436,8 +436,10 @@ class Qtile(CommandObject):
 
     def grab_key(self, key: Key | KeyChord) -> None:
         """Grab the given key event"""
-        keysym, mask_key = self.core.grab_key(key)
-        self.keys_map[(keysym, mask_key)] = key
+        syms = self.core.grab_key(key)
+        if syms in self.keys_map:
+            logger.warning("Key spec duplicated, overriding previous: %s", key)
+        self.keys_map[syms] = key
 
     def ungrab_key(self, key: Key | KeyChord) -> None:
         """Ungrab a given key event"""


### PR DESCRIPTION
An alternative would be to ignore the duplicate (keep the first), or support specifying multiple `Key`s and keep lists in `self.keys_map` (which is already what `self.mouse_map` does, so one can actually specify multiple `Mouse` instances which get sequentially triggered).

However, as is this does not change behaviour.