### PR TITLE
Use spawncmd aliases for prompt completion

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1576,7 +1576,7 @@ class Qtile(CommandObject):
 
         try:
             mb = self.widgets_map[widget]
-            mb.start_input(prompt, f, complete)
+            mb.start_input(prompt, f, complete, aliases=aliases)
         except KeyError:
             logger.error("No widget named '%s' present.", widget)
 

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -125,6 +125,13 @@ def test_completion():
     assert c.actual() == s
     c.reset()
 
+    assert c.complete("z", aliases={"z": "a"}) == "z"
+    assert c.actual() == "a"
+    c.reset()
+    assert c.complete("/bi", aliases={"z": "a"}) == "/bin/"
+    assert c.actual() == "/bin"
+    c.reset()
+
 
 @gb_config
 def test_draw(manager):


### PR DESCRIPTION
This lets tab completion of the prompt widget also work for aliases used for the `spawncmd` command.