### PR TITLE
wlroots-next: chase wlroots master

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -60,8 +60,6 @@ from wlroots.wlr_types import (
     xdg_decoration_v1,
 )
 from wlroots.wlr_types.cursor import Cursor, WarpMode
-from wlroots.wlr_types.idle import Idle
-from wlroots.wlr_types.idle_inhibit_v1 import IdleInhibitorManagerV1, IdleInhibitorV1
 from wlroots.wlr_types.keyboard import Keyboard
 from wlroots.wlr_types.layer_shell_v1 import LayerShellV1, LayerSurfaceV1
 from wlroots.wlr_types.output_management_v1 import (
@@ -286,9 +284,6 @@ class Core(base.Core, wlrq.HasListeners):
         self.add_listener(
             output_power_manager.set_mode_event, self._on_output_power_manager_set_mode
         )
-        self.idle = Idle(self.display)
-        idle_ihibitor_manager = IdleInhibitorManagerV1(self.display)
-        self.add_listener(idle_ihibitor_manager.new_inhibitor_event, self._on_new_idle_inhibitor)
         PrimarySelectionV1DeviceManager(self.display)
         virtual_keyboard_manager_v1 = vkeyboard.VirtualKeyboardManagerV1(self.display)
         self.add_listener(
@@ -564,7 +559,6 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_button(self, _listener: Listener, event: pointer.PointerButtonEvent) -> None:
         assert self.qtile is not None
-        self.idle.notify_activity(self.seat)
         pressed = event.button_state == input_device.ButtonState.PRESSED
         if pressed:
             self._focus_by_click()
@@ -581,7 +575,6 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_cursor_motion(self, _listener: Listener, event: pointer.PointerMotionEvent) -> None:
         assert self.qtile is not None
-        self.idle.notify_activity(self.seat)
 
         dx = event.delta_x
         dy = event.delta_y
@@ -610,7 +603,6 @@ class Core(base.Core, wlrq.HasListeners):
         self, _listener: Listener, event: pointer.PointerMotionAbsoluteEvent
     ) -> None:
         assert self.qtile is not None
-        self.idle.notify_activity(self.seat)
 
         x, y = self.cursor.absolute_to_layout_coords(event.pointer.base, event.x, event.y)
         self.cursor.move(x - self.cursor.x, y - self.cursor.y)
@@ -621,7 +613,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerPinchBeginEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_pinch_begin(self.seat, event.time_msec, event.fingers)
 
     def _on_cursor_pinch_update(
@@ -638,7 +629,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerPinchEndEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_pinch_end(self.seat, event.time_msec, event.cancelled)
 
     def _on_cursor_swipe_begin(
@@ -646,7 +636,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerSwipeBeginEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_swipe_begin(self.seat, event.time_msec, event.fingers)
 
     def _on_cursor_swipe_update(
@@ -661,7 +650,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerSwipeEndEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_swipe_end(self.seat, event.time_msec, event.cancelled)
 
     def _on_cursor_hold_begin(
@@ -669,7 +657,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerHoldBeginEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_hold_begin(self.seat, event.time_msec, event.fingers)
 
     def _on_cursor_hold_end(
@@ -677,7 +664,6 @@ class Core(base.Core, wlrq.HasListeners):
         _listener: Listener,
         event: pointer.PointerHoldEndEvent,
     ) -> None:
-        self.idle.notify_activity(self.seat)
         self._gestures.send_hold_end(self.seat, event.time_msec, event.cancelled)
 
     def _on_new_pointer_constraint(
@@ -702,23 +688,6 @@ class Core(base.Core, wlrq.HasListeners):
     ) -> None:
         device = self._add_new_pointer(new_pointer_event.new_pointer.pointer.base)
         logger.info("New virtual pointer: %s %s", *device.get_info())
-
-    def _on_new_idle_inhibitor(
-        self, _listener: Listener, idle_inhibitor: IdleInhibitorV1
-    ) -> None:
-        logger.debug("Signal: idle_inhibitor new_inhibitor")
-
-        if self.qtile is None:
-            return
-
-        for win in self.qtile.windows_map.values():
-            if isinstance(win, (window.Window, window.Static)):
-                win.surface.for_each_surface(win.add_idle_inhibitor, idle_inhibitor)
-                if idle_inhibitor.data:
-                    # We break if the .data attribute was set, because that tells us
-                    # that `win.add_idle_inhibitor` identified this inhibitor as
-                    # belonging to that window.
-                    break
 
     def _on_input_inhibitor_activate(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: input_inhibitor activate")
@@ -1338,21 +1307,6 @@ class Core(base.Core, wlrq.HasListeners):
 
         logger.warning("Couldn't determine what was under the pointer. Please report.")
         return None
-
-    def check_idle_inhibitor(self) -> None:
-        """
-        Checks if any window that is currently mapped has idle inhibitor
-        and if so inhibits idle
-        """
-        assert self.qtile is not None
-
-        for win in self.qtile.windows_map.values():
-            if not isinstance(win, window.Internal) and win.is_idle_inhibited:
-                # TODO: do we also need to check that the window is mapped?
-                self.idle.set_enabled(self.seat, False)
-                return
-
-        self.idle.set_enabled(self.seat, True)
 
     def get_screen_info(self) -> list[tuple[int, int, int, int]]:
         """Get the output information"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1224,9 +1224,11 @@ class Core(base.Core, wlrq.HasListeners):
                         if ftm_handle := prev_win.ftm_handle:
                             ftm_handle.set_activated(False)
 
-            elif previous_surface.is_xwayland_surface:
-                prev_xwayland_surface = xwayland.Surface.from_wlr_surface(previous_surface)
-                if not win or win.surface != prev_xwayland_surface:
+            else:
+                prev_xwayland_surface = xwayland.Surface.try_from_wlr_surface(previous_surface)
+                if prev_xwayland_surface is not None and (
+                    not win or win.surface != prev_xwayland_surface
+                ):
                     prev_xwayland_surface.activate(False)
                     if prev_win := prev_xwayland_surface.data:
                         if ftm_handle := prev_win.ftm_handle:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -426,16 +426,6 @@ class Core(base.Core, wlrq.HasListeners):
         output = Output(self, wlr_output)
         self.outputs.append(output)
 
-        # This is run during tests, when we want to fix the output's geometry
-        if wlr_output.is_headless and "PYTEST_CURRENT_TEST" in os.environ:
-            if len(self.outputs) == 1:
-                # First test output
-                wlr_output.set_custom_mode(800, 600, 0)
-            else:
-                # Second test output
-                wlr_output.set_custom_mode(640, 480, 0)
-            wlr_output.commit()
-
         # Let the output layout place it
         if not self.output_layout.add_auto(wlr_output):
             logger.warning("Failed to add output to layout.")

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -529,9 +529,8 @@ class Core(base.Core, wlrq.HasListeners):
 
                 xdg_surface.data = self.scene.xdg_surface_create(tree, xdg_surface)
 
-            elif parent_surface.is_layer_surface:
+            elif parent := LayerSurfaceV1.try_from_wlr_surface(parent_surface):
                 # A layer shell window created this popup
-                parent = LayerSurfaceV1.from_wlr_surface(parent_surface)
                 win = cast(layer.LayerStatic, parent.data)
                 self.scene.xdg_surface_create(win.popup_tree, xdg_surface)
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -51,6 +51,7 @@ from wlroots.wlr_types import (
     ScreencopyManagerV1,
     Surface,
     Viewporter,
+    OutputState,
     XCursorManager,
     XdgOutputManagerV1,
     input_device,
@@ -75,7 +76,14 @@ from wlroots.wlr_types.output_power_management_v1 import (
     OutputPowerV1SetModeEvent,
 )
 from wlroots.wlr_types.pointer_constraints_v1 import PointerConstraintsV1, PointerConstraintV1
-from wlroots.wlr_types.scene import Scene, SceneBuffer, SceneNodeType, SceneSurface, SceneTree
+from wlroots.wlr_types.scene import (
+    Scene,
+    SceneBuffer,
+    SceneNodeType,
+    SceneSurface,
+    SceneTree,
+    SceneOutput,
+)
 from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
@@ -423,7 +431,22 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_new_output(self, _listener: Listener, wlr_output: wlrOutput) -> None:
         logger.debug("Signal: backend new_output_event")
-        output = Output(self, wlr_output)
+
+        scene_output = SceneOutput.create(self.scene, wlr_output)
+
+        # Initialise output
+        wlr_output.init_render(self.allocator, self.renderer)
+        if mode := wlr_output.preferred_mode():
+            state = OutputState()
+            state.set_mode(mode)
+            state.set_enabled()
+            if not wlr_output.commit_state(state):
+                state.finish()
+                scene_output.destroy()
+                logger.warning("Failed to initialise output (%s)", wlr_output.name)
+                return
+
+        output = Output(self, wlr_output, scene_output)
         self.outputs.append(output)
 
         # This is run during tests, when we want to fix the output's geometry

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -437,7 +437,9 @@ class Core(base.Core, wlrq.HasListeners):
             wlr_output.commit()
 
         # Let the output layout place it
-        self.output_layout.add_auto(wlr_output)
+        if not self.output_layout.add_auto(wlr_output):
+            logger.warning("Failed to add output to layout.")
+            return
 
         # Set the current output as we have none defined
         # Now that we have our first output we can warp the pointer there too
@@ -877,7 +879,8 @@ class Core(base.Core, wlrq.HasListeners):
 
                 # `add` will add outputs that have been removed. Any other outputs that
                 # are already in the layout are just moved as if we had used `move`.
-                self.output_layout.add(wlr_output, state.x, state.y)
+                if not self.output_layout.add(wlr_output, state.x, state.y):
+                    logger.warning("Failed to add output to layout.")
                 wlr_output.set_transform(state.transform)
                 wlr_output.set_scale(state.scale)
             else:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -217,7 +217,7 @@ class Core(base.Core, wlrq.HasListeners):
         # Set up shell
         self.xdg_shell = XdgShell(self.display)
         self.add_listener(self.xdg_shell.new_surface_event, self._on_new_xdg_surface)
-        self.layer_shell = LayerShellV1(self.display)
+        self.layer_shell = LayerShellV1(self.display, 4)
         self.add_listener(self.layer_shell.new_surface_event, self._on_new_layer_surface)
 
         # Set up scene-graph tree, which looks like this from bottom to top:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -446,7 +446,7 @@ class Core(base.Core, wlrq.HasListeners):
         # We also set the cursor image as we're initializing the cursor here anyways
         if not self._current_output:
             self._current_output = output
-            self.cursor_manager.set_cursor_image("default", self.cursor)
+            self.cursor.set_xcursor(self._cursor_manager, "default")
             box = Box(*output.get_geometry())
             x = box.x + box.width / 2
             y = box.y + box.height / 2
@@ -749,7 +749,7 @@ class Core(base.Core, wlrq.HasListeners):
             # If we have a client who exclusively gets input, no other client's
             # surfaces are allowed to get pointer input.
             if isinstance(win, base.Internal) or not win.belongs_to_client(self.exclusive_client):
-                self.cursor_manager.set_cursor_image("default", self.cursor)
+                self.cursor.set_xcursor(self._cursor_manager, "default")
                 self.seat.pointer_notify_clear_focus()
                 return
 
@@ -944,7 +944,7 @@ class Core(base.Core, wlrq.HasListeners):
                         logger.debug(
                             "Pointer focus withheld from window not owned by exclusive client."
                         )
-                        self.cursor_manager.set_cursor_image("default", self.cursor)
+                        self.cursor.set_xcursor(self._cursor_manager, "default")
                         self.seat.pointer_notify_clear_focus()
                         self._hovered_window = win
                     return
@@ -968,7 +968,7 @@ class Core(base.Core, wlrq.HasListeners):
                                 )
                         elif self.seat.pointer_state.focused_surface:
                             # moved from a Window or Static to an Internal
-                            self.cursor_manager.set_cursor_image("default", self.cursor)
+                            self.cursor.set_xcursor(self._cursor_manager, "default")
                             self.seat.pointer_notify_clear_focus()
                     win.process_pointer_enter(cx, cy)
                     self._hovered_window = win
@@ -983,7 +983,7 @@ class Core(base.Core, wlrq.HasListeners):
                 # The pointer is on the border of a client's window
                 if self.seat.pointer_state.focused_surface:
                     # We just moved out of a client's surface
-                    self.cursor_manager.set_cursor_image("default", self.cursor)
+                    self.cursor.set_xcursor(self._cursor_manager, "default")
                     self.seat.pointer_notify_clear_focus()
 
             if win is not self.qtile.current_window:
@@ -1023,7 +1023,7 @@ class Core(base.Core, wlrq.HasListeners):
                     )
                 else:
                     # We just moved out of a Window or Static
-                    self.cursor_manager.set_cursor_image("default", self.cursor)
+                    self.cursor.set_xcursor(self._cursor_manager, "default")
                     self.seat.pointer_notify_clear_focus()
                 self._hovered_window = None
 
@@ -1064,7 +1064,7 @@ class Core(base.Core, wlrq.HasListeners):
         device = inputs.Pointer(self, wlr_device)
         self._pointers.append(device)
         self.cursor.attach_input_device(wlr_device)
-        self.cursor_manager.set_cursor_image("default", self.cursor)
+        self.cursor.set_xcursor(self._cursor_manager, "default")
 
         # Map input device to output if required.
         if output_name := pointer.Pointer.from_input_device(wlr_device).output_name:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -51,7 +51,6 @@ from wlroots.wlr_types import (
     ScreencopyManagerV1,
     Surface,
     Viewporter,
-    OutputState,
     XCursorManager,
     XdgOutputManagerV1,
     input_device,
@@ -76,14 +75,7 @@ from wlroots.wlr_types.output_power_management_v1 import (
     OutputPowerV1SetModeEvent,
 )
 from wlroots.wlr_types.pointer_constraints_v1 import PointerConstraintsV1, PointerConstraintV1
-from wlroots.wlr_types.scene import (
-    Scene,
-    SceneBuffer,
-    SceneNodeType,
-    SceneSurface,
-    SceneTree,
-    SceneOutput,
-)
+from wlroots.wlr_types.scene import Scene, SceneBuffer, SceneNodeType, SceneSurface, SceneTree
 from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
@@ -431,22 +423,7 @@ class Core(base.Core, wlrq.HasListeners):
 
     def _on_new_output(self, _listener: Listener, wlr_output: wlrOutput) -> None:
         logger.debug("Signal: backend new_output_event")
-
-        scene_output = SceneOutput.create(self.scene, wlr_output)
-
-        # Initialise output
-        wlr_output.init_render(self.allocator, self.renderer)
-        if mode := wlr_output.preferred_mode():
-            state = OutputState()
-            state.set_mode(mode)
-            state.set_enabled()
-            if not wlr_output.commit_state(state):
-                state.finish()
-                scene_output.destroy()
-                logger.warning("Failed to initialise output (%s)", wlr_output.name)
-                return
-
-        output = Output(self, wlr_output, scene_output)
+        output = Output(self, wlr_output)
         self.outputs.append(output)
 
         # This is run during tests, when we want to fix the output's geometry

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -196,7 +196,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         # Set up cursor
         self.cursor = Cursor(self.output_layout)
-        self.cursor_manager = XCursorManager(24)
+        self._cursor_manager = XCursorManager(24)
         self._gestures = PointerGesturesV1(self.display)
         self.add_listener(self.seat.request_set_cursor_event, self._on_request_cursor)
         self.add_listener(self.cursor.axis_event, self._on_cursor_axis)
@@ -355,7 +355,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         if self._xwayland:
             self._xwayland.destroy()
-        self.cursor_manager.destroy()
+        self._cursor_manager.destroy()
         self.cursor.destroy()
         self.output_layout.destroy()
         self.seat.destroy()
@@ -813,8 +813,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.xwayland_atoms: dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
 
         # Set the default XWayland cursor
-        xcursor = self.cursor_manager.get_xcursor("default")
-        if xcursor:
+        if xcursor := self._cursor_manager.get_xcursor("default"):
             image = next(xcursor.images, None)
             if image:
                 self._xwayland.set_cursor(

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -446,7 +446,7 @@ class Core(base.Core, wlrq.HasListeners):
         # We also set the cursor image as we're initializing the cursor here anyways
         if not self._current_output:
             self._current_output = output
-            self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+            self.cursor_manager.set_cursor_image("default", self.cursor)
             box = Box(*output.get_geometry())
             x = box.x + box.width / 2
             y = box.y + box.height / 2
@@ -751,7 +751,7 @@ class Core(base.Core, wlrq.HasListeners):
             # If we have a client who exclusively gets input, no other client's
             # surfaces are allowed to get pointer input.
             if isinstance(win, base.Internal) or not win.belongs_to_client(self.exclusive_client):
-                self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                self.cursor_manager.set_cursor_image("default", self.cursor)
                 self.seat.pointer_notify_clear_focus()
                 return
 
@@ -815,7 +815,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.xwayland_atoms: dict[int, str] = wlrq.get_xwayland_atoms(self._xwayland)
 
         # Set the default XWayland cursor
-        xcursor = self.cursor_manager.get_xcursor("left_ptr")
+        xcursor = self.cursor_manager.get_xcursor("default")
         if xcursor:
             image = next(xcursor.images, None)
             if image:
@@ -944,7 +944,7 @@ class Core(base.Core, wlrq.HasListeners):
                         logger.debug(
                             "Pointer focus withheld from window not owned by exclusive client."
                         )
-                        self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                        self.cursor_manager.set_cursor_image("default", self.cursor)
                         self.seat.pointer_notify_clear_focus()
                         self._hovered_window = win
                     return
@@ -968,7 +968,7 @@ class Core(base.Core, wlrq.HasListeners):
                                 )
                         elif self.seat.pointer_state.focused_surface:
                             # moved from a Window or Static to an Internal
-                            self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                            self.cursor_manager.set_cursor_image("default", self.cursor)
                             self.seat.pointer_notify_clear_focus()
                     win.process_pointer_enter(cx, cy)
                     self._hovered_window = win
@@ -983,7 +983,7 @@ class Core(base.Core, wlrq.HasListeners):
                 # The pointer is on the border of a client's window
                 if self.seat.pointer_state.focused_surface:
                     # We just moved out of a client's surface
-                    self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                    self.cursor_manager.set_cursor_image("default", self.cursor)
                     self.seat.pointer_notify_clear_focus()
 
             if win is not self.qtile.current_window:
@@ -1023,7 +1023,7 @@ class Core(base.Core, wlrq.HasListeners):
                     )
                 else:
                     # We just moved out of a Window or Static
-                    self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+                    self.cursor_manager.set_cursor_image("default", self.cursor)
                     self.seat.pointer_notify_clear_focus()
                 self._hovered_window = None
 
@@ -1064,7 +1064,7 @@ class Core(base.Core, wlrq.HasListeners):
         device = inputs.Pointer(self, wlr_device)
         self._pointers.append(device)
         self.cursor.attach_input_device(wlr_device)
-        self.cursor_manager.set_cursor_image("left_ptr", self.cursor)
+        self.cursor_manager.set_cursor_image("default", self.cursor)
 
         # Map input device to output if required.
         if output_name := pointer.Pointer.from_input_device(wlr_device).output_name:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -511,9 +511,8 @@ class Core(base.Core, wlrq.HasListeners):
                 raise RuntimeError("Can't place a popup without any outputs enabled.")
 
             parent_surface = xdg_surface.popup.parent
-            if parent_surface.is_xdg_surface:
+            if parent_xdg_surface := XdgSurface.try_from_surface(parent_surface):
                 # An XDG shell window or popup created this popup
-                parent_xdg_surface = XdgSurface.from_surface(parent_surface)
 
                 if parent_xdg_surface.role == XdgSurfaceRole.TOPLEVEL:
                     # If the immediate parent is a toplevel, we're a level 1 popup
@@ -847,12 +846,14 @@ class Core(base.Core, wlrq.HasListeners):
             return
 
         surface = event.surface
-        if surface and surface.is_xdg_surface:
-            xdg_surface = XdgSurface.from_surface(surface)
-            if win := xdg_surface.data:
-                win.handle_activation_request(focus_on_window_activation)
-            else:
-                logger.debug("Failed to find window to activate. Ignoring request.")
+        if surface:
+            xdg_surface = XdgSurface.try_from_surface(surface)
+            if xdg_surface is not None:
+                if win := xdg_surface.data:
+                    win.handle_activation_request(focus_on_window_activation)
+                else:
+                    # Shouldn't happen.
+                    logger.debug("Failed to find window to activate. Ignoring request.")
 
     def _output_manager_reconfigure(self, config: OutputConfigurationV1, apply: bool) -> None:
         """
@@ -1216,8 +1217,7 @@ class Core(base.Core, wlrq.HasListeners):
 
         if previous_surface is not None:
             # Deactivate the previously focused surface
-            if previous_surface.is_xdg_surface:
-                previous_xdg_surface = XdgSurface.from_surface(previous_surface)
+            if previous_xdg_surface := XdgSurface.try_from_surface(previous_surface):
                 if not win or win.surface != previous_xdg_surface:
                     previous_xdg_surface.set_activated(False)
                     if prev_win := previous_xdg_surface.data:

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -252,8 +252,6 @@ class Keyboard(_Device):
             self.qtile = self.core.qtile
             assert self.qtile is not None
 
-        self.core.idle.notify_activity(self.seat)
-
         if event.state == KEY_PRESSED and not self.core.exclusive_client:
             # translate libinput keycode -> xkbcommon
             keycode = event.keycode + 8

--- a/libqtile/backend/wayland/layer.py
+++ b/libqtile/backend/wayland/layer.py
@@ -92,8 +92,8 @@ class LayerStatic(Static[LayerSurfaceV1]):
         self.popup_tree.node.data = self.data_handle
 
         # Set up listeners
-        self.add_listener(surface.map_event, self._on_map)
-        self.add_listener(surface.unmap_event, self._on_unmap)
+        self.add_listener(surface.surface.map_event, self._on_map)
+        self.add_listener(surface.surface.unmap_event, self._on_unmap)
         self.add_listener(surface.destroy_event, self._on_destroy)
         self.add_listener(surface.surface.commit_event, self._on_commit)
 

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from pywayland.server import Listener
+    from wlroots.wlr_types.output import OutputEventRequestState
 
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.layer import LayerStatic
@@ -67,6 +68,7 @@ class Output(HasListeners):
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)
         self.add_listener(wlr_output.frame_event, self._on_frame)
+        self.add_listener(wlr_output.request_state_event, self._on_request_state)
 
         # The layers enum indexes into this list to get a list of surfaces
         self.layers: list[list[LayerStatic]] = [[] for _ in range(len(LayerShellV1Layer))]
@@ -104,6 +106,10 @@ class Output(HasListeners):
 
         # Inform clients of the frame
         self.scene_output.send_frame_done(Timespec.get_monotonic_time())
+
+    def _on_request_state(self, _listener: Listener, request: OutputEventRequestState) -> None:
+        logger.debug("Signal: output request_state")
+        self.wlr_output.commit_state(request.state)
 
     def get_geometry(self) -> tuple[int, int, int, int]:
         width, height = self.wlr_output.effective_resolution()

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from wlroots.util.box import Box
@@ -66,9 +67,18 @@ class Output(HasListeners):
         state = OutputState()
         state.set_enabled()
 
-        # For now, just select the output's preferred mode.
+        # Select the output's preferred mode.
         if mode := wlr_output.preferred_mode():
             state.set_mode(mode)
+
+        # During tests, we want to fix the geometry of the 1 or 2 outputs.
+        if wlr_output.is_headless and "PYTEST_CURRENT_TEST" in os.environ:
+            if not core.outputs:
+                # First test output
+                state.set_custom_mode(800, 600, 0)
+            else:
+                # Second test output
+                state.set_custom_mode(640, 480, 0)
 
         # Commit this initial state.
         wlr_output.commit_state(state)

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -24,8 +24,7 @@ from typing import TYPE_CHECKING
 
 from wlroots.util.box import Box
 from wlroots.util.clock import Timespec
-from wlroots.wlr_types import Output as wlrOutput
-from wlroots.wlr_types import SceneOutput
+from wlroots.wlr_types import Output as wlrOutput, OutputState
 from wlroots.wlr_types.layer_shell_v1 import (
     LayerShellV1Layer,
     LayerSurfaceV1KeyboardInteractivity,
@@ -39,6 +38,7 @@ if TYPE_CHECKING:
 
     from pywayland.server import Listener
     from wlroots.wlr_types.output import OutputEventRequestState
+    from wlroots.wlr_types import SceneOutput
 
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.layer import LayerStatic
@@ -48,22 +48,17 @@ if TYPE_CHECKING:
 
 
 class Output(HasListeners):
-    def __init__(self, core: Core, wlr_output: wlrOutput):
+    def __init__(self, core: Core, wlr_output: wlrOutput, scene_output: SceneOutput):
         self.core = core
         self.renderer = core.renderer
         self.wlr_output = wlr_output
+        self.scene_output = scene_output
         self._reserved_space = (0, 0, 0, 0)
-        self.scene_output = SceneOutput.create(core.scene, wlr_output)
 
         # These will get updated on the output layout's change event
         self.x = 0
         self.y = 0
 
-        # Initialise wlr_output
-        wlr_output.init_render(core.allocator, core.renderer)
-        wlr_output.set_mode(wlr_output.preferred_mode())
-        wlr_output.enable()
-        wlr_output.commit()
         wlr_output.data = self
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -30,7 +30,6 @@ from pywayland.server import Client, Listener
 from wlroots import PtrHasData
 from wlroots.util.box import Box
 from wlroots.wlr_types import Buffer
-from wlroots.wlr_types.idle_inhibit_v1 import IdleInhibitorV1
 from wlroots.wlr_types.pointer_constraints_v1 import (
     PointerConstraintV1,
     PointerConstraintV1StateField,
@@ -115,7 +114,6 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         self.y = 0
         self._opacity: float = 1.0
         self._wm_class: str | None = None
-        self._idle_inhibitors_count: int = 0
         self._urgent = False
 
         # Create a scene-graph tree for this window and its borders
@@ -232,15 +230,6 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     def _on_foreign_request_close(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: foreign_toplevel_management request_close")
         self.kill()
-
-    def _on_inhibitor_destroy(self, listener: Listener, surface: Surface) -> None:
-        # We don't have reference to the inhibitor, but it doesn't really
-        # matter we only need to keep count of how many inhibitors there are
-        self._idle_inhibitors_count -= 1
-        listener.remove()
-        if self._idle_inhibitors_count == 0:
-            self.core.check_idle_inhibitor()
-            # TODO: do we also need to check idle inhibitors when unmapping?
 
     def hide(self) -> None:
         self.container.node.set_enabled(enabled=False)
@@ -597,24 +586,6 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     def match(self, match: config.Match) -> bool:
         return match.compare(self)
 
-    def add_idle_inhibitor(
-        self,
-        surface: Surface,
-        _x: int,
-        _y: int,
-        inhibitor: IdleInhibitorV1,
-    ) -> None:
-        if surface == inhibitor.surface:
-            self._idle_inhibitors_count += 1
-            inhibitor.data = self
-            self.add_listener(inhibitor.destroy_event, self._on_inhibitor_destroy)
-            if self._idle_inhibitors_count == 1:
-                self.core.check_idle_inhibitor()
-
-    @property
-    def is_idle_inhibited(self) -> bool:
-        return self._idle_inhibitors_count > 0
-
     def _items(self, name: str) -> ItemT:
         if name == "group":
             return True, []
@@ -779,7 +750,6 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
         qtile: Qtile,
         surface: S,
         wid: int,
-        idle_inhibitor_count: int = 0,
     ):
         base.Static.__init__(self)
         self.core = core
@@ -795,7 +765,6 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
         self.bordercolor: list[ffi.CData] = [_rgb((0, 0, 0, 1))]
         self.opacity: float = 1.0
         self._wm_class: str | None = None
-        self._idle_inhibitors_count = idle_inhibitor_count
         self.ftm_handle: ftm.ForeignToplevelHandleV1 | None = None
         self.data_handle = ffi.new_handle(self)
         surface.data = self.data_handle
@@ -859,32 +828,6 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
     def _on_foreign_request_close(self, _listener: Listener, _data: Any) -> None:
         logger.debug("Signal: foreign_toplevel_management static request_close")
         self.kill()
-
-    def _on_inhibitor_destroy(self, listener: Listener, surface: Surface) -> None:
-        # We don't have reference to the inhibitor, but it doesn't really
-        # matter we only need to keep count of how many inhibitors there are
-        self._idle_inhibitors_count -= 1
-        listener.remove()
-        if self._idle_inhibitors_count == 0:
-            self.core.check_idle_inhibitor()
-
-    def add_idle_inhibitor(
-        self,
-        surface: Surface,
-        _x: int,
-        _y: int,
-        inhibitor: IdleInhibitorV1,
-    ) -> None:
-        if surface == inhibitor.surface:
-            self._idle_inhibitors_count += 1
-            inhibitor.data = self
-            self.add_listener(inhibitor.destroy_event, self._on_inhibitor_destroy)
-            if self._idle_inhibitors_count == 1:
-                self.core.check_idle_inhibitor()
-
-    @property
-    def is_idle_inhibited(self) -> bool:
-        return self._idle_inhibitors_count > 0
 
     def belongs_to_client(self, other: Client) -> bool:
         return other == Client.from_resource(self.surface.surface._ptr.resource)  # type: ignore

--- a/libqtile/backend/wayland/wlrq.py
+++ b/libqtile/backend/wayland/wlrq.py
@@ -199,40 +199,27 @@ class Dnd(HasListeners):
 
     def __init__(self, core: Core, wlr_drag: data_device_manager.Drag):
         self.core = core
-        self.x: float = core.cursor.x
-        self.y: float = core.cursor.y
-        self.width: int = 0  # Set upon surface commit
-        self.height: int = 0
-
         self.icon = cast(data_device_manager.DragIcon, wlr_drag.icon)
         self.add_listener(self.icon.destroy_event, self._on_destroy)
-        self.add_listener(self.icon.surface.commit_event, self._on_icon_commit)
+        self.node = SceneTree.drag_icon_create(core.drag_icon_tree, self.icon).node
 
-        tree = SceneTree.subsurface_tree_create(core.drag_icon_tree, self.icon.surface)
-        self.node = tree.node
-
+        # The data handle at .data is used for finding what's under the cursor when it's
+        # moved.
         self.data_handle = ffi.new_handle(self)
         self.node.data = self.data_handle
 
     def finalize(self) -> None:
         self.finalize_listeners()
         self.core.live_dnd = None
-        self.node.data = None
         self.node.destroy()
+        self.node.data = None
         self.data_handle = None
 
     def _on_destroy(self, _listener: Listener, _event: Any) -> None:
         logger.debug("Signal: wlr_drag destroy")
         self.finalize()
 
-    def _on_icon_commit(self, _listener: Listener, _event: Any) -> None:
-        self.width = self.icon.surface.current.width
-        self.height = self.icon.surface.current.height
-        self.position(self.core.cursor.x, self.core.cursor.y)
-
     def position(self, cx: float, cy: float) -> None:
-        self.x = cx
-        self.y = cy
         self.node.set_position(int(cx), int(cy))
 
 

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -66,8 +66,8 @@ class XdgWindow(Window[XdgSurface]):
         surface.data = self.data_handle
         self.tree = core.scene.xdg_surface_create(self.container, surface)
 
-        self.add_listener(surface.map_event, self._on_map)
-        self.add_listener(surface.unmap_event, self._on_unmap)
+        self.add_listener(surface.surface.map_event, self._on_map)
+        self.add_listener(surface.surface.unmap_event, self._on_unmap)
         self.add_listener(surface.destroy_event, self._on_destroy)
         self.add_listener(surface.toplevel.request_maximize_event, self._on_request_maximize)
         self.add_listener(surface.toplevel.request_fullscreen_event, self._on_request_fullscreen)

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -284,7 +284,6 @@ class XdgWindow(Window[XdgSurface]):
             self.core,
             self.qtile,
             self,
-            self._idle_inhibitors_count,
         )
 
 
@@ -296,12 +295,9 @@ class XdgStatic(Static[XdgSurface]):
         core: Core,
         qtile: Qtile,
         win: XdgWindow,
-        idle_inhibitor_count: int,
     ):
         surface = win.surface
-        Static.__init__(
-            self, core, qtile, surface, win.wid, idle_inhibitor_count=idle_inhibitor_count
-        )
+        Static.__init__(self, core, qtile, surface, win.wid)
 
         if surface.toplevel.title:
             self.name = surface.toplevel.title

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -59,8 +59,8 @@ class XWindow(Window[xwayland.Surface]):
             self.name = title
 
         # Add some listeners
-        self.add_listener(surface.map_event, self._on_map)
-        self.add_listener(surface.unmap_event, self._on_unmap)
+        self.add_listener(surface.surface.map_event, self._on_map)
+        self.add_listener(surface.surface.unmap_event, self._on_unmap)
         self.add_listener(surface.request_activate_event, self._on_request_activate)
         self.add_listener(surface.request_configure_event, self._on_request_configure)
         self.add_listener(surface.destroy_event, self._on_destroy)

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -337,7 +337,7 @@ class XWindow(Window[xwayland.Surface]):
         hook.fire("client_managed", self.qtile.windows_map[self._wid])
 
     def _to_static(self) -> XStatic:
-        return XStatic(self.core, self.qtile, self, self._idle_inhibitors_count)
+        return XStatic(self.core, self.qtile, self)
 
 
 class XStatic(Static[xwayland.Surface]):
@@ -350,12 +350,9 @@ class XStatic(Static[xwayland.Surface]):
         core: Core,
         qtile: Qtile,
         win: XWindow,
-        idle_inhibitor_count: int,
     ):
         surface = win.surface
-        Static.__init__(
-            self, core, qtile, surface, win.wid, idle_inhibitor_count=idle_inhibitor_count
-        )
+        Static.__init__(self, core, qtile, surface, win.wid)
         self._wm_class = surface.wm_class
 
         self.add_listener(surface.map_event, self._on_map)


### PR DESCRIPTION
This updates the `wlroots-next` branch to catch up to wlroots' master branch as of writing.

See https://github.com/flacjacket/pywlroots/pull/129 for pywlroots `wlroots-next` branch that this depends on (generally with same commit messages).

Commits are in chronological order (of merge to wlroots master) with the wlroots commit hash and message in their message. Checking out one of the wlroots commits, as well as pywlroots and qtile wlroots-next commits with the same hash mentioned, should compile and run. Obviously sometimes there are bugs (in any of the 3 projects).

Couple things to note as current issues:

- The KDE `idle` protocol was dropped, which we used, so currently there is no idle protocol implementated in qtile.
- Commit [(wlroots 26676c8) xwm: use unified map logic](https://github.com/qtile/qtile/commit/e9d5193135dcf8a65a519ebf0aec0a90e96ba4af) broke XWayland with a segfault that raises when an X client connects. I'm not sure if this is a wlroots bug but I suggest not running this branch if this is an issue.