### PR TITLE
`widget.Wttr`: Allow automatic location

### DIFF
--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -61,7 +61,7 @@ class Wttr(GenPollUrl):
         ),
         (
             "location",
-            None,
+            {},
             "Dictionary. Key is a city or place name, or GPS coordinates. "
             "Value is a display name.",
         ),
@@ -86,9 +86,6 @@ class Wttr(GenPollUrl):
         self.url = self._get_url()
 
     def _get_url(self):
-        if not self.location:
-            return None
-
         params = {
             "format": self.format,
             "lang": self.lang,

--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -63,7 +63,8 @@ class Wttr(GenPollUrl):
             "location",
             {},
             "Dictionary. Key is a city or place name, or GPS coordinates. "
-            "Value is a display name.",
+            "Value is a display name. If the dictionary is empty, "
+            "the location will be determined based on your IP address.",
         ),
         (
             "units",

--- a/test/widgets/test_wttr.py
+++ b/test/widgets/test_wttr.py
@@ -32,4 +32,4 @@ def test_wttr_methods():
 
 def test_wttr_no_location():
     wttr = widget.Wttr()
-    assert wttr._get_url() is None
+    assert wttr._get_url() == "https://wttr.in/?m&format=3&lang=en"


### PR DESCRIPTION
[wttr.in](https://wttr.in) uses your IP address if no location is provided. I made a minor change to make `widget.Wttr` also support this.