### PR TITLE
Split Wayland and X11 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     build:
         runs-on: ubuntu-22.04
-        name: "python ${{ matrix.python-version }}"
+        name: "python ${{ matrix.python-version }} on ${{ matrix.backend }}"
         strategy:
             matrix:
                 # If you change one of these, be sure to update:
@@ -17,6 +17,7 @@ jobs:
                 # If adding new python versions, consider also updating
                 # python version in .readthedocs.yaml
                 python-version: [pypy-3.9, 3.9, '3.10', '3.11']
+                backend: ['x11', 'wayland']
         steps:
             - uses: actions/checkout@v3
             - name: Set up python ${{ matrix.python-version }}
@@ -31,14 +32,18 @@ jobs:
                   libdbus-1-dev libgirepository1.0-dev gir1.2-gtk-3.0 gir1.2-notify-0.7 gir1.2-gudev-1.0 graphviz \
                   imagemagick git xserver-xephyr xterm xvfb dbus-x11 libnotify-bin \
                   libxcb-composite0-dev libxcb-icccm4-dev libxcb-res0-dev libxcb-render0-dev libxcb-res0-dev \
-                  libxcb-xfixes0-dev vlc volumeicon-alsa
+                  libxcb-xfixes0-dev vlc volumeicon-alsa libxkbcommon-dev
                 sudo pip -q install meson PyGObject
-                pip -q install tox tox-gh-actions 
-                bash -x ./scripts/ubuntu_wayland_setup
+                pip -q install tox tox-gh-actions
+            - name: Install wayland
+              if: ${{ matrix.backend == 'wayland' }}
+              run: bash -x ./scripts/ubuntu_wayland_setup
             - name: Run Tests
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]
                 tox
+              env:
+                BACKEND: ${{ matrix.backend }}
             - name: Upload coverage data to coveralls.io
               # For speed purposes, we don't do coverage reporting on pypy 3.9
               if: ${{ matrix.python-version != 'pypy-3.9' }}
@@ -47,7 +52,7 @@ jobs:
                 coveralls --service=github
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
+                COVERALLS_FLAG_NAME: ${{ format('{0}-{1}', matrix.python-version, matrix.backend) }}
                 COVERALLS_PARALLEL: true
                 COVERALLS_SERVICE_JOB_ID: ${{ github.run_id }}
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Qtile x.xx.x, released XXXX-XX-XX:
     * features
+      - Change how `tox` runs tests. See https://docs.qtile.org/en/latest/manual/contributing.html#running-tests-locally
+      for more information on how to run tests locally.
     * bugfixes
 
 Qtile 0.23.0, released 2023-09-24:

--- a/docs/manual/contributing.rst
+++ b/docs/manual/contributing.rst
@@ -126,22 +126,36 @@ Running tests locally
 This section gives an overview about ``tox`` so that you don't have to search
 `its documentation <https://tox.readthedocs.io/en/latest/>`_ just to get
 started.
+
 Checks are grouped in so-called ``environments``. Some of them are configured to
 check that the code works (the usual unit test, e.g. ``py39``, ``pypy3``),
 others make sure that your code conforms to the style guide (``pep8``,
 ``codestyle``, ``mypy``). A third kind of test verifies that the documentation
 and packaging processes work (``docs``, ``docstyle``, ``packaging``).
 
+We have configured ``tox`` to run the full suite of tests whenever a pull request
+is submitted/updated. To reduce the amount of time taken by these tests, we have
+created separate environments for both python versions and backends (e.g. tests for
+x11 and wayland run in parallel for each python version that we currently support).
+
+These environments were designed with automation in mind so there are separate
+``test`` environments which should be used for running qtile's tests locally. By default,
+tests will only run on x11 backend (but see below for information on how to set the
+backend).
+
 The following examples show how to run tests locally:
-   * To run the functional tests, use ``tox -e py39`` (or a different
-     environment). You can specify to only run a specific test file or even a
-     specific test within that file with the following commands:
+   * To run the functional tests, use ``tox -e test``. You can specify to only
+     run a specific test file or even a specific test within that file with
+     the following commands:
 
      .. code-block:: bash
 
