### PR TITLE
Allow XStatic configure requests.

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -732,6 +732,12 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         self.defunct = True
         if self.group:
             self.group.remove(self)
+
+        conf_x = x
+        conf_y = y
+        conf_width = width
+        conf_height = height
+
         if x is None:
             x = self.x + self.borderwidth
         if y is None:
@@ -748,7 +754,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             for rect in self._borders.pop():
                 rect.node.destroy()
 
-        win = self._to_static()
+        win = self._to_static(conf_x, conf_y, conf_width, conf_height)
 
         # Pass ownership of the foreign toplevel handle to the static window.
         if self.ftm_handle:
@@ -767,7 +773,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         return self.container.node.enabled
 
     @abc.abstractmethod
-    def _to_static(self) -> Static:
+    def _to_static(self, x: int | None, y: int | None, width: int | None, height: int | None) -> Static:
         # This must return a new `Static` subclass instance
         pass
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -733,6 +733,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         if self.group:
             self.group.remove(self)
 
+        # Keep track of user-specified geometry to support X11.
+        # Respect configure requests only if these are `None` here.
         conf_x = x
         conf_y = y
         conf_width = width

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -279,7 +279,7 @@ class XdgWindow(Window[XdgSurface]):
 
         hook.fire("client_managed", win)
 
-    def _to_static(self) -> XdgStatic:
+    def _to_static(self, x: int | None, y: int | None, width: int | None, height: int | None) -> XdgStatic:
         return XdgStatic(
             self.core,
             self.qtile,

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 
 import typing
 
-from xcffib.xproto import ConfigWindow
-
 from wlroots import xwayland
 from wlroots.wlr_types import SceneTree
 
@@ -344,6 +342,17 @@ class XWindow(Window[xwayland.Surface]):
         )
 
 
+class ConfigWindow:
+    """The XCB_CONFIG_WINDOW_* constants.
+
+    Reproduced here to remove a dependency on xcffib.
+    """
+    X = 1
+    Y = 2
+    Width = 4
+    Height = 8
+
+
 class XStatic(Static[xwayland.Surface]):
     """A static window belonging to the XWayland shell."""
 
@@ -374,7 +383,6 @@ class XStatic(Static[xwayland.Surface]):
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)
         self.add_listener(surface.destroy_event, self._on_destroy)
-        self.add_listener(surface.surface.commit_event, self._on_commit)
         self.add_listener(surface.request_configure_event, self._on_request_configure)
         self.add_listener(surface.set_title_event, self._on_set_title)
         self.add_listener(surface.set_class_event, self._on_set_class)
@@ -405,10 +413,6 @@ class XStatic(Static[xwayland.Surface]):
         win = XWindow(self.core, self.qtile, self.surface)
         self.core.pending_windows.add(win)
 
-    def _on_commit(self, _listener: Listener, _data: Any) -> None:
-        pass
-        # logger.debug("Signal: xstatic commit")
-
     def _on_request_configure(self, _listener: Listener, event: SurfaceConfigureEvent) -> None:
         logger.debug("Signal: xstatic request_configure")
         cw = ConfigWindow
@@ -433,8 +437,7 @@ class XStatic(Static[xwayland.Surface]):
     def unhide(self) -> None:
         if self not in self.core.pending_windows:
             # Only when mapping does the xwayland_surface have a wlr_surface that we can
-            # listen for commits on and create a tree for.
-            self.add_listener(self.surface.surface.commit_event, self._on_commit)
+            # create a tree for.
             if not self.tree:
                 self.tree = SceneTree.subsurface_tree_create(self.container, self.surface.surface)
                 self.tree.node.set_position(self.borderwidth, self.borderwidth)

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -375,10 +375,10 @@ class XStatic(Static[xwayland.Surface]):
         )
         self._wm_class = surface.wm_class
 
-        self.conf_x = x
-        self.conf_y = y
-        self.conf_width = width
-        self.conf_height = height
+        self._conf_x = x
+        self._conf_y = y
+        self._conf_width = width
+        self._conf_height = height
 
         self.add_listener(surface.map_event, self._on_map)
         self.add_listener(surface.unmap_event, self._on_unmap)
@@ -416,13 +416,13 @@ class XStatic(Static[xwayland.Surface]):
     def _on_request_configure(self, _listener: Listener, event: SurfaceConfigureEvent) -> None:
         logger.debug("Signal: xstatic request_configure")
         cw = ConfigWindow
-        if self.conf_x is None and event.mask & cw.X:
+        if self._conf_x is None and event.mask & cw.X:
             self.x = event.x
-        if self.conf_y is None and event.mask & cw.Y:
+        if self._conf_y is None and event.mask & cw.Y:
             self.y = event.y
-        if self.conf_width is None and event.mask & cw.Width:
+        if self._conf_width is None and event.mask & cw.Width:
             self.width = event.width
-        if self.conf_height is None and event.mask & cw.Height:
+        if self._conf_height is None and event.mask & cw.Height:
             self.height = event.height
         self.place(self.x, self.y, self.width, self.height, self.borderwidth, self.bordercolor)
 


### PR DESCRIPTION
In the X11 backend, static windows are allowed to change their position and size, unless those parameters were set explicitly in Window.static().  This commit implements the same behavior for XStatic windows in the Wayland backend.  This fixes gkrellm.