### PR TITLE
Update ReadTheDocs dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,10 @@ build:
     - xvfb
     - dbus-x11
     - libnotify-bin
+  jobs:
+    pre_install:
+      - pip install xcffib wheel
+      - pip install --no-cache --upgrade --no-build-isolation cairocffi
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -35,5 +39,3 @@ python:
   install:
   # This first requirements file installs a pinned version of cffi as latest version causes crashes
   - requirements: docs/requirements-rtd.txt
-  - requirements: docs/requirements.txt
-  - requirements: requirements.txt

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -3,3 +3,12 @@
 # and the latest release of cffi.
 # We can pin the version here for the docs build.
 cffi<=1.15.0
+setuptools_scm
+sphinx
+sphinx_rtd_theme
+funcparserlib==1.0.0a0
+sphinxcontrib-seqdiag
+numpydoc
+pytest
+PyGObject
+dbus-next

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,10 @@ commands =
     # However, rebuilding on pypy doesn't work so we'll pin the version instead
     # See: https://github.com/tych0/xcffib/issues/134
     pypy3: pip install cffi==1.15.0
-    pip install xcffib>=0.10.1
-    pip install cairocffi
+    pip install xcffib>=0.10.1 wheel
+    # The 1.5.0 release of cairocffi cannot be built in a clean folder as it will fail to
+    # to build with xcb suppport. https://github.com/Kozea/cairocffi/issues/212
+    pip install --no-cache --upgrade --no-build-isolation cairocffi
     pip install pywlroots>=0.15.24,<0.16.0
     python3 setup.py -q install
     {toxinidir}/scripts/ffibuild
@@ -103,18 +105,19 @@ deps =
     mypy == 0.960
     bowler
     dbus-next
-    xcffib >= 0.10.1
     PyGObject
     pytest >= 6.2.1
     types-python-dateutil
     types-pytz
     types-pkg_resources
 commands =
-    pip install -r requirements.txt pywayland>=0.4.14 xkbcommon>=0.3
+    pip install --ignore-installed xcffib wheel
+    pip install --ignore-installed --no-cache --upgrade --no-build-isolation cairocffi
+    pip install pywayland>=0.4.14 xkbcommon>=0.3
     pip install pywlroots>=0.15.24,<0.16.0
     mypy -p libqtile
     # also run the tests that require mypy
-    pip install .
+    pip install --no-build-isolation .
     {toxinidir}/scripts/ffibuild
 # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
     python3 -m pytest -- test/test_check.py test/test_migrate.py


### PR DESCRIPTION
Use packaged version of cairocffi and xcffib to prevent mismatches with pip versions.

EDIT: Hmm more to it than this.