### PR TITLE
Remove Heisenbugs

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -50,7 +50,13 @@ from libqtile.extension.base import _Extension
 from libqtile.group import _Group
 from libqtile.log_utils import logger
 from libqtile.scratchpad import ScratchPad
-from libqtile.utils import get_cache_dir, lget, send_notification, subscribe_for_resume_events
+from libqtile.utils import (
+    cancel_tasks,
+    get_cache_dir,
+    lget,
+    send_notification,
+    subscribe_for_resume_events,
+)
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
@@ -318,6 +324,7 @@ class Qtile(CommandObject):
 
     def finalize(self) -> None:
         self._finalize_configurables()
+        cancel_tasks()
         self.core.finalize()
 
     def _process_screens(self, reloading: bool = False) -> None:

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -379,6 +379,8 @@ unsubscribe = Unsubscribe()
 
 
 def _fire_async_event(co):
+    from libqtile.utils import create_task
+
     loop = None
     with contextlib.suppress(RuntimeError):
         loop = asyncio.get_running_loop()
@@ -386,7 +388,7 @@ def _fire_async_event(co):
     if loop is None:
         asyncio.run(co)
     else:
-        asyncio.create_task(co)
+        create_task(co)
 
 
 def fire(event, *args, **kwargs):

--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -22,7 +22,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import asyncio
 from typing import Any
 
 try:
@@ -35,6 +34,7 @@ except ImportError:
     has_dbus = False
 
 from libqtile.log_utils import logger
+from libqtile.utils import create_task
 
 BUS_NAME = "org.freedesktop.Notifications"
 SERVICE_PATH = "/org/freedesktop/Notifications"
@@ -169,7 +169,7 @@ if has_dbus:
                     logger.error("Unable to remove notify on_close callback. Unknown callback.")
 
             if not self.callbacks:
-                return asyncio.create_task(self._release())
+                return create_task(self._release())
 
         async def _release(self):
             """

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -33,7 +33,7 @@ from shutil import which
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, TypeVar, Union
+    from typing import Any, Callable, Coroutine, TypeVar, Union
 
     ColorType = Union[str, tuple[int, int, int], tuple[int, int, int, float]]
     ColorsType = Union[ColorType, list[ColorType]]
@@ -51,6 +51,38 @@ except ImportError:
 
 from libqtile import hook
 from libqtile.log_utils import logger
+
+# Create a list to collect references to tasks so they're not garbage collected
+# before they've run
+TASKS: list[asyncio.Task[None]] = []
+
+
+def create_task(coro: Coroutine) -> asyncio.Task | None:
+    """
+    Wrapper for asyncio.create_task.
+
+    Stores task so garbage collector doesn't remove it and removes reference when it's done.
+    See: https://textual.textualize.io/blog/2023/02/11/the-heisenbug-lurking-in-your-async-code/
+    for more info about the issue this solves.
+    """
+    loop = asyncio.get_running_loop()
+    if not loop:
+        return None
+
+    def tidy(task: asyncio.Task) -> None:
+        TASKS.remove(task)
+
+    task = asyncio.create_task(coro)
+    TASKS.append(task)
+    task.add_done_callback(tidy)
+
+    return task
+
+
+def cancel_tasks() -> None:
+    """Cancel scheduled tasks."""
+    for task in TASKS:
+        task.cancel()
 
 
 class QtileError(Exception):
@@ -487,7 +519,7 @@ async def find_dbus_service(service: str, session_bus: bool) -> bool:
 
 
 def subscribe_for_resume_events() -> None:
-    task = asyncio.create_task(
+    task = create_task(
         add_signal_receiver(
             on_resume,
             session_bus=False,
@@ -497,7 +529,8 @@ def subscribe_for_resume_events() -> None:
             check_service=True,
         )
     )
-    task.add_done_callback(_resume_callback)
+    if task is not None:
+        task.add_done_callback(_resume_callback)
 
 
 def _resume_callback(task: asyncio.Task) -> None:

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -42,6 +42,7 @@ from libqtile.command import interface
 from libqtile.command.base import CommandError, CommandObject, expose_command
 from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
+from libqtile.utils import create_task
 
 if TYPE_CHECKING:
     from typing import Any
@@ -225,7 +226,7 @@ class _Widget(CommandObject, configurable.Configurable):
         self.drawer = bar.window.create_drawer(self.bar.width, self.bar.height)
         if not self.configured:
             self.qtile.call_soon(self.timer_setup)
-            self.qtile.call_soon(asyncio.create_task, self._config_async())
+            self.qtile.call_soon(create_task, self._config_async())
 
     async def _config_async(self):
         """
