### PR TITLE
Fix CPU widget for psutil bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.
+        - Fix `CPU` precision bug with specific version of `psutil`
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/widget/cpu.py
+++ b/libqtile/widget/cpu.py
@@ -50,7 +50,10 @@ class CPU(base.ThreadPoolText):
 
         variables["load_percent"] = round(psutil.cpu_percent(), 1)
         freq = psutil.cpu_freq()
-        variables["freq_current"] = round(freq.current / 1000, 1)
+        if psutil.__version__ == "5.9.0":
+            variables["freq_current"] = round(freq.current, 1)
+        else:
+            variables["freq_current"] = round(freq.current / 1000, 1)
         variables["freq_max"] = round(freq.max / 1000, 1)
         variables["freq_min"] = round(freq.min / 1000, 1)
 

--- a/test/widgets/test_cpu.py
+++ b/test/widgets/test_cpu.py
@@ -31,6 +31,8 @@ from libqtile.bar import Bar
 
 
 class MockPsutil(ModuleType):
+    __version__ = "5.8.0"
+
     @classmethod
     def cpu_percent(cls):
         return 2.6


### PR DESCRIPTION
This is to replace #3503. I didn't rebase that PR as it's on that user's `master` branch and I'm not comfortable force pushing to that.

This addresses the issue in psutil 5.9.0 where the cpu frequency is provided with the wrong precision.