### PR TITLE
Another go at packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,150 @@ on:
   release:
     types: [published]
 jobs:
+  build-wayland:
+    name: Build Wayland libraries
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    env:
+      libdrm-version: "2.4.114"
+      seatd-version: "0.6.3"
+      pixman-version: "0.42.0"
+      wayland-protocols-version: "1.31"
+      wayland-version: "1.22.0"
+      wlroots-version: "0.16.2"
+    steps:
+      - name: Install dependencies
+        run: |
+          yum -y install \
+            hwdata \
+            python3-pip \
+            libffi-devel \
+            libinput-devel \
+            libpciaccess-devel \
+            libudev-devel \
+            libxkbcommon-x11-devel \
+            libxml2-devel \
+            mesa-libEGL-devel \
+            mesa-libgbm-devel \
+            xcb-util-devel \
+            xcb-util-image-devel \
+            xcb-util-keysyms-devel \
+            xcb-util-renderutil-devel \
+            xcb-util-wm-devel \
+            xorg-x11-server-Xwayland \
+            ninja-build \
+            wget
+      - name: Set environment variables
+        run: |
+          echo "CPATH=${HOME}/wayland/usr/include" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${HOME}/wayland/usr/lib" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=${HOME}/wayland/usr/lib" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${HOME}/wayland/usr/share/pkgconfig:${HOME}/wayland/usr/lib/pkgconfig" >> $GITHUB_ENV
+      - name: Download and unpack Wayland source
+        run: |
+          wget $WAYLAND_URL
+          wget $WAYLAND_PROTOCOLS_URL
+          wget $LIBDRM_URL
+          wget -O seatd.tar.gz $SEATD_URL
+          wget $PIXMAN_URL
+          wget -O wlroots.tar.gz $WLROOTS_URL
+          tar -xJf wayland-${{ env.wayland-version }}.tar.xz
+          tar -xJf wayland-protocols-${{ env.wayland-protocols-version }}.tar.xz
+          tar -xzf drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          tar -xjf pixman-pixman-${{ env.pixman-version }}.tar.bz2
+          tar -xzf seatd.tar.gz
+          tar -xzf wlroots.tar.gz
+        env:
+          WAYLAND_URL: https://gitlab.freedesktop.org/wayland/wayland/-/releases/${{ env.wayland-version }}/downloads/wayland-${{ env.wayland-version }}.tar.xz
+          WAYLAND_PROTOCOLS_URL: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/${{ env.wayland-protocols-version }}/downloads/wayland-protocols-${{ env.wayland-protocols-version }}.tar.xz
+          LIBDRM_URL: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{ env.libdrm-version }}/drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          SEATD_URL: https://git.sr.ht/~kennylevinsen/seatd/archive/${{ env.seatd-version }}.tar.gz
+          PIXMAN_URL: https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-${{ env.pixman-version }}/pixman-pixman-${{ env.pixman-version }}.tar.bz2
+          WLROOTS_URL: https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${{ env.wlroots-version }}/wlroots-${{ env.wlroots-version }}.tar.gz
+      - name: Install meson
+        run: |
+          pip3 install meson
+      - name: Build wayland
+        working-directory: wayland-${{ env.wayland-version }}
+        run: |
+          meson build --prefix=/usr -Ddocumentation=false
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          ninja -C build install
+      - name: Build wayland-protocols
+        working-directory: wayland-protocols-${{ env.wayland-protocols-version }}
+        run: |
+          meson build --prefix=/usr
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          ninja -C build install
+      - name: Build libdrm
+        working-directory: drm-libdrm-${{ env.libdrm-version }}
+        run: |
+          meson build --prefix=/usr
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          ninja -C build install
+      - name: Build seatd
+        working-directory: seatd-${{ env.seatd-version }}
+        run: |
+          meson build --prefix=/usr
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          ninja -C build install
+      - name: Build pixman
+        working-directory: pixman-pixman-${{ env.pixman-version }}
+        run: |
+          meson build --prefix=/usr
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+          ninja -C build install
+      - name: Build wlroots
+        working-directory: wlroots-${{ env.wlroots-version }}
+        run: |
+          meson build --prefix=/usr -Dxwayland=enabled
+          ninja -C build
+          DESTDIR=~/wayland ninja -C build install
+      - name: Create artifact
+        run: tar czf ~/wayland.tar.gz -C ${HOME}/wayland/ .
+      - name: Upload built libraries
+        uses: actions/upload-artifact@v3
+        with:
+          name: wayland
+          path: ~/wayland.tar.gz
+          if-no-files-found: error
   build-wheel:
     name: Build wheels
     runs-on: ubuntu-latest
