### PR TITLE
WLRQ: Setup the dnd destroy listener using self.icon

### DIFF
--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -205,7 +205,7 @@ class Dnd(HasListeners):
         self.height: int = 0
 
         self.icon = cast(data_device_manager.DragIcon, wlr_drag.icon)
-        self.add_listener(wlr_drag.destroy_event, self._on_destroy)
+        self.add_listener(self.icon.destroy_event, self._on_destroy)
         self.add_listener(self.icon.surface.commit_event, self._on_icon_commit)
 
         tree = SceneTree.subsurface_tree_create(core.drag_icon_tree, self.icon.surface)


### PR DESCRIPTION
As far as I can tell we're not actually destroying it double but just setting up the signal wrong

It seems like if we use wlr_drag.destroy_event we can get segfaults when destroying. Using self.icon for the destroy event fixes this. Fixes one crash of #4421