### PR TITLE
[x11 layering] Fix bug with multiple transients

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
       - Change how `tox` runs tests. See https://docs.qtile.org/en/latest/manual/contributing.html#running-tests-locally
       for more information on how to run tests locally.
     * bugfixes
+      - Fix two bugs in stacking transient windows in X11
 
 Qtile 0.23.0, released 2023-09-24:
     !!! Dependency Changes !!!

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1044,14 +1044,15 @@ class _Window:
         windows.sort(key=lambda w: stack.index(w[0].wid))
 
         # Get lists of windows on lower, higher or same "layer" as window
-        lower = [w[0].wid for w in windows if w[1] is None and w[2] > layering]
-        higher = [w[0].wid for w in windows if w[1] is None and w[2] < layering]
-        same = [w[0].wid for w in windows if w[1] is None and w[2] == layering]
+        lower = [w[0].wid for w in windows if w[2] > layering]
+        higher = [w[0].wid for w in windows if w[2] < layering]
+        same = [w[0].wid for w in windows if w[2] == layering]
 
         # We now need to identify the new position in the stack
 
         # If the window has a parent, the window should just be put above it
-        if parent:
+        # If the parent isn't being managed by qtile then it may not be stacked correctly
+        if parent and parent in self.qtile.windows_map:
             sibling = parent
             above = True
 


### PR DESCRIPTION
Google Earth identified a couple of issues with the layering code:
- The `transient_for` property for some windows returned the ID of a window that was not being managed by qtile. As a result, the parent window would not have been stacked and placing the new window above this would therefore put the new window in the wrong stack position.
- Transient windows were excluded from the list of windows in different layers and so, if an app has multiple transient windows, a new window would not be stacked after the last transient.

Draft for now as I'd like some feedback.