### PR TITLE
Add link info for requirements of canto

### DIFF
--- a/libqtile/widget/canto.py
+++ b/libqtile/widget/canto.py
@@ -29,7 +29,12 @@ from libqtile.widget import base
 
 
 class Canto(base.ThreadPoolText):
-    """Display RSS feeds updates using the canto console reader"""
+    """Display RSS feeds updates using the canto console reader
+
+    Widget requirements: canto_
+
+    .. _canto: https://codezen.org/canto-ng/
+    """
 
     defaults = [
         ("fetch", False, "Whether to fetch new items on update"),


### PR DESCRIPTION
Hi,

This adds some more informative markup in the docstring of the canto widget to link to the dependency's home-page.