### PR TITLE
Fix Volume widget volume-getting command execution

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -228,7 +228,9 @@ class Volume(base._TextBox):
         if self.volume_up_command is not None:
             volume_up_cmd = self.volume_up_command
         else:
-            volume_up_cmd = self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
+            volume_up_cmd = self.create_amixer_command(
+                "-q", "sset", self.channel, "{}%+".format(self.step)
+            )
 
         subprocess.call(volume_up_cmd, shell=True)
 
@@ -237,7 +239,9 @@ class Volume(base._TextBox):
         if self.volume_down_command is not None:
             volume_down_cmd = self.volume_down_command
         else:
-            volume_down_cmd = self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
+            volume_down_cmd = self.create_amixer_command(
+                "-q", "sset", self.channel, "{}%-".format(self.step)
+            )
 
         subprocess.call(volume_down_cmd, shell=True)
 

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -130,7 +130,7 @@ class Volume(base._TextBox):
             cmd.extend(["-D", str(self.device)])
 
         cmd.extend([x for x in args])
-        # Escape existing quotation marks and construct the command with adequate qutation marks
+        # Escape existing quotation marks and construct the command with adequate quotation marks
         return " ".join(map(lambda x: r'"' + x.replace(r'"', r'\"') + r'"', cmd))
 
     def button_press(self, x, y, button):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -199,13 +199,13 @@ class Volume(base._TextBox):
             if self.get_volume_command:
                 get_volume_cmd = self.get_volume_command
 
-            mixer_out = subprocess.getoutput(get_volume_cmd)
+            mixer_out = self.call_process(get_volume_cmd)
         except subprocess.CalledProcessError:
             return -1
 
         check_mute = mixer_out
         if self.check_mute_command:
-            check_mute = subprocess.getoutput(self.check_mute_command)
+            check_mute = self.call_process(self.check_mute_command)
 
         if self.check_mute_string in check_mute:
             return -1

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -130,7 +130,8 @@ class Volume(base._TextBox):
             cmd.extend(["-D", str(self.device)])
 
         cmd.extend([x for x in args])
-        return cmd
+        # Escape existing quotation marks and construct the command with adequate qutation marks
+        return " ".join(map(lambda x: r'"' + x.replace(r'"', r'\"') + r'"', cmd))
 
     def button_press(self, x, y, button):
         base._TextBox.button_press(self, x, y, button)
@@ -199,13 +200,13 @@ class Volume(base._TextBox):
             if self.get_volume_command:
                 get_volume_cmd = self.get_volume_command
 
-            mixer_out = self.call_process(get_volume_cmd)
+            mixer_out = subprocess.getoutput(get_volume_cmd)
         except subprocess.CalledProcessError:
             return -1
 
         check_mute = mixer_out
         if self.check_mute_command:
-            check_mute = self.call_process(self.check_mute_command)
+            check_mute = subprocess.getoutput(self.check_mute_command)
 
         if self.check_mute_string in check_mute:
             return -1
@@ -229,7 +230,7 @@ class Volume(base._TextBox):
             subprocess.call(self.volume_up_command, shell=True)
         else:
             subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
+                self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step)), shell=True
             )
 
     @expose_command()
@@ -238,7 +239,7 @@ class Volume(base._TextBox):
             subprocess.call(self.volume_down_command, shell=True)
         else:
             subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
+                self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step)), shell=True
             )
 
     @expose_command()
@@ -246,7 +247,7 @@ class Volume(base._TextBox):
         if self.mute_command is not None:
             subprocess.call(self.mute_command, shell=True)
         else:
-            subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"))
+            subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"), shell=True) 
 
     @expose_command()
     def run_app(self):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -130,8 +130,7 @@ class Volume(base._TextBox):
             cmd.extend(["-D", str(self.device)])
 
         cmd.extend([x for x in args])
-        # Escape existing quotation marks and construct the command with adequate quotation marks
-        return " ".join(map(lambda x: r'"' + x.replace(r'"', r'\"') + r'"', cmd))
+        return subprocess.list2cmdline(cmd)
 
     def button_press(self, x, y, button):
         base._TextBox.button_press(self, x, y, button)
@@ -195,10 +194,10 @@ class Volume(base._TextBox):
 
     def get_volume(self):
         try:
-            get_volume_cmd = self.create_amixer_command("sget", self.channel)
-
-            if self.get_volume_command:
+            if self.get_volume_command is not None:
                 get_volume_cmd = self.get_volume_command
+            else:
+                get_volume_cmd = self.create_amixer_command("sget", self.channel)
 
             mixer_out = subprocess.getoutput(get_volume_cmd)
         except subprocess.CalledProcessError:
@@ -227,27 +226,29 @@ class Volume(base._TextBox):
     @expose_command()
     def increase_vol(self):
         if self.volume_up_command is not None:
-            subprocess.call(self.volume_up_command, shell=True)
+            volume_up_cmd = self.volume_up_command
         else:
-            subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step)), shell=True
-            )
+            volume_up_cmd = self.create_amixer_command("-q", "sset", self.channel, "{}%+".format(self.step))
+
+        subprocess.call(volume_up_cmd, shell=True)
 
     @expose_command()
     def decrease_vol(self):
         if self.volume_down_command is not None:
-            subprocess.call(self.volume_down_command, shell=True)
+            volume_down_cmd = self.volume_down_command
         else:
-            subprocess.call(
-                self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step)), shell=True
-            )
+            volume_down_cmd = self.create_amixer_command("-q", "sset", self.channel, "{}%-".format(self.step))
+
+        subprocess.call(volume_down_cmd, shell=True)
 
     @expose_command()
     def mute(self):
         if self.mute_command is not None:
-            subprocess.call(self.mute_command, shell=True)
+            mute_cmd = self.mute_command
         else:
-            subprocess.call(self.create_amixer_command("-q", "sset", self.channel, "toggle"), shell=True) 
+            mute_cmd = self.create_amixer_command("-q", "sset", self.channel, "toggle")
+
+        subprocess.call(mute_cmd, shell=True)
 
     @expose_command()
     def run_app(self):


### PR DESCRIPTION
Pull request #3332 changed `self.call_process` to `subprocess.getoutput` in the Volume widget. This PR reverts that change.

PR #3332 shouldn't have changed that because the `create_amixer_command` function, which is used to generate command for amixer in the widget, outputs a command in the form of a list of command arguments. `self.call_process` accepts commands in the argument list form while `subproces.getoutput` instead treats the list given as `[command, *args]` where `command` is the actual command executed and `args` are treated as _shell_ parameters, according to [this discussion](https://github.com/qtile/qtile/pull/3332#discussion_r1057588716).

Meanwhile, as I pointed out [here](https://github.com/qtile/qtile/pull/3332#discussion_r1057727841), PR #3332 didn't really break the Volume widget because the first `(\d?\d?\d?)%` in the output of `amixer` happened to be the master volume. So this PR does not introduce any user-visible change either.