-        tox -e py39 # Run all tests with python 3.9 as the interpreter
-        tox -e py39 -- -x test/widgets/test_widgetbox.py  # run a single file
-        tox -e py39 -- -x test/widgets/test_widgetbox.py::test_widgetbox_widget
+        tox -e test # Run all tests in default python version
+        tox -e test -- -x test/widgets/test_widgetbox.py  # run a single file
+        tox -e test -- -x test/widgets/test_widgetbox.py::test_widgetbox_widget
+        tox -e test -- --backend=wayland --backend=x11  # run tests on both backends
+        tox -e test-both  # same as above 
+        tox -e test-wayland  # Just run tests on wayland backend
 
    * To run style and building checks, use ``tox -e docs,packaging,pep8,...``.
      You can use ``-p auto`` to run the environments in parallel.

--- a/tox.ini
+++ b/tox.ini
@@ -3,19 +3,43 @@ skip_missing_interpreters = True
 skipsdist=True
 minversion = 4.0.12
 envlist =
-    pypy3,
-    py39,
-    py310,
-    py311,
+    # Python environments with specific backend
+    py{py3,39,310,311}-{x11,wayland}
     docs,
     pep8,
     codestyle,
     docstyle,
     mypy,
     packaging,
-    vulture
+    vulture,
+    # For running pytest locally
+    test-{x11,wayland,both}
 
-[testenv]
+# Set up some variables that can be used multiple times
+[base]
+deps =
+    setuptools >= 40.5.0
+    dbus-next
+    wheel
+    cffi
+    xcffib >= 1.4.0
+    cairocffi >= 1.6.0
+    # We use "!x11" here so pywayland is installed both in CI wayland environment
+    # But also when users run locally (as both backends are run in that scenario)
+    !x11: pywayland==0.4.15
+    !x11: xkbcommon >= 0.3
+testdeps = 
+    pytest >= 6.2.1
+    {wayland,x11}: coverage
+    bowler
+    PyGObject   
+commands =
+    !x11: pip install pywlroots==0.16.4
+    pip install .
+    !x11: {toxinidir}/scripts/ffibuild
+
+# These are the environments that should be triggered by Github Actions
+[testenv:py{py3,39,310,311}-{wayland,x11}]
 # This is required in order to get UTF-8 output inside of the subprocesses
 # that our tests use.
 setenv = LC_CTYPE = en_US.UTF-8
@@ -24,45 +48,64 @@ passenv = DISPLAY,WAYLAND_DISPLAY,LDFLAGS,CFLAGS
 allowlist_externals = 
     */ffibuild
     convert
-# xcffib has to be installed before cairocffi
 deps =
-    pytest >= 6.2.1
-    coverage
-    setuptools >= 40.5.0
-    bowler
-    xkbcommon >= 0.3
-    pywayland == 0.4.15
-    dbus-next
-    PyGObject
-    wheel
-    cffi
-    xcffib >= 1.4.0
-    cairocffi >= 1.6.0
+    {[base]deps}
+    {[base]testdeps}
 # pywayland has to be installed before pywlroots
 commands =
-    # cffi's binary wheel is incompatible with some libffi libraries so we force build here
-    # See: https://github.com/Kozea/cairocffi/issues/202
-    !pypy3: pip install --force-reinstall --no-binary :all: cffi
-    # However, rebuilding on pypy doesn't work so we'll pin the version instead
-    # See: https://github.com/tych0/xcffib/issues/134
-    pypy3: pip install cffi==1.15.0
-    ; pip install xcffib>=1.4.0 wheel
-    # The 1.5.0 release of cairocffi cannot be built in a clean folder as it will fail to
-    # to build with xcb suppport. https://github.com/Kozea/cairocffi/issues/212
-    pip install pywlroots==0.16.4
-    pip install .
-    {toxinidir}/scripts/ffibuild
-    # pypy3 is very slow when running coverage reports so we skip it
-    pypy3: python3 -m pytest --backend=x11 --backend=wayland {posargs}
-    py39: coverage run -m pytest --backend=x11 --backend=wayland {posargs}
-    py3{10,11}: coverage run -m pytest --backend=x11 --backend=wayland {posargs}
+    {[base]commands}
 
