### PR TITLE
Added default apps in groups

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -717,6 +717,9 @@ class Group:
     label:
         The display name of the group. Use this to define a display name other than name
         of the group. If set to ``None``, the display name is set to the name.
+    default_app:
+        The default application to spawn when the group is selected and ``group.spawn_default_app()``
+        is called. If not specified, nothing will happen when ``group.spawn_default_app()`` is called.
 
     """
 
@@ -734,9 +737,11 @@ class Group:
         screen_affinity: int | None = None,
         position: int = sys.maxsize,
         label: str | None = None,
+        default_app: str | None = None,
     ) -> None:
         self.name = name
         self.label = label
+        self.default_app = default_app
         self.exclusive = exclusive
         self.spawn = spawn
         self.layout = layout

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -536,9 +536,11 @@ class Qtile(CommandObject):
         layouts: list[Layout] | None = None,
         label: str | None = None,
         index: int | None = None,
+        default_app: str | None = None,
     ) -> bool:
+        print(f"default_app: {default_app}")
         if name not in self.groups_map.keys():
-            g = _Group(name, layout, label=label)
+            g = _Group(name, layout, label=label, default_app=default_app)
             if index is None:
                 self.groups.append(g)
             else:

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -115,7 +115,9 @@ class DGroups:
         rule = Rule(group.matches, group=group.name)
         self.rules.append(rule)
         if start:
-            self.qtile.add_group(group.name, group.layout, group.layouts, group.label)
+            self.qtile.add_group(group.name, group.layout,
+                                 group.layouts, group.label,
+                                 default_app=group.default_app)
 
     def _setup_groups(self):
         for group in self.groups:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -48,10 +48,11 @@ class _Group(CommandObject):
     A group is identified by its name but displayed in GroupBox widget by its label.
     """
 
-    def __init__(self, name, layout=None, label=None):
+    def __init__(self, name, layout=None, label=None, default_app: str = None):
         self.name = name
         self.label = name if label is None else label
         self.custom_layout = layout  # will be set on _configure
+        self.default_app = default_app
         self.windows = []
         self.tiled_windows = set()
         self.qtile = None
@@ -566,6 +567,15 @@ class _Group(CommandObject):
         """
         self.label = label if label is not None else self.name
         hook.fire("changegroup")
+
+    @expose_command()
+    def spawn_default_app(self):
+        """
+        Spawn the default app for this group if it exists.
+        """
+        if self.default_app:
+            if self.qtile.spawn(self.default_app) < 0:
+                logger.warning("spawn_default_app: The application could not be spawned.")
 
     def __repr__(self):
         return "<group.Group (%r)>" % self.name


### PR DESCRIPTION
This project adds functionality to groups that allows the user to set a default application for each group, and then spawn the default app for the current group with a single key bind (such as mod+t).

Since my implementation in the `qtile-examples` repo wasn't clean enough for my liking, this is the more integrated version. That alternative implementation can be found [here](https://github.com/qtile/qtile-examples/pull/85). My intention is to present both solutions, and let the maintainers decide which implementation they would prefer.