### PR TITLE
feat: Add options to set initial caps lock and num lock state

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -171,7 +171,7 @@ pywayland, pywlroots and python-xkbcommon. Also note that we may not have yet
 caught up with the latest wlroots release ourselves.
 
 .. note::
-   We currently support wlroots==0.16.0,<0.17.0 and pywlroots==0.16.4.
+   We currently support wlroots>=0.16.0,<0.17.0 and pywlroots>=0.16.5,<0.17.0.
 
 With the Wayland dependencies in place, Qtile can be run either from a TTY, or
 within an existing X11 or Wayland session where it will run inside a nested

--- a/docs/manual/wayland.rst
+++ b/docs/manual/wayland.rst
@@ -13,7 +13,7 @@ and :ref:`troubleshooting <debugging-wayland>` for tips on how to debug Wayland
 problems.
 
 .. note::
-   We currently support wlroots>=0.16.0,<0.17.0 and pywlroots==0.16.4.
+   We currently support wlroots>=0.16.0,<0.17.0 and pywlroots>=0.16.5,<0.17.0.
 
 Backend-Specific Configuration
 ==============================

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from pywayland.protocol.wayland import WlKeyboard
+from wlroots.wlr_types.keyboard import ModifiersMask
 from xkbcommon import xkb
 
 from libqtile import configurable
@@ -142,6 +143,8 @@ class InputConfig(configurable.Configurable):
         ("kb_variant", None, "Keyboard variant i.e. ``XKB_DEFAULT_VARIANT``"),
         ("kb_repeat_rate", 25, "Keyboard key repeats made per second"),
         ("kb_repeat_delay", 600, "Keyboard delay in milliseconds before repeating"),
+        ("kb_numlock", None, "``True`` or ``False`` Enable numlock on startup"),
+        ("kb_capslock", None, "``True`` or ``False`` Enable capslock on startup"),
     ]
 
     def __init__(self, **config: Any) -> None:
@@ -278,6 +281,15 @@ class Keyboard(_Device):
 
         self.seat.keyboard_notify_key(event)
 
+    def _set_num_caps_lock(self, numlock: bool | None, capslock: bool | None) -> None:
+        """Set the initial num/caps lock state of the keyboard."""
+        mask = ModifiersMask(self.keyboard)
+        if numlock:
+            mask.add("Mod2")
+        if capslock:
+            mask.add("Lock")
+        self.keyboard.notify_modifiers(mask)
+
     def configure(self, configs: dict[str, InputConfig]) -> None:
         """Applies ``InputConfig`` rules to this keyboard device."""
         config = self._match_config(configs)
@@ -285,6 +297,7 @@ class Keyboard(_Device):
         if config:
             self.keyboard.set_repeat_info(config.kb_repeat_rate, config.kb_repeat_delay)
             self.set_keymap(config.kb_layout, config.kb_options, config.kb_variant)
+            self._set_num_caps_lock(config.kb_numlock, config.kb_capslock)
 
 
 class Pointer(_Device):

--- a/scripts/ubuntu_wayland_setup
+++ b/scripts/ubuntu_wayland_setup
@@ -8,7 +8,7 @@
 set -e
 
 # The versions we want
-WAYLAND=1.21.0
+WAYLAND=1.22.0
 WAYLAND_PROTOCOLS=1.31
 WLROOTS=0.16.2
 SEATD=0.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ wayland =
   xkbcommon>=0.3
   # NOTE: When updating the major or minor version of pywlroots here, also update:
   # tox.ini, docs/manual/install/index.rst, docs/manual/wayland.rst
-  pywlroots==0.16.4
+  pywlroots>=0.16.5,<0.17.0
 widgets =
   dbus-next
   imaplib2

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ testdeps =
     PyGObject   
     isort
 commands =
-    !x11: pip install pywlroots==0.16.4
+    !x11: pip install pywlroots==0.16.5
     pip install .
     !x11: {toxinidir}/scripts/ffibuild
 


### PR DESCRIPTION
This adds the ability  set an initial state for the caps lock and num lock using kb_capslock and kb_numlock options.

Closes:
https://github.com/qtile/qtile/issues/4225