### PR TITLE
move to pycairo 1.25.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ jobs:
     build:
         runs-on: ubuntu-22.04
         name: "python ${{ matrix.python-version }} on ${{ matrix.backend }}"
-        # pypy is segfaulting at the moment so let's allow it to fail.
-        continue-on-error: ${{ matrix.python-version == 'pypy-3.9' }}
         strategy:
             matrix:
                 # If you change one of these, be sure to update:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cairocffi >= 1.6.0
 cffi >= 1.1.0
 xcffib >= 1.4.0
+pycairo >= 1.25.1


### PR DESCRIPTION
This reverts commit e410b9d0d7c0ed0d3bfcc97cccc478adadad8715 and adds a requirements.txt entry for pycairo >= 1.25.1 which contains the fix here: https://github.com/pygobject/pycairo/pull/344 hopefully mitigating our crashes.