### PR TITLE
Test coverage failure with 7.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
               if: ${{ matrix.python-version != 'pypy-3.9' }}
               run: |
                 pip -q install coveralls
-                coveralls --service=github
+                coveralls --service=github-actions
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 COVERALLS_FLAG_NAME: ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -49,9 +49,9 @@ commands =
     {toxinidir}/scripts/ffibuild
     # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
     # pypy3 is very slow when running coverage reports so we skip it
-    pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland {posargs}
-    py39: coverage run -m pytest -W error --backend=x11 --backend=wayland {posargs}
-    py3{10,11}: coverage run -m pytest --backend=x11 --backend=wayland {posargs}
+    pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland -k widgetbox {posargs}
+    py39: coverage run -m pytest -W error --backend=x11 --backend=wayland -k widgetbox {posargs}
+    py3{10,11}: coverage run -m pytest --backend=x11 --backend=wayland -k widgetbox {posargs}
 
     # Coverage runs tests in parallel so we need to combine results into a single file
     !pypy3: coverage combine -q
@@ -132,6 +132,6 @@ commands =
 [gh-actions]
 python =
     pypy-3.9: pypy3
-    3.9: py39, mypy
-    3.10: py310, mypy
-    3.11: py311, mypy, packaging, pep8, codestyle, docstyle, vulture
+    3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
Not to be merged. Just for testing purposes.

Latest version of `coverage` seems to result in failures when uploading to coveralls.io.