### PR TITLE
PulseVolume widget: fix high CPU usage

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix `Notify` bug when apps close notifications.
         - Fix `CPU` precision bug with specific version of `psutil`
         - Fix config being reevaluated twice during reload (e.g. all hooks from config were doubled)
+        - Fix `PulseVolume` high CPU usage when update_interval set to 0.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -176,7 +176,7 @@ class PulseVolume(Volume):
 
     @expose_command()
     def increase_vol(self, value=None):
-        if value is None:
+        if not value:
             value = self.step
         base = self.default_sink["base_volume"]
         volume = ffi.new(
@@ -197,7 +197,7 @@ class PulseVolume(Volume):
 
     @expose_command()
     def decrease_vol(self, value=None):
-        if value is None:
+        if not value:
             value = self.step
         volume_level = int(value * self.default_sink["base_volume"] / 100)
         if not volume_level and max(self.default_sink["values"]) == 0:
@@ -249,5 +249,5 @@ class PulseVolume(Volume):
         if self.theme_path:
             self.setup_images()
         self.poll()
-        if self.update_interval is not None:
+        if self.update_interval:
             self.timeout_add(self.update_interval, self.timer_setup)


### PR DESCRIPTION
[pranavsetpal](https://github.com/pranavsetpal):
> Sorry for the late reply, was a bit a busy, but yes,
> 
> > * ```
> >      if self.update_interval is not None:
> >   ```
> > 
> > 
> > * ```
> >      if self.update_interval:
> >          self.timeout_add(self.update_interval, self.timer_setup)
> >      if self.theme_path:
> >          self.setup_images()
> >   ```
> 
> This change fixes the issue for when update_interval is 0.

fixes: #3966