### PR TITLE
Add separate "lint" and "test" extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,10 +61,15 @@ doc =
   sphinx_rtd_theme
   sphinxcontrib-seqdiag
   numpydoc
-test =
+lint =
   flake8
   pep8-naming
   coverage
+test =
+  pytest >= 6.2.1
+  bowler
+  dbus-next
+  PyGObject
 ipython =
   ipykernel
   jupyter_console


### PR DESCRIPTION
Distribution [packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_linters) usually recommends running the upstream test suite during the package build, but not the upstream linters.  Being able to install the corresponding dependencies for each separately would be useful.