+    needs: build-wayland
     container: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
       matrix:
         python-version: ["cp3.9", "cp3.10", "cp3.11", "pp3.9"]
     steps:
       - name: Install dependencies
-        run: dnf install -y cairo-devel libffi-devel
+        run: |
+          dnf install -y \
+          cairo-devel \
+          libffi-devel \
+          libxkbcommon-devel \
+          libudev-devel \
+          libinput-devel \
+          libpciaccess \
+          libxkbcommon-x11-devel \
+          mesa-libEGL \
+          mesa-libgbm \
+          xcb-util \
+          xcb-util-image \
+          xcb-util-keysyms \
+          xcb-util-renderutil \
+          xcb-util-wm-devel
+      - name: Download wayland libraries
+        uses: actions/download-artifact@v3
+        with:
+          name: wayland
+      - name: Unpack wayland artifact
+        run: tar xf wayland.tar.gz -C /
       - uses: actions/checkout@v2
       - name: Set environment variables
         run: |
@@ -26,13 +160,16 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
       - name: Build wheels
         run: |
-          python -m pip install cffi
-          python setup.py bdist_wheel
+          python -m pip install cffi build auditwheel
+          python -m build --wheel .
+          ls dist/
+          auditwheel show dist/qtile-*.whl
+          auditwheel repair --plat manylinux_2_28_x86_64 -w output_wheels dist/qtile-*.whl
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
           name: wheels-${{ matrix.python-version }}
