### PR TITLE
Don't try to update Qtile.keys_map in Qtile.grab_keys

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -432,7 +432,7 @@ class Qtile(CommandObject):
         """
         self.core.ungrab_keys()
         for key in self.keys_map.values():
-            self.grab_key(key)
+            self.core.grab_key(key)
 
     def grab_key(self, key: Key | KeyChord) -> None:
         """Grab the given key event"""


### PR DESCRIPTION
e577389 added log warnings when a key that is already present in `Qtile.keys_map` gets grabbed. However, the X Core calls `Qtile.grab_keys` when it detects a keyboard (at least in Xephyr), re-grabbing all keys and emitting lots of warnings. This avoids those warnings and instead just forwards the key grabs to the core.