### PR TITLE
[x11] Add pseudo-transparency

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -149,6 +149,12 @@ configuration variables that control specific aspects of Qtile's behavior:
       - ``True``
       - If things like steam games want to auto-minimize themselves when losing
         focus, should we respect this or not?
+    * - ``x11_fake_transparency``
+      - ``False``
+      - When set to ``True``, this enables "pseudotransparency" which means that
+        transparency in bars and widgets will be emulated by copying the desktop
+        image to the background of the bar/widget. This is primarily useful if
+        you wish to use the ``Systray`` widget with a semi-transparent background.
 
 
 Testing your configuration

--- a/docs/manual/config/screens.rst
+++ b/docs/manual/config/screens.rst
@@ -52,7 +52,13 @@ entire window.
 
 .. note::
     In X11 backends, transparency will be disabled in a bar if the ``background``
-    color is fully opaque.
+    color is fully opaque. This is primarily to prevent a rendering issue with
+    the ``Systray`` widget where icons will be displayed with a fully transparent
+    background, regardless of the colour of the bar/widget.
+
+    X11 users should use "pseudotransparency" (by setting
+    ``x11_fake_transparency=True`` in their config) if they want to use a
+    semi-transparent background in their bar with the ``Systray`` widget.
 
 Users can add borders to the bar by using the ``border_width`` and
 ``border_color`` parameters. Providing a single value sets the value for all

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -662,7 +662,7 @@ class Core(base.Core):
                 self.qtile.config.x11_fake_transparency,
             )
         ):
-            self.root_pixmap = self._get_root_pixmap()
+            self._get_root_pixmap()
 
             for screen in self.qtile.screens:
                 for gap in screen.gaps:

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -266,9 +266,6 @@ class Drawer(drawer.Drawer):
             if self.root_pixmap is not None:
                 self.pseudo_pixmap = self._create_pixmap()
                 self._root_surface = self._create_xcb_surface(self.pseudo_pixmap)
-                self._pseudo_surface = cairocffi.RecordingSurface(
-                    cairocffi.CONTENT_COLOR_ALPHA, None
-                )
             else:
                 logger.warning("Unable to get root pixmap. Disabling pseudotransparency.")
                 self.pseudotransparent = False
@@ -284,8 +281,8 @@ class Drawer(drawer.Drawer):
             self.pseudo_pixmap,
             self._gc,
             *pos,
-            0,
-            0,
+            src_x,
+            src_y,
             width,
             height,
         )

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -172,7 +172,9 @@ class Drawer(drawer.Drawer):
 
     def _paint(self):
         # Only attempt to run RecordingSurface's operations if ie actually need to
-        if self.needs_update:
+        # - If we're using pseudotransparency then we must paint the background image
+        # - If there's content (self.needs_update) then we draw that contents
+        if self.pseudotransparent or self.needs_update:
             # Paint RecordingSurface operations to the XCBSurface
             ctx = cairocffi.Context(self._xcb_surface)
 

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -273,17 +273,13 @@ class Drawer(drawer.Drawer):
             self.pseudo_pixmap = self._create_pixmap()
             self._root_surface = self._create_xcb_surface(self.pseudo_pixmap)
 
-        pos = (
-            self._win.x + offsetx,
-            self._win.y + offsety,
-        )
-
         with self.qtile.core.masked():
             self.qtile.core.conn.conn.core.CopyArea(
                 self.qtile.core.root_pixmap,
                 self.pseudo_pixmap,
                 self._gc,
-                *pos,
+                self._win.x + offsetx,
+                self._win.y + offsety,
                 src_x,
                 src_y,
                 width,

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -275,17 +275,17 @@ class Drawer(drawer.Drawer):
             self._win.x + offsetx,
             self._win.y + offsety,
         )
-
-        self.qtile.core.conn.conn.core.CopyArea(
-            self.root_pixmap,
-            self.pseudo_pixmap,
-            self._gc,
-            *pos,
-            src_x,
-            src_y,
-            width,
-            height,
-        )
+        with self.qtile.core.masked():
+            self.qtile.core.conn.conn.core.CopyArea(
+                self.root_pixmap,
+                self.pseudo_pixmap,
+                self._gc,
+                *pos,
+                src_x,
+                src_y,
+                width,
+                height,
+            )
 
     def _get_root_pixmap(self):
         root_win = self.qtile.core.conn.default_screen.root

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -285,10 +285,12 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             # X11 only:
             # To preserve correct display of SysTray widget, we need a 24-bit
             # window where the user requests an opaque bar.
+            print(f"{'x11_fake_transparency' in qtile.config.__dict__=}")
             if qtile.core.name == "x11":
                 depth = (
                     32
                     if has_transparency(self.background)
+                    and not qtile.config.x11_fake_transparency
                     else qtile.core.conn.default_screen.root_depth
                 )
 

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -284,8 +284,7 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
             # X11 only:
             # To preserve correct display of SysTray widget, we need a 24-bit
