### PR TITLE
only include libqtile in our wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ enabled = true
 [tool.setuptools.dynamic]
 readme = {file = "README.rst"}
 
+[tool.setuptools.packages.find]
+include = ["libqtile*"]
+
 [project]
 name = "qtile"
 description = "A pure-Python tiling window manager."


### PR DESCRIPTION
This makes me wonder about two other things people have asked us to distribute:

1. the tests/, so maintainers can run our automated tests on their builds
2. resources/ (for qtile.desktop, admittedly small)

But hey, at least we aren't dumping stuff in peoples' site-packages/ with this commit.

Fixes #4443