### PR TITLE
 Don't mask AttributeErrors that arise during startup 

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -133,7 +133,7 @@ def check_config(args):
 
 def add_subcommand(subparsers, parents):
     parser = subparsers.add_parser(
-        "check", parents=parents, help="Check a configuration file for errors"
+        "check", parents=parents, help="Check a configuration file for errors."
     )
     parser.add_argument(
         "-c",
@@ -143,6 +143,6 @@ def add_subcommand(subparsers, parents):
             path.join(getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
         ),
         dest="configfile",
-        help="Use the specified configuration file",
+        help="Use the specified configuration file.",
     )
     parser.set_defaults(func=check_config)

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -189,17 +189,17 @@ def cmd_obj(args) -> None:
 
 def add_subcommand(subparsers, parents):
     epilog = textwrap.dedent(
-        """\
-    Examples:
-     qtile cmd-obj
-     qtile cmd-obj -o cmd
-     qtile cmd-obj -o cmd -f prev_layout -i
-     qtile cmd-obj -o cmd -f prev_layout -a 3 # prev_layout on group 3
-     qtile cmd-obj -o group 3 -f focus_back
-     qtile cmd-obj -o cmd -f restart # restart qtile
-     """
+        """
+        Examples:
+         qtile cmd-obj
+         qtile cmd-obj -o cmd
+         qtile cmd-obj -o cmd -f prev_layout -i
+         qtile cmd-obj -o cmd -f prev_layout -a 3 # prev_layout on group 3
+         qtile cmd-obj -o group 3 -f focus_back
+         qtile cmd-obj -o cmd -f restart # restart qtile
+        """
     )
-    description = "qtile.command functionality exposed to the shell."
+    description = "Access the command interface from a shell."
     parser = subparsers.add_parser(
         "cmd-obj",
         help=description,
@@ -226,5 +226,5 @@ def add_subcommand(subparsers, parents):
         action="store_true",
         help="With both --object and --function args prints documentation for function.",
     )
-    parser.add_argument("--socket", "-s", help="Path of the Qtile IPC socket.")
+    parser.add_argument("--socket", "-s", help="Use specified socket for IPC.")
     parser.set_defaults(func=cmd_obj)

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -60,11 +60,11 @@ def main():
     help_.set_defaults(func=print_help)
 
     options = main_parser.parse_args()
-    try:
+    if func := getattr(options, "func", None):
         log_level = getattr(logging, options.log_level)
         init_log(log_level, log_path=get_default_log())
