### PR TITLE
Fix two bugs when adding/removing screens

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -432,6 +432,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         """Kill the window when the bar's screen is no longer being used."""
         assert self.qtile is not None
 
+        if self.future:
+            self.future.cancel()
+
         for name, w in self.qtile.widgets_map.copy().items():
             if w in self.widgets:
                 w.finalize()
@@ -440,6 +443,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         if self.window:
             self.window.kill()
             self.window = None
+
+        # Reset some flags to allow the bar to be reconfigured as needed
+        self._configured = False
+        self._draw_queued = False
 
     def _resize(self, length: int, widgets: list[_Widget]) -> None:
         # We want consecutive stretch widgets to split one 'block' of space between them

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -384,7 +384,11 @@ class Qtile(CommandObject):
                 if grp is None:
                     grp = self.add_autogen_group(i)
 
-            reconfigure_gaps = (x, y, w, h) != (scr.x, scr.y, scr.width, scr.height)
+            # If the screen has changed position and/or size, or is a new screen then make sure that any gaps/bars
+            # are reconfigured
+            reconfigure_gaps = ((x, y, w, h) != (scr.x, scr.y, scr.width, scr.height)) or (
+                i + 1 > len(self.screens)
+            )
 
             if not hasattr(scr, "group"):
                 # Ensure that this screen actually *has* a group, as it won't get

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -226,6 +226,9 @@ class _Widget(CommandObject, configurable.Configurable):
         self.bar = bar
         self.drawer = bar.window.create_drawer(self.bar.width, self.bar.height)
 
+        # Clear this flag as widget may be restarted (e.g. if screen removed and re-added)
+        self.finalized = False
+
         # Timers are added to futures list so they can be cancelled if the `finalize` method is
         # called before the timers have fired.
         if not self.configured:
@@ -253,6 +256,10 @@ class _Widget(CommandObject, configurable.Configurable):
             self.layout.finalize()
         self.drawer.finalize()
         self.finalized = True
+
+        # Reset configuration status so the widget can be reconfigured
+        # e.g. when screen is re-added
+        self.configured = False
 
     def clear(self):
         self.drawer.set_source_rgb(self.bar.background)


### PR DESCRIPTION
There are two bugs that can arise when a screen is disconnected and plugged back in:

1) Disconnecting the screen calls `kill_window()` on the gaps on that screen. However, that method does not include a call to cancel any scheduled timers (e.g. `self.draw()`) so the bar my try to draw finalised widgets resulting in a PangoError when the bar tries to get the size of the widgets in `self._resize()`.

2) Reconnecting a screen could result in widgets on that screen not updating. This was because the screen uses previously initialised/configured widgets and so `self.configured` and `self.finalized` were both `True`. This prevented widgets from being reconfigured correctly as well as blocking any timers.