### PR TITLE
Fix Mpris2 metadata format bug

### DIFF
--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -184,7 +184,7 @@ class Mpris2(base._TextBox):
             logger.warning(
                 "The use of `display_metadata is deprecated. Please use `format` instead."
             )
-            self.format = " - ".join(config["display_metadata"])
+            self.format = " - ".join(f"{{{s}}}" for s in config["display_metadata"])
 
         self._formatter = Mpris2Formatter()
 

--- a/test/widgets/test_mpris2widget.py
+++ b/test/widgets/test_mpris2widget.py
@@ -197,3 +197,13 @@ def test_mpris2_no_scroll(fake_qtile, patched_module, fake_window):
 
     mp.parse_message(*METADATA_PAUSED.body)
     assert mp.text == "Paused: Never Gonna Give You Up - Whenever You Need Somebody - Rick Astley"
+
+
+def test_mpris2_deprecated_format(patched_module):
+    """
+    Previously, metadata was displayed by using a list of fields.
+    Now, we use a `format` string. The widget should create this when a user
+    provides `display_metadata` in their config.
+    """
+    mp = patched_module.Mpris2(display_metadata=["xesam:title", "xesam:artist"])
+    assert mp.format == "{xesam:title} - {xesam:artist}"


### PR DESCRIPTION
The `Mpris2` widget now uses a `format` string to display metadata. Previously, desired fields were passed as a list to the `display_metadata` parameter. The widget allows this old parameter by converting it to a format string. However, there was a bug in the conversion that meant that, instead of generating a valid format string (with field names inside curly brackets), the widget just generated a literal string.

This PR fixes the error and generates the correct format string. This will also fix a rendering bug in the widget's screenshot on our docs!