### PR TITLE
maximize windows that wanted to maximize

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -157,6 +157,7 @@ Qtile 0.23.0, released 2023-09-24:
           - added `only_focused` setting to Max layout, allowing to draw multiple clients on top of each other when
             set to False
         - Add `suspend` hook to run functions before system goes to sleep.
+        - Add ability to maximize window using header bar buttons.
     * bugfixes
         - Fix bug where Window.center() centers window on the wrong screen when using multiple monitors.
         - Fix `Notify` bug when apps close notifications.

--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -297,6 +297,11 @@ class Window(_Window, metaclass=ABCMeta):
         """Does this window want to be fullscreen?"""
         return False
 
+    @property
+    def wants_to_maximize(self) -> bool:
+        """Does this window want to be maximize?"""
+        return False
+
     def match(self, match: config._Match) -> bool:
         """Compare this window against a Match instance."""
         return match.compare(self)

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -144,6 +144,8 @@ net_wm_states = (
 WindowStates = {
     None: "normal",
     "_NET_WM_STATE_FULLSCREEN": "fullscreen",
+    "_NET_WM_STATE_MAXIMIZED_VERT": "maximized",
+    "_NET_WM_STATE_MAXIMIZED_HORZ": "maximized",
     "_NET_WM_STATE_DEMANDS_ATTENTION": "urgent",
 }
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -256,6 +256,8 @@ class _Group(CommandObject):
         win.group = self
         if self.qtile.config.auto_fullscreen and win.wants_to_fullscreen:
             win._float_state = FloatStates.FULLSCREEN
+        elif self.qtile.config.auto_fullscreen and win.wants_to_maximize:
+            win._float_state = FloatStates.MAXIMIZED
         elif self.floating_layout.match(win) and not win.fullscreen:
             win._float_state = FloatStates.FLOATING
             if self.qtile.config.floats_kept_above:


### PR DESCRIPTION
This is for the gnome apps that have maximize buttons in the header bar. It also tracks the state of the window and updates button state when maximize is triggered by qtile itself.

![2023-08-30_16-06](https://github.com/qtile/qtile/assets/46163506/f862813a-dd96-455f-a46d-df1f0584d6db)

![2023-08-30_16-07](https://github.com/qtile/qtile/assets/46163506/fa748b2b-f4c5-4d1f-83d2-f1584369d844)
