### PR TITLE
Add ability to move current window to Slice

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to add a group at a specified index
         - Add ability to open the `WidgetBox` widgets at startup.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
+        - Add `move_to_slice` command to move current window to single layout in `Slice` layout
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/test/layouts/test_slice.py
+++ b/test/layouts/test_slice.py
@@ -162,3 +162,28 @@ def test_command_propagation_direct_call(manager):
     org_height = manager.c.window.info()["height"]
     manager.c.layout.eval("self.toggle_split()")
     assert manager.c.window.info()["height"] != org_height
+
+
+@slice_config
+def test_move_to_slice(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    info = manager.c.layout.info()
+
+    # Neither of these windows should be in the slice
+    assert not info["single"]["window"]
+
+    # Move current window to slice
+    manager.c.layout.move_to_slice()
+    info = manager.c.layout.info()
+    assert info["single"]["window"] == "two"
+    assert info["stack"]["clients"] == ["one"]
+    assert_focused(manager, "two")
+
+    # Switch focus to "one" and put it in slice
+    manager.c.group.focus_back()
+    assert_focused(manager, "one")
+    manager.c.layout.move_to_slice()
+    info = manager.c.layout.info()
+    assert info["single"]["window"] == "one"
+    assert info["stack"]["clients"] == ["two"]


### PR DESCRIPTION
Currently, only windows matching the defined rule can be added to the single layout in `Slice`. This PR adds a new `move_to_slice` command to move the current window to the slice.