### PR TITLE
add YandexDisk widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to add a group at a specified index
         - Add ability to open the `WidgetBox` widgets at startup.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
+        - New widget: YandexDisk
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -94,6 +94,7 @@ widgets = {
     "WindowTabs": "windowtabs",
     "Wlan": "wlan",
     "Wttr": "wttr",
+    "YandexDisk": "yandexdisk",
 }
 
 __all__, __dir__, __getattr__ = lazify_imports(widgets, __package__, fallback=make_error)

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -24,7 +24,7 @@ from libqtile.widget import base
 
 
 class YandexDisk(base.InLoopPollText):
-    """A simple widget to show YandexDisk folder sync status.
+    """A simple widget to show YandexDisk client folder sync status.
 
     Yandex.Disk_ is a service that lets you store files on Yandex servers.
 

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -23,6 +23,13 @@ import os
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
+status_mapping = {
+    "idle": "IDLE",
+    "stopped": "STOPPED",
+    "busy": "BUSY",
+    "index": "INDEX",
+}
+
 
 class YandexDisk(base.InLoopPollText):
     """A simple widget to show YandexDisk client folder sync status.
@@ -35,11 +42,7 @@ class YandexDisk(base.InLoopPollText):
 
     defaults = [
         ("sync_folder", "~/Yandex.Disk/", "Yandex.Disk folder path"),
-        (
-            "daemon_stopped",
-            "Error: daemon not started",
-            "Text when Yandex.Disk daemon is stopped",
-        ),
+        ("status_mapping", status_mapping, "Sync status mapping"),
         ("update_interval", 10, "The delay in seconds between updates"),
         ("format", "{status}", "Display format"),
     ]
@@ -58,15 +61,18 @@ class YandexDisk(base.InLoopPollText):
 
     def _get_status(self):
         with open(self.sync_folder, "r") as file:
-            return file.read().split("\n")[-1]
+            status = file.read().split("\n")[-1]
+            return status
 
     def poll(self):
         try:
             status = self._get_status()
         except FileNotFoundError:
-            return self.daemon_stopped
+            status = "stopped"
         except Exception:
             logger.exception("Error getting status for yandex.disk")
             return "Error"
+
+        status = self.status_mapping.get(status, status)
 
         return self.format.format(status=status)

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -58,6 +58,8 @@ class YandexDisk(base.InLoopPollText):
     def poll(self):
         try:
             status = self._get_status()
+        except FileNotFoundError:
+            return "Error: daemon not started"
         except Exception:
             logger.exception("Error getting status for yandex.disk")
             return "Error"

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -58,6 +58,7 @@ class YandexDisk(base.InLoopPollText):
         try:
             status = self._get_status()
         except Exception as e:
-            return f"Error: {e}"
+            logger.exception("Error getting status for yandex.disk")
+            return "Error"
 
         return self.format.format(status=status)

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -110,13 +110,13 @@ class YandexDisk(base.InLoopPollText):
 
     @staticmethod
     def _get_progress_log_dict(log_data):
-        file_size = int(log_data.pop(-1))
+        total_size = int(log_data.pop(-1))
         log_data.pop(-1)
         synced_size = int(log_data.pop(-1))
         filename = " ".join(log_data)
         return {
             "filename": filename,
             "synced_size": synced_size,
-            "file_size": file_size,
-            "percentage": int((synced_size / file_size) * 100),
+            "total_size": total_size,
+            "percentage": int((synced_size / total_size) * 100),
         }

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -48,7 +48,7 @@ class YandexDisk(base.InLoopPollText):
         ("status_mapping", status_mapping, "Sync status mapping"),
         ("update_interval", 5, "The delay in seconds between updates"),
         ("format", "{status}{progress}", "Display format"),
-        ("progress_format", " ({filename} {percentage}%)", "Progress format"),
+        ("progress_format", " ({filename} {percentage:.1%}%)", "Progress format"),
     ]
 
     def __init__(self, **config):
@@ -110,13 +110,14 @@ class YandexDisk(base.InLoopPollText):
 
     @staticmethod
     def _get_progress_log_dict(log_data):
-        total_size = int(log_data.pop(-1))
-        log_data.pop(-1)
-        synced_size = int(log_data.pop(-1))
-        filename = " ".join(log_data)
-        return {
-            "filename": filename,
-            "synced_size": synced_size,
-            "total_size": total_size,
-            "percentage": int((synced_size / total_size) * 100),
-        }
+        if log_data[-1].isdigit():
+            total_size = int(log_data.pop(-1))
+            log_data.pop(-1)
+            synced_size = int(log_data.pop(-1))
+            filename = " ".join(log_data)
+            return {
+                "filename": filename,
+                "synced_size": synced_size,
+                "total_size": total_size,
+                "percentage": synced_size / total_size,
+            }

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2022 Egor Martynov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+
+from libqtile.widget import base
+
+class YandexDisk(base.InLoopPollText):
+    """A simple widget to show YandexDisk folder sync status.
+
+    Yandex.Disk_ is a service that lets you store files on Yandex servers.
+
+    .. _Yandex.Disk: http://disk.yandex.com/
+
+    """
+    
+    defaults = [
+        ("sync_folder", "~/Yandex.Disk/", "Yandex.Disk folder path"),
+        ("update_interval", 10, "The delay in seconds between updates"),
+        ("format", "{status}", "Display format"),
+    ]
+
+    def __init__(self, **config):
+        base.InLoopPollText.__init__(self, **config)
+        self.add_defaults(YandexDisk.defaults)
+
+        self.sync_folder = os.path.expanduser(os.path.join(
+            self.sync_folder,
+            ".sync",
+            "status",
+        ))
+
+    def _get_status(self):
+        with open(self.sync_folder, "r") as file:
+            return file.read().split("\n")[-1]
+
+    def poll(self):
+        try:
+            status = self._get_status()
+        except Exception as e:
+            return f"Error: {e}"
+
+        return self.format.format(status=status)

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -20,6 +20,7 @@
 
 import os
 
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -57,7 +58,7 @@ class YandexDisk(base.InLoopPollText):
     def poll(self):
         try:
             status = self._get_status()
-        except Exception as e:
+        except Exception:
             logger.exception("Error getting status for yandex.disk")
             return "Error"
 

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -49,7 +49,7 @@ class YandexDisk(base.InLoopPollText):
         ("status_mapping", status_mapping, "Sync status mapping"),
         ("update_interval", 5, "The delay in seconds between updates"),
         ("format", "{status}{progress}", "Display format"),
-        ("progress_format", " ({filename} {percentage:.1%})", "Progress format"),
+        ("progress_format", " ({file_name} {percentage:.1%})", "Progress format"),
     ]
 
     def __init__(self, **config):
@@ -117,8 +117,11 @@ class YandexDisk(base.InLoopPollText):
             synced_size = int(log_data[1])
             total_size = int(log_data[3])
 
+            file_path = log_data[0]
+
             return {
-                "filename": log_data[0],
+                "file_name": os.path.basename(file_path),
+                "file_path": file_path,
                 "synced_size": synced_size,
                 "total_size": total_size,
                 "percentage": synced_size / total_size,

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -22,6 +22,7 @@ import os
 
 from libqtile.widget import base
 
+
 class YandexDisk(base.InLoopPollText):
     """A simple widget to show YandexDisk folder sync status.
 
