### PR TITLE
X11 Core: Bring back motion notify cap that is off by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,7 +65,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - Fix unfullscreening bug in conjunction with Chromium based clients when auto_fullscreen is set to `False`.
         - Ensure `CurrentLayoutIcon` expands paths for custom folders.
         - Fix vertical alignment of icons in `TaskList` widget
-        - Fix laggy resize/positioning of floating windows in X11 by handling motion notify events later
+        - Fix laggy resize/positioning of floating windows in X11 by handling motion notify events later. We also introduced a cap setting if you want to limit these events further, e.g. for limiting resource usage. This is configurable with the x11_drag_polling_rate variable for each `Screen` which is set to None by default, indicating no cap.
     * python version support
         - We have added support for python 3.11 and pypy 3.9.
         - python 3.7, 3.8 and pypy 3.7 are not longer supported.

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -418,6 +418,8 @@ class Screen(CommandObject):
     resized to fill it. If the mode is ``"stretch"``, the image is stretched to fit all
     of it into the screen.
 
+    The ``x11_drag_polling_rate`` parameter specifies the rate for drag events in the X11 backend. By default this is set to None, indicating no limit. Because in the X11 backend we already handle motion notify events later, the performance should already be okay. However, to limit these events further you can use this variable and e.g. set it to your monitor refresh rate. 60 would mean that we handle a drag event 60 times per second.
+
     """
 
     group: _Group
@@ -431,6 +433,7 @@ class Screen(CommandObject):
         right: BarType | None = None,
         wallpaper: str | None = None,
         wallpaper_mode: str | None = None,
+        x11_drag_polling_rate: int | None = None,
         x: int | None = None,
         y: int | None = None,
         width: int | None = None,
@@ -442,6 +445,7 @@ class Screen(CommandObject):
         self.right = right
         self.wallpaper = wallpaper
         self.wallpaper_mode = wallpaper_mode
+        self.x11_drag_polling_rate = x11_drag_polling_rate
         self.qtile: Qtile | None = None
         # x position of upper left corner can be > 0
         # if one screen is "right" of the other

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -148,6 +148,10 @@ screens = [
             # border_width=[2, 0, 2, 0],  # Draw top and bottom borders
             # border_color=["ff00ff", "000000", "ff00ff", "000000"]  # Borders are magenta
         ),
+        # You can uncomment this variable if you see that on X11 floating resize/moving is laggy
+        # By default we handle these events delayed to already improve performance, however your system might still be struggling
+        # This variable is set to None (no cap) by default, but you can set it to 60 to indicate that you limit it to 60 events per second
+        # x11_drag_polling_rate = 60,
     ),
 ]
 


### PR DESCRIPTION
Previously we introduced this but Nvidia users complained that floating resize/move was still laggy. Now we handle MOTION NOTIFY events later. In this commit we bring back the cap for users that want to have a cap set for resource reasons or that they simply see that the "handling later" fix is not good enough.

It is off by default. I also added a comment in the default config.

Reported by @purplebar0 at https://github.com/qtile/qtile/pull/4141#issuecomment-1636754538