### PR TITLE
Config: Set group after configuring bar

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -469,9 +469,9 @@ class Screen(CommandObject):
         self.width = width
         self.height = height
 
-        self.set_group(group)
         for i in self.gaps:
             i._configure(qtile, self, reconfigure=reconfigure_gaps)
+        self.set_group(group)
         if self.wallpaper:
             self.wallpaper = os.path.expanduser(self.wallpaper)
             self.paint(self.wallpaper, self.wallpaper_mode)

--- a/test/widgets/test_windowtabs.py
+++ b/test/widgets/test_windowtabs.py
@@ -66,8 +66,10 @@ def test_single_window_states(manager):
     def widget_text():
         return manager.c.bar["top"].info()["widgets"][0]["text"]
 
-    # Default _TextBox text is " " and no hooks fired yet.
-    assert widget_text() == " "
+    # When no windows are spawned the text should be ""
+    # Initially TextBox has " " but the Config.set_group function already
+    # calls focus_change hook, so the text should be updated to ""
+    assert widget_text() == ""
 
     # Load a window
     proc = manager.test_window("one")
@@ -86,8 +88,7 @@ def test_single_window_states(manager):
     manager.c.window.toggle_floating()
     assert widget_text() == "<b>V one</b>"
 
-    # Kill the window and check text again
-    # NB hooks fired so empty string is now ""
+    # Kill the window and check empty string again
     manager.kill_window(proc)
     assert widget_text() == ""
 


### PR DESCRIPTION
When we do not do this then the layout.show() method gets a screen_rect that does not account for the bar borders. So we first configure the gaps (bars) such that the screen gets the correct screen_rect when used in set_group that further calls group.set_screen, which calls layout.show()

You can observe this issue with the treetab layout. Start qtile with a bar that has borders and have the treetab be the first layout to be shown. You can see that the heading is not set correctly, when you spawn a window or switch to and back to the group it fixes itself.

Got on startup:
![gotonstartup](https://github.com/qtile/qtile/assets/46386452/e6ea94bd-5d33-40f1-9be6-8e4f34e6c8e5)


Want on startup (this is after I switched groups and back):
![wantonstartup](https://github.com/qtile/qtile/assets/46386452/28eb6bc3-a106-4939-af01-afcf065502d6)

