### PR TITLE
Battery widget: recognize 'Not charging' state (on linux)

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -59,7 +59,8 @@ class BatteryState(Enum):
     DISCHARGING = 2
     FULL = 3
     EMPTY = 4
-    UNKNOWN = 5
+    NOT_CHARGING = 5
+    UNKNOWN = 6
 
 
 BatteryStatus = NamedTuple(
@@ -275,6 +276,8 @@ class _LinuxBattery(_Battery, configurable.Configurable):
             state = BatteryState.CHARGING
         elif stat == "Discharging":
             state = BatteryState.DISCHARGING
+        elif stat == "Not charging":
+            state = BatteryState.NOT_CHARGING
         else:
             state = BatteryState.UNKNOWN
 
@@ -320,6 +323,7 @@ class Battery(base.ThreadPoolText):
         ("discharge_char", "V", "Character to indicate the battery is discharging"),
         ("full_char", "=", "Character to indicate the battery is full"),
         ("empty_char", "x", "Character to indicate the battery is empty"),
+        ("not_charging_char", "*", "Character to indicate the batter is not charging"),
         ("unknown_char", "?", "Character to indicate the battery status is unknown"),
         ("format", "{char} {percent:2.0%} {hour:d}:{min:02d} {watt:.2f} W", "Display format"),
         ("hide_threshold", None, "Hide the text when there is enough energy 0 <= x < 1"),
@@ -430,6 +434,8 @@ class Battery(base.ThreadPoolText):
             if self.show_short_text:
                 return "Empty"
             char = self.empty_char
+        elif status.state == BatteryState.NOT_CHARGING:
+            char = self.not_charging_char
         else:
             char = self.unknown_char
 

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -121,6 +121,22 @@ def test_text_battery_empty(monkeypatch):
     assert text == "Empty"
 
 
+def test_text_battery_not_charging(monkeypatch):
+    loaded_bat = BatteryStatus(
+        state=BatteryState.NOT_CHARGING,
+        percent=0.5,
+        power=15.0,
+        time=1729,
+    )
+
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery()
+
+    text = batt.poll()
+    assert text == "* 50% 0:28 15.00 W"
+
+
 def test_text_battery_unknown(monkeypatch):
     loaded_bat = BatteryStatus(
         state=BatteryState.UNKNOWN,


### PR DESCRIPTION
Linux has a ["Not charging"](https://github.com/torvalds/linux/blob/94f6f0550c625fab1f373bb86a6669b45e9748b3/drivers/power/supply/power_supply_sysfs.c#L79) battery state, which is currently not understood by the Battery widget. This change adds an extra configurable character for this case.

- As far as I can tell, `acpiconf` on FreeBSD doesn't have an equivalent state so I didn't touch the FreeBSD implementation.
- I am not entirely sure what causes the battery state to be "Not charging". On my machine I've only seen it when the battery is full or almost full. (I don't know how it decides between "Full" and "Not charging" though, I have seen both)
- I'm happy to tweak the behaviour of this case as long as I can configure this case to be distinguishable from "Unknown". `"*"` was an arbitrary choice for the default char, and I considered displaying as "Full" with short text if the battery is nearly full but decided to keep the initial PR simple.

## Testing
I've manually verified it works how I expect on my machine. I added a test case but had difficulty setting up a dev environment, so I haven't actually run that test. I assume it will be run automatically before merging.
