### PR TITLE
Fix `PangoLayout` error on widget reload

### DIFF
--- a/test/widgets/test_base.py
+++ b/test/widgets/test_base.py
@@ -46,7 +46,7 @@ class TimerWidget(_Widget):
 
     @expose_command()
     def get_active_timers(self):
-        active = [x for x in self._futures if x._scheduled]
+        active = [x for x in self._futures if getattr(x, "_scheduled", False)]
         return len(active)
 
 

--- a/test/widgets/test_chord.py
+++ b/test/widgets/test_chord.py
@@ -111,7 +111,10 @@ def test_chord_widget(fake_window, fake_qtile):
     assert chord.background == BASE_BACKGROUND
     assert chord.foreground == BASE_FOREGROUND
 
-    # Finalize the widget to prevent segfault
+    # Finalize the widget to prevent segfault (the drawer needs to be finalised)
+    # We clear the _futures attribute as there are no real timers in it and calls
+    # to `cancel()` them will fail.
+    chord._futures = []
     chord.finalize()
 
 


### PR DESCRIPTION
We experience `PangoLayout` errors if widgets try to draw to drawers that have been finalised. This can happen when timers schedule drawing. We deal with this by making sure timers are cancelled when widgets are finalised. However, we only finalise timers that have been created by `self.timeout_add`. Timers set by `qtile.call_soon/later` are not tracked. These method are used to set initial timers for widgets at the end of `_configure` so, if these timers have not yet triggered before the widget is finalised then they will still be triggered.

This PR fixes that issue by ensuring that initial timers are also set via `timeout_add` so that they can be cancelled on finalising the widget.

Fixes #3869