### PR TITLE
Fix incorrect typing with Dropdown config

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -1046,7 +1046,7 @@ class DropDown(configurable.Configurable):
         ),
     )
 
-    def __init__(self, name: str, cmd: str, **config: dict[str, Any]) -> None:
+    def __init__(self, name: str, cmd: str, **config: Any) -> None:
         """
         Initialize :class:`DropDown` window wrapper.
 


### PR DESCRIPTION
Remove the `Dict` typing from the `config` parameter of dropdown `__init__` method as kwargs are annotated only by there content.