### PR TITLE
save/restore window geometry for fullscreen and maximized modes

### DIFF
--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -37,6 +37,11 @@ class _Window(CommandObject, metaclass=ABCMeta):
         # Window object from being managed, now that a Static is being used instead
         self.defunct: bool = False
 
+        self.base_x: int | None = None
+        self.base_y: int | None = None
+        self.base_width: int | None = None
+        self.base_height: int | None = None
+
     @property
     @abstractmethod
     def wid(self) -> int:
@@ -123,12 +128,14 @@ class _Window(CommandObject, metaclass=ABCMeta):
         return None
 
     def _save_geometry(self):
+        """Save current window geometry."""
         self.base_x = self.x
         self.base_y = self.y
         self.base_width = self.width
         self.base_height = self.height
 
     def _restore_geometry(self):
+        """Restore previously saved window geometry."""
         if self.base_x is not None:
             self.x = self.base_x
         if self.base_y is not None:

--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -122,6 +122,22 @@ class _Window(CommandObject, metaclass=ABCMeta):
     def _select(self, name, sel):
         return None
 
+    def _save_geometry(self):
+        self.base_x = self.x
+        self.base_y = self.y
+        self.base_width = self.width
+        self.base_height = self.height
+
+    def _restore_geometry(self):
+        if self.base_x is not None:
+            self.x = self.base_x
+        if self.base_y is not None:
+            self.y = self.base_y
+        if self.base_width is not None:
+            self.width = self.base_width
+        if self.base_height is not None:
+            self.height = self.base_height
+
     @abstractmethod
     @expose_command()
     def info(self) -> dict[str, Any]:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -448,10 +448,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             )
 
             if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
-                self.base_x = self.x
-                self.base_y = self.y
-                self.base_width = self.width
-                self.base_height = self.height
+                self._save_geometry()
 
             bw = self.group.floating_layout.fullscreen_border_width if self.group else 0
             self._reconfigure_floating(
@@ -462,14 +459,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
                 new_float_state=FloatStates.FULLSCREEN,
             )
         elif self._float_state == FloatStates.FULLSCREEN:
-            if self.base_x is not None:
-                self.x = self.base_x
-            if self.base_y is not None:
-                self.y = self.base_y
-            if self.base_width is not None:
-                self.width = self.base_width
-            if self.base_height is not None:
-                self.height = self.base_height
+            self._restore_geometry()
             self.floating = False
 
     @abc.abstractmethod
@@ -488,10 +478,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             )
 
             if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
-                self.base_x = self.x
-                self.base_y = self.y
-                self.base_width = self.width
-                self.base_height = self.height
+                self._save_geometry()
 
             bw = self.group.floating_layout.max_border_width if self.group else 0
             self._reconfigure_floating(
@@ -503,14 +490,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             )
         else:
             if self._float_state == FloatStates.MAXIMIZED:
-                if self.base_x is not None:
-                    self.x = self.base_x
-                if self.base_y is not None:
-                    self.y = self.base_y
-                if self.base_width is not None:
-                    self.width = self.base_width
-                if self.base_height is not None:
-                    self.height = self.base_height
+                self._restore_geometry()
                 self.floating = False
 
         if self.ftm_handle:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -153,11 +153,6 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         # attribute optional to avoid the destroy().
         self.ftm_handle: ftm.ForeignToplevelHandleV1 | None = None
 
-        self.base_x: int | None = None
-        self.base_y: int | None = None
-        self.base_width: int | None = None
-        self.base_height: int | None = None
-
     def finalize(self) -> None:
         self.finalize_listeners()
         self.surface.data = None

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -153,6 +153,11 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         # attribute optional to avoid the destroy().
         self.ftm_handle: ftm.ForeignToplevelHandleV1 | None = None
 
+        self.base_x: int | None = None
+        self.base_y: int | None = None
+        self.base_width: int | None = None
+        self.base_height: int | None = None
+
     def finalize(self) -> None:
         self.finalize_listeners()
         self.surface.data = None
@@ -441,6 +446,13 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             screen = (self.group and self.group.screen) or self.qtile.find_closest_screen(
                 self.x, self.y
             )
+
+            if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
+                self.base_x = self.x
+                self.base_y = self.y
+                self.base_width = self.width
+                self.base_height = self.height
+
             bw = self.group.floating_layout.fullscreen_border_width if self.group else 0
             self._reconfigure_floating(
                 screen.x,
@@ -450,6 +462,14 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
                 new_float_state=FloatStates.FULLSCREEN,
             )
         elif self._float_state == FloatStates.FULLSCREEN:
+            if self.base_x is not None:
+                self.x = self.base_x
+            if self.base_y is not None:
+                self.y = self.base_y
+            if self.base_width is not None:
+                self.width = self.base_width
+            if self.base_height is not None:
+                self.height = self.base_height
             self.floating = False
 
     @abc.abstractmethod
