### PR TITLE
docs: drop note about old ubuntus

### DIFF
--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -14,13 +14,6 @@ To install the git version see :ref:`installing-from-source`
 Note: As of Ubuntu 20.04 (Focal Fossa), the package has been outdated
 and removed from the Ubuntu's official package list.
 
-On other recent Ubuntu (17.04 or greater) and Debian unstable versions,
-there are Qtile packages available via:
-
-.. code-block:: bash
-
-    sudo apt-get install qtile
-
 Debian 11 (bullseye)
 --------------------
 


### PR DESCRIPTION
17.04 (and 18.04) are now end of life, so this is no longer relevant.

Reported-by: Christian Reis <kiko@luizalabs.com>