### PR TITLE
Fix number of bugs in the bar

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -185,6 +185,8 @@ class Drawer:
         offsety: int = 0,
         width: int | None = None,
         height: int | None = None,
+        src_x: int = 0,
+        src_y: int = 0,
     ):
         """
         A wrapper for the draw operation.
@@ -205,9 +207,20 @@ class Drawer:
             the X portion of the canvas to draw at the starting point.
         height :
             the Y portion of the canvas to draw at the starting point.
+        src_x  :
+            the X position of the origin in the source surface
+        src_y  :
+            the Y position of the origin in the source surface
         """
         if self._enabled:
-            self._draw(offsetx, offsety, width, height)
+            self._draw(
+                offsetx=offsetx,
+                offsety=offsety,
+                width=width,
+                height=height,
+                src_x=src_x,
+                src_y=src_y,
+            )
             if self.has_mirrors:
                 self._create_last_surface()
                 ctx = cairocffi.Context(self.last_surface)
@@ -222,6 +235,8 @@ class Drawer:
         offsety: int = 0,
         width: int | None = None,
         height: int | None = None,
+        src_x: int = 0,
+        src_y: int = 0,
     ):
         """
         This draws our cached operations to the Internal window.
@@ -237,6 +252,10 @@ class Drawer:
             the X portion of the canvas to draw at the starting point.
         height :
             the Y portion of the canvas to draw at the starting point.
+        src_x  :
+            the X position of the origin in the source surface
+        src_y  :
+            the Y position of the origin in the source surface
         """
 
     def new_ctx(self):

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -49,6 +49,8 @@ class Drawer(drawer.Drawer):
         offsety: int = 0,
         width: int | None = None,
         height: int | None = None,
+        src_x: int = 0,
+        src_y: int = 0,
     ) -> None:
         if offsetx > self._win.width:
             return
@@ -76,7 +78,9 @@ class Drawer(drawer.Drawer):
         # Paint recorded operations to our window's underlying ImageSurface
         with cairocffi.Context(self._win.surface) as context:
             context.set_operator(cairocffi.OPERATOR_SOURCE)
-            context.set_source_surface(self.surface, offsetx, offsety)
+            # Adjust the source surface position by src_x and src_y e.g. if we want
+            # to render part of the surface in a different position
+            context.set_source_surface(self.surface, offsetx - src_x, offsety - src_y)
             context.rectangle(offsetx, offsety, width, height)
             context.fill()
 

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -175,6 +175,8 @@ class Drawer(drawer.Drawer):
         offsety: int = 0,
         width: int | None = None,
         height: int | None = None,
+        src_x: int = 0,
+        src_y: int = 0,
     ):
         self.current_rect = (offsetx, offsety, width, height)
 
@@ -193,8 +195,8 @@ class Drawer(drawer.Drawer):
             self._pixmap,
             self._win.wid,
             self._gc,
-            0,
-            0,  # srcx, srcy
+            src_x,
+            src_y,  # srcx, srcy
             offsetx,
             offsety,  # dstx, dsty
             self.width if width is None else width,


### PR DESCRIPTION
c840df2 introduced a change to Bar.draw to ensure that a bar was completely filled even when there were insufficient widgets to fill the bar.

However, this introduced a bug:

1) When the bar is drawn, it clears the entire bar and then redraws
   every widget. However, the clearing is unnecessary as widgets also
   clear the surface before they are drawn. The bar's clearing therefore
   results in flickering of the bar as there may be a gap between
   clearing the bar and the widgets drawing themselves, particularly
   when there are a large number of widgets in the bar.

That bug revealed another:

2) Drawing the borders also cleared the entire bar so flickering would
   also occur when a user used borders in their config.

Which, in turn, revealed another:

3) Bar borders were not being rendered correctly for vertical bars
   (surprised this wasn't flagged earlier...)

This PR addresses all of these issues by:
- Removing the need to clear the bar's surface when it's drawn. Borders will now only clear the part of the bar covered by those borders.
- Similarly, filling any bar space no occupied by widgets will only draw in that space.