### PR TITLE
Fix layout issue with killed scratchpads

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -345,6 +345,8 @@ class _ClientList:
         elif idx <= self._current_idx:
             self._current_idx = max(0, self._current_idx - 1)
 
+        return self[self._current_idx]
+
     def rotate_up(self, maintain_index=True):
         """
         Rotate the list. The first client is moved to last position.


### PR DESCRIPTION
When a scratchpad is killed (rather than toggled) it can prevent layouts from setting layout correctly when tiled windows are closed.

I'm not entirely sure why this happens but the bug is fixed by having `layout._ClientList.remove` return the next window which allows the layout to focus the window correctly.

If you want to test this, first verify the bug exists in current master:
- Use `MonadTall` layout
- Open two windows (they open side by side)
- Close left-hand window, remaining window fills layouts
- Open another window (so you have two windows again)
- Open a scratchpad
- Kill scratchpad window (not hide)
- Close currently focused window
- Layout does not correctly adjust layout