+    # pypy3 is very slow when running coverage reports so we skip it
+    pypy3-x11: python3 -m pytest --backend=x11 {posargs}
+    pypy3-wayland: python3 -m pytest --backend=wayland {posargs}
+    py3{9,10,11}-x11: coverage run -m pytest --backend=x11 {posargs}
+    py3{9,10,11}-wayland: coverage run -m pytest --backend=wayland {posargs}
+
+    # Coverage is only run via GithubActions
     # Coverage runs tests in parallel so we need to combine results into a single file
-    !pypy3: coverage combine -q
+    !pypy3-{wayland,x11}: coverage combine -q
     # Include a text summary in the build log
-    !pypy3: coverage report -m
+    !pypy3-{wayland,x11}: coverage report -m
     # Create an xml summary to be submitted to coveralls.io
-    !pypy3: coverage xml
+    !pypy3-{wayland,x11}: coverage xml
+
+# Basic environment for local testing
+[testenv:test]
+# This is required in order to get UTF-8 output inside of the subprocesses
+# that our tests use.
+setenv = LC_CTYPE = en_US.UTF-8
+# Pass Display down to have it for the tests available
+passenv = DISPLAY,WAYLAND_DISPLAY,LDFLAGS,CFLAGS
+allowlist_externals = 
+    */ffibuild
+    convert
+deps =
+    {[base]deps}
+    {[base]testdeps}
+# pywayland has to be installed before pywlroots
+commands =
+    {[base]commands}
+    python -m pytest {posargs}
+
+# Additional local environments with specified backends
+[testenv:test-{x11,wayland,both}]
+# This is required in order to get UTF-8 output inside of the subprocesses
+# that our tests use.
+setenv = LC_CTYPE = en_US.UTF-8
+# Pass Display down to have it for the tests available
+passenv = DISPLAY,WAYLAND_DISPLAY,LDFLAGS,CFLAGS
+allowlist_externals = 
+    */ffibuild
+    convert
+deps =
+    {[base]deps}
+    {[base]testdeps}
+# pywayland has to be installed before pywlroots
+commands =
+    {[base]commands}
+    x11: python -m pytest --backend=x11 {posargs}
+    wayland: python -m pytest --backend=wayland {posargs}
+    both: python -m pytest --backend=wayland --backend=x11 {posargs}
 
 [testenv:packaging]
 deps =
@@ -102,24 +145,18 @@ commands =
 [testenv:mypy]
 allowlist_externals=*/ffibuild
 deps =
+    {[base]deps}
     mypy == 1.4.1
     bowler
-    dbus-next
-    PyGObject
     pytest >= 6.2.1
     types-python-dateutil
     types-pytz
     types-pkg_resources
-    xcffib >= 1.4.0
-    cairocffi >= 1.6.0
-    wheel
+    xkbcommon>=0.3
 commands =
-    pip install -r requirements.txt pywayland>=0.4.14 xkbcommon>=0.3
-    pip install pywlroots==0.16.4
+    {[base]commands}
     mypy -p libqtile
     # also run the tests that require mypy
-    pip install .
-    {toxinidir}/scripts/ffibuild
     python3 -m pytest -- test/test_check.py test/test_migrate.py
 
 [testenv:docs]
@@ -140,3 +177,8 @@ python =
     3.9: py39, mypy
     3.10: py310, mypy
     3.11: py311, mypy, packaging, pep8, codestyle, docstyle, vulture
+
+[gh-actions:env]
+BACKEND =
+    x11: x11
+    wayland: wayland


### PR DESCRIPTION
This PR runs the X11 and Wayland backends in parallel runners which shortens our run time. Tests completed in 22 mins on my fork.

The `tox.ini` file is pretty messy and needs some love but we can do that separately.

One issue I have with this PR is that it makes it a bit harder for users to run`tox` locally. This is because, to save duplicating lines, I set the `--backend` option by using an environmental variable (which is set in Github Actions). To run tests, users would need to run `BACKEND=wayland tox -e py311`. If we add more lines to `tox.ini`, we could have users run `tox -e py311-wayland` (I'm assuming most users aren't going to run full test suite locally on both backends).

Branch protections would need updating too as I've changed job names.

Would welcome thoughts.