### PR TITLE
Add more info to widget error handling

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -834,7 +834,7 @@ class ThreadPoolText(_TextBox):
                         self.timeout_add(self.update_interval, self.timer_setup)
 
                 except Exception:
-                    logger.exception("Failed to reschedule.")
+                    logger.exception("Failed to reschedule timer for %s.", self.name)
             else:
                 logger.warning("%s's poll() returned None, not rescheduling", self.name)
 


### PR DESCRIPTION
If a widget timer fails to reschedule it may not always include details of which widget the error relates to if the error arises in core qile modules (e.g. pangocffi layouts). This can make debugging harder. This PR just adds the widget name to the error message.