### PR TITLE
Update CI to tox 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
                   libxcb-composite0-dev libxcb-icccm4-dev libxcb-res0-dev libxcb-render0-dev libxcb-res0-dev \
                   libxcb-xfixes0-dev vlc volumeicon-alsa
                 sudo pip -q install meson PyGObject
-                pip -q install "tox<4" tox-gh-actions 
+                pip -q install tox tox-gh-actions 
                 bash -x ./scripts/ubuntu_wayland_setup
             - name: Run Tests
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
                 # python version in .readthedocs.yaml
                 python-version: [pypy-3.9, 3.9, '3.10', '3.11']
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Run Tests
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]
-                tox
+                tox -vv
             - name: Upload coverage data to coveralls.io
               # For speed purposes, we don't do coverage reporting on pypy 3.9
               if: ${{ matrix.python-version != 'pypy-3.9' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Run Tests
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]
-                tox -vv
+                tox
             - name: Upload coverage data to coveralls.io
               # For speed purposes, we don't do coverage reporting on pypy 3.9
               if: ${{ matrix.python-version != 'pypy-3.9' }}

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,9 @@ envlist =
 # that our tests use.
 setenv = LC_CTYPE = en_US.UTF-8
 # Pass Display down to have it for the tests available
-passenv = DISPLAY,WAYLAND_DISPLAY
+passenv = DISPLAY,WAYLAND_DISPLAY,LDFLAGS,CFLAGS
 allowlist_externals = 
-    ffibuild
+    */ffibuild
     convert
 # xcffib has to be installed before cairocffi
 deps =
@@ -34,6 +34,9 @@ deps =
     pywayland == 0.4.15
     dbus-next
     PyGObject
+    wheel
+    xcffib >= 1.4.0
+    cairocffi >= 1.6.0
 # pywayland has to be installed before pywlroots
 commands =
     # cffi's binary wheel is incompatible with some libffi libraries so we force build here
@@ -42,7 +45,7 @@ commands =
     # However, rebuilding on pypy doesn't work so we'll pin the version instead
     # See: https://github.com/tych0/xcffib/issues/134
     pypy3: pip install cffi==1.15.0
-    pip install xcffib>=1.4.0 wheel
+    ; pip install xcffib>=1.4.0 wheel
     # The 1.5.0 release of cairocffi cannot be built in a clean folder as it will fail to
     # to build with xcb suppport. https://github.com/Kozea/cairocffi/issues/212
     pip install --no-cache --upgrade --no-build-isolation cairocffi
@@ -97,7 +100,7 @@ commands =
     - pydocstyle --match "(?!(test)?_).*\.py" libqtile/
 
 [testenv:mypy]
-allowlist_externals=/**/qtile/scripts/ffibuild
+allowlist_externals=*/ffibuild
 deps =
     mypy == 1.4.1
     bowler
@@ -107,6 +110,9 @@ deps =
     types-python-dateutil
     types-pytz
     types-pkg_resources
+    xcffib >= 1.4.0
+    cairocffi >= 1.6.0
+    wheel
 commands =
     pip install --ignore-installed xcffib wheel
     pip install --ignore-installed --no-cache --upgrade --no-build-isolation cairocffi

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     dbus-next
     PyGObject
     wheel
+    cffi
     xcffib >= 1.4.0
     cairocffi >= 1.6.0
 # pywayland has to be installed before pywlroots
@@ -48,9 +49,8 @@ commands =
     ; pip install xcffib>=1.4.0 wheel
     # The 1.5.0 release of cairocffi cannot be built in a clean folder as it will fail to
     # to build with xcb suppport. https://github.com/Kozea/cairocffi/issues/212
-    pip install --no-cache --upgrade --no-build-isolation cairocffi
     pip install pywlroots>=0.16.4,<0.17.0
-    pip install --no-build-isolation .
+    pip install .
     {toxinidir}/scripts/ffibuild
     # pypy3 is very slow when running coverage reports so we skip it
     pypy3: python3 -m pytest --backend=x11 --backend=wayland {posargs}
@@ -114,13 +114,11 @@ deps =
     cairocffi >= 1.6.0
     wheel
 commands =
-    pip install --ignore-installed xcffib wheel
-    pip install --ignore-installed --no-cache --upgrade --no-build-isolation cairocffi
     pip install -r requirements.txt pywayland>=0.4.14 xkbcommon>=0.3
     pip install pywlroots>=0.16.4,<0.17.0
     mypy -p libqtile
     # also run the tests that require mypy
-    pip install --no-build-isolation .
+    pip install .
     {toxinidir}/scripts/ffibuild
     python3 -m pytest -- test/test_check.py test/test_migrate.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skip_missing_interpreters = True
 skipsdist=True
-minversion = 1.8
+minversion = 4.0.12
 envlist =
     pypy3,
     py39,
@@ -20,8 +20,10 @@ envlist =
 # that our tests use.
 setenv = LC_CTYPE = en_US.UTF-8
 # Pass Display down to have it for the tests available
-passenv = DISPLAY WAYLAND_DISPLAY
-whitelist_externals=convert
+passenv = DISPLAY,WAYLAND_DISPLAY
+allowlist_externals = 
+    ffibuild
+    convert
 # xcffib has to be installed before cairocffi
 deps =
     pytest >= 6.2.1
@@ -95,6 +97,7 @@ commands =
     - pydocstyle --match "(?!(test)?_).*\.py" libqtile/
 
 [testenv:mypy]
+allowlist_externals=/**/qtile/scripts/ffibuild
 deps =
     mypy == 1.4.1
     bowler


### PR DESCRIPTION
tox-gh-actions now supports tox 4.

Also fix `passenv` error with whitespace.

Let's see if this passes.