### PR TITLE
Validate config types when loading

### DIFF
--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -8,8 +8,8 @@ CORES = [
 ]
 
 
-def get_core(backend, *args):
+def get_core(backend):
     if backend not in CORES:
         raise QtileError(f"Backend {backend} does not exist")
 
-    return importlib.import_module(f"libqtile.backend.{backend}.core").Core(*args)
+    return importlib.import_module(f"libqtile.backend.{backend}.core").Core

--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -56,6 +56,16 @@ class Core(CommandObject, metaclass=ABCMeta):
     def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the screen information"""
 
+    @staticmethod
+    def get_keys() -> list[str] | None:
+        """Get a list of valid keys."""
+        return None
+
+    @staticmethod
+    def get_modifiers() -> list[str] | None:
+        """Get a list of valid modifier keys."""
+        return None
+
     @abstractmethod
     def grab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Configure the backend to grab the key event"""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -57,14 +57,6 @@ _IGNORED_EVENTS = {
 }
 
 
-def get_keys() -> list[str]:
-    return list(xcbq.keysyms.keys())
-
-
-def get_modifiers() -> list[str]:
-    return list(xcbq.ModMasks.keys())
-
-
 class ExistingWMException(Exception):
     pass
 
@@ -231,6 +223,14 @@ class Core(base.Core):
             loop = asyncio.get_running_loop()
             loop.remove_reader(self.fd)
             self.fd = None
+
+    @staticmethod
+    def get_keys() -> list[str] | None:
+        return list(xcbq.keysyms.keys())
+
+    @staticmethod
+    def get_modifiers() -> list[str] | None:
+        return list(xcbq.ModMasks.keys())
 
     def on_config_load(self, initial) -> None:
         """Assign windows to groups"""

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -24,17 +24,21 @@
 from __future__ import annotations
 
 import importlib
+import inspect
+import os
 import sys
+import types
+import typing
+from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, Literal, Optional, Union
 
-if TYPE_CHECKING:
-    from typing import Any
-
-    from typing_extensions import Literal
-
-    from libqtile.config import Group, Key, Mouse, Rule, Screen
-    from libqtile.layout.base import Layout
+import libqtile
+from libqtile.backend import get_core
+from libqtile.config import Group, Key, Mouse, Rule, Screen
+from libqtile.layout.base import Layout
+from libqtile.log_utils import logger
+from libqtile.resources import default_config
 
 
 class ConfigError(Exception):
@@ -52,6 +56,8 @@ from libqtile.layout.base import Layout
 
 class Config:
     # All configuration options
+    # While we support Python 3.9 we can't use the | operator in types as annotations
+    # are evaluated at runtime for config validation.
     keys: list[Key]
     mouse: list[Mouse]
     groups: list[Group]
@@ -63,40 +69,46 @@ class Config:
     layouts: list[Layout]
     floating_layout: Layout
     screens: list[Screen]
+    fake_screens: Optional[list[Screen]]
     auto_fullscreen: bool
     widget_defaults: dict[str, Any]
     extension_defaults: dict[str, Any]
-    bring_front_click: bool | Literal["floating_only"]
+    bring_front_click: Union[bool, Literal["floating_only"]]
     floats_kept_above: bool
     reconfigure_screens: bool
     wmname: str
     auto_minimize: bool
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but
     # doing so forces the import, creating a hard dependency for wlroots.
-    wl_input_rules: dict[str, Any] | None
+    wl_input_rules: Optional[dict[str, Any]]
 
-    def __init__(self, file_path=None, **settings):
-        """Create a Config() object from settings
+    def __init__(self, file_path: str | None = None) -> None:
+        """This stores loaded configuration values.
 
