### PR TITLE
Group + Manager: Set screen_affinity properly on startup

### DIFF
--- a/docs/manual/faq.rst
+++ b/docs/manual/faq.rst
@@ -85,6 +85,17 @@ of binding keys to ``lazy.group[name].toscreen()``, use this:
 
 .. code-block:: python
 
+    groups = [
+        # Screen affinity here is used to make
+        # sure the groups startup on the right screens
+        Group(name="1", screen_affinity=0),
+        Group(name="2", screen_affinity=0),
+        Group(name="3", screen_affinity=0),
+        Group(name="q", screen_affinity=1),
+        Group(name="w", screen_affinity=1),
+        Group(name="e", screen_affinity=1),
+    ]
+
     def go_to_group(name: str) -> Callable:
         def _inner(qtile: Qtile) -> None:
             if len(qtile.screens) == 1:

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -115,7 +115,13 @@ class DGroups:
         rule = Rule(group.matches, group=group.name)
         self.rules.append(rule)
         if start:
-            self.qtile.add_group(group.name, group.layout, group.layouts, group.label)
+            self.qtile.add_group(
+                group.name,
+                group.layout,
+                group.layouts,
+                group.label,
+                screen_affinity=group.screen_affinity,
+            )
 
     def _setup_groups(self):
         for group in self.groups:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -48,7 +48,8 @@ class _Group(CommandObject):
     A group is identified by its name but displayed in GroupBox widget by its label.
     """
 
-    def __init__(self, name, layout=None, label=None):
+    def __init__(self, name, layout=None, label=None, screen_affinity=None):
+        self.screen_affinity = screen_affinity
         self.name = name
         self.label = name if label is None else label
         self.custom_layout = layout  # will be set on _configure


### PR DESCRIPTION
We had screen_affinity defined to "clamp groups to screens" but this was not actually correctly used on startup.

On startup we should also check the screen affinity and properly create new groups if no available group can be found for the screen. Right now it just assigned *any* available group to a screen. This should fix #3880

Edit and BTW: "Dynamic group" terminology is super confusing, they're just the normal groups as that is where the groups are added from (?)