### PR TITLE
 X11 Window: Return true for focus success after sending TAKE_FOCUS protocol event

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1243,6 +1243,7 @@ class _Window:
             )
 
             self.window.send_event(e)
+            return True
 
         # we didn't focus this time. but now the window knows if it wants
         # focus, it should SetFocus() itself; we'll get another notification


### PR DESCRIPTION
Fixes #4372 

First commit was cherry picked from #4357 and will be removed once that is merged

See for some hilarious X11 rant about this https://github.com/sminez/penrose/issues/120#issuecomment-766362138

Logic is from i3: https://github.com/i3/i3/blob/next/src/manage.c#L642-L644