### PR TITLE
Expose next/prev_group commands of GroupBox

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -35,6 +35,7 @@ from functools import partial
 from typing import Any
 
 from libqtile import hook
+from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
@@ -292,6 +293,7 @@ class GroupBox(_GroupBase):
         self.click = x
         _GroupBase.button_press(self, x, y, button)
 
+    @expose_command()
     def next_group(self):
         group = None
         current_group = self.qtile.current_group
@@ -302,6 +304,7 @@ class GroupBox(_GroupBase):
             group = next(i)
         self.go_to_group(group)
 
+    @expose_command()
     def prev_group(self):
         group = None
         current_group = self.qtile.current_group


### PR DESCRIPTION
I found these commands very useful if you want to move only between active groups with opened windows.

Also why don't just _somehow_ expose every function of every object  but with some `force` flag only. This will allow users to  use any command without specifically expose it but only if they know what they are doing.