### PR TITLE
Fix icon position in BatteryIcon

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -486,7 +486,7 @@ class BatteryIcon(base._Widget):
         self.length_type = bar.STATIC
         self.length = 0
         self.image_padding = 0
-        self.surfaces: dict[str, Img] = {}
+        self.images: dict[str, Img] = {}
         self.current_icon = "battery-missing"
 
         self._battery = self._load_battery(**config)
@@ -518,7 +518,7 @@ class BatteryIcon(base._Widget):
             img.resize(height=new_height)
             if img.width > self.length:
                 self.length = int(img.width + self.image_padding * 2)
-            self.surfaces[key] = img.pattern
+            self.images[key] = img
 
     def update(self) -> None:
         status = self._battery.update_status()
@@ -529,8 +529,12 @@ class BatteryIcon(base._Widget):
 
     def draw(self) -> None:
         self.drawer.clear(self.background or self.bar.background)
-        self.drawer.ctx.set_source(self.surfaces[self.current_icon])
+        image = self.images[self.current_icon]
+        self.drawer.ctx.save()
+        self.drawer.ctx.translate(0, (self.bar.height - image.height) // 2)
+        self.drawer.ctx.set_source(image.pattern)
         self.drawer.ctx.paint()
+        self.drawer.ctx.restore()
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
 
     @staticmethod

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -1,4 +1,3 @@
-import cairocffi
 import pytest
 
 from libqtile import images
@@ -193,9 +192,9 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     batt.fontsize = 12
     batt.bar = fake_bar
     batt.setup_images()
-    assert len(batt.surfaces) == len(BatteryIcon.icon_names)
-    for name, surfpat in batt.surfaces.items():
-        assert isinstance(surfpat, cairocffi.SurfacePattern)
+    assert len(batt.images) == len(BatteryIcon.icon_names)
+    for name, img in batt.images.items():
+        assert isinstance(img, images.Img)
 
 
 def test_images_default(fake_bar):
@@ -207,9 +206,9 @@ def test_images_default(fake_bar):
     batt.fontsize = 12
     batt.bar = fake_bar
     batt.setup_images()
-    assert len(batt.surfaces) == len(BatteryIcon.icon_names)
-    for name, surfpat in batt.surfaces.items():
-        assert isinstance(surfpat, cairocffi.SurfacePattern)
+    assert len(batt.images) == len(BatteryIcon.icon_names)
+    for name, img in batt.images.items():
+        assert isinstance(img, images.Img)
 
 
 def test_battery_background(fake_qtile, fake_window, monkeypatch):


### PR DESCRIPTION
BatteryIcon icons were not positioned correctly vertically when a scale other than 1 was applied. This PR fixes that by applying a translation before painting the icon to the drawer..

Fixes #4043