### PR TITLE
Add different timeouts for notifications

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,10 @@ Qtile x.xx.x, released XXXX-XX-XX:
       - The `StockTicker` widget `function` option is being deprecated: rename it to `func`.
       - The formatting of `NetWidget` has changed, if you use the `format` parameter in your config include 
         `up_suffix`, `total_suffix` and `down_suffix` to display the respective units.
+      - The `Notify` widget now has separate `default_timeout` properties for differenct urgency levels. Previously,
+        `default_timeout` was `None` which meant that there was no timeout for all notifications (unless this had been
+        set by the client sending the notification). Now, `default_timeout` is for normal urgency notifications and this
+        has been set to a default of 10 seconds. `default_timeout_urgent`, for critical notifications, has a timeout of `None`.
     * features
         - Add ability to set icon size in `LaunchBar` widget.
         - Add 'warp_pointer' option to `Drag` that when set will warp the pointer to the bottom right of

--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -51,7 +51,9 @@ class Notify(base._TextBox):
     defaults = [
         ("foreground_urgent", "ff0000", "Foreground urgent priority colour"),
         ("foreground_low", "dddddd", "Foreground low priority  colour"),
-        ("default_timeout", None, "Default timeout (seconds) for notifications"),
+        ("default_timeout_low", 5, "Default timeout (seconds) for low urgency notifications."),
+        ("default_timeout", 10, "Default timeout (seconds) for normal notifications"),
+        ("default_timeout_urgent", None, "Default timeout (seconds) for urgent notifications"),
         ("audiofile", None, "Audiofile played during notifications"),
         ("action", True, "Enable handling of default action upon right click"),
         (
@@ -94,6 +96,15 @@ class Notify(base._TextBox):
         if notifier is None:
             logger.warning("You must install dbus-next to use the Notify widget.")
 
+        # Create a tuple of our default timeouts. Urgency is an integer of 0-2
+        # (see https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html#urgency-levels)
+        # so they will work as the index of the tuple.
+        self._timeouts = (
+            self.default_timeout_low,
+            self.default_timeout,
+            self.default_timeout_urgent,
+        )
+
     async def _config_async(self):
         if notifier is None:
             return
@@ -135,10 +146,18 @@ class Notify(base._TextBox):
             self.timeout_add(
                 notif.timeout / 1000, self.clear, method_args=(ClosedReason.expired,)
             )
-        elif self.default_timeout:
-            self.timeout_add(
-                self.default_timeout, self.clear, method_args=(ClosedReason.expired,)
-            )
+        else:
+            urgency = getattr(notif.hints.get("urgency"), "value", 1)
+            try:
+                timeout = self._timeouts[urgency]
+            except IndexError:
+                logger.warning(
+                    "Notification had an unexpected urgency value. Treating as normal priority."
+                )
+                timeout = self._timeouts[1]
+
+            if timeout:
+                self.timeout_add(timeout, self.clear, method_args=(ClosedReason.expired,))
         self.bar.draw()
         return True
 


### PR DESCRIPTION
Allows users to set different default timeouts for low, normal and urgent priority notifications.