### PR TITLE
CI: allow pypy3.9 to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     build:
         runs-on: ubuntu-22.04
         name: "python ${{ matrix.python-version }} on ${{ matrix.backend }}"
+        # pypy is segfaulting at the moment so let's allow it to fail.
+        continue-on-error: ${{ matrix.python-version == 'pypy-3.9' }}
         strategy:
             matrix:
                 # If you change one of these, be sure to update:


### PR DESCRIPTION
Pypy3 is segfaulting in CI (see #4502). Let's allow pypy3.9 to fail for now.

If this works, we'll need to update branch protections to remove pypy3.9 requirement too.