### PR TITLE
Pulse widget - refactor to use single server connection

### DIFF
--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -191,7 +191,9 @@ class PulseVolume(Volume):
     serves no purpose for this widget).
 
     The widget relies on the `pulsectl_asyncio <https://pypi.org/project/pulsectl-asyncio/>`__
-    library to access the libpulse bindings.
+    library to access the libpulse bindings. If you are using python 3.11 you must use
+    ``pulsectl_asyncio >= 1.0.0``.
+
     """
 
     defaults = [


### PR DESCRIPTION
Previously, each widget instance created its own connection to the pulse server. This is unnecessary given all widgets are retrieving the same data.

This PR addresses this by creating a single connection and allowing widgets to subscribe to that one connection.