### PR TITLE
Fix width issue for scrolling text

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -457,6 +457,12 @@ class _TextBox(_Widget):
             "Whether text should scroll completely away (True) or stop when the end of the text is shown (False)",
         ),
         ("scroll_hide", False, "Whether the widget should hide when scrolling has finished"),
+        (
+            "scroll_fixed_width",
+            False,
+            "When ``scroll=True`` the ``width`` parameter is a maximum width and, when text is shorter than this, the widget will resize. "
+            "Setting ``scroll_fixed_width=True`` will force the widget to have a fixed width, regardless of the size of the text.",
+        ),
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -557,7 +563,11 @@ class _TextBox(_Widget):
             self._is_scrolling = True
             self._should_scroll = True
         else:
-            self.length_type = bar.CALCULATED
+            if self.scroll_fixed_width:
+                self.length_type = bar.STATIC
+                self.length = self._scroll_width
+            else:
+                self.length_type = bar.CALCULATED
             self._should_scroll = False
 
     def calculate_length(self):

--- a/test/widgets/test_base.py
+++ b/test/widgets/test_base.py
@@ -189,6 +189,13 @@ class ScrollingTextConfig(BareConfig):
                     TextBox("NoWidth", name="no_width", scroll=True),
                     TextBox("ShortText", name="short_text", width=100, scroll=True),
                     TextBox("Longer text " * 5, name="longer_text", width=100, scroll=True),
+                    TextBox(
+                        "ShortFixedWidth",
+                        name="fixed_width",
+                        width=200,
+                        scroll=True,
+                        scroll_fixed_width=True,
+                    ),
                 ],
                 32,
             )
@@ -257,3 +264,14 @@ def test_text_scroll_long_text(manager):
 
     # Check actually scrolling
     wait_for_scroll(widget)
+
+
+@scrolling_text_config
+def test_scroll_fixed_width(manager):
+    widget = manager.c.widget["fixed_width"]
+
+    _, layout = widget.eval("self.layout.width")
+    assert int(layout) < 200
+
+    # Widget width is fixed at set width
+    assert widget.info()["width"] == 200


### PR DESCRIPTION
Currently, when widgets have `scroll=True` set, the `width` parameter acts as maximum width. Where the width of the text is less than this value, the widget will shrink accordingly. This may be undesirable for users wishing to have a fixed width at all times.

This PR adds a new parameter, `scroll_fixed_width`, which, when set to `True`, forces the text widget to have a fixed width at all times.

Fixes #4101