@@ -466,6 +486,13 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             screen = (self.group and self.group.screen) or self.qtile.find_closest_screen(
                 self.x, self.y
             )
+
+            if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
+                self.base_x = self.x
+                self.base_y = self.y
+                self.base_width = self.width
+                self.base_height = self.height
+
             bw = self.group.floating_layout.max_border_width if self.group else 0
             self._reconfigure_floating(
                 screen.dx,
@@ -476,6 +503,14 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             )
         else:
             if self._float_state == FloatStates.MAXIMIZED:
+                if self.base_x is not None:
+                    self.x = self.base_x
+                if self.base_y is not None:
+                    self.y = self.base_y
+                if self.base_width is not None:
+                    self.width = self.base_width
+                if self.base_height is not None:
+                    self.height = self.base_height
                 self.floating = False
 
         if self.ftm_handle:

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -508,11 +508,6 @@ class _Window:
         # don't match the requirements to be in any of the other layers.
         self.previous_layer = (False, False, True, False, False, False)
 
-        self.base_x: int | None = None
-        self.base_y: int | None = None
-        self.base_width: int | None = None
-        self.base_height: int | None = None
-
         self.bordercolor = None
         self.state = NormalState
         self._float_state = FloatStates.NOT_FLOATING

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1754,10 +1754,7 @@ class Window(_Window, base.Window):
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
 
             if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
