### PR TITLE
Wayland: Opacity, shadows and corner radius with scenefx

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -21,6 +21,7 @@ ffi.set_source(
         "/usr/include/pixman-1",
         "/usr/include/libdrm",
         wlr.include_dir,
+        wlr.scenefx_include,
     ],
 )
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -371,8 +371,9 @@ class Core(base.Core, wlrq.HasListeners):
         if not scene_surface.surface.is_xdg_surface:
             return
         xdg_surface = XdgSurface.from_surface(scene_surface.surface)
-        if xdg_surface.role == XdgSurfaceRole.TOPLEVEL:
-            scene_buffer.set_opacity(win.opacity)
+        if xdg_surface.role != XdgSurfaceRole.TOPLEVEL:
+            return
+        scene_buffer.set_opacity(win.opacity)
 
         if not xdg_surface.surface.is_subsurface:
             scene_buffer.set_corner_radius(win.corner_radius)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -368,14 +368,17 @@ class Core(base.Core, wlrq.HasListeners):
         scene_surface = SceneSurface.from_buffer(scene_buffer)
         if not scene_surface:
             return
-        if not scene_surface.surface.is_xdg_surface:
-            return
-        xdg_surface = XdgSurface.from_surface(scene_surface.surface)
-        if xdg_surface.role != XdgSurfaceRole.TOPLEVEL:
+        # TODO: Do something with the xwayland surface role?
+        is_x = scene_surface.surface.is_xwayland_surface
+        is_way_top = False
+        if scene_surface.surface.is_xdg_surface:
+            xdg_surface = XdgSurface.from_surface(scene_surface.surface)
+            is_way_top = xdg_surface.role == XdgSurfaceRole.TOPLEVEL
+        if not is_way_top and not is_x:
             return
         scene_buffer.set_opacity(win.opacity)
 
-        if not xdg_surface.surface.is_subsurface:
+        if not scene_surface.surface.is_subsurface:
             scene_buffer.set_corner_radius(win.corner_radius)
             if win.shadow:
                 scene_buffer.set_shadow_data(win.shadow, win.shadowblur)

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -363,6 +363,14 @@ class Core(base.Core, wlrq.HasListeners):
         self.display.destroy()
         self.qtile = None
 
+    def win_from_node(self, node) -> Window | None:
+        tree = node.parent
+        while tree and tree.node.data is None:
+            tree = tree.node.parent
+        if tree:
+            return tree.node.data
+        return None
+
     @property
     def display_name(self) -> str:
         return self.socket.decode()
@@ -1315,16 +1323,9 @@ class Core(base.Core, wlrq.HasListeners):
                 # We got a node that is part of a window, walk up the scene graph to
                 # find the window object. It could also be an XDG popup, which can be
                 # the child of either an XDG window or a layer shell window.
-                tree = node.parent
-                while tree and tree.node.data is None:
-                    tree = tree.node.parent
-                if tree:
-                    win = tree.node.data
-                    assert win is not None
-                    return win, scene_surface.surface, sx, sy
-                # We shouldn't get here.
-                logger.warning("Failed finding the window under the pointer. Please report.")
-                return None
+                win = self.win_from_node(node)
+                assert win is not None
+                return win, scene_surface.surface, sx, sy
 
             # We didn't get a wlr_scene_surface, so we're dealing with an internal window
             # Internal windows have a scenetree for borders. The parent's data we will use to cast to an internal window

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -52,7 +52,6 @@ class Output(HasListeners):
         self.renderer = core.renderer
         self.wlr_output = wlr_output
         self._reserved_space = (0, 0, 0, 0)
-        self.scene_output = SceneOutput.create(core.scene, wlr_output)
 
         # These will get updated on the output layout's change event
         self.x = 0
@@ -64,6 +63,8 @@ class Output(HasListeners):
         wlr_output.enable()
         wlr_output.commit()
         wlr_output.data = self
+
+        self.scene_output = SceneOutput.create(core.scene, wlr_output)
 
         self.add_listener(wlr_output.destroy_event, self._on_destroy)
         self.add_listener(wlr_output.frame_event, self._on_frame)

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -97,6 +97,7 @@ class Output(HasListeners):
         self.finalize()
 
     def _on_frame(self, _listener: Listener, _data: Any) -> None:
+        self.core.configure_node_scenefx(self.core.windows_tree.node)
         try:
             self.scene_output.commit()
         except RuntimeError:


### PR DESCRIPTION
Draft. Depends on https://github.com/jwijenbergh/pywlroots/tree/scenefx (make sure to fetch submodules!) and https://github.com/wlrfx/scenefx

TODO:
- [ ]: Only unset shadow when needed for efficiency
- [ ]: Create a better Qtile API than setting window properties (maybe global config settings like bordercolor with wl_ prefixes?)
- [ ]: Make scenefx optional (detect that it is installed somehow), NO-OP opacity, shadows, corner radius if not
- [ ]: Align borders with corner radius
- [ ]: Is the xwayland implementation correct?

Opacity is now in wlroots too so in the future we wont need scenefx for this

Usage is setting the relevant properties, E.g. I just used this for testing:

```python
# add to keys
Key([mod, "control"], "x", lazy.function(set_eye_candy))

def set_eye_candy(qtile):
    curr = qtile.current_window
    if curr.opacity < 1:
        curr.opacity = 1
        curr.shadow = None
        curr.shadowblur = 20
        curr.corner_radius = 0
    else:
        curr.opacity = 0.7
        curr.shadow = "#ff0000"
        curr.shadowblur = 500
        curr.corner_radius = 10
```

To set the setting globally right now you can e.g. use a hook:

```python
@hook.subscribe.client_new
def new_win(win):
    win.opacity = 0.9
    win.shadow = "#000000aa"
    win.shadowblur = 40
    win.corner_radius = 10
```

Much love to the Scenefx team!

Using this branch in nix: https://gist.github.com/jwijenbergh/9d5de199f5ff8cda9b5439308032251b