### PR TITLE
Hide notifications & taskbars from tasklist

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -263,6 +263,12 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
     @property
     def windows(self):
+        if self.qtile.core.name == "x11":
+            return [
+                w
+                for w in self.bar.screen.group.windows
+                if w.window.get_wm_type() in ("normal", None)
+            ]
         return self.bar.screen.group.windows
 
     def calc_box_widths(self):


### PR DESCRIPTION
Notifications & other "technical" windows make the taskbar blink with no added value.
This patch solves this issue.