### PR TITLE
Ensure icons are centered in TaskList widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix setting tiled position by mouse for layouts using _SimpleLayoutBase. To support this in other layouts, add a swap method taking two windows.
         - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.
         - Ensure `CurrentLayoutIcon` expands paths for custom folders.
+        - Fix vertical alignment of icons in `TaskList` widget
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -531,7 +531,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             return
 
         x = offset + self.borderwidth + self.padding_x
-        y = self.padding_y + self.borderwidth
+        y = (self.height - self.icon_size) // 2
 
         self.drawer.ctx.save()
         self.drawer.ctx.translate(x, y)


### PR DESCRIPTION
The vertical alignment of the icons ignored the `icon_size` property resulting in misaligned icons.

Fixes #3873