### PR TITLE
Fullscreen windows shouldn't be draggable

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -796,7 +796,7 @@ class Qtile(CommandObject):
                         if status in (interface.ERROR, interface.EXCEPTION):
                             logger.error("Mouse command error %s: %s", i.name, val)
                         handled = True
-            elif isinstance(m, Drag):
+            elif isinstance(m, Drag) and not self.current_window.fullscreen:
                 if m.start:
                     i = m.start
                     status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs))


### PR DESCRIPTION
Closes #2387

@m-col In that issue you said you'd prefer if we could drag fullscreen windows but restoring the window original format while doing so. I'd be happy to see that later, I'm just trying to move a little forward. I think the logical order would be to 1/ merge this 2/ to fix issue #2415 and 3/ to implement that said feature. Would you be able to live with it in the meantime? :)