### PR TITLE
Fix pangocffi error in WindowTabs widget

### DIFF
--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from libqtile import bar, hook
+from libqtile import bar, hook, pangocffi
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -76,6 +76,7 @@ class WindowTabs(base._TextBox):
             elif w.floating:
                 state = "V "
             task = "%s%s" % (state, w.name if w and w.name else " ")
+            task = pangocffi.markup_escape_text(task)
             if w is self.bar.screen.group.current_window:
                 task = task.join(self.selected)
             names.append(task)

--- a/test/widgets/test_windowtabs.py
+++ b/test/widgets/test_windowtabs.py
@@ -125,3 +125,14 @@ def test_selected(manager):
 
     manager.kill_window(window_one)
     assert widget_text() == ""
+
+
+@windowtabs_config
+def test_escaping_text(manager):
+    """
+    Ampersands can cause a crash if not escaped before passing to
+    pangocffi.parse_markup.
+    Test that the widget can parse text safely.
+    """
+    manager.test_window("Text & Text")
+    assert manager.c.widget["windowtabs"].info()["text"] == "<b>Text &amp; Text</b>"


### PR DESCRIPTION
The `WindowTabs` widget does not escape text before updating the widget. This means that an ampersand in the window name will cause the widget to crash.

This PR adds escaping before updating the text.

Fixes #4107