### PR TITLE
Fix Notify widget finalisation

### DIFF
--- a/libqtile/notify.py
+++ b/libqtile/notify.py
@@ -26,7 +26,7 @@ from typing import Any
 
 try:
     from dbus_next.aio import MessageBus
-    from dbus_next.constants import NameFlag
+    from dbus_next.constants import NameFlag, RequestNameReply
     from dbus_next.service import ServiceInterface, method, signal
 
     has_dbus = True
@@ -129,22 +129,42 @@ if has_dbus:
             self.callbacks = []
             self.close_callbacks = []
             self._service = None
+            self.bus = None
 
         async def service(self):
-            if self._service is None:
-                try:
-                    self.bus = await MessageBus().connect()
+            if not self.callbacks:
+                if self.bus is None:
+                    try:
+                        self.bus = await MessageBus().connect()
+                    except Exception:
+                        logger.exception("Dbus connection failed")
+                        self._service = None
+                        return self._service
+
                     self._service = NotificationService(self)
                     self.bus.export(SERVICE_PATH, self._service)
-                    await self.bus.request_name(
-                        BUS_NAME,
-                        flags=NameFlag.ALLOW_REPLACEMENT
-                        | NameFlag.REPLACE_EXISTING
-                        | NameFlag.DO_NOT_QUEUE,
+
+                reply = await self.bus.request_name(
+                    BUS_NAME,
+                    flags=NameFlag.ALLOW_REPLACEMENT
+                    | NameFlag.REPLACE_EXISTING
+                    | NameFlag.DO_NOT_QUEUE,
+                )
+
+                # Check the reply to see if another server is already running.
+                # Other replies could be RequestNameReply.PRIMARY_OWNER or
+                # RequestNameReply.ALREADY_ONWER. Both would indicate qtile server
+                # is running successfully so we don't need to check for them.
+                # RequestNameReply.IN_QUEUE should not be possible as we pass
+                # NameFlag.DO_NOT_QUEUE when requesting the name.
+                if reply == RequestNameReply.EXISTS:
+                    logger.warning(
+                        "Cannot start notification server as another server is already running."
                     )
-                except Exception:
-                    logger.exception("Dbus connection failed")
                     self._service = None
+                    self.bus.disconnect()
+                    self.bus = None
+
             return self._service
 
         async def register(self, callback, capabilities=None, on_close=None):

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -207,23 +207,5 @@ class Notify(base._TextBox):
             self._invoke()
 
     def finalize(self):
-        # We may need some async calls as part of the finalize call
-        # We run this with `call_soon_threadsafe` as this waits for
-        # the job to finish before continuing. This is important as,
-        # if the config is just reloading, we need to finish deregistering
-        # the notification server before the new Notify widget instance
-        # registers and creates a new server.
-        self.qtile.call_soon_threadsafe(self._finalize)
-        base._TextBox.finalize(self)
-
-    async def _finalize(self):
-        if notifier is not None:
-            task = notifier.unregister(self.update)
-
-            # If the notifier has no more callbacks then it needs to be stopped.
-            # The returned task will handle the release of the service name from
-            # dbus. We await it here to make sure it's finished before we
-            # complete the finalisation of this widget.
-            if task:
-                await task
+        notifier.unregister(self.update)
         base._TextBox.finalize(self)


### PR DESCRIPTION
The `Notify` widget was failing to remove callbacks when the widget was finalised. This meant that callbacks were triggered on widgets that no longer had an active `Drawer` resulting in error messages.

This PR simplifies the finalisation process by removing the call for the notifier to release the service name from bus. The name will be released automatically when qtile shuts down so there is no need to explicitly call the method.

Fixes #4153


Note: If a user starts a notification server like `dunst` this should replace qtile's server. However, if `dunst` is subsequently stopped, qtile's server will not be restarted.