@@ -351,9 +352,9 @@ class _Widget(CommandObject, configurable.Configurable):
         self._remove_dead_timers()
         try:
             if asyncio.iscoroutinefunction(method):
-                asyncio.create_task(method(*method_args))
+                create_task(method(*method_args))
             elif asyncio.iscoroutine(method):
-                asyncio.create_task(method)
+                create_task(method)
             else:
                 method(*method_args)
         except:  # noqa: E722

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -33,7 +33,7 @@ from dbus_next.constants import MessageType
 
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
-from libqtile.utils import _send_dbus_message, add_signal_receiver
+from libqtile.utils import _send_dbus_message, add_signal_receiver, create_task
 from libqtile.widget import base
 
 if TYPE_CHECKING:
@@ -249,7 +249,7 @@ class Mpris2(base._TextBox):
         if message.message_type != MessageType.SIGNAL:
             return
 
-        asyncio.create_task(self.process_message(message))
+        create_task(self.process_message(message))
 
     async def process_message(self, message):
         current_player = message.sender
@@ -373,7 +373,8 @@ class Mpris2(base._TextBox):
         if self._current_player is None:
             return
 
-        task = asyncio.create_task(self._send_player_cmd(cmd))
+        task = create_task(self._send_player_cmd(cmd))
+        assert task
         task.add_done_callback(self._task_callback)
 
     async def _send_player_cmd(self, cmd: str) -> Message | None:

--- a/test/widgets/test_notify.py
+++ b/test/widgets/test_notify.py
@@ -206,17 +206,15 @@ def test_invoke_and_clear(manager_nospawn, minimal_conf_noscreen):
     # object so we rely on "eval" applying "exec".
     handler = textwrap.dedent(
         """
-        import asyncio
-
-        from libqtile.utils import add_signal_receiver
+        from libqtile.utils import add_signal_receiver, create_task
 
         class SignalListener:
             def __init__(self):
                 self.action_invoked = None
                 self.notification_closed = None
                 global add_signal_receiver
-                global asyncio
-                asyncio.create_task(
+                global create_task
+                create_task(
                     add_signal_receiver(
                         self.on_notification_closed,
                         session_bus=True,
@@ -224,7 +222,7 @@ def test_invoke_and_clear(manager_nospawn, minimal_conf_noscreen):
                     )
                 )
 
-                asyncio.create_task(
+                create_task(
                     add_signal_receiver(
                         self.on_action_invoked,
                         session_bus=True,
@@ -247,12 +245,10 @@ def test_invoke_and_clear(manager_nospawn, minimal_conf_noscreen):
     # expose actions so we need a lower-level call
     notification_with_actions = textwrap.dedent(
         """
-        import asyncio
-
         from dbus_next import Variant
         from dbus_next.constants import MessageType
 
-        from libqtile.utils import _send_dbus_message
+        from libqtile.utils import _send_dbus_message, create_task
 
         notification = [
             "qtile",
@@ -265,7 +261,7 @@ def test_invoke_and_clear(manager_nospawn, minimal_conf_noscreen):
             5000
         ]
 
-        asyncio.create_task(
+        create_task(
             _send_dbus_message(
                 True,
                 MessageType.METHOD_CALL,
@@ -290,6 +286,9 @@ def test_invoke_and_clear(manager_nospawn, minimal_conf_noscreen):
 
     # Create our signal listener
     manager_nospawn.c.eval(handler)
+
+    _, result = manager_nospawn.c.eval("self.signal_listener")
+    print(result)
 
     # Send first notification and check time and display time
     notif_1 = [NS]


### PR DESCRIPTION
As mentioned by @tych0, there are potential "Heisenbugs" in our code base where we use `asyncio.create_task` but don't retain a reference to the created task. In those scenarios, the garbage collector could collect the task before it's executed.

This PR stores created tasks in a list and periodically removed completed tasks from that list to limit its size.