### PR TITLE
[x11] Fix two stacking issues

### DIFF
--- a/docs/BUILDING
+++ b/docs/BUILDING
@@ -12,7 +12,7 @@ $ deactivate
 
 To build on Ubuntu:
 
-$ sudo apt-get install python-sphinxcontrib.seqdiag graphiz
+$ sudo apt-get install graphiz
 
 Install: https://github.com/:snide/sphinx_rtd_theme
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,6 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    "sphinxcontrib.seqdiag",
     "numpydoc",
     "sphinx_qtile",
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ questions, you can find support in the following places:
     manual/ref/hooks
     manual/ref/extensions
     manual/commands/keybindings
+    manual/stacking
 
 .. toctree::
     :maxdepth: 1

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -76,7 +76,11 @@ configuration variables that control specific aspects of Qtile's behavior:
       - ``False``
       - When clicked, should the window be brought to the front or not. If this
         is set to "floating_only", only floating windows will get affected (This
-        sets the X Stack Mode to Above.)
+        sets the X Stack Mode to Above.). This will ignore the layering rules and
+        will therefore bring windows above other windows, even if they have been set
+        as "kept_above". This may cause issues with docks and other similar apps as these
+        may end up hidden behind other windows. Setting this to ``False`` or ``"floating_only"``
+        may therefore be required when using these apps.
     * - ``cursor_warp``
       - ``False``
       - If true, the cursor follows the focus as directed by the keyboard,

--- a/docs/manual/stacking.rst
+++ b/docs/manual/stacking.rst
@@ -1,0 +1,75 @@
+Window stacking
+===============
+
+A number of window commands (``move_up/down()``, ``bring_to_front()`` etc.) relate to
+the stacking order of windows.
+
+The aim of this page is to provide more details as to how stacking is implemented in Qtile.
+
+.. important::
+
+    Currently, stacking is only implemented in the X11 background. Support will be added to the
+    Wayland backend in future and this page will be updated accordingly.
+
+Layer priority groups
+~~~~~~~~~~~~~~~~~~~~~
+
+We have tried to adhere to the `EWMH specification`_. Windows are therefore stacked, from the bottom,
+according to the following priority rules:
+
+- windows of type _NET_WM_TYPE_DESKTOP
+- windows having state _NET_WM_STATE_BELOW
+- windows not belonging in any other layer
+- windows of type _NET_WM_TYPE_DOCK (unless they have state
+  _NET_WM_TYPE_BELOW) and windows having state _NET_WM_STATE_ABOVE
+- focused windows having state _NET_WM_STATE_FULLSCREEN
+
+Qtile had then added an additional layer so that ``Scratchpad`` windows are placed above everything else.
+
+.. _EWMH specification: https://specifications.freedesktop.org/wm-spec/1.3/ar01s07.html#STACKINGORDER
+
+Tiled windows will open in the default, "windows not belonging in any other layer", layer. If
+``floats_kept_above`` is set to ``True`` in the config then new floating windows will have the
+``_NET_WM_STATE_ABOVE`` property set which will ensure they remain above tiled windows.
+
+Moving windows
+~~~~~~~~~~~~~~
+
+Imagine you have four tiled windows stacked (from the top) as follows:
+
+.. code::
+
+    "One"
+    "Two"
+    "Three"
+    "Four"
+
+If you call ``move_up()`` on window "Four", the result will be:
+
+.. code::
+
+    "One"
+    "Two"
+    "Four"
+    "Three"
+
+If you now call ``move_to_top()`` on window "Three", the result will be:
+
+.. code::
+
+    "Three"
+    "One"
+    "Two"
+    "Four"
+
+.. note::
+
+    ``bring_to_front()`` has a special behaviour in Qtile. This will bring any window to the very top
+    of the stack, disregarding the priority rules set out above. When that window loses focus, it will
+    be restacked in the appropriate location.
+
+    This can cause undesirable results if the config contains ``bring_front_click=True`` and the user has
+    an app like a dock which is activated by mousing over the window. In this situation, tiled windows will
+    be displayed above the dock making it difficult to activate. To fix this, set ``bring_front_click`` to
+    ``False`` to disable the behaviour completely, or ``"floating_only"`` to only have this behaviour apply
+    to floating windows.

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -8,7 +8,6 @@ setuptools_scm
 sphinx<7.0.0
 sphinx_rtd_theme
 funcparserlib==1.0.0a0
-sphinxcontrib-seqdiag
 numpydoc
 pytest
 PyGObject

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,6 @@ setuptools_scm
 sphinx<7.0.0
 sphinx_rtd_theme
 funcparserlib==1.0.0a0
-sphinxcontrib-seqdiag
 numpydoc
 pytest
 xcffib >= 1.4.0

--- a/libqtile/backend/base.py
+++ b/libqtile/backend/base.py
@@ -482,7 +482,13 @@ class Window(_Window, metaclass=ABCMeta):
     @abstractmethod
     @expose_command()
     def bring_to_front(self) -> None:
-        """Bring the window to the front"""
+        """
+        Bring the window to the front.
+
+        In X11, `bring_to_front` ignores all other layering rules and brings the
+        window to the very front. When that window loses focus, it will be stacked
+        again according the appropriate rules.
+        """
 
     @abstractmethod
     @expose_command()

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,6 @@ console_scripts =
 doc =
   sphinx
   sphinx_rtd_theme
-  sphinxcontrib-seqdiag
   numpydoc
 lint =
   flake8


### PR DESCRIPTION
1) window.bring_to_front ignored stacking rules. This has been amended so that stacking rules are respected.
2) Static windows were ignored by stacking rules. This has also been amended to ensure that these windows are included.

Fixes #4355

@ervinpopescu - would be great if you could test this.