### PR TITLE
Improve `qtile check` error message on missing dep

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -99,7 +99,7 @@ def check_deps() -> None:
 
     for dep in ["mypy", "stubtest"]:
         if shutil.which(dep) is None:
-            print(f"{dep} was not found. Please install it and try again.")
+            print(f"{dep} was not found in PATH. Please install it, add to PATH and try again.")
             ok = False
 
     if not ok:


### PR DESCRIPTION
As an unexperienced Python user, I get from the original error message to install the dependencies with `pip install xxx`, but not know it's necessary to add to PATH. See my original question https://github.com/qtile/qtile/discussions/4067