### PR TITLE
WidgetBox: add box_is_open default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
           setting `border_focus_stack` and `border_normal_stack` variables.
         - New widget: GenPollCommand
-        - Add ability to add a group at a specified index
+		- Add ability to add a group at a specified index
+		- Add ability to open the `WidgetBox` widgets at startup.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,8 +26,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to have different border color when windows are stacked in Stack layout. Requires 
           setting `border_focus_stack` and `border_normal_stack` variables.
         - New widget: GenPollCommand
-		- Add ability to add a group at a specified index
-		- Add ability to open the `WidgetBox` widgets at startup.
+        - Add ability to add a group at a specified index
+        - Add ability to open the `WidgetBox` widgets at startup.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -67,13 +67,13 @@ class WidgetBox(base._Widget):
         ),
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
+        ("box_is_open", False, "Default box state"),
         ("widgets", list(), "A list of widgets to include in the box"),
     ]
 
     def __init__(self, _widgets: list[base._Widget] | None = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
-        self.box_is_open = False
         self.add_callbacks({"Button1": self.toggle})
 
         if _widgets:
@@ -124,6 +124,10 @@ class WidgetBox(base._Widget):
         # Disable drawing of the widget's contents
         for w in self.widgets:
             w.drawer.disable()
+
+        if self.box_is_open:
+            self.box_is_open = False
+            self.toggle()
 
     def calculate_length(self):
         return self.layout.width

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -179,6 +179,3 @@ class WidgetBox(base._Widget):
         self.toggle_widgets()
         self.set_box_label()
         self.bar.draw()
-
-    def finalize(self):
-        base._Widget.finalize(self)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from libqtile import bar
+from libqtile import bar, hook
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
@@ -68,6 +68,7 @@ class WidgetBox(base._Widget):
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
         ("widgets", list(), "A list of widgets to include in the box"),
+        ("start_opened", False, "Open the box at startup"),
     ]
 
     def __init__(self, _widgets: list[base._Widget] | None = None, **config):
@@ -88,6 +89,9 @@ class WidgetBox(base._Widget):
             val = self.close_button_location
             logger.warning("Invalid value for 'close_button_location': %s", val)
             self.close_button_location = "left"
+
+        if self.start_opened:
+            hook.subscribe.startup(self.toggle)
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
@@ -175,3 +179,8 @@ class WidgetBox(base._Widget):
         self.toggle_widgets()
         self.set_box_label()
         self.bar.draw()
+
+    def finalize(self):
+        if self.start_opened:
+            hook.unsubscribe.startup(self.toggle)
+        base._Widget.finalize(self)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -91,7 +91,7 @@ class WidgetBox(base._Widget):
             self.close_button_location = "left"
 
         if self.start_opened:
-            hook.subscribe.startup(self.toggle)
+            hook.subscribe.startup_once(self.toggle)
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
@@ -181,6 +181,4 @@ class WidgetBox(base._Widget):
         self.bar.draw()
 
     def finalize(self):
-        if self.start_opened:
-            hook.unsubscribe.startup(self.toggle)
         base._Widget.finalize(self)

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -67,13 +67,13 @@ class WidgetBox(base._Widget):
         ),
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
-        ("box_is_open", False, "Default box state"),
         ("widgets", list(), "A list of widgets to include in the box"),
     ]
 
     def __init__(self, _widgets: list[base._Widget] | None = None, **config):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WidgetBox.defaults)
+        self.box_is_open = False
         self.add_callbacks({"Button1": self.toggle})
 
         if _widgets:
@@ -124,10 +124,6 @@ class WidgetBox(base._Widget):
         # Disable drawing of the widget's contents
         for w in self.widgets:
             w.drawer.disable()
-
-        if self.box_is_open:
-            self.box_is_open = False
-            self.toggle()
 
     def calculate_length(self):
         return self.layout.width

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -76,9 +76,7 @@ def test_widgetbox_start_opened(manager_nospawn, minimal_conf_noscreen):
     config = minimal_conf_noscreen
     tbox = TextBox(text="Text Box")
     widget_box = WidgetBox(widgets=[tbox], start_opened=True)
-    config.screens = [
-        libqtile.config.Screen(top=libqtile.bar.Bar([widget_box], 10))
-    ]
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([widget_box], 10))]
 
     manager_nospawn.start(config)
 

--- a/test/widgets/test_widgetbox.py
+++ b/test/widgets/test_widgetbox.py
@@ -72,6 +72,21 @@ def test_widgetbox_widget(fake_qtile, fake_window):
     assert fakebar.widgets == [tb_one, tb_two, widget_box]
 
 
+def test_widgetbox_start_opened(manager_nospawn, minimal_conf_noscreen):
+    config = minimal_conf_noscreen
+    tbox = TextBox(text="Text Box")
+    widget_box = WidgetBox(widgets=[tbox], start_opened=True)
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([widget_box], 10))
+    ]
+
+    manager_nospawn.start(config)
+
+    topbar = manager_nospawn.c.bar["top"]
+    widgets = [w["name"] for w in topbar.info()["widgets"]]
+    assert widgets == ["widgetbox", "textbox"]
+
+
 def test_widgetbox_mirror(manager_nospawn, minimal_conf_noscreen):
     config = minimal_conf_noscreen
     tbox = TextBox(text="Text Box")


### PR DESCRIPTION
This Pull Request adds a `box_is_open` "default" in widgetbox, so widgetbox can be opened by default.
My setup:
```
widget.WidgetBox(widgets=[
                    ...
                ], foreground=foreground, ..., box_is_open=True),
```
When I launch qtile, half of the widgets in the box are not displayed.
![](https://i.imgur.com/T4jq4nM.png)

Can anyone help me solve this bug? I can't figure out on my own.