-            # window where the user requests an opaque bar.
-            print(f"{'x11_fake_transparency' in qtile.config.__dict__=}")
+            # window where the user requests an opaque bar or they're using pseudotransparency.
             if qtile.core.name == "x11":
                 depth = (
                     32

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -71,6 +71,7 @@ class Config:
     reconfigure_screens: bool
     wmname: str
     auto_minimize: bool
+    x11_fake_transparency: bool
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but
     # doing so forces the import, creating a hard dependency for wlroots.
     wl_input_rules: dict[str, Any] | None

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -190,6 +190,7 @@ floating_layout = layout.Floating(
 auto_fullscreen = True
 focus_on_window_activation = "smart"
 reconfigure_screens = True
+x11_fake_transparency = False
 
 # If things like steam games want to auto-minimize themselves when losing
 # focus, should we respect this or not?

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -30,7 +30,7 @@
 from __future__ import annotations
 
 import xcffib
-from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, SetMode
+from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, ExposeEvent, SetMode
 
 from libqtile import bar
 from libqtile.backend.x11 import window
@@ -122,7 +122,7 @@ class Icon(window._Window):
 
         # Copy the widget's pixmap to the new pixmap
         self.qtile.core.conn.conn.core.CopyArea(
-            drawer.pseudo_pixmap,
+            drawer.pixmap,
             self._pixmap,
             drawer._gc,
             x,
@@ -135,6 +135,13 @@ class Icon(window._Window):
 
         # Apply the pixmap to the window
         self.window.set_attribute(backpixmap=self._pixmap)
+
+        # We need to send an Expose event to force the window to redraw
+        event = xcffib.xproto.ExposeEvent.synthetic(
+            self.window.wid, 0, 0, self.width, self.height, 0
+        )
+        self.window.send_event(event, mask=EventMask.Exposure)
+        self.qtile.core.conn.flush()
 
     handle_UnmapNotify = handle_DestroyNotify  # noqa: N815
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -138,9 +138,7 @@ class Icon(window._Window):
             self.window.set_attribute(backpixmap=self._pixmap)
 
         # We need to send an Expose event to force the window to redraw
-        event = ExposeEvent.synthetic(
-            self.window.wid, 0, 0, self.width, self.height, 0
-        )
+        event = ExposeEvent.synthetic(self.window.wid, 0, 0, self.width, self.height, 0)
         self.window.send_event(event, mask=EventMask.Exposure)
         self.qtile.core.conn.flush()
 

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -121,23 +121,24 @@ class Icon(window._Window):
             )
 
         # Copy the widget's pixmap to the new pixmap
-        self.qtile.core.conn.conn.core.CopyArea(
-            drawer.pixmap,
-            self._pixmap,
-            drawer._gc,
-            x,
-            y,  # Source x, y positions equal the icon's offset in the widget
-            0,
-            0,  # Pixmap is placed at 0, 0 in new pixmap
-            self.width,
-            self.height,
-        )
+        with self.qtile.core.masked():
+            self.qtile.core.conn.conn.core.CopyArea(
+                drawer.pixmap,
+                self._pixmap,
+                drawer._gc,
+                x,
+                y,  # Source x, y positions equal the icon's offset in the widget
+                0,
+                0,  # Pixmap is placed at 0, 0 in new pixmap
+                self.width,
+                self.height,
+            )
 
-        # Apply the pixmap to the window
-        self.window.set_attribute(backpixmap=self._pixmap)
+            # Apply the pixmap to the window
+            self.window.set_attribute(backpixmap=self._pixmap)
 
         # We need to send an Expose event to force the window to redraw
-        event = xcffib.xproto.ExposeEvent.synthetic(
+        event = ExposeEvent.synthetic(
             self.window.wid, 0, 0, self.width, self.height, 0
         )
         self.window.send_event(event, mask=EventMask.Exposure)

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ testdeps =
 commands =
     !x11: pip install pywlroots==0.16.4
     pip install .
-    !x11: {toxinidir}/scripts/ffibuild
+    !x11: {toxinidir}/scripts/ffibuild -v
 
 # These are the environments that should be triggered by Github Actions
 [testenv:py{py3,39,310,311}-{wayland,x11}]


### PR DESCRIPTION
Adds a new config option, `x11_fake_transparency`, to emulate transparency in bars/widgets by copying the root window contents to the background of the bar/widget before rendering the contents on top.

Primary benefit of this is to prevent issues with the `Systray` widget which cannot currently be displayed with semi-transparent backgrounds.

Unlike the previous version, I've (largely) managed to contain the logic to the x11 backend.

Draft for now as some things to check:
- [x] Check behaviour when widgets don't fill bar
- [x] Check multiple screen behaviour (e.g. positioning)
- [x] Fix `Systray` behaviour
- [x] Handle wallpaper changes (both by `set_wallpaper` and by external commands)
