### PR TITLE
`Mpd2Widget` widget: add fallbacks for `artist` status key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           function is not executed, e.g. due to failing the `.when()` check.
         - Add ability to set custom "Undefined" status key value to `Mpd2Widget`.
         - Made the `Mpd2Widget` `artist` status key dynamic.
+        - `Mpd2Widget` now searches for artist name in all similar keys (i.e `albumartist`, `performer`, etc.).
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,7 +44,6 @@ Qtile x.xx.x, released XXXX-XX-XX:
           When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
           function is not executed, e.g. due to failing the `.when()` check.
         - Add ability to set custom "Undefined" status key value to `Mpd2Widget`.
-        - Made the `Mpd2Widget` `artist` status key dynamic.
         - `Mpd2Widget` now searches for artist name in all similar keys (i.e `albumartist`, `performer`, etc.).
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
           When set to `False`, the keys are passed to the focused client. A key is never swallowed if the
           function is not executed, e.g. due to failing the `.when()` check.
         - Add ability to set custom "Undefined" status key value to `Mpd2Widget`.
+        - Made the `Mpd2Widget` `artist` status key dynamic.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -316,6 +316,13 @@ class Mpd2(base.ThreadPoolText):
         if "song" in self.status_format and song_info["song"] != self.undefined_value:
             song_info["currentsong"] = str(int(song_info["song"]) + 1)
 
+        if "artist" in self.status_format and song_info["artist"] == self.undefined_value:
+            artist_keys = ("albumartist", "performer", "composer", "conductor", "ensemble")
+            for key in artist_keys:
+                if song_info[key] != self.undefined_value:
+                    song_info["artist"] = song_info[key]
+                    break
+
         # mpd serializes tags containing commas as lists.
         for key in song_info:
             if isinstance(song_info[key], list):

--- a/libqtile/widget/mpd2widget.py
+++ b/libqtile/widget/mpd2widget.py
@@ -113,6 +113,10 @@ class Mpd2(base.ThreadPoolText):
             '{play_status} {idle_message} \
                 [{repeat}{random}{single}{consume}{updating_db}]'
 
+            Note that the ``artist`` key fallbacks to similar keys in specific order.
+            (``artist`` -> ``albumartist`` -> ``performer`` ->
+             -> ``composer`` -> ``conductor`` -> ``ensemble``)
+
     idle_message:
         text to display instead of song information when MPD is idle.
         (i.e. no song in queue)

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -212,6 +212,6 @@ def test_mpd2_widget_custom_undefined_value(mpd2_manager):
 def test_mpd2_widget_dynamic_artist_value(mpd2_manager):
     """Quick test to check dynamic artist value"""
     widget = mpd2_manager.c.widget["mpd2"]
-    widget.eval(f"self.client._index = 4")
+    widget.eval("self.client._index = 4")
     widget.eval("self.update(self.poll())")
     assert widget.info()["text"] == "⏸ C418/Sweden [-----]"

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -39,6 +39,7 @@ class MockMPD(ModuleType):
             {"title": "Sweet Caroline", "artist": "Neil Diamond"},
             {"title": "Marea", "artist": "Fred Again.."},
             {},
+            {"title": "Sweden", "performer": "C418"},
         ]
 
         def __init__(self):
@@ -206,3 +207,11 @@ def test_mpd2_widget_custom_undefined_value(mpd2_manager):
     """Quick test to check undefined_value option"""
     widget = mpd2_manager.c.widget["mpd2"]
     assert widget.info()["text"] == "Never gonna give you up (Unknown)"
+
+
+def test_mpd2_widget_dynamic_artist_value(mpd2_manager):
+    """Quick test to check dynamic artist value"""
+    widget = mpd2_manager.c.widget["mpd2"]
+    widget.eval(f"self.client._index = 4")
+    widget.eval("self.update(self.poll())")
+    assert widget.info()["text"] == "⏸ C418/Sweden [-----]"


### PR DESCRIPTION
This PR adds fallbacks for `artist` status key. If it is equal to `Undefined`, qtile will search for it in other similar keys.