@@ -30,7 +31,7 @@ class YandexDisk(base.InLoopPollText):
     .. _Yandex.Disk: http://disk.yandex.com/
 
     """
-    
+
     defaults = [
         ("sync_folder", "~/Yandex.Disk/", "Yandex.Disk folder path"),
         ("update_interval", 10, "The delay in seconds between updates"),
@@ -41,11 +42,13 @@ class YandexDisk(base.InLoopPollText):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(YandexDisk.defaults)
 
-        self.sync_folder = os.path.expanduser(os.path.join(
-            self.sync_folder,
-            ".sync",
-            "status",
-        ))
+        self.sync_folder = os.path.expanduser(
+            os.path.join(
+                self.sync_folder,
+                ".sync",
+                "status",
+            )
+        )
 
     def _get_status(self):
         with open(self.sync_folder, "r") as file:

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -35,6 +35,11 @@ class YandexDisk(base.InLoopPollText):
 
     defaults = [
         ("sync_folder", "~/Yandex.Disk/", "Yandex.Disk folder path"),
+        (
+            "daemon_stopped",
+            "Error: daemon not started",
+            "Text when Yandex.Disk daemon is stopped",
+        ),
         ("update_interval", 10, "The delay in seconds between updates"),
         ("format", "{status}", "Display format"),
     ]
@@ -59,7 +64,7 @@ class YandexDisk(base.InLoopPollText):
         try:
             status = self._get_status()
         except FileNotFoundError:
-            return "Error: daemon not started"
+            return self.daemon_stopped
         except Exception:
             logger.exception("Error getting status for yandex.disk")
             return "Error"

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -34,7 +34,9 @@ status_mapping = {
 class YandexDisk(base.InLoopPollText):
     """A simple widget to show YandexDisk client folder sync status.
 