-        options.func(options)
-    except AttributeError:
+        func(options)
+    else:
         main_parser.print_usage()
         print("")
         print("Did you mean:")

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -34,7 +34,7 @@ def main():
 
     main_parser = argparse.ArgumentParser(
         prog="qtile",
-        description="A full-featured, pure-Python tiling window manager.",
+        description="A full-featured tiling window manager for X11 and Wayland.",
     )
     main_parser.add_argument(
         "-v",
@@ -56,7 +56,7 @@ def main():
     def print_help(options):
         main_parser.print_help()
 
-    help_ = subparsers.add_parser("help", help="Print help information and exit")
+    help_ = subparsers.add_parser("help", help="Print help message and exit.")
     help_.set_defaults(func=print_help)
 
     options = main_parser.parse_args()

--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -244,7 +244,7 @@ def do_migrate(args):
 
 def add_subcommand(subparsers, parents):
     parser = subparsers.add_parser(
-        "migrate", parents=parents, help="Migrate a configuration file to the current API"
+        "migrate", parents=parents, help="Migrate a configuration file to the current API."
     )
     parser.add_argument(
         "-c",
@@ -253,11 +253,11 @@ def add_subcommand(subparsers, parents):
         default=os.path.expanduser(
             os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
         ),
-        help="Use the specified configuration file (migrates every .py file in this directory)",
+        help="Use the specified configuration file (migrates every .py file in this directory).",
     )
     parser.add_argument(
         "--yes",
         action="store_true",
-        help="Automatically apply diffs with no confirmation",
+        help="Automatically apply diffs with no confirmation.",
     )
     parser.set_defaults(func=do_migrate)

--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -65,14 +65,14 @@ def run_cmd(opts) -> None:
 
 def add_subcommand(subparsers, parents):
     parser = subparsers.add_parser(
-        "run-cmd", parents=parents, help="A wrapper around the command graph"
+        "run-cmd", parents=parents, help="A wrapper around the command graph."
     )
-    parser.add_argument("-s", "--socket", help="Use specified communication socket.")
+    parser.add_argument("-s", "--socket", help="Use specified socket for IPC.")
     parser.add_argument(
         "-i", "--intrusive", action="store_true", help="If the new window should be intrusive."
     )
     parser.add_argument(
-        "-f", "--float", action="store_true", help="If the new window should be float."
+        "-f", "--float", action="store_true", help="If the new window should be floating."
     )
     parser.add_argument(
         "-b",

--- a/libqtile/scripts/shell.py
+++ b/libqtile/scripts/shell.py
@@ -37,14 +37,16 @@ def qshell(args) -> None:
 
 
 def add_subcommand(subparsers, parents):
-    parser = subparsers.add_parser("shell", parents=parents, help="shell-like interface to qtile")
+    parser = subparsers.add_parser(
+        "shell", parents=parents, help="A shell-like interface to Qtile."
+    )
     parser.add_argument(
         "-s",
         "--socket",
         action="store",
         type=str,
         default=None,
-        help="Use specified socket to connect to qtile.",
+        help="Use specified socket for IPC.",
     )
     parser.add_argument(
         "-c",
@@ -60,6 +62,6 @@ def add_subcommand(subparsers, parents):
         action="store_true",
         default=False,
         dest="is_json",
-        help="Use json in order to communicate with qtile server.",
+        help="Use JSON to communicate with Qtile.",
     )
     parser.set_defaults(func=qshell)

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -95,7 +95,7 @@ def start(options):
 
 
 def add_subcommand(subparsers, parents):
-    parser = subparsers.add_parser("start", parents=parents, help="Start the window manager")
+    parser = subparsers.add_parser("start", parents=parents, help="Start a Qtile session.")
     parser.add_argument(
         "-c",
         "--config",
@@ -104,7 +104,7 @@ def add_subcommand(subparsers, parents):
             path.join(getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
         ),
         dest="configfile",
-        help="Use the specified configuration file",
+        help="Use the specified configuration file.",
     )
     parser.add_argument(
         "-s",
@@ -112,7 +112,7 @@ def add_subcommand(subparsers, parents):
         action="store",
         default=None,
         dest="socket",
-        help="Path of the Qtile IPC socket.",
+        help="Use specified socket for IPC.",
     )
     parser.add_argument(
         "-n",
@@ -120,13 +120,13 @@ def add_subcommand(subparsers, parents):
         action="store_true",
         default=False,
         dest="no_spawn",
-        help="Avoid spawning apps. (Used for restart)",
+        help="Avoid spawning apps. (Used when restarting Qtile)",
     )
     parser.add_argument(
         "--with-state",
         default=None,
         dest="state",
-        help="Pickled QtileState object (typically used only internally)",
+        help="Pickled QtileState object. (Used when restarting Qtile).",
     )
     parser.add_argument(
         "-b",

--- a/libqtile/scripts/top.py
+++ b/libqtile/scripts/top.py
@@ -184,9 +184,11 @@ def top(opts):
 
 
 def add_subcommand(subparsers, parents):
-    parser = subparsers.add_parser("top", parents=parents, help="resource usage information")
+    parser = subparsers.add_parser(
+        "top", parents=parents, help="A top-like resource usage monitor."
+    )
     parser.add_argument(
-        "-L", "--lines", type=int, dest="lines", default=10, help="Number of lines."
+        "-L", "--lines", type=int, dest="lines", default=10, help="Number of lines to show."
     )
     parser.add_argument(
         "-r",
@@ -194,7 +196,7 @@ def add_subcommand(subparsers, parents):
         dest="raw",
         action="store_true",
         default=False,
-        help="Output raw without curses",
+        help="Output raw without curses.",
     )
     parser.add_argument(
         "-t",
@@ -202,16 +204,16 @@ def add_subcommand(subparsers, parents):
         type=float,
         dest="seconds",
         default=1.5,
-        help="Number of seconds to refresh",
+        help="Refresh rate.",
     )
     parser.add_argument(
         "--force-start",
         dest="force_start",
         action="store_true",
         default=False,
-        help="Force start tracemalloc on qtile",
+        help="Force start tracemalloc on Qtile.",
     )
     parser.add_argument(
-        "-s", "--socket", type=str, dest="socket", help="Use specified communication socket."
+        "-s", "--socket", type=str, dest="socket", help="Use specified socket for IPC."
     )
     parser.set_defaults(func=top)


### PR DESCRIPTION
 Commit 1:
```
Proofread qtile command messages

- Normalises sentence case and adds periods
- Uses same message for all `--socket` arguments (a few subcommands use
  it)
- Update command description to drop "pure python", which isn't quite
  true these days
```
Commit 2:
```
 Don't mask AttributeErrors that arise during startup

When our argparsing runs the target subcommand, it does so inside a try
block which appears to have been added to catch the absence of
`options.func` when someone just runs `qtile`, rather than `qtile
start`. This has the side effect of hiding any AttributeErrors that
arise early on in startup e.g. when the core is being created. This
doesn't affect users so much (except those really living on the edge)
but it can be annoying during development. Instead, this does the
attribute check explicitly.
```

Closes #4152
