### PR TITLE
WL: print message at wayland core.py ffi module no import

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -94,7 +94,7 @@ try:
     # Continue if ffi not built, so that docs can be built without wayland deps.
     from libqtile.backend.wayland._ffi import lib
 except ModuleNotFoundError:
-    pass
+    print("Warning: Wayland backend not built. Backend will not run.")
 
 if TYPE_CHECKING:
     from typing import Any, Generator


### PR DESCRIPTION
Adds a slightly better message when this file is imported from but `lib` couldn't be loaded. We allow this so that the docs env doesn't need pywlroots. But sometimes if the core is used a `NameError` is raised when accessing `lib` at qtile startup, and it isn't clear why.

E.g. see #4450