### PR TITLE
fix TaskList icons' vertical centering issue

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -531,7 +531,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
             return
 
         x = offset + self.borderwidth + self.padding_x
-        y = (self.height - self.icon_size) // 2
+        y = ((self.height // 2) - (self.icon_size // 2)) // 2
 
         self.drawer.ctx.save()
         self.drawer.ctx.translate(x, y)


### PR DESCRIPTION
One line fix that tries to address #1714 and #3873, as the fixes still do not work on my local system running on the main dev branch ([described here](https://github.com/qtile/qtile/issues/1714#issuecomment-1627198379)).