### PR TITLE
Fix #4115 by looking through PPIDs in addition to PIDs if proper conf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.
         - Ensure `CurrentLayoutIcon` expands paths for custom folders.
         - Fix vertical alignment of icons in `TaskList` widget
+        - Fix spawn logic to handle windows created by child processes (set catch_child_window to `True` in group configuration to enable this behavior)
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -717,7 +717,9 @@ class Group:
     label:
         The display name of the group. Use this to define a display name other than name
         of the group. If set to ``None``, the display name is set to the name.
-
+    grab_child_window:
+        When an app is spawned at group creation, this options allows to capture windows created by child 
+        processes of the started process. 
     """
 
     def __init__(
@@ -734,11 +736,13 @@ class Group:
         screen_affinity: int | None = None,
         position: int = sys.maxsize,
         label: str | None = None,
+        grab_child_window: bool = False
     ) -> None:
         self.name = name
         self.label = label
         self.exclusive = exclusive
         self.spawn = spawn
+        self.grab_child_window = grab_child_window
         self.layout = layout
         self.layouts = layouts or []
         self.persist = persist


### PR DESCRIPTION
Fix #4115 by looking through PPIDs in addition to PIDs if proper config is set
(I added config because this could lead to a performance hit, also it changes the behavior of additional child window).

To test it I just had to put any program that spawns a window inside a bash script and spawn that one: with property missing (or set to Flase) it goes to the group 1, with the setting it goes to the proper group