### PR TITLE
X11 Window: Workaround unfullscreen redrawing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           per screen with the x11_drag_polling_rate variable.
         - Fix XMonad layout faulty call to nonexistent _shrink_up
         - Fix setting tiled position by mouse for layouts using _SimpleLayoutBase. To support this in other layouts, add a swap method taking two windows.
+        - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -649,10 +649,17 @@ class _Window:
     def update_state(self):
         triggered = ["urgent"]
 
+        state = self.window.get_net_wm_state()
+
         if self.qtile.config.auto_fullscreen:
             triggered.append("fullscreen")
-
-        state = self.window.get_net_wm_state()
+        # This might seem a bit weird but it's to workaround a bug in chromium based clients not properly redrawing
+        # The bug is described in https://github.com/qtile/qtile/issues/4176
+        # This only happens when auto fullscreen is set to false because we then do not obey the disable fullscreen state
+        # So here we simply re-place the window at the coordinates which will magically solve the issue
+        # This only seems to be an issue with unfullscreening, thus we check if we're fullscreen and the window wants to unfullscreen
+        elif self.fullscreen and "fullscreen" not in state:
+            self._reconfigure_floating(new_float_state=FloatStates.FULLSCREEN)
 
         for s in triggered:
             setattr(self, s, (s in state))


### PR DESCRIPTION
See the comment in the code. It's a workaround and I'm not entirely sure yet if it's maybe something we do wrong in Qtile.

Fixes https://github.com/qtile/qtile/issues/4176

I don't think this can be tested properly