### PR TITLE
Fix Wayland CFFI build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include README.rst
 include MANIFEST.in
 include CONTRIBUTING.md
+include libqtile/backend/wayland/_ffi*.so
 
 exclude .coveragerc
 exclude .pylintrc

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+path = Path(__file__).parent / ".." / ".." / ".." / ".."
+sys.path.insert(0, path.absolute().as_posix())
+
 import wlroots.ffi_build as wlr
 from cffi import FFI
 


### PR DESCRIPTION
This PR changes how the Wayland CFFI modules are built when the package is installed. It addresses the `ModuleNotFound` error by adding the build environment to the python path to ensure modules can be found before they're installed.