### PR TITLE
Adding exc_info to asyncio's exception handler

### DIFF
--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -59,7 +59,7 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
             # CancelledErrors happen when we simply cancel the main task during
             # a normal restart procedure
             if not isinstance(exc, asyncio.CancelledError):
-                logger.exception("Exception in event loop:")
+                logger.exception("Exception in event loop:", exc_info=exc)  # noqa: G202
         else:
             logger.error("unhandled error in event loop: %s", context["msg"])
 


### PR DESCRIPTION
As per discussion in #4026, we do need `exc_info` to be passed here.