-    Yandex.Disk_ is a service that lets you store files on Yandex servers.
+    Yandex.Disk_ is a cloud service created by Yandex that lets users store
+    files on "cloud" servers and share them with others online.
+    The service is based on syncing data between different devices.
 
     .. _Yandex.Disk: http://disk.yandex.com/
 

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -46,7 +46,7 @@ class YandexDisk(base.InLoopPollText):
     defaults = [
         ("sync_folder", "~/Yandex.Disk/", "Yandex.Disk folder path"),
         ("status_mapping", status_mapping, "Sync status mapping"),
-        ("update_interval", 1, "The delay in seconds between updates"),
+        ("update_interval", 5, "The delay in seconds between updates"),
         ("format", "{status}{progress}", "Display format"),
         ("progress_format", " ({filename} {percentage}%)", "Progress format"),
     ]

--- a/libqtile/widget/yandexdisk.py
+++ b/libqtile/widget/yandexdisk.py
@@ -26,6 +26,7 @@ from libqtile.widget import base
 status_mapping = {
     "idle": "IDLE",
     "stopped": "STOPPED",
+    "paused": "PAUSED",
     "busy": "BUSY",
     "index": "INDEX",
 }

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -24,11 +24,8 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
 
 
 @pytest.fixture
-def widget(monkeypatch):
-    def result(self):
-        yield yandexdisk_folder
-
-    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", result)
+@pytest.mark.parametrize(yandexdisk.YandexDisk, [{"sync_folder": yandexdisk_folder}], indirect=True)
+def widget():
     yield yandexdisk.YandexDisk
 
 

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os
+
 import pytest
 
 from libqtile.widget import yandexdisk
@@ -28,6 +30,9 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
     yandexdisk.YandexDisk, [{"sync_folder": yandexdisk_folder}], indirect=True
 )
 def widget():
+    status_file = os.path.join(yandexdisk_folder, ".sync", "status")
+    with open(status_file, "w") as file:
+        file.write("99999\nindex")
     yield yandexdisk.YandexDisk
 
 

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -1,0 +1,15 @@
+import pytest
+
+from libqtile.widget import yandexdisk
+from test.widgets.test_yandexdisk import yandexdisk_folder
+
+
+@pytest.fixture
+def widget(monkeypatch):
+    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk.sync_folder", yandexdisk_folder)
+    yield yandexdisk.YandexDisk
+
+
+@pytest.mark.parametrize("screenshot_manager", indirect=True)
+def ss_yandexdisk(screenshot_manager):
+    screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -24,7 +24,9 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
 
 
 @pytest.fixture
-@pytest.mark.parametrize(yandexdisk.YandexDisk, [{"sync_folder": yandexdisk_folder}], indirect=True)
+@pytest.mark.parametrize(
+    yandexdisk.YandexDisk, [{"sync_folder": yandexdisk_folder}], indirect=True
+)
 def widget():
     yield yandexdisk.YandexDisk
 

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -1,3 +1,22 @@
+# Copyright (c) 2022 Egor Martynov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import pytest
 
 from libqtile.widget import yandexdisk

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -25,14 +25,10 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
 
 @pytest.fixture
 def widget(monkeypatch):
-    def get_status(self):
+    def result(self):
         yield yandexdisk_folder
 
-    def get_latest_log(self):
-        return "21214-142356.408", "DIGEST", ['"random.dat"', "9", "/", "10"]
-
-    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", get_status)
-    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_latest_log", get_latest_log)
+    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", result)
     yield yandexdisk.YandexDisk
 
 

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -25,10 +25,13 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
 
 @pytest.fixture
 def widget(monkeypatch):
-    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk.sync_folder", yandexdisk_folder)
+    def result(self):
+        yield yandexdisk_folder
+
+    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", result)
     yield yandexdisk.YandexDisk
 
 
