### PR TITLE
fixed double margin problem in the columns layout

### DIFF
--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -301,13 +301,14 @@ class Columns(Layout):
     def configure(self, client: Window, screen_rect: ScreenRect) -> None:
         "Position client based on order and sizes"
 
-        # percentage_of_space: percent of a clients fair share of the available space
-        # available_space: the size of the space in pixels
+        # percentage_of_space: percentage of the available space when
+        #                      divided equally among the clients
+        # available_space: the size of the available space in pixels
         # clients_in_space: number of clients that are going to share the space
         def get_pixels_from_relative_size(percentage_of_space, available_space, clients_in_space):
             return round(0.01 * percentage_of_space * available_space / clients_in_space)
 
-        # percent of space occupied by the window horizontally
+        # percentage of the space occupied by the windows to the left of the client
         pos_x = 0
         for col in self.columns:
             if client in col:
@@ -317,7 +318,7 @@ class Columns(Layout):
             client.hide()
             return
 
-        # percent of space occupied by the window vertically
+        # percentage of the space occupied by the windows above the client
         pos_y = 0
         for c in col:
             if client == c:

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -365,7 +365,6 @@ class Columns(Layout):
             )
             y += get_pixels_from_relative_size(pos_y, usable_height, num_clients_vertically)
         else:
-            num_windows_vertically = 1
             height = usable_height
         height -= 2 * border + gap_y
 

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -208,11 +208,6 @@ def test_columns_margins_single_window(manager):
 
     # margin_on_single is set
     manager.c.next_layout()
-    info = manager.c.window.info()
-    assert info["x"] == 30
-    assert info["y"] == 30
-    assert info["width"] == WIDTH - 60
-    assert info["height"] == HEIGHT - 60
 
     assert_dimensions(
         manager,
@@ -336,6 +331,7 @@ def test_columns_initial_ratio_left(manager):
     info = manager.c.window.info()
     assert info["width"] == WIDTH / 2
 
+
 @columns_config
 def test_columns_margins_muliple_windows_three_columns(manager):
     num_columns = 3
@@ -384,7 +380,7 @@ def test_columns_margins_muliple_windows_margin(manager):
     win_height = round(window_size(HEIGHT, num_windows, 0, GAP, BORDER))
     assert_dimensions(manager, GAP, GAP, win_width, win_height)
 
-    # move to the window in the top right of the screen
+    # move to the window in the top right corner of the screen
     manager.c.layout.right()
     num_windows = windows_in_current_column(manager)
 
@@ -398,7 +394,7 @@ def test_columns_margins_muliple_windows_margin(manager):
         win_height,
     )
 
-    # move to the window in the bottom right of the screen
+    # move to the window in the bottom right corner of the screen
     manager.c.layout.down()
     assert_dimensions(
         manager,

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -22,8 +22,9 @@ import pytest
 import libqtile.config
 from libqtile import layout
 from libqtile.confreader import Config
+from libqtile.resources.default_config import floating_layout
 from test.helpers import HEIGHT, WIDTH
-from test.layouts.layout_utils import assert_focus_path, assert_focused, assert_dimensions
+from test.layouts.layout_utils import assert_dimensions, assert_focus_path, assert_focused
 
 MARGIN = 10
 MARGIN_ON_SINGLE = 30
@@ -38,7 +39,7 @@ class ColumnsConfig(Config):
         layout.Columns(margin=MARGIN, border=BORDER),
         layout.Columns(margin=MARGIN, margin_on_single=MARGIN_ON_SINGLE, border=BORDER),
     ]
-    floating_layout = libqtile.resources.default_config.floating_layout
+    floating_layout = floating_layout
     keys = []
     mouse = []
     screens = []


### PR DESCRIPTION
In order to avoid the issue of duplicated margins, I had to remove the option to set distinct margins for different sides of the window. I don't really see what the benefit of exposing this to the user would be anyway.

With this patch, the user will be able to set the margin to a number and have that be the gap between the windows and between the outermost windows and the edge of the screen. I think this is the behaviour the majority of the users expect the margin argument to have.

I also updated and added some tests for the columns layout.