### PR TITLE
Drawer refactor take3

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -264,15 +264,38 @@ class Drawer:
         else:
             ctx.set_source_rgba(*utils.rgb(colour))
 
-    def clear(self, colour):
+    def clear_rect(self, x=0, y=0, width=0, height=0):
+        """
+        Erases the background area specified by parameters. By default,
+        the whole Drawer is cleared.
+
+        The ability to clear a smaller area may be useful when you want to
+        erase a smaller area of the drawer (e.g. drawing widget decorations).
+        """
+        if width <= 0:
+            width = self.width
+        if height <= 0:
+            height = self.height
+
         self.ctx.save()
         self.ctx.set_operator(cairocffi.OPERATOR_CLEAR)
-        self.ctx.rectangle(0, 0, self.width, self.height)
+        self.ctx.rectangle(x, y, width, height)
         self.ctx.fill()
+        self.ctx.restore()
+
+    def clear(self, colour):
+        """Clears background of the Drawer and fills with specified colour."""
+        self.ctx.save()
+
+        # Erase the background
+        self.clear_rect()
+
+        # Fill drawer with new colour
         self.ctx.set_operator(cairocffi.OPERATOR_SOURCE)
         self.set_source_rgb(colour)
         self.ctx.rectangle(0, 0, self.width, self.height)
         self.ctx.fill()
+
         self.ctx.restore()
 
     def textlayout(self, text, colour, font_family, font_size, font_shadow, markup=False, **kw):

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -59,12 +59,11 @@ class Drawer(drawer.Drawer):
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         drawer.Drawer.__init__(self, qtile, win, width, height)
         self._xcb_surface = None
+        self._pixmap = None
         self._gc = None
         self._depth, self._visual = qtile.core.conn.default_screen._get_depth_and_visual(
             win._depth
         )
-        # Create an XCBSurface and pixmap
-        self._check_xcb()
 
     def finalize(self):
         self._free_xcb_surface()
@@ -201,6 +200,12 @@ class Drawer(drawer.Drawer):
             self.height if height is None else height,
         )
 
+        # We release the XCBSurface and pixmap here so we start from a clean
+        # slate next time we draw
+        # This is currently needed as "clear" functions do not remove contents when
+        # using a transparent background.
+        self._free_xcb_surface()
+
     def _find_root_visual(self):
         for i in self.qtile.core.conn.default_screen.allowed_depths:
             for v in i.visuals:
@@ -213,15 +218,3 @@ class Drawer(drawer.Drawer):
             colour = utils.remove_transparency(colour)
 
         drawer.Drawer.set_source_rgb(self, colour, ctx)
-
-    def clear(self, colour):
-        # Check if we need to re-create XCBSurface
-        self._check_xcb()
-
-        # Draw background straigt to XCB surface
-        ctx = cairocffi.Context(self._xcb_surface)
-        ctx.save()
-        ctx.set_operator(cairocffi.OPERATOR_SOURCE)
-        self.set_source_rgb(colour, ctx=ctx)
-        ctx.paint()
-        ctx.restore()


### PR DESCRIPTION
There is an apparent issue/limitation with the cairo library where setting the `OPERATOR_CLEAR` library in a `RecordingSurface` will not clear the background when painted to an `XCBSurface`. This means that, for our x11 backend code, we need to clear the underlying `XCBSurface`
directly.

To simplify this, our `Drawer.clear` method (which actually clears and paints a background colour) has been updated to include a call to a new method, `clear_rect`, which does the erasing of the background. For X11, this new method clears the `XCBSurface` rather than the recording surface.

The new method also accepts optional parameters to allow us to clear a subset of the `Drawer`. This is currently only used by third_party libraries (i.e. qtile-extras) and should help them avoid the need for writing backend-specific code.