### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,13 @@ jobs:
   build-wheel:
     name: Build wheels
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       matrix:
         python-version: ["cp3.9", "cp3.10", "cp3.11", "pp3.9"]
     steps:
       - name: Install dependencies
-        run: |
-          apt update
-          apt-get install -y --no-install-recommends \
-            libcairo-dev \
-            libffi-dev
+        run: dnf install -y cairo-devel libffi-devel
       - uses: actions/checkout@v2
       - name: Set environment variables
         run: |
@@ -30,14 +26,13 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Build wheels
         run: |
-          pip install xcffib
+          python -m pip install cffi
           python setup.py bdist_wheel
-          auditwheel repair --plat manylinux2014_x86_64 -w output_wheels dist/qtile-*.whl
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels-${{ matrix.python-version }}
-          path: output_wheels/*.whl
+          path: dist/*.whl
   test-wheel:
     name: Test wheels
     runs-on: ubuntu-latest
@@ -70,15 +65,12 @@ jobs:
   build-source:
     name: Build source
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_24_x86_64
+    container: quay.io/pypa/manylinux_2_28_x86_64
     env:
       python-version: "cp3.11"
     steps:
       - name: Install dependencies
-        run: |
-          apt update
-          apt-get install -y --no-install-recommends \
-            libcairo-dev
+        run: dnf install -y cairo-devel libffi-devel
       - uses: actions/checkout@v2
       - name: Set environment variables
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = [ "setuptools>=41", "wheel", "setuptools-git-versioning<2", ]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 98
 exclude = 'libqtile/_ffi.*\.py|libqtile/backend/x11/_ffi.*\.py|test/configs/syntaxerr.py'
@@ -8,3 +12,11 @@ testpaths = ["test"]
 filterwarnings = [
     "error:::libqtile",
 ]
+
+[tool.setuptools-git-versioning]
+enabled = true
+
+[project]
+name = "qtile"
+description = "A pure-Python tiling window manager."
+dynamic = ["version", "readme"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,13 @@ filterwarnings = [
 [tool.setuptools-git-versioning]
 enabled = true
 
+[tool.setuptools.dynamic]
+readme = {file = "README.md"}
+
 [project]
 name = "qtile"
 description = "A pure-Python tiling window manager."
-dynamic = ["version", "readme"]
+dynamic = ["version"]
+
+[project.scripts]
+qtile = "libqtile.scripts.main:main"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,36 +1,3 @@
-[metadata]
-url = https://qtile.org
-license = MIT
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-author = Aldo Cortesi
-author_email = aldo@nullcube.com
-maintainer = Sean Vig
-maintainer_email = sean.v.775@gmail.com
-keywords =
-  qtile
-  tiling
-  window
-  manager
-classifiers =
-  Development Status :: 3 - Alpha
-  Intended Audience :: End Users/Desktop
-  License :: OSI Approved :: MIT License
-  Operating System :: POSIX :: BSD :: FreeBSD
-  Operating System :: POSIX :: Linux
-  Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.9
-  Programming Language :: Python :: 3.10
-  Programming Language :: Python :: 3.11
-  Programming Language :: Python :: Implementation :: CPython
-  Programming Language :: Python :: Implementation :: PyPy
-  Topic :: Desktop Environment :: Window Managers
-project_urls =
-  Documentation = https://docs.qtile.org/
-  Code = https://github.com/qtile/qtile/
-  Issue tracker = https://github.com/qtile/qtile/issues
-  Contributing = https://docs.qtile.org/en/latest/manual/contributing.html
-
 [options]
 packages = find_namespace:
 python_requires >= 3.9
@@ -48,10 +15,6 @@ tests_require =
   pep8-naming
   psutil
   coverage
-
-[options.entry_points]
-console_scripts =
-  qtile = libqtile.scripts.main:main
 
 [options.extras_require]
 doc =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [metadata]
-name = qtile
 url = https://qtile.org
 license = MIT
-description = A pure-Python tiling window manager.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 author = Aldo Cortesi


### PR DESCRIPTION
* manylinux_2_24 is EOL and broken, so we upgrade to manylinux_2_28
* manylinux_2_28 uses AlmaLinux 8, that's dnf-based, so we update install accordingly
* xcffib isn't needed at build time anymore since we moved to inline (#4289), but we still need cffi to build PulseAudio stuff, so we just install cffi
* `auditwheel repair --plat manylinux2014_x86_64` now fails with the following error, so I guess we have no other choice than removing it and only build for the latest Linux versions?

```
auditwheel: error: cannot repair "dist/qtile-0.1.dev1+gc02152d-cp310-cp310-linux_x86_64.whl" to "manylinux2014_x86_64" ABI because of the presence of too-recent versioned symbols. You'll need to compile the wheel on an older toolchain.
```

Context: I was trying to release a beta version, but the release action is completely broken: https://github.com/qtile/qtile/actions/runs/5275820671

@flacjacket that would be awesome if you could take a quick look :)