### PR TITLE
Backend + Group: Fix setting tiled position by mouse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix laggy resize in X11 by limiting the MotionNotify fps to a default of 120. This is configurable
           per screen with the x11_drag_polling_rate variable.
         - Fix XMonad layout faulty call to nonexistent _shrink_up
+        - Fix setting tiled position by mouse for layouts using _SimpleLayoutBase. To support this in other layouts, add a swap method taking two windows.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -531,7 +531,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
                     and window.x <= cx <= (window.x + window.width)
                     and window.y <= cy <= (window.y + window.height)
                 ):
-                    self.group.swap(self, window)
+                    self.group.layout.swap(self, window)
                     return
 
     @expose_command()

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -531,12 +531,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
                     and window.x <= cx <= (window.x + window.width)
                     and window.y <= cy <= (window.y + window.height)
                 ):
-                    clients = self.group.layout.clients
-                    index1 = clients.index(self)
-                    index2 = clients.index(window)
-                    clients[index1], clients[index2] = clients[index2], clients[index1]
-                    self.group.layout.focused = index2
-                    self.group.layout_all()
+                    self.group.swap(self, window)
                     return
 
     @expose_command()

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1862,5 +1862,5 @@ class Window(_Window, base.Window):
             if window == self or window.floating:
                 continue
             if self._is_in_window(curx, cury, window):
-                self.group.swap(self, window)
+                self.group.layout.swap(self, window)
                 return

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1862,10 +1862,5 @@ class Window(_Window, base.Window):
             if window == self or window.floating:
                 continue
             if self._is_in_window(curx, cury, window):
-                clients = self.group.layout.clients
-                index1 = clients.index(self)
-                index2 = clients.index(window)
-                clients[index1], clients[index2] = clients[index2], clients[index1]
-                self.group.layout.focused = index2
-                self.group.layout_all()
-                break
+                self.group.swap(self, window)
+                return

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -265,12 +265,6 @@ class _Group(CommandObject):
         if focus:
             self.focus(win, warp=True, force=force)
 
-    def swap(self, win, win_other):
-        try:
-            self.layout.swap(win, win_other)
-        except AttributeError:
-            logger.warning("This layout does not support swapping tiled windows")
-
     def remove(self, win, force=False):
         self.windows.remove(win)
         hadfocus = self._remove_from_focus_history(win)

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -265,6 +265,12 @@ class _Group(CommandObject):
         if focus:
             self.focus(win, warp=True, force=force)
 
+    def swap(self, win, win_other):
+        try:
+            self.layout.swap(win, win_other)
+        except AttributeError:
+            logger.warning("This layout does not support swapping tiled windows")
+
     def remove(self, win, force=False):
         self.windows.remove(win)
         hadfocus = self._remove_from_focus_history(win)

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import configurable
 from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.interface import CommandError
 
 if TYPE_CHECKING:
     from typing import Any
@@ -93,6 +94,10 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
     def hide(self):
         """Called when layout is being hidden"""
         pass
+
+    def swap(self, c1, c2):
+        """Swap the two given clients c1 and c2"""
+        raise CommandError(f"layout: {self.name} does not support swapping windows")
 
     def focus(self, client):
         """Called whenever the focus changes"""

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -487,6 +487,11 @@ class _SimpleLayoutBase(Layout):
         client = self.focus_previous(self.clients.current_client) or self.focus_last()
         self.group.focus(client, True)
 
+    def swap(self, window1, window2):
+        self.clients.swap(window1, window2)
+        self.group.layout_all()
+        self.group.focus(window1)
+
     def next(self):
         if self.clients.current_client is None:
             return

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -712,9 +712,7 @@ class MonadTall(_SimpleLayoutBase):
     @expose_command()
     def swap(self, window1, window2):
         """Swap two windows"""
-        self.clients.swap(window1, window2, 1)
-        self.group.layout_all()
-        self.group.focus(window1)
+        _SimpleLayoutBase.swap(self, window1, window2)
 
     @expose_command("shuffle_left")
     def swap_left(self):


### PR DESCRIPTION
It gave an AttributeError:

```python
    self.group.layout.focused = index2
AttributeError: can't set attribute 'focused'
```

Let's just use the layout swap method instead of the hacky .clients (which would only work for clientlist). To avoid duplicated code let's make a swap method in group. This checks if the layout also supports a swap method to avoid erroring out

Fixes part of https://github.com/qtile/qtile/issues/855#issuecomment-540725219 as it now works, however not for any layout of course. For a layout to support this just simply implement a "swap" method. I have added support for `_SimpleLayoutBase` by moving the implementation from the `XMonad` layout