### PR TITLE
Relax regex on qtile shell command arg parsing

### DIFF
--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -319,7 +319,7 @@ class QSh:
             else:
                 return "Invalid builtin: {}".format(cmd)
 
-        command_match = re.fullmatch(r"(?P<cmd>\w+)\((?P<args>[\w\s,]*)\)", line)
+        command_match = re.fullmatch(r"(?P<cmd>\w+)\((?P<args>.*)\)", line)
         if command_match:
             cmd = command_match.group("cmd")
             args = command_match.group("args")


### PR DESCRIPTION
Qtile shell currently uses a regular expression to split the command name from the arguments. However, the arguments only match a limited subset of characters; characters like `.`, `[]` etc are not matched resulting in an `InvalidCommand`. This limits the usefulness of the `eval` command in particular.

This PR fixes this by allowing any characters to be passed as args.