### PR TITLE
Layout XMonad: Fix shrink_up call typo

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix `Battery` widget on FreeBSD without explicit `battery` index given.
         - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 120. This is configurable
           per screen with the x11_drag_polling_rate variable.
+        - Fix XMonad layout faulty call to nonexistent _shrink_up
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -468,7 +468,7 @@ class MonadTall(_SimpleLayoutBase):
             left -= per_amt - self._shrink(idx, per_amt)
         # apply non-equal shrinkage secondary pass
         # in order to use up any left over shrink amounts
-        left = self._shrink_up(cidx, left)
+        left = self.shrink_up(cidx, left)
         # return whatever could not be applied
         return left
 


### PR DESCRIPTION
`Shrink_up` gave an attributeError and then broke `shrink_drown` by leaving gaps

![image](https://user-images.githubusercontent.com/46386452/219884357-24f8c0ae-6d58-40b7-a631-72aa3f079fda.png)
