### PR TITLE
Allow bar to float above windows

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ Qtile x.xx.x, released XXXX-XX-XX:
         - `func: Callable`: Enable call when the result of the callable evaluates to True
         - `condition: bool`: a boolean value to determine whether the lazy object should be run. Unlike `func`, the
           condition is evaluated once when the config file is first loaded.
+      - Add ability to have bar drawns over windows by adding `reserve=False` to bar's config to
+        stop the bar reserving screen space.
     * bugfixes
       - Fix two bugs in stacking transient windows in X11
       - Checking configs containing `qtile.core.name` with `python config.py` don't fail anymore (but `qtile.core.name`

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -184,6 +184,11 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         ("margin", 0, "Space around bar as int or list of ints [N E S W]."),
         ("border_color", "#000000", "Border colour as str or list of str [N E S W]"),
         ("border_width", 0, "Width of border as int of list of ints [N E S W]"),
+        (
+            "reserve",
+            True,
+            "Reserve screen space (when set to 'False', bar will be drawn above windows).",
+        ),
     ]
 
     def __init__(self, widgets: list[_Widget], size: int, **config: Any) -> None:
@@ -343,8 +348,8 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             )
             qtile.renamed_widgets.clear()
 
-        hook.subscribe.setgroup(self.keep_below)
-        hook.subscribe.startup_complete(self.keep_below)
+        hook.subscribe.setgroup(self.set_layer)
+        hook.subscribe.startup_complete(self.set_layer)
 
         self._remove_crashed_widgets(crashed_widgets)
         self.draw()
@@ -765,9 +770,13 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         # TODO: drop the screen and position args, update relevant tests
         self.process_button_click(x, y, button)
 
-    def keep_below(self) -> None:
+    def set_layer(self) -> None:
         if self.window:
-            self.window.keep_below(enable=True)
+            if self.reserve:
+                self.window.keep_below(enable=True)
+            else:
+                # Bar is not reserving screen space so let's keep above other windows
+                self.window.keep_above(enable=True)
 
 
 BarType = typing.Union[Bar, Gap]

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -490,27 +490,31 @@ class Screen(CommandObject):
 
     @property
     def dx(self) -> int:
-        return self.x + self.left.size if self.left else self.x
+        if self.left and getattr(self.left, "reserve", True):
+            return self.x + self.left.size
+        return self.x
 
     @property
     def dy(self) -> int:
-        return self.y + self.top.size if self.top else self.y
+        if self.top and getattr(self.top, "reserve", True):
+            return self.y + self.top.size
+        return self.y
 
     @property
     def dwidth(self) -> int:
         val = self.width
-        if self.left:
+        if self.left and getattr(self.left, "reserve", True):
             val -= self.left.size
-        if self.right:
+        if self.right and getattr(self.right, "reserve", True):
             val -= self.right.size
         return val
 
     @property
     def dheight(self) -> int:
         val = self.height
-        if self.top:
+        if self.top and getattr(self.top, "reserve", True):
             val -= self.top.size
-        if self.bottom:
+        if self.bottom and getattr(self.bottom, "reserve", True):
             val -= self.bottom.size
         return val
 

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -632,3 +632,30 @@ def test_unsupported_widget(manager_nospawn):
     manager_nospawn.start(UnsupportedConfig)
 
     assert len(manager_nospawn.c.bar["top"].info()["widgets"]) == 0
+
+
+class DontReserveBarConfig(GBConfig):
+    screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar([libqtile.widget.Spacer()], 50, reserve=False),
+        )
+    ]
+    layouts = [libqtile.layout.max.Max()]
+
+
+dont_reserve_bar_config = pytest.mark.parametrize(
+    "manager", [DontReserveBarConfig], indirect=True
+)
+
+
+@dont_reserve_bar_config
+def test_dont_reserve_bar(manager):
+    """Bar is drawn over tiled windows."""
+    manager.test_window("Window")
+    info = manager.c.window.info()
+
+    # Window should fill entire screen
+    assert info["x"] == 0
+    assert info["y"] == 0
+    assert info["width"] == 800
+    assert info["height"] == 600


### PR DESCRIPTION
Adds `floating` parameter to `Bar` to allow the bar to float above tiled windows. Useful when users want to have bar visibility toggled with a keypress but don't want their windows resized.