### PR TITLE
Fix a typo in the TaskList widget documentation

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -172,7 +172,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         (
             "window_name_location_offset",
             0,
-            "The offset given to window loction",
+            "The offset given to the window location",
         ),
     ]
 


### PR DESCRIPTION
The documentation for the `window_name_location_offset` parameter in the TaskList widget contained `loction` instead of `location`.
There should also be a `the` before `window` in this sentence.
This simple PR fixes those typos.