### PR TITLE
README: drop www from website url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,10 +54,10 @@ Please also consider submitting useful scripts etc. to the qtile-examples repo
 
 .. |logo| image:: https://raw.githubusercontent.com/qtile/qtile/master/logo.png
     :alt: Logo
-    :target: https://www.qtile.org
+    :target: https://qtile.org
 .. |website| image:: https://img.shields.io/badge/website-qtile.org-blue.svg
     :alt: Website
-    :target: https://www.qtile.org
+    :target: https://qtile.org
 .. |pypi| image:: https://img.shields.io/pypi/v/qtile.svg
     :alt: PyPI
     :target: https://pypi.org/project/qtile/


### PR DESCRIPTION
The SSL cert github serves is not valid for www.qtile.org, just qtile.org. Let's drop the www here.