### PR TITLE
add ability to set custom "Undefined" status key value to `Mpd2Widget`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           By default the keys are not passed (swallowed), so this argument is set to `True`.
           When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
           function is not executed, e.g. due to failing the `.when()` check.
+        - Add ability to set custom "Undefined" status key value to `Mpd2Widget`.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -69,6 +69,8 @@ default_format = (
     "{play_status} {artist}/{title} " + "[{repeat}{random}{single}{consume}{updating_db}]"
 )
 
+default_undefined_status_value = "Undefined"
+
 
 def default_cmd():
     return None
@@ -116,6 +118,11 @@ class Mpd2(base.ThreadPoolText):
         (i.e. no song in queue)
 
         Default:: "MPD IDLE"
+
+    undefined_value:
+        text to display when status key is undefined
+
+        Default:: "Undefined"
 
     prepare_status:
         dict of functions to replace values in status with custom characters.
@@ -165,6 +172,11 @@ class Mpd2(base.ThreadPoolText):
         ("status_format", default_format, "format for displayed song info."),
         ("idle_format", default_idle_format, "format for status when mpd has no playlist."),
         ("idle_message", default_idle_message, "text to display when mpd is idle."),
+        (
+            "undefined_value",
+            default_undefined_status_value,
+            "text to display when status key is undefined.",
+        ),
         ("timeout", 30, "MPDClient timeout"),
         ("idletimeout", 5, "MPDClient idle command timeout"),
         ("no_connection", "No connection", "Text when mpd is disconnected"),
@@ -256,8 +268,7 @@ class Mpd2(base.ThreadPoolText):
 
     def formatter(self, status, current_song):
         """format song info."""
-        default = "Undefined"
-        song_info = defaultdict(lambda: default)
+        song_info = defaultdict(lambda: self.undefined_value)
         song_info["play_status"] = self.play_states[status["state"]]
 
         if status["state"] == "stop" and current_song == {}:
@@ -272,7 +283,7 @@ class Mpd2(base.ThreadPoolText):
         del song_info["time"]
 
         song_info.update(status)
-        if song_info["updating_db"] == default:
+        if song_info["updating_db"] == self.undefined_value:
             song_info["updating_db"] = "0"
         if not callable(self.prepare_status["repeat"]):
             for k in self.prepare_status:
@@ -290,11 +301,19 @@ class Mpd2(base.ThreadPoolText):
         # Remaining should default to '00:00' if either or both are missing.
         # These values are also used for coloring text by progress, if wanted.
         if "remaining" in self.status_format or self.color_progress:
-            total = float(song_info["fulltime"]) if song_info["fulltime"] != default else 0.0
-            elapsed = float(song_info["elapsed"]) if song_info["elapsed"] != default else 0.0
+            total = (
+                float(song_info["fulltime"])
+                if song_info["fulltime"] != self.undefined_value
+                else 0.0
+            )
+            elapsed = (
+                float(song_info["elapsed"])
+                if song_info["elapsed"] != self.undefined_value
+                else 0.0
+            )
             song_info["remaining"] = "{:.2f}".format(float(total - elapsed))
 
-        if "song" in self.status_format and song_info["song"] != default:
+        if "song" in self.status_format and song_info["song"] != self.undefined_value:
             song_info["currentsong"] = str(int(song_info["song"]) + 1)
 
         # mpd serializes tags containing commas as lists.

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import sys
-from collections import defaultdict
 from types import ModuleType
 
 import pytest

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import sys
+from collections import defaultdict
 from types import ModuleType
 
 import pytest
@@ -191,7 +192,18 @@ def test_mpd2_widget_idle_message(mpd2_manager):
 @pytest.mark.parametrize(
     "mpd2_manager", [{"status_format": "{currentsong}: {artist}/{title}"}], indirect=True
 )
-def test_mpd_widget_current_song(mpd2_manager):
+def test_mpd2_widget_current_song(mpd2_manager):
     """Quick test to check currentsong info"""
     widget = mpd2_manager.c.widget["mpd2"]
     assert widget.info()["text"] == "1: Rick Astley/Never gonna give you up"
+
+
+@pytest.mark.parametrize(
+    "mpd2_manager",
+    [{"undefined_value": "Unknown", "status_format": "{title} ({year})"}],
+    indirect=True,
+)
+def test_mpd2_widget_custom_undefined_value(mpd2_manager):
+    """Quick test to check undefined_value option"""
+    widget = mpd2_manager.c.widget["mpd2"]
+    assert widget.info()["text"] == "Never gonna give you up (Unknown)"


### PR DESCRIPTION
This PR implements "undefined_value" option to `Mpd2Widget`.

Since it is very opinionated, we can allow user to change this value (like a `idle_message`).

_In my opinion, "Undefined" looks bad in the status bar, changing it to something like "[-]" would be better.
I see it regularly, because a lot of my music doesn't have any tags._