-          path: dist/*.whl
+          path: output_wheels/qtile*.whl
   test-wheel:
     name: Test wheels
     runs-on: ubuntu-latest
@@ -70,7 +207,7 @@ jobs:
       python-version: "cp3.11"
     steps:
       - name: Install dependencies
-        run: dnf install -y cairo-devel libffi-devel
+        run: dnf install -y cairo-devel libffi-devel libxkbcommon-devel
       - uses: actions/checkout@v2
       - name: Set environment variables
         run: |
@@ -81,7 +218,8 @@ jobs:
           PYTHON_VERSION: ${{ env.python-version }}
       - name: Build source
         run: |
-          python setup.py sdist
+          python -m pip install build
+          python -m build --sdist .
       - name: Upload source
         uses: actions/upload-artifact@v2
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,8 @@ exclude requirements.txt
 exclude requirements-dev.txt
 exclude libqtile/_ffi*.py
 exclude libqtile/backend/x11/_ffi*.py
+exclude libqtile/backend/wayland/_ffi*.*
+exclude libqtile/backend/wayland/_libinput*.*
 exclude Makefile
 exclude dev.sh
 exclude logo.png

--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -196,3 +196,8 @@ window:
 
 See the :ref:`Wayland <wayland>` page for more information on running Qtile as
 a Wayland compositor.
+
+Similar to the xsession example above, a wayland session file can be used to start qtile
+from a login manager. To use this, you should create a `qtile-wayland.desktop
+<https://github.com/qtile/qtile/blob/master/resources/qtile-wayland.desktop>`_ file in
+``/usr/share/wayland-sessions``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,16 @@
 [build-system]
-requires = [ "setuptools>=41", "wheel", "setuptools-git-versioning<2", ]
-build-backend = "setuptools.build_meta"
-
-[tool.black]
-line-length = 98
-exclude = 'libqtile/_ffi.*\.py|libqtile/backend/x11/_ffi.*\.py|test/configs/syntaxerr.py'
-
-[tool.pytest.ini_options]
-python_files = "test_*.py"
-testpaths = ["test"]
-filterwarnings = [
-    "error:::libqtile",
+requires = [
+    "setuptools>=60",
+    "setuptools-scm>=7.0",
+    "wheel",
+    "pywlroots>=0.16.4,<0.17.0"
 ]
-
-[tool.setuptools-git-versioning]
-enabled = true
-
-[tool.setuptools.dynamic]
-readme = {file = "README.rst"}
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "qtile"
 description = "A pure-Python tiling window manager."
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
 license = {text = "MIT"}
 classifiers = [
     "Intended Audience :: End Users/Desktop",
@@ -30,6 +18,9 @@ classifiers = [
     "Operating System :: POSIX :: BSD :: FreeBSD",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Desktop Environment :: Window Managers",
@@ -44,3 +35,22 @@ classifiers = [
 
 [project.scripts]
 qtile = "libqtile.scripts.main:main"
+
+[tool.setuptools.packages.find]
+include = ["libqtile*"]
+
+[tool.setuptools_scm]
+
+[tool.setuptools.dynamic]
+readme = {file = "README.rst"}
+
+[tool.black]
+line-length = 98
+exclude = 'libqtile/_ffi.*\.py|libqtile/backend/x11/_ffi.*\.py|test/configs/syntaxerr.py'
+
+[tool.pytest.ini_options]
+python_files = "test_*.py"
+testpaths = ["test"]
+filterwarnings = [
+    "error:::libqtile",
+]

--- a/scripts/ffibuild
+++ b/scripts/ffibuild
@@ -30,8 +30,6 @@ scripts = [
 
 
 def build(builder: Builder, verbose: bool) -> bool:
-    print("Building", builder.name)
-
     p = run(["python3", builder.path], capture_output=True)
 
     if p.returncode:

--- a/setup.py
+++ b/setup.py
@@ -26,54 +26,20 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 import importlib
 import sys
-import textwrap
+from pathlib import Path
 
 from setuptools import setup
-from setuptools.command.install import install
 
-
-class CheckCairoXcb(install):
-    def cairo_xcb_check(self):
-        try:
-            from cairocffi import cairo
-
-            cairo.cairo_xcb_surface_create
-            return True
-        except AttributeError:
-            return False
-
-    def finalize_options(self):
-        if not self.cairo_xcb_check():
-            print(
-                textwrap.dedent(
-                    """
-
-            It looks like your cairocffi was not built with xcffib support.  To fix this:
-
-              - Ensure a recent xcffib is installed (pip install 'xcffib>=1.4.0')
-              - The pip cache is cleared (remove ~/.cache/pip, if it exists)
-              - Reinstall cairocffi, either:
-
-                  pip install --no-deps --ignore-installed cairocffi
-
-                or
-
-                  pip uninstall cairocffi && pip install cairocffi
-            """
-                )
-            )
-
-            sys.exit(1)
-        install.finalize_options(self)
+ROOT = Path(__file__).parent.resolve()
+sys.path.insert(0, ROOT.as_posix())
 
 
 def can_import(module):
     try:
         importlib.import_module(module)
-    except ModuleNotFoundError:
+    except Exception:
         return False
     return True
 
@@ -96,7 +62,6 @@ def get_cffi_modules():
 
 
 setup(
-    cmdclass={"install": CheckCairoXcb},
     use_scm_version=True,
     cffi_modules=get_cffi_modules(),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -68,10 +68,10 @@ commands =
 deps =
     check-manifest
     twine
+    build
 commands =
     check-manifest
-    python3 setup.py check -m -s
-    python3 setup.py sdist
+    python3 -m build --sdist .
     twine check dist/*
 
 [testenv:pep8]


### PR DESCRIPTION
I've had another go at this.

What I've done here is include `pywlroots` in the build requirements and then use a custom build backend to try to build the cffi bindings. This will fail if wayland headers etc aren't available (e.g. on readthedocs) but it allows the build to continue.

