### PR TITLE
TaskList: add `markup_focused_floating` option

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -146,6 +146,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             'e.g., "{}" or "<span underline="low">{}</span>"',
         ),
         (
+            "markup_focused_floating",
+            None,
+            "Text markup of the focused and floating window state. Supports pangomarkup with markup=True."
+            'e.g., "{}" or "<span underline="low">{}</span>"',
+        ),
+        (
             "icon_size",
             None,
             "Icon size. " "(Calculated if set to None. Icons are hidden if set to 0.)",
@@ -216,6 +222,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             or self.markup_maximized
             or self.markup_floating
             or self.markup_focused
+            or self.markup_focused_floating
         ):
             enforce_markup = True
         else:
@@ -229,11 +236,15 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         elif window.maximized:
             state = self.txt_maximized
             markup_str = self.markup_maximized
+        elif window is window.group.current_window:
+            if window.floating:
+                state = self.txt_floating
+                markup_str = self.markup_focused_floating or self.markup_floating
+            else:
+                markup_str = self.markup_focused
         elif window.floating:
             state = self.txt_floating
             markup_str = self.markup_floating
-        elif window is window.group.current_window:
-            markup_str = self.markup_focused
 
         window_location = (
             f"[{window.group.windows.index(window) + self.window_name_location_offset}] "

--- a/test/widgets/test_tasklist.py
+++ b/test/widgets/test_tasklist.py
@@ -165,6 +165,22 @@ def test_tasklist_custom_markup(tasklist_manager):
     assert widget.info()["text"] == "One|Two"
 
 
+@configure_tasklist(markup_focused="({})", markup_focused_floating="[{}]")
+def test_tasklist_focused_and_floating(tasklist_manager):
+    widget = tasklist_manager.c.widget["tasklist"]
+
+    tasklist_manager.test_window("One")
+    tasklist_manager.test_window("Two")
+    assert widget.info()["text"] == "One|(Two)"
+
+    # Test floating
+    tasklist_manager.c.window.toggle_floating()
+    assert widget.info()["text"] == "One|[Two]"
+
+    tasklist_manager.c.window.toggle_floating()
+    assert widget.info()["text"] == "One|(Two)"
+
+
 @configure_tasklist(margin=0)
 def test_tasklist_click_task(tasklist_manager):
     tasklist_manager.test_window("One")


### PR DESCRIPTION
This fixes the mutual exclusion of `markup_focused` and `markup_floating` for windows both focused and floating (fixed version of #4192).