-@pytest.mark.parametrize("screenshot_manager", indirect=True)
+@pytest.mark.parametrize("screenshot_manager", [{}], indirect=True)
 def ss_yandexdisk(screenshot_manager):
     screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_yandexdisk.py
+++ b/test/widgets/docs_screenshots/ss_yandexdisk.py
@@ -25,10 +25,14 @@ from test.widgets.test_yandexdisk import yandexdisk_folder
 
 @pytest.fixture
 def widget(monkeypatch):
-    def result(self):
+    def get_status(self):
         yield yandexdisk_folder
 
-    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", result)
+    def get_latest_log(self):
+        return "21214-142356.408", "DIGEST", ['"random.dat"', "9", "/", "10"]
+
+    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_status", get_status)
+    monkeypatch.setattr("libqtile.widget.yandexdisk.YandexDisk._get_latest_log", get_latest_log)
     yield yandexdisk.YandexDisk
 
 

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -78,4 +78,4 @@ def test_yandexdisk_progress(yandexdisk_folder):
 
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
 
-    assert yandexdisk.poll() == 'INDEX ("random.dat" 90.0%)'
+    assert yandexdisk.poll() == "INDEX (random.dat 90.0%)"

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -1,3 +1,22 @@
+# Copyright (c) 2022 Egor Martynov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import os
 
 from libqtile import widget

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
+import tempfile
 
 import pytest
 
@@ -26,16 +27,16 @@ from libqtile import widget
 
 @pytest.fixture
 def yandexdisk_folder():
-    tmp = "/var/tmp/qtile/test/widgets/yandexdisk"
-    sync_folder = os.path.join(tmp, "Yandex.Disk")
+    with tempfile.TemporaryDirectory() as tmp:
+        sync_folder = os.path.join(tmp, "Yandex.Disk")
 
-    status_file = os.path.join(sync_folder, ".sync", "status")
-    os.makedirs(os.path.dirname(status_file), exist_ok=True)
+        status_file = os.path.join(sync_folder, ".sync", "status")
+        os.makedirs(os.path.dirname(status_file), exist_ok=True)
 
-    with open(status_file, "w") as f:
-        f.write("99999\nidle")
+        with open(status_file, "w") as f:
+            f.write("99999\nidle")
 
-    yield sync_folder
+        yield sync_folder
 
 
 def test_yandexdisk(yandexdisk_folder):

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -45,9 +45,10 @@ def test_yandexdisk_idle(yandexdisk_folder):
 
 
 def test_yandexdisk_stopped(yandexdisk_folder):
-    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder, daemon_stopped="stopped")
+    assert yandexdisk.daemon_stopped == "stopped"
 
     status_file = os.path.join(yandexdisk_folder, ".sync", "status")
     os.remove(status_file)
 
-    assert yandexdisk.poll() == "Error: daemon not started"
+    assert yandexdisk.poll() == yandexdisk.daemon_stopped

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -30,11 +30,20 @@ def yandexdisk_folder():
     with tempfile.TemporaryDirectory() as tmp:
         sync_folder = os.path.join(tmp, "Yandex.Disk")
 
+        corelog_file = os.path.join(
+            sync_folder,
+            ".sync",
+            "core.log",
+        )
+
         status_file = os.path.join(sync_folder, ".sync", "status")
         os.makedirs(os.path.dirname(status_file), exist_ok=True)
 
         with open(status_file, "w") as f:
             f.write("99999\nidle")
+
+        with open(corelog_file, "w") as f:
+            f.write('21214-142356.408 DIGEST "random.dat" 9 / 10\n')
 
         yield sync_folder
 
@@ -54,7 +63,6 @@ def test_yandexdisk_stopped(yandexdisk_folder):
 
 
 def test_yandexdisk_mapping(yandexdisk_folder):
-
     status_mapping = {"idle": "-.-"}
 
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder, status_mapping=status_mapping)
@@ -63,20 +71,10 @@ def test_yandexdisk_mapping(yandexdisk_folder):
 
 
 def test_yandexdisk_progress(yandexdisk_folder):
-
-    corelog_folder = os.path.join(
-        yandexdisk_folder,
-        ".sync",
-        "core.log",
-    )
-
     status_file = os.path.join(yandexdisk_folder, ".sync", "status")
 
     with open(status_file, "w") as f:
         f.write("99999\nindex")
