### PR TITLE
Bump build environments to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         name: "python ${{ matrix.python-version }}"
         env:
           WAYLAND: 1.20.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     # This should be bumped to 3.11 once there is a dbus-next release > 0.2.3
     python: "3.10"


### PR DESCRIPTION
Update build environments for GitHub Actions and ReadTheDocs to Ubuntu 22.04.