### PR TITLE
X11 Core: Handle motion notify events later

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.
         - Ensure `CurrentLayoutIcon` expands paths for custom folders.
         - Fix vertical alignment of icons in `TaskList` widget
+        - Fix laggy resize/positioning of floating windows in X11 by handling motion notify events later
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,8 +60,6 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix config being reevaluated twice during reload (e.g. all hooks from config were doubled)
         - Fix `PulseVolume` high CPU usage when update_interval set to 0.
         - Fix `Battery` widget on FreeBSD without explicit `battery` index given.
-        - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 120. This is configurable
-          per screen with the x11_drag_polling_rate variable.
         - Fix XMonad layout faulty call to nonexistent _shrink_up
         - Fix setting tiled position by mouse for layouts using _SimpleLayoutBase. To support this in other layouts, add a swap method taking two windows.
         - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -164,9 +164,6 @@ class Core(base.Core):
             | xcbq.PointerMotionHintMask
         )
 
-        # The last time we were handling a MotionNotify event
-        self._last_motion_time = 0
-
     @property
     def name(self):
         return "x11"
@@ -654,12 +651,6 @@ class Core(base.Core):
     def handle_MotionNotify(self, event) -> None:  # noqa: N802
         assert self.qtile is not None
 
-        # Limit the motion notify events from happening too frequently
-        # Here we limit it to the config value
-        resize_fps = self.qtile.current_screen.x11_drag_polling_rate
-        if (event.time - self._last_motion_time) <= (1000 / resize_fps):
-            return
-        self._last_motion_time = event.time
         self.qtile.process_button_motion(event.event_x, event.event_y)
 
     def handle_ConfigureRequest(self, event):  # noqa: N802

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -418,11 +418,6 @@ class Screen(CommandObject):
     resized to fill it. If the mode is ``"stretch"``, the image is stretched to fit all
     of it into the screen.
 
-    The ``x11_drag_polling_rate`` parameter specifies the rate for drag events in the X11
-    backend. By default this is set to 120, but if you prefer it you can set it lower for
-    better performance or higher if you have a high refresh rate monitor. 120 would mean
-    that we handle a drag event 120 times per second.
-
     """
 
     group: _Group
@@ -436,7 +431,6 @@ class Screen(CommandObject):
         right: BarType | None = None,
         wallpaper: str | None = None,
         wallpaper_mode: str | None = None,
-        x11_drag_polling_rate: int = 120,
         x: int | None = None,
         y: int | None = None,
         width: int | None = None,
@@ -448,7 +442,6 @@ class Screen(CommandObject):
         self.right = right
         self.wallpaper = wallpaper
         self.wallpaper_mode = wallpaper_mode
-        self.x11_drag_polling_rate = x11_drag_polling_rate
         self.qtile: Qtile | None = None
         # x position of upper left corner can be > 0
         # if one screen is "right" of the other


### PR DESCRIPTION
This is a different approach to limiting motion notifies by handling
the events later. Inspired by AwesomeWM. See
https://github.com/awesomeWM/awesome/blob/master/awesome.c#L396. Hopefully this fixes the nvidia laggy behaviour.

See #4119 
