### PR TITLE
libqtile: configreader: ensure config is not evaluated twice during reload fixes #4064

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.
         - Fix `CPU` precision bug with specific version of `psutil`
+        - Fix config being reevaluated twice during reload (e.g. all hooks from config were doubled)
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -108,6 +108,14 @@ class Config:
             if hasattr(module, "__file__") and module.__file__ is not None:
                 subpath = Path(module.__file__)
 
+                if subpath == path:
+                    # do not reevaluate config itself here, we want only
+                    # reload all submodules. Also we cant reevaluate config
+                    # here, because it will cache all current modules before they
+                    # are reloaded. Thus, config file should be reloaded after
+                    # this routine.
+                    continue
+
                 # Check if the module is in the config folder or subfolder
                 # if so, reload it
                 if folder in subpath.parents:

--- a/test/configs/reloading.py
+++ b/test/configs/reloading.py
@@ -88,4 +88,6 @@ if hasattr(qtile, "test_data"):
     floating_layout = layout.Floating()
     wmname = "TEST"
 
+    qtile.test_data_config_evaluations += 1
+
 groups.append(ScratchPad("S", dropdowns))

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1167,7 +1167,10 @@ def test_reload_config(manager_nospawn):
 
     # Reload #1 - with libqtile.qtile.test_data
     manager_nospawn.c.eval("self.test_data = 1")
+    manager_nospawn.c.eval("self.test_data_config_evaluations = 0")
     manager_nospawn.c.reload_config()
+    # should be readed twice (check+read), but no more
+    assert manager_nospawn.c.eval("self.test_data_config_evaluations") == (True, "2")
     assert manager_nospawn.c.eval("len(self.keys_map)") == (True, "2")
     assert manager_nospawn.c.eval("len(self.mouse_map)") == (True, "2")
     assert "".join(manager_nospawn.c.get_groups().keys()) == "123456789S"
@@ -1192,6 +1195,7 @@ def test_reload_config(manager_nospawn):
 
     # Reload #2 - back to without libqtile.qtile.test_data
     manager_nospawn.c.eval("del self.test_data")
+    manager_nospawn.c.eval("del self.test_data_config_evaluations")
     manager_nospawn.c.reload_config()
     assert manager_nospawn.c.eval("len(self.keys_map)") == (True, "1")
     assert manager_nospawn.c.eval("len(self.mouse_map)") == (True, "1")


### PR DESCRIPTION
fixes #4064 