### PR TITLE
more auto_minimize hackery

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1276,6 +1276,7 @@ class Window(_Window, base.Window):
     def __init__(self, window, qtile):
         _Window.__init__(self, window, qtile)
         self._wm_class: list[str] | None = None
+        self.ignored_minimize = False
         self.update_wm_class()
         self.update_name()
         self.set_group()
@@ -1379,7 +1380,7 @@ class Window(_Window, base.Window):
             )
             return
 
-        if self._float_state == FloatStates.FULLSCREEN and self.qtile.config.auto_minimize:
+        if self._float_state == FloatStates.FULLSCREEN and self.ignored_minimize:
             self.floating = False
             return
 
@@ -1727,8 +1728,12 @@ class Window(_Window, base.Window):
             state = data.data32[0]
             if state == NormalState:
                 self.minimized = False
-            elif state == IconicState and self.qtile.config.auto_minimize:
-                self.minimized = True
+                self.ignored_minimize = False
+            elif state == IconicState:
+                if self.qtile.config.auto_minimize:
+                    self.minimized = True
+                else:
+                    self.ignored_minimize = True
         else:
             logger.debug("Unhandled client message: %s", atoms.get_name(opcode))
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1379,7 +1379,7 @@ class Window(_Window, base.Window):
             )
             return
 
-        if self._float_state == FloatStates.FULLSCREEN:
+        if self._float_state == FloatStates.FULLSCREEN and self.qtile.config.auto_minimize:
             self.floating = False
             return
 


### PR DESCRIPTION
when steam games lose focus, they try to:

1. set IconicState
2. remove _NET_WM_FULLSCREEN

previously with the auto_minimize behavior we ignored the first part, which was fine. If a user only had one monitor, when _NET_WM_FULLSCREEN is removed, we toggle_floating() and re-place() the window according to where the bar was. Except that people with one monitor didn't see this behavior.

If users have multiple monitors, this removal of _NET_WM_FULLSCREEN results in a toggle_floating() which moves the fullscreen window to not being fullscreen, which makes it pop into the current layout, which is weird.

Instead, let's not respect _NET_WM_FULLSCREEN removals like we're not respecting setting to IconicState, and get rid of both of these problems.

Maybe this is a hack-on-hack, and we should find some other way to implement this. I can't really tell myself, but I don't want things to auto minimize just because I switch screens.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>