-        Only attributes found in Config.__annotations__ will be added to object.
-        config attribute precedence is 1.) **settings 2.) self 3.) default_config
+        Config.__annotations__ lists all possible options and their types. Default
+        values are loaded from the default config at startup, and then are attempted to
+        be loaded from the config (assuming the config is error-free).
         """
-        self.file_path = file_path
-        self.update(**settings)
+        if file_path:
+            self.file_path: Path | None = Path(file_path)
+            sys.path.insert(0, self.file_path.parent.as_posix())
+        else:
+            # Not specifying a path is mainly useful for tests.
+            self.file_path = None
 
-    def update(self, *, fake_screens=None, **settings):
-        from libqtile.resources import default_config
+        # Load default values, which need to be kept around in case a setting is removed
+        # from the user config and the default value is needed again.
+        self._defaults: dict[str, Any] = {
+            k: getattr(default_config, k) for k in Config.__annotations__.keys()
+        }
+        self.__dict__.update(self._defaults)
 
-        if fake_screens:
-            self.fake_screens = fake_screens
-
-        default = vars(default_config)
-        for key in self.__annotations__.keys():
-            try:
-                value = settings[key]
-            except KeyError:
-                value = getattr(self, key, default[key])
-            setattr(self, key, value)
+        # Load valid types. From 3.10 we have inspect.get_annotations.
+        # See https://docs.python.org/3/howto/annotations.html
+        if hasattr(inspect, "get_annotations"):
+            self._types = inspect.get_annotations(Config, eval_str=True)
+        else:
+            self._types = {k: eval(v) for k, v in Config.__annotations__.items()}
 
     def _reload_config_submodules(self, path: Path) -> None:
         """Reloads python files from same folder as config file."""
@@ -119,43 +131,125 @@ class Config:
                 if folder in subpath.parents:
                     importlib.reload(module)
 
-    def load(self):
-        if not self.file_path:
-            return
-
-        path = Path(self.file_path)
-        name = path.stem
-        sys.path.insert(0, path.parent.as_posix())
-
-        if name in sys.modules:
-            self._reload_config_submodules(path)
-            config = importlib.reload(sys.modules[name])
-        else:
-            config = importlib.import_module(name)
-
-        self.update(**vars(config))
+    def load(self) -> None:
+        new_config = self._do_load()
+        self.__dict__.update(new_config)
 
     def validate(self) -> None:
-        """
-        Validate the configuration against the X11 core, if it makes sense.
-        """
+        self._do_load()
+
+    def _do_load(self) -> dict[str, Any]:
+        path = self.file_path
+
+        if path is None:
+            # This is a test config that doesn't load from file. Instead, config values
+            # were specified as class attributes on a subclass.
+            classattrs = {}
+            keys = self._defaults.keys()
+            # follow the parents of test classes up to Config and object.
+            for cls in reversed(self.__class__.mro()[:-2]):
+                attrs = vars(cls)
+                classattrs.update({k: v for k, v in attrs.items() if k in keys})
+            return classattrs
+
+        name = path.stem
+
         try:
-            from libqtile.backend.x11 import core
-        except ImportError:
-            return
+            if name in sys.modules:
+                self._reload_config_submodules(path)
+                config = importlib.reload(sys.modules[name])
+            else:
+                config = importlib.import_module(name)
+        except Exception as e:
+            raise ConfigError from e
+
+        settings = vars(config)
+        specified_keys = self._types.keys() & settings.keys()
+        new_config = self._defaults.copy()
+
+        # Values must pass type checking to be applied.
+        errors = set()
+        for key in specified_keys:
+            valid_type = self._types[key]
+            value = settings[key]
+
+            if self._check_type(valid_type, value):
+                new_config[key] = value
+            else:
+                errors.add(key)
+
+        if errors:
+            logger.warning("Didn't load (invalid types): %s", ", ".join(errors))
+
+        # Check the values
+        try:
+            self._check_values(new_config)
+        except ConfigError as e:
+            # Continue anyway, but log that something didn't validate.
+            logger.warning(e.args[0])
+
+        return new_config
+
+    def _check_type(self, valid_type: Any, value: Any) -> bool:
+        """
+        Perform basic run-time type checking of a value using annotations.
+        """
+        if origin := typing.get_origin(valid_type):
+            # valid_type is parameterised, so let's check the origin and arguments
+            args = typing.get_args(valid_type)
+
+            if origin is list:
+                check = partial(self._check_type, args[0])
+                return all(map(check, value))
+
+            if origin is Literal:
+                return value in args
+
+            if origin is dict:
+                check_keys = partial(self._check_type, args[0])
+                check_vals = partial(self._check_type, args[1])
+                return all(map(check_keys, value.keys())) and all(map(check_vals, value.values()))
+
+            if origin in (types.UnionType, typing.Union):
+                return any(self._check_type(t, value) for t in args)
+
+            # This function hasn't accounted for this type yet. Log that this happened,
+            # but assume the type check would have passed.
+            logger.warning("Config type checking didn't check: %s", valid_type)
+            return True
+
+        # valid_type is not parameterised, it's either Any or something we can
+        # isinstance directly.
+        return valid_type is Any or isinstance(value, valid_type)
+
+    def _check_values(self, config: dict[str, Any]) -> None:
+        """Try to check that the values in the config are valid."""
+        if libqtile.qtile is not None:
+            # First try to get the running core from the current process
+            core = libqtile.qtile.core
+        else:
+            # Otherwise, try to import a core
+            if "WAYLAND_DISPLAY" in os.environ:
+                core_name = "wayland"
+            else:
+                core_name = "x11"
+            try:
+                core = get_core(core_name)
+            except ImportError:
+                return
 
         valid_keys = core.get_keys()
         valid_mods = core.get_modifiers()
-        # we explicitly do not want to set self.keys and self.mouse above,
-        # because they are dynamically resolved from the default_config. so we
-        # need to ignore the errors here about missing attributes.
-        for k in self.keys:
-            if k.key.lower() not in valid_keys:
-                raise ConfigError("No such key: %s" % k.key)
-            for m in k.modifiers:
-                if m.lower() not in valid_mods:
-                    raise ConfigError("No such modifier: %s" % m)
-        for ms in self.mouse:
-            for m in ms.modifiers:
-                if m.lower() not in valid_mods:
-                    raise ConfigError("No such modifier: %s" % m)
+
+        if valid_keys is not None:
+            for k in self.keys:
+                if k.key.lower() not in valid_keys:
+                    raise ConfigError(f"No such key: {k.key}")
+                for m in k.modifiers:
+                    if m.lower() not in valid_mods:
+                        raise ConfigError(f"No such modifier: {m}")
+        if valid_mods is not None:
+            for ms in self.mouse:
+                for m in ms.modifiers:
+                    if m.lower() not in valid_mods:
+                        raise ConfigError(f"No such modifier: {m}")

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -111,13 +111,12 @@ class Qtile(CommandObject):
     def load_config(self, initial: bool = False) -> None:
         try:
             self.config.load()
-            self.config.validate()
         except Exception as e:
             logger.exception("Configuration error:")
             send_notification("Configuration error", str(e))
 
         if hasattr(self.core, "wmname"):
-            self.core.wmname = getattr(self.config, "wmname", "qtile")  # type: ignore
+            self.core.wmname = self.config.wmname  # type: ignore
 
         self.dgroups = DGroups(self, self.config.groups, self.config.dgroups_key_binder)
 
@@ -246,7 +245,7 @@ class Qtile(CommandObject):
         if not self.core.supports_restarting:
             raise CommandError(f"Backend does not support restarting: {self.core.name}")
         try:
-            self.config.load()
+            self.config.validate()
         except Exception as error:
             logger.exception("Preventing restart because of a configuration error:")
             send_notification("Configuration error", str(error.__context__))
@@ -281,7 +280,7 @@ class Qtile(CommandObject):
         logger.debug("Reloading the configuration file")
 
         try:
-            self.config.load()
+            self.config.validate()
         except Exception as error:
             logger.exception("Configuration error:")
             send_notification("Configuration error", str(error))
@@ -350,7 +349,7 @@ class Qtile(CommandObject):
         current_groups = [s.group for s in self.screens]
         screens = []
 
-        if hasattr(self.config, "fake_screens"):
+        if self.config.fake_screens:
             screen_info = [(s.x, s.y, s.width, s.height) for s in self.config.fake_screens]
             config = self.config.fake_screens
         else:
@@ -1210,7 +1209,7 @@ class Qtile(CommandObject):
     @expose_command()
     def validate_config(self) -> None:
         try:
-            self.config.load()
+            self.config.validate()
         except Exception as error:
             send_notification("Configuration check", str(error))
         else:

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -23,6 +23,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+#
+#
+# See the documentation for a reference on all options at:
+# http://docs.qtile.org/en/stable/manual/config/index.html#configuration-variables.
+# This config specifies default values that Qtile uses internally as fallback values in
+# case your own config doesn't contain a certain option. The first time you use Qtile it
+# will make a copy of this config at ~/.config/qtile/config.py. Feel free to remove any
+# config options if you're happy with the defaults.
 
 from libqtile import bar, layout, widget
 from libqtile.config import Click, Drag, Group, Key, Match, Screen
@@ -197,6 +205,10 @@ auto_minimize = True
 
 # When using the Wayland backend, this can be used to configure input devices.
 wl_input_rules = None
+
+# This can be used instead of `screens` to split a physical monitor into multiple
+# 'screens': http://docs.qtile.org/en/stable/manual/config/screens.html#fake-screens
+fake_screens = None
 
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -73,13 +73,16 @@ def main():
     if func := getattr(options, "func", None):
         log_level = getattr(logging, options.log_level)
         init_log(log_level, log_path=options.log_path)
-        func(options)
+        # TODO: make these return bools
+        ret_val = int(bool(func(options)))
     else:
         main_parser.print_usage()
         print("")
         print("Did you mean:")
         print(" ".join(sys.argv + ["start"]))
-        sys.exit(1)
+        ret_val = 1
+
+    sys.exit(ret_val)
 
 
 if __name__ == "__main__":

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -48,7 +48,7 @@ def rename_process():
 
 
 def make_qtile(options):
-    kore = libqtile.backend.get_core(options.backend)
+    kore = libqtile.backend.get_core(options.backend)()
 
     if not path.isfile(options.configfile):
         try:

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -32,9 +32,8 @@ from __future__ import annotations
 import xcffib
 from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, SetMode
 
-from libqtile import bar
+from libqtile import bar, confreader
 from libqtile.backend.x11 import window
-from libqtile.confreader import ConfigError
 from libqtile.widget import base
 
 XEMBED_PROTOCOL_VERSION = 0
@@ -151,7 +150,7 @@ class Systray(base._Widget, window._Window):  # type: ignore[misc]
             return
 
         if Systray._instances > 0:
-            raise ConfigError("Only one Systray can be used.")
+            raise confreader.ConfigError("Only one Systray can be used.")
 
         self.conn = conn = qtile.core.conn
         win = conn.create_window(-1, -1, 1, 1)

--- a/test/configs/bad_type.py
+++ b/test/configs/bad_type.py
@@ -1,0 +1,1 @@
+keys = ["not a Key()"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -35,7 +35,13 @@ def load_config(name):
     return f
 
 
-def test_validate():
+def test_validate_types():
+    f = confreader.Config(configs_dir / "bad_type.py")
+    with pytest.raises(confreader.ConfigError):
+        f.load()
+
+
+def test_validate_values():
     # bad key
     f = load_config("basic.py")
     f.keys[0].key = "nonexistent"
@@ -55,7 +61,7 @@ def test_basic():
 
 
 def test_syntaxerr():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(confreader.ConfigError):
         load_config("syntaxerr.py")
 
 


### PR DESCRIPTION
This largely rewrites the `Config` class to clean up some unused code and validate specified options in user configs using the class's type annotations.

This validation extends the existing `Config.validate` functionality to do basic runtime type checking.

After the type-checking, it carries out the existing check on the values of keys and modifiers.

Only if both stages pass successfully does the loaded config change in any way.

The base Core class is given static methods used to provide `Config` with valid keys and modifiers for value checking. These methods can return a list of valid values, or alternatively (by default), `None`, which lets validation continue without checking. Backends then can then override these with implementations that provide their set of valid key/mod names.