### PR TITLE
Test coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ whitelist_externals=convert
 # xcffib has to be installed before cairocffi
 deps =
     pytest >= 6.2.1
-    coverage
+    coverage < 7.2.4
     setuptools >= 40.5.0
     bowler
     xkbcommon >= 0.3
@@ -49,9 +49,9 @@ commands =
     {toxinidir}/scripts/ffibuild
     # py310 currently fails with -W error, see: https://gitlab.gnome.org/GNOME/pygobject/-/issues/476
     # pypy3 is very slow when running coverage reports so we skip it
-    pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland {posargs}
-    py39: coverage run -m pytest -W error --backend=x11 --backend=wayland {posargs}
-    py3{10,11}: coverage run -m pytest --backend=x11 --backend=wayland {posargs}
+    pypy3: python3 -m pytest -W error --backend=x11 --backend=wayland -k widgetbox {posargs}
+    py39: coverage run -m pytest -W error --backend=x11 --backend=wayland -k widgetbox {posargs}
+    py3{10,11}: coverage run -m pytest --backend=x11 --backend=wayland -k widgetbox {posargs}
 
     # Coverage runs tests in parallel so we need to combine results into a single file
     !pypy3: coverage combine -q
@@ -132,6 +132,6 @@ commands =
 [gh-actions]
 python =
     pypy-3.9: pypy3
-    3.9: py39, mypy
-    3.10: py310, mypy
-    3.11: py311, mypy, packaging, pep8, codestyle, docstyle, vulture
+    3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
Not to be merged. Testing only.

This PR ensures `coverage` is not 7.2.4 version. If this one passes and #4244 fails then the issue would appear to be `coverage 7.2.4`.