### PR TITLE
pyproject: more (hopefully the last?) porting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,25 @@ readme = {file = "README.rst"}
 [project]
 name = "qtile"
 description = "A pure-Python tiling window manager."
-dynamic = ["version"]
+dynamic = ["version", "readme"]
+license = {text = "MIT"}
+classifiers = [
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: BSD :: FreeBSD",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Desktop Environment :: Window Managers",
+]
+
+[project.urls]
+"Homepage" = "https://qtile.org"
+"Documentation" = "https://docs.qtile.org/"
+"Code" = "https://github.com/qtile/qtile/"
+"Issue tracker" = "https://github.com/qtile/qtile/issues"
+"Contributing" = "https://docs.qtile.org/en/latest/manual/contributing.html"
 
 [project.scripts]
 qtile = "libqtile.scripts.main:main"


### PR DESCRIPTION
Here's the last bits of what I think we should port to pyproject.toml before releasing.

* I dropped the "Alpha" Classifier, we're beyond alpha, I've been using qtile as a daily driver for nearly 15 years
* I dropped the point-release python version Classifiers (i.e. 3.8, 3.9, etc.). These are not that interesting and a pain to maintain.
* I dropped Sean Vig as the listed maintainer. We list all the maintainers at the bottom of the readme, which ends up in the long_description. No reason to maintain two maintainer lists.
* I dropped Aldo as the Author:. There are lots of authors of qtile, this info is available from the git log.

My hope is that this will not give a syntax error when uploading source now during the release workflow. I've inspected the output with:

    python3 setup.py bdist_wheel --keep-temp && cat build/bdist.linux-x86_64/wheel/qtile-*.dist-info/METADATA

and it looks pretty similar to the METADATA from the current release.