-                self.base_x = self.x
-                self.base_y = self.y
-                self.base_width = self.width
-                self.base_height = self.height
+                self._save_geometry()
 
             bw = self.group.floating_layout.fullscreen_border_width
             self._enablefloating(
@@ -1773,14 +1770,7 @@ class Window(_Window, base.Window):
             return
 
         if self._float_state == FloatStates.FULLSCREEN:
-            if self.base_x is not None:
-                self.x = self.base_x
-            if self.base_y is not None:
-                self.y = self.base_y
-            if self.base_width is not None:
-                self.width = self.base_width
-            if self.base_height is not None:
-                self.height = self.base_height
+            self._restore_geometry()
             self.floating = False
             self.change_layer()
             return
@@ -1795,10 +1785,7 @@ class Window(_Window, base.Window):
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
 
             if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
-                self.base_x = self.x
-                self.base_y = self.y
-                self.base_width = self.width
-                self.base_height = self.height
+                self._save_geometry()
 
             bw = self.group.floating_layout.max_border_width
             self._enablefloating(
@@ -1810,14 +1797,7 @@ class Window(_Window, base.Window):
             )
         else:
             if self._float_state == FloatStates.MAXIMIZED:
-                if self.base_x is not None:
-                    self.x = self.base_x
-                if self.base_y is not None:
-                    self.y = self.base_y
-                if self.base_width is not None:
-                    self.width = self.base_width
-                if self.base_height is not None:
-                    self.height = self.base_height
+                self._restore_geometry()
                 self.floating = False
 
     @property

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -508,6 +508,11 @@ class _Window:
         # don't match the requirements to be in any of the other layers.
         self.previous_layer = (False, False, True, False, False, False)
 
+        self.base_x: int | None = None
+        self.base_y: int | None = None
+        self.base_width: int | None = None
+        self.base_height: int | None = None
+
         self.bordercolor = None
         self.state = NormalState
         self._float_state = FloatStates.NOT_FLOATING
@@ -1748,6 +1753,12 @@ class Window(_Window, base.Window):
             needs_change = self._float_state != FloatStates.FULLSCREEN
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
 
+            if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
+                self.base_x = self.x
+                self.base_y = self.y
+                self.base_width = self.width
+                self.base_height = self.height
+
             bw = self.group.floating_layout.fullscreen_border_width
             self._enablefloating(
                 screen.x,
@@ -1762,6 +1773,14 @@ class Window(_Window, base.Window):
             return
 
         if self._float_state == FloatStates.FULLSCREEN:
+            if self.base_x is not None:
+                self.x = self.base_x
+            if self.base_y is not None:
+                self.y = self.base_y
+            if self.base_width is not None:
+                self.width = self.base_width
+            if self.base_height is not None:
+                self.height = self.base_height
             self.floating = False
             self.change_layer()
             return
@@ -1775,6 +1794,12 @@ class Window(_Window, base.Window):
         if do_maximize:
             screen = self.group.screen or self.qtile.find_closest_screen(self.x, self.y)
 
+            if self._float_state not in (FloatStates.MAXIMIZED, FloatStates.FULLSCREEN):
+                self.base_x = self.x
+                self.base_y = self.y
+                self.base_width = self.width
+                self.base_height = self.height
+
             bw = self.group.floating_layout.max_border_width
             self._enablefloating(
                 screen.dx,
@@ -1785,6 +1810,14 @@ class Window(_Window, base.Window):
             )
         else:
             if self._float_state == FloatStates.MAXIMIZED:
+                if self.base_x is not None:
+                    self.x = self.base_x
+                if self.base_y is not None:
+                    self.y = self.base_y
+                if self.base_width is not None:
+                    self.width = self.base_width
+                if self.base_height is not None:
+                    self.height = self.base_height
                 self.floating = False
 
     @property

--- a/test/test_floating.py
+++ b/test/test_floating.py
@@ -25,15 +25,6 @@ from libqtile import bar, layout, widget
 from libqtile.config import Screen
 from libqtile.confreader import Config
 
-LEFT_ALT = "mod1"
-WINDOWS = "mod4"
-FONTSIZE = 13
-CHAM1 = "8AE234"
-CHAM3 = "4E9A06"
-GRAPH_KW = dict(
-    line_width=1, graph_color=CHAM3, fill_color=CHAM3 + ".3", border_width=1, border_color=CHAM3
-)
-
 
 class FakeScreenConfig(Config):
     auto_fullscreen = True

--- a/test/test_floating.py
+++ b/test/test_floating.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023 Yonnji
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+import libqtile.config
+from libqtile import bar, layout, widget
+from libqtile.config import Screen
+from libqtile.confreader import Config
+
+LEFT_ALT = "mod1"
+WINDOWS = "mod4"
+FONTSIZE = 13
+CHAM1 = "8AE234"
+CHAM3 = "4E9A06"
+GRAPH_KW = dict(
+    line_width=1, graph_color=CHAM3, fill_color=CHAM3 + ".3", border_width=1, border_color=CHAM3
+)
+
+
+class FakeScreenConfig(Config):
+    auto_fullscreen = True
+    floating_layout = layout.Floating()
+    groups = [
+        libqtile.config.Group(
+            "a",
+            layouts=[floating_layout],
+        ),
+    ]
+    layouts = [
+        layout.Tile(),
+    ]
+    keys = []
+    mouse = []
+    fake_screens = [
+        Screen(
+            top=bar.Bar(
+                [widget.GroupBox(), widget.WindowName(), widget.Clock()],
+                10,
+            ),
+            width=1920,
+            height=1080,
+        ),
+    ]
+    screens = []
+
+
+fakescreen_config = pytest.mark.parametrize("manager", [FakeScreenConfig], indirect=True)
+
+
+@fakescreen_config
+def test_maximize(manager):
+    """Ensure that maximize saves and restores geometry"""
+    manager.test_window("one")
+    manager.c.window.set_position_floating(50, 20)
+    manager.c.window.set_size_floating(1280, 720)
+    assert manager.c.window.info()["width"] == 1280
+    assert manager.c.window.info()["height"] == 720
+    assert manager.c.window.info()["x"] == 50
+    assert manager.c.window.info()["y"] == 20
+    assert manager.c.window.info()["group"] == "a"
+
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()["width"] == 1920
+    assert manager.c.window.info()["height"] == 1070
+    assert manager.c.window.info()["x"] == 0
+    assert manager.c.window.info()["y"] == 10
+    assert manager.c.window.info()["group"] == "a"
+
+    manager.c.window.toggle_maximize()
+    assert manager.c.window.info()["width"] == 1280
+    assert manager.c.window.info()["height"] == 720
+    assert manager.c.window.info()["x"] == 50
+    assert manager.c.window.info()["y"] == 20
+    assert manager.c.window.info()["group"] == "a"
+
+
+@fakescreen_config
+def test_fullscreen(manager):
+    """Ensure that fullscreen saves and restores geometry"""
+    manager.test_window("one")
+    manager.c.window.set_position_floating(50, 20)
+    manager.c.window.set_size_floating(1280, 720)
+    assert manager.c.window.info()["width"] == 1280
+    assert manager.c.window.info()["height"] == 720
+    assert manager.c.window.info()["x"] == 50
+    assert manager.c.window.info()["y"] == 20
+    assert manager.c.window.info()["group"] == "a"
+
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.window.info()["width"] == 1920
+    assert manager.c.window.info()["height"] == 1080
+    assert manager.c.window.info()["x"] == 0
+    assert manager.c.window.info()["y"] == 0
+    assert manager.c.window.info()["group"] == "a"
+
+    manager.c.window.toggle_fullscreen()
+    assert manager.c.window.info()["width"] == 1280
+    assert manager.c.window.info()["height"] == 720
+    assert manager.c.window.info()["x"] == 50
+    assert manager.c.window.info()["y"] == 20
+    assert manager.c.window.info()["group"] == "a"


### PR DESCRIPTION
It's useful in floating only workspaces. When you open YouTube video in fullscreen mode in browser and then exit it, the browser's window geometry will be restored back. The same applies to other apps and maximized windows.