### PR TITLE
Move `GenPollCommand`'s default Button1 callback to `ThreadPoolText` class.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to spawn the `WidgetBox` widget opened.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
+        - Add ability to force update a `OpenWeather` widget on `Button1` mouse callback.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to spawn the `WidgetBox` widget opened.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
-        - Add ability to force update a `OpenWeather` widget on `Button1` mouse callback.
+        - Add ability to force update a `GenPollUrl` widgets on `Button1` mouse callback.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,8 +31,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to spawn the `WidgetBox` widget opened.
         - Add ability to swap focused window based on index, and change the order of windows inside current group
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
-        - Add ability to force update a `GenPollUrl` widgets on `Button1` mouse callback.
-        - Move `GenPollCommand`'s default Button1 callback to `ThreadPoolText` class.
+        - Add ability to force update ThreadPoolText widgets on `Button1` callback.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Add ability to swap focused window based on index, and change the order of windows inside current group
         - Add `move_to_slice` command to move current window to single layout in `Slice` layout
         - Add ability to force update a `GenPollUrl` widgets on `Button1` mouse callback.
+        - Move `GenPollCommand`'s default Button1 callback to `ThreadPoolText` class.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -784,6 +784,9 @@ class ThreadPoolText(_TextBox):
     def __init__(self, text, **config):
         super().__init__(text, **config)
         self.add_defaults(ThreadPoolText.defaults)
+
+    def _configure(self, qtile, bar):
+        super()._configure(qtile, bar)
         self.add_callbacks({"Button1": self.force_update})
 
     def timer_setup(self):

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -784,6 +784,7 @@ class ThreadPoolText(_TextBox):
     def __init__(self, text, **config):
         super().__init__(text, **config)
         self.add_defaults(ThreadPoolText.defaults)
+        self.add_callbacks({"Button1": self.force_update})
 
     def timer_setup(self):
         def on_done(future):

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -61,10 +61,6 @@ class GenPollUrl(base.ThreadPoolText):
         if self.data and not isinstance(self.data, str):
             self.data = json.dumps(self.data).encode()
 
-    def _configure(self, qtile, bar):
-        base.ThreadPoolText._configure(self, qtile, bar)
-        self.add_callbacks({"Button1": self.force_update})
-
     def fetch(self):
         req = Request(self.url, self.data, self.headers)
         res = urlopen(req)
@@ -111,10 +107,6 @@ class GenPollCommand(base.ThreadPoolText):
     def __init__(self, **config):
         base.ThreadPoolText.__init__(self, "", **config)
         self.add_defaults(GenPollCommand.defaults)
-
-    def _configure(self, qtile, bar):
-        base.ThreadPoolText._configure(self, qtile, bar)
-        self.add_callbacks({"Button1": self.force_update})
 
     def poll(self):
         process = subprocess.run(

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -61,6 +61,10 @@ class GenPollUrl(base.ThreadPoolText):
         if self.data and not isinstance(self.data, str):
             self.data = json.dumps(self.data).encode()
 
+    def _configure(self, qtile, bar):
+        base.ThreadPoolText._configure(self, qtile, bar)
+        self.add_callbacks({"Button1": self.force_update})
+
     def fetch(self):
         req = Request(self.url, self.data, self.headers)
         res = urlopen(req)

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -260,6 +260,7 @@ class OpenWeather(GenPollUrl):
     def __init__(self, **config):
         GenPollUrl.__init__(self, **config)
         self.add_defaults(OpenWeather.defaults)
+        self.add_callbacks({"Button1": self.force_update})
         self.symbols.update(self.weather_symbols)
 
     @property

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -260,7 +260,6 @@ class OpenWeather(GenPollUrl):
     def __init__(self, **config):
         GenPollUrl.__init__(self, **config)
         self.add_defaults(OpenWeather.defaults)
-        self.add_callbacks({"Button1": self.force_update})
         self.symbols.update(self.weather_symbols)
 
     @property


### PR DESCRIPTION
This PR adds default `force_update` callback to `GenPollUrl` class just like in the `GenPollCommand` class.