### PR TITLE
Remove on_close callback when Notify finalised

### DIFF
--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -226,5 +226,5 @@ class Notify(base._TextBox):
             self._invoke()
 
     def finalize(self):
-        notifier.unregister(self.update)
+        notifier.unregister(self.update, on_close=self.on_close)
         base._TextBox.finalize(self)


### PR DESCRIPTION
The `on_close` callback was not being removed when the Notify widget was finalised. New callbacks would be added each time the the config is reloaded but, as the old callbacks were not removed, multiple callbacks would be fired.