### PR TITLE
Wayland XWindow: Only restack the surface on unhide

### DIFF
--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -162,7 +162,12 @@ class XWindow(Window[xwayland.Surface]):
                     self.tree.node.set_position(self.borderwidth, self.borderwidth)
 
                 self.container.node.set_enabled(enabled=True)
-                self.bring_to_front()
+                # Hack: This is to fix pointer focus on xwayland dialogs
+                # We previously did bring_to_front here but then that breaks fullscreening (xwayland windows will always be on top)
+                # So we now only restack the surface
+                # This means that if the dialog is behind the xwayland toplevel (and bring front click being false), focus might break
+                # We need to fix this properly with z layering
+                self.surface.restack(None, 0)  # XCB_STACK_MODE_ABOVE
                 return
 
         # This is the first time this window has mapped, so we need to do some initial


### PR DESCRIPTION
Previously the bring_to_front fix was made such that xwayland dialogs had proper focus. However, the only part of bring_to_front we need is the surface restacking. If we do a full bring_to_front then xwayland toplevels will come on top of fullscreen toplevels.

Let's do this 'hacky' patch up until we fix it properly with z-layering.

To give some explanation in proper english, bug on master which this fixes:

Spawn xterm (anything that uses xwayland), spawn alacritty/foot (anything that runs wayland). Fullscreen the wayland terminal, xterm will still be on top.