### PR TITLE
Change method for starting WidgetBox opened

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,7 +28,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           setting `border_focus_stack` and `border_normal_stack` variables.
         - New widget: GenPollCommand
         - Add ability to add a group at a specified index
-        - Add ability to open the `WidgetBox` widgets at startup.
+        - Add ability to spawn the `WidgetBox` widget opened.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from libqtile import bar, hook
+from libqtile import bar
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import Systray, base
@@ -68,7 +68,7 @@ class WidgetBox(base._Widget):
         ("text_closed", "[<]", "Text when box is closed"),
         ("text_open", "[>]", "Text when box is open"),
         ("widgets", list(), "A list of widgets to include in the box"),
-        ("start_opened", False, "Open the box at startup"),
+        ("start_opened", False, "Spawn the box opened"),
     ]
 
     def __init__(self, _widgets: list[base._Widget] | None = None, **config):
@@ -89,9 +89,6 @@ class WidgetBox(base._Widget):
             val = self.close_button_location
             logger.warning("Invalid value for 'close_button_location': %s", val)
             self.close_button_location = "left"
-
-        if self.start_opened:
-            hook.subscribe.startup_once(self.toggle)
 
     def _configure(self, qtile, bar):
         base._Widget._configure(self, qtile, bar)
@@ -128,6 +125,10 @@ class WidgetBox(base._Widget):
         # Disable drawing of the widget's contents
         for w in self.widgets:
             w.drawer.disable()
+
+        # We're being cautious: `box_is_open` should never be True here...
+        if self.start_opened and not self.box_is_open:
+            self.qtile.call_soon(self.toggle)
 
     def calculate_length(self):
         return self.layout.width


### PR DESCRIPTION
Per discussion in #4050, the correct behaviour for `start_opened` should be that the widgetbox is opened every time the widget is configured, rather than a single time when qtile is first started.