### PR TITLE
x11: Catch ConnectionExceptions when finalising following server disconnect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to update the widget only once if `update_interval` is None.
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
         - Made the `NetWidget` text formattable.
+        - Qtile no longer floods the log following X server disconnection, instead handling those errors.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -810,11 +810,11 @@ class Core(base.Core):
         """Try to close windows gracefully before exiting"""
 
         try:
-            pids = [
-                pid
-                for win in self.qtile.windows_map.values()
-                if not isinstance(win, base.Internal) and (pid := win.get_pid())
-            ]
+            pids = []
+            for win in self.qtile.windows_map.values():
+                if not isinstance(win, base.Internal):
+                    if pid := win.get_pid():
+                        pids.append(pid)
         except xcffib.ConnectionException:
             logger.warning("Server disconnected, couldn't close windows gracefully.")
             return

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -170,13 +170,11 @@ class Core(base.Core):
         return "x11"
 
     def finalize(self) -> None:
-        try:
+        with contextlib.suppress(xcffib.ConnectionException):
             self.conn.conn.core.DeletePropertyChecked(
                 self._root.wid,
                 self.conn.atoms["_NET_SUPPORTING_WM_CHECK"],
             ).check()
-        except xcffib.ConnectionException:
-            pass
         self.qtile = None
         self.conn.finalize()
 

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING
 
 import cairocffi
@@ -83,11 +84,8 @@ class Drawer(base.Drawer):
 
     def _free_gc(self):
         if self._gc is not None:
-            try:
+            with contextlib.suppress(xcffib.ConnectionException):
                 self.qtile.core.conn.conn.core.FreeGC(self._gc)
-            except xcffib.ConnectionException:
-                # Qtile got disconnected from the X server
-                pass
             self._gc = None
 
     def _create_xcb_surface(self):
@@ -118,11 +116,8 @@ class Drawer(base.Drawer):
 
     def _free_pixmap(self):
         if self._pixmap is not None:
-            try:
+            with contextlib.suppress(xcffib.ConnectionException):
                 self.qtile.core.conn.conn.core.FreePixmap(self._pixmap)
-            except xcffib.ConnectionException:
-                # Qtile got disconnected from the X server
-                pass
             self._pixmap = None
 
     def _check_xcb(self):

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -83,7 +83,11 @@ class Drawer(base.Drawer):
 
     def _free_gc(self):
         if self._gc is not None:
-            self.qtile.core.conn.conn.core.FreeGC(self._gc)
+            try:
+                self.qtile.core.conn.conn.core.FreeGC(self._gc)
+            except xcffib.ConnectionException:
+                # Qtile got disconnected from the X server
+                pass
             self._gc = None
 
     def _create_xcb_surface(self):
@@ -114,7 +118,11 @@ class Drawer(base.Drawer):
 
     def _free_pixmap(self):
         if self._pixmap is not None:
-            self.qtile.core.conn.conn.core.FreePixmap(self._pixmap)
+            try:
+                self.qtile.core.conn.conn.core.FreePixmap(self._pixmap)
+            except xcffib.ConnectionException:
+                # Qtile got disconnected from the X server
+                pass
             self._pixmap = None
 
     def _check_xcb(self):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1126,7 +1126,11 @@ class Internal(_Window, base.Internal):
         if self.window.wid in self.qtile.windows_map:
             # It will be present during config reloads; absent during shutdown as this
             # will follow graceful_shutdown
-            self.qtile.core.conn.conn.core.DestroyWindow(self.window.wid)
+            try:
+                self.qtile.core.conn.conn.core.DestroyWindow(self.window.wid)
+            except xcffib.ConnectionException:
+                # Qtile disconnected from the X server
+                pass
 
     def handle_Expose(self, e):  # noqa: N802
         self.process_window_expose()

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1126,11 +1126,8 @@ class Internal(_Window, base.Internal):
         if self.window.wid in self.qtile.windows_map:
             # It will be present during config reloads; absent during shutdown as this
             # will follow graceful_shutdown
-            try:
+            with contextlib.suppress(xcffib.ConnectionException):
                 self.qtile.core.conn.conn.core.DestroyWindow(self.window.wid)
-            except xcffib.ConnectionException:
-                # Qtile disconnected from the X server
-                pass
 
     def handle_Expose(self, e):  # noqa: N802
         self.process_window_expose()

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -37,6 +37,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import operator
 from itertools import chain, repeat
@@ -632,10 +633,8 @@ class Connection:
         return window.XWindow(self, wid)
 
     def disconnect(self):
-        try:
+        with contextlib.suppress(xcffib.ConnectionException):
             self.conn.disconnect()
-        except xcffib.ConnectionException:
-            logger.error("Failed to disconnect, connection already failed?")
         self._connected = False
 
     def flush(self):

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -278,21 +278,25 @@ class Systray(base._Widget, window._Window):  # type: ignore[misc]
     def finalize(self):
         base._Widget.finalize(self)
         atoms = self.conn.atoms
-        self.conn.conn.core.SetSelectionOwner(
-            0,
-            atoms["_NET_SYSTEM_TRAY_S{:d}".format(self.screen)],
-            xcffib.CurrentTime,
-        )
-        self.hide()
 
-        root = self.qtile.core._root.wid
-        for icon in self.tray_icons:
-            self.conn.conn.core.ReparentWindow(icon.window.wid, root, 0, 0)
-        self.conn.conn.flush()
+        try:
+            self.conn.conn.core.SetSelectionOwner(
+                0,
+                atoms["_NET_SYSTEM_TRAY_S{:d}".format(self.screen)],
+                xcffib.CurrentTime,
+            )
+            self.hide()
+
+            root = self.qtile.core._root.wid
+            for icon in self.tray_icons:
+                self.conn.conn.core.ReparentWindow(icon.window.wid, root, 0, 0)
+            self.conn.conn.flush()
+
+            self.conn.conn.core.DestroyWindow(self.wid)
+        except xcffib.ConnectionException:
+            self.hidden = True  # Usually set in self.hide()
 
         del self.qtile.windows_map[self.wid]
-        self.conn.conn.core.DestroyWindow(self.wid)
-
         Systray._instances -= 1
 
     def info(self):


### PR DESCRIPTION
This follows on from #3374 which aimed to suppress the noisy log messages. This approach instead catches and handles the exceptions (usually ignoring them and continuing), letting Qtile continue to shut down in a more graceful way.

Thanks @elParaguayo and @jwijenbergh for looking into this on #3374 (and apologies for missing the ping). I wanted to avoid globally blocking all logging so here instead just accounted for some specific points in the code where the exception is expected to be raised in the absence of an X connection.