### PR TITLE
wlan: Add Ethernet information support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to add a group at a specified index
         - Add ability to open the `WidgetBox` widgets at startup.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
+        - Add ability to check Ethernet status with Wlan widget
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/test/widgets/test_wlan.py
+++ b/test/widgets/test_wlan.py
@@ -48,8 +48,8 @@ class MockIwlib(ModuleType):
     }
 
     @classmethod
-    def get_iwconfig(cls, interface):
-        return cls.DATA.get(interface, dict())
+    def get_iwconfig(cls, wifi_interface):
+        return cls.DATA.get(wifi_interface, dict())
 
 
 # Patch the widget with our mock iwlib module.
@@ -68,8 +68,8 @@ def patched_wlan(monkeypatch):
     "kwargs,expected",
     [
         ({}, "QtileNet 49/70"),
-        ({"format": "{essid} {percent:2.0%}"}, "QtileNet 70%"),
-        ({"interface": "wlan1"}, "Disconnected"),
+        ({"format_wifi": "{essid} {percent:2.0%}"}, "QtileNet 70%"),
+        ({"wifi_interface": "wlan1"}, "Disconnected"),
     ],
 )
 def test_wlan_display(minimal_conf_noscreen, manager_nospawn, patched_wlan, kwargs, expected):


### PR DESCRIPTION
If show_eth is True, then the widget will also show the Ethernet status (cable connection and link status) using linux sysfs. The user can also decide if wants to display wifi, Ethernet or both informations on the widget.

Related-to: #4054