### PR TITLE
Layout Base: Remove layout_all from _SimpleLayoutBase focus

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -472,7 +472,6 @@ class _SimpleLayoutBase(Layout):
 
     def focus(self, client):
         self.clients.current_client = client
-        self.group.layout_all()
 
     def focus_first(self):
         return self.clients.focus_first()


### PR DESCRIPTION
This generates way too many configure events. As far as I can tell this is not needed, group already calls `layout_all` when focus changes.

Before this if you had 10 layouts (that use _SimpleLayoutBase) configured, it called configure on the current layout *for the focused client* 10 times too much. See

https://github.com/qtile/qtile/blob/9b1c8d1f901b1c8f98d23062c1889499ee6f35ee/libqtile/group.py#L230

This is pretty expensive for custom layouts

To test do e.g.:

```diff
diff --git a/libqtile/layout/xmonad.py b/libqtile/layout/xmonad.py
index 6ddce71a..c9ca0e40 100644
--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -309,6 +309,7 @@ class MonadTall(_SimpleLayoutBase):
 
     def configure(self, client, screen_rect):
         "Position client based on order and sizes"
+        print("configure called", client.wid)
         self.screen_rect = screen_rect
 
         # if no sizes or normalize flag is set, normalize
```

And go to an empty group with the xmonad layout