-
-    with open(corelog_folder, "w") as f:
-        f.write('21214-142356.408 DIGEST "random.dat" 9 / 10\n')
 
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
 

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -60,3 +60,24 @@ def test_yandexdisk_mapping(yandexdisk_folder):
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder, status_mapping=status_mapping)
 
     assert yandexdisk.poll() == "-.-"
+
+
+def test_yandexdisk_progress(yandexdisk_folder):
+
+    corelog_folder = os.path.join(
+        yandexdisk_folder,
+        ".sync",
+        "core.log",
+    )
+
+    status_file = os.path.join(yandexdisk_folder, ".sync", "status")
+
+    with open(status_file, "w") as f:
+        f.write("99999\nindex")
+
+    with open(corelog_folder, "w") as f:
+        f.write('21214-142356.408 DIGEST "random.dat" 9 / 10\n')
+
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
+
+    assert yandexdisk.poll() == 'INDEX ("random.dat" 90%)'

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -41,14 +41,22 @@ def yandexdisk_folder():
 
 def test_yandexdisk_idle(yandexdisk_folder):
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
-    assert yandexdisk.poll() == "idle"
+    assert yandexdisk.poll() == "IDLE"
 
 
 def test_yandexdisk_stopped(yandexdisk_folder):
-    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder, daemon_stopped="stopped")
-    assert yandexdisk.daemon_stopped == "stopped"
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
 
     status_file = os.path.join(yandexdisk_folder, ".sync", "status")
     os.remove(status_file)
 
-    assert yandexdisk.poll() == yandexdisk.daemon_stopped
+    assert yandexdisk.poll() == "STOPPED"
+
+
+def test_yandexdisk_mapping(yandexdisk_folder):
+
+    status_mapping = {"idle": "-.-"}
+
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder, status_mapping=status_mapping)
+
+    assert yandexdisk.poll() == "-.-"

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -19,9 +19,9 @@
 # SOFTWARE.
 import os
 
-from libqtile import widget
-
 import pytest
+
+from libqtile import widget
 
 
 @pytest.fixture
@@ -39,5 +39,5 @@ def yandexdisk_folder():
 
 
 def test_yandexdisk(yandexdisk_folder):
-    YandexDisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
-    assert YandexDisk.poll() == "idle"
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
+    assert yandexdisk.poll() == "idle"

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -1,0 +1,24 @@
+import os
+
+from libqtile import widget
+
+import pytest
+
+
+@pytest.fixture
+def yandexdisk_folder():
+    tmp = "/var/tmp/qtile/test/widgets/yandexdisk"
+    sync_folder = os.path.join(tmp, "Yandex.Disk")
+
+    status_file = os.path.join(sync_folder, ".sync", "status")
+    os.makedirs(os.path.dirname(status_file), exist_ok=True)
+
+    with open(status_file, "w") as f:
+        f.write("99999\nidle")
+
+    yield sync_folder
+
+
+def test_yandexdisk(yandexdisk_folder):
+    YandexDisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
+    assert YandexDisk.poll() == "idle"

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -39,6 +39,15 @@ def yandexdisk_folder():
         yield sync_folder
 
 
-def test_yandexdisk(yandexdisk_folder):
+def test_yandexdisk_idle(yandexdisk_folder):
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
     assert yandexdisk.poll() == "idle"
+
+
+def test_yandexdisk_stopped(yandexdisk_folder):
+    yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
+
+    status_file = os.path.join(yandexdisk_folder, ".sync", "status")
+    os.remove(status_file)
+
+    assert yandexdisk.poll() == "Error: daemon not started"

--- a/test/widgets/test_yandexdisk.py
+++ b/test/widgets/test_yandexdisk.py
@@ -78,4 +78,4 @@ def test_yandexdisk_progress(yandexdisk_folder):
 
     yandexdisk = widget.YandexDisk(sync_folder=yandexdisk_folder)
 
-    assert yandexdisk.poll() == 'INDEX ("random.dat" 90%)'
+    assert yandexdisk.poll() == 'INDEX ("random.dat" 90.0%)'


### PR DESCRIPTION
This PR adds a widget for [Yandex.Disk](https://yandex.com/support/disk-desktop-linux/) client.

I have a question. How do I make fake status files in tests?