### PR TITLE
X11 Core: Fix laggy resize by doing MotionNotifies with default 120 fps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix config being reevaluated twice during reload (e.g. all hooks from config were doubled)
         - Fix `PulseVolume` high CPU usage when update_interval set to 0.
         - Fix `Battery` widget on FreeBSD without explicit `battery` index given.
+        - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 60. This is configurable per screen with the x11_drag_polling_rate variable.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,7 +38,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix config being reevaluated twice during reload (e.g. all hooks from config were doubled)
         - Fix `PulseVolume` high CPU usage when update_interval set to 0.
         - Fix `Battery` widget on FreeBSD without explicit `battery` index given.
-        - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 60. This is configurable per screen with the x11_drag_polling_rate variable.
+        - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 120. This is configurable
+          per screen with the x11_drag_polling_rate variable.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -162,6 +162,9 @@ class Core(base.Core):
             | xcbq.PointerMotionHintMask
         )
 
+        # The last time we were handling a MotionNotify event
+        self._last_motion_time = 0
+
     @property
     def name(self):
         return "x11"
@@ -637,6 +640,12 @@ class Core(base.Core):
     def handle_MotionNotify(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 
+        # Limit the motion notify events from happening too frequently
+        # Here we limit it to the config value
+        resize_fps = self.qtile.current_screen.x11_drag_polling_rate
+        if (event.time - self._last_motion_time) <= (1000 / resize_fps):
+            return
+        self._last_motion_time = event.time
         self.qtile.process_button_motion(event.event_x, event.event_y)
 
     def handle_ConfigureRequest(self, event):  # noqa: N802

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -369,7 +369,10 @@ class Screen(CommandObject):
     resized to fill it. If the mode is ``"stretch"``, the image is stretched to fit all
     of it into the screen.
 
-    The ``x11_drag_polling_rate`` parameter specifies the rate for drag events in the X11 backend. By default this is set to 60, but if you prefer it you can set it to your monitor's refresh rate. 60 would mean that we handle a drag event 60 times per second.
+    The ``x11_drag_polling_rate`` parameter specifies the rate for drag events in the X11
+    backend. By default this is set to 120, but if you prefer it you can set it lower for
+    better performance or higher if you have a high refresh rate monitor. 120 would mean
+    that we handle a drag event 120 times per second.
 
     """
 
@@ -384,7 +387,7 @@ class Screen(CommandObject):
         right: BarType | None = None,
         wallpaper: str | None = None,
         wallpaper_mode: str | None = None,
-        x11_drag_polling_rate: int = 60,
+        x11_drag_polling_rate: int = 120,
         x: int | None = None,
         y: int | None = None,
         width: int | None = None,

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -369,6 +369,8 @@ class Screen(CommandObject):
     resized to fill it. If the mode is ``"stretch"``, the image is stretched to fit all
     of it into the screen.
 
+    The ``x11_drag_polling_rate`` parameter specifies the rate for drag events in the X11 backend. By default this is set to 60, but if you prefer it you can set it to your monitor's refresh rate. 60 would mean that we handle a drag event 60 times per second.
+
     """
 
     group: _Group
@@ -382,6 +384,7 @@ class Screen(CommandObject):
         right: BarType | None = None,
         wallpaper: str | None = None,
         wallpaper_mode: str | None = None,
+        x11_drag_polling_rate: int = 60,
         x: int | None = None,
         y: int | None = None,
         width: int | None = None,
@@ -394,6 +397,7 @@ class Screen(CommandObject):
         self.right = right
         self.wallpaper = wallpaper
         self.wallpaper_mode = wallpaper_mode
+        self.x11_drag_polling_rate = x11_drag_polling_rate
         self.qtile: Qtile | None = None
         # x position of upper left corner can be > 0
         # if one screen is "right" of the other


### PR DESCRIPTION
Inspired by this 2014 commit from dwm:

https://git.suckless.org/dwm/commit/3d1090ba896319368c4771b88d325fcee368a608.html

The fps is configurable per screen

Fixes #1584 #3680