### PR TITLE
support XDG_CONFIG_DIRS

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -14,11 +14,13 @@ Qtile looks in the following places for a configuration file, in order:
 * The location specified by the ``-c`` argument.
 * ``$XDG_CONFIG_HOME/qtile/config.py``, if it is set
 * ``~/.config/qtile/config.py``
+* first ``qtile/config.py`` found in ``$XDG_CONFIG_DIRS`` (defaults to ``/etc/xdg``)
 * It reads the module ``libqtile.resources.default_config``, included by
   default with every Qtile installation.
 
 Qtile will try to create the configuration file as a copy of the default
-config, if it doesn't exist yet.
+config, if it doesn't exist yet, this one will be placed inside of 
+``$XDG_CONFIG_HOME/qtile/config.py`` (if set) or ``~/.config/qtile/config.py``.
 
 Default Configuration
 =====================

--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -22,9 +22,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from os import environ, getenv, path
+from os import environ, path
 
 from libqtile import confreader
+from libqtile.utils import get_config_file
 
 
 def type_check_config_vars(tempdir, config_name):
@@ -139,9 +140,7 @@ def add_subcommand(subparsers, parents):
         "-c",
         "--config",
         action="store",
-        default=path.expanduser(
-            path.join(getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
-        ),
+        default=get_config_file(),
         dest="configfile",
         help="Use the specified configuration file.",
     )

--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -27,6 +27,7 @@ from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from libqtile.utils import get_config_file
 from libqtile.scripts.migrations import MIGRATIONS, load_migrations
 
 if TYPE_CHECKING:
@@ -242,9 +243,7 @@ def add_subcommand(subparsers, parents):
         "-c",
         "--config",
         action="store",
-        default=os.path.expanduser(
-            os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
-        ),
+        default=get_config_file(),
         help="Use the specified configuration file (migrates every .py file in this directory).",
     )
     parser.add_argument(

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -24,12 +24,13 @@
 from __future__ import annotations
 
 import locale
-from os import getenv, makedirs, path
+from os import makedirs, path
 from sys import exit
 from typing import TYPE_CHECKING
 
 import libqtile.backend
 from libqtile import confreader
+from libqtile.utils import get_config_file
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -117,9 +118,7 @@ def add_subcommand(subparsers, parents):
         "-c",
         "--config",
         action="store",
-        default=path.expanduser(
-            path.join(getenv("XDG_CONFIG_HOME", "~/.config"), "qtile", "config.py")
-        ),
+        default=get_config_file(),
         dest="configfile",
         help="Use the specified configuration file.",
     )

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -202,13 +202,15 @@ def get_cache_dir() -> str:
 
 
 def get_config_file():
-    config_home = os.getenv("XDG_CONFIG_HOME", "~/.config")
-    if (config_file := Path(f"{config_home}/qtile/config.py").expanduser()).exists():
+    config_home = Path(os.getenv("XDG_CONFIG_HOME", "~/.config")).expanduser()
+    config_file = config_home.joinpath("qtile/config.py")
+    if config_file.exists():
         return config_file
 
     xdg_config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg/").split(":")
     for config_dir in xdg_config_dirs:
-        if (system_wide_config := Path(f"{config_dir}/qtile/config.py")).expanduser().exists():
+        system_wide_config = Path(config_dir).expanduser().joinpath("qtile/config.py")
+        if system_wide_config.exists():
             return system_wide_config
 
     return config_file

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -31,6 +31,7 @@ from collections.abc import Sequence
 from random import randint
 from shutil import which
 from typing import TYPE_CHECKING
+from pathlib import Path
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Coroutine, TypeVar, Union
@@ -198,6 +199,21 @@ def get_cache_dir() -> str:
     if not os.path.exists(cache_directory):
         os.makedirs(cache_directory)
     return cache_directory
+
+def _get_config_file():
+    config_home = os.getenv("XDG_CONFIG_HOME", "~/.config")
+    if (config_file:= Path(f"{config_home}/qtile/config.py")).exists():
+        return config_file
+
+    xdg_config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg/").split(":")
+    for config_dir in xdg_config_dirs:
+        if (system_wide_config := Path(f"{config_dir}/qtile/config.py")).exists():
+            return system_wide_config
+
+    return config_file
+
+def get_config_file():
+    return _get_config_file().expanduser()
 
 
 def describe_attributes(obj: Any, attrs: list[str], func: Callable = lambda x: x) -> str:

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -200,20 +200,18 @@ def get_cache_dir() -> str:
         os.makedirs(cache_directory)
     return cache_directory
 
-def _get_config_file():
+
+def get_config_file():
     config_home = os.getenv("XDG_CONFIG_HOME", "~/.config")
-    if (config_file:= Path(f"{config_home}/qtile/config.py")).exists():
+    if (config_file := Path(f"{config_home}/qtile/config.py").expanduser()).exists():
         return config_file
 
     xdg_config_dirs = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg/").split(":")
     for config_dir in xdg_config_dirs:
-        if (system_wide_config := Path(f"{config_dir}/qtile/config.py")).exists():
+        if (system_wide_config := Path(f"{config_dir}/qtile/config.py")).expanduser().exists():
             return system_wide_config
 
     return config_file
-
-def get_config_file():
-    return _get_config_file().expanduser()
 
 
 def describe_attributes(obj: Any, attrs: list[str], func: Callable = lambda x: x) -> str:


### PR DESCRIPTION
PR for #4483 

1. Checks in `${XDG_CONFIG_HOME:-~/.config}` for `qtile/config.py`
2. Checks in $XDG_CONFIG_DIRS for `qtile/config.py`
3. If not a single one was wound it returns `${XDG_CONFIG_HOME:-~/.config}/qtile/config.py` where `make_qtile` will then place the default configuration file 