### PR TITLE
WL: Ignore activation requests if window has no group

### DIFF
--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -188,7 +188,11 @@ class XdgWindow(Window[XdgSurface]):
 
     def handle_activation_request(self, focus_on_window_activation: str) -> None:
         """Respond to XDG activation requests targeting this window."""
-        assert self.qtile is not None and self.group
+        assert self.qtile is not None
+
+        if self.group is None:
+            # Likely still pending, ignore this request.
+            return
 
         if focus_on_window_activation == "focus":
             logger.debug("Focusing window (focus_on_window_activation='focus')")


### PR DESCRIPTION
Windows that haven't are not assigned groups shouldn't have any activation requests respected.

Fixes #4378