### PR TITLE
Add boolean and func options to .when()

### DIFF
--- a/libqtile/__init__.py
+++ b/libqtile/__init__.py
@@ -20,15 +20,15 @@
 # SOFTWARE.
 
 
-class UndefinedCore:
+class _UndefinedCore:
     name = None
 
 
-class UndefinedQtile:
-    core = UndefinedCore()
+class _UndefinedQtile:
+    core = _UndefinedCore()
 
 
-qtile = UndefinedQtile()
+qtile = _UndefinedQtile()
 
 
 def init(q):

--- a/libqtile/__init__.py
+++ b/libqtile/__init__.py
@@ -20,7 +20,15 @@
 # SOFTWARE.
 
 
-qtile = None
+class UndefinedCore:
+    name = None
+
+
+class UndefinedQtile:
+    core = UndefinedCore()
+
+
+qtile = UndefinedQtile()
 
 
 def init(q):

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -24,9 +24,10 @@ from typing import TYPE_CHECKING
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.command.interface import CommandInterface
+from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from typing import Iterable
+    from typing import Callable, Iterable
 
     from libqtile.command.graph import SelectorType
     from libqtile.config import Match
@@ -53,6 +54,8 @@ class LazyCall:
         self._if_no_focused: bool = False
         self._layouts: set[str] = set()
         self._when_floating = True
+        self._check: bool | None = None
+        self._func: Callable | None = None
 
     def __call__(self, *args, **kwargs):
         """Convenience method to allow users to pass arguments to
@@ -93,14 +96,22 @@ class LazyCall:
 
     def when(
         self,
+        check: bool | None = None,
+        *,
         focused: Match | None = None,
         if_no_focused: bool = False,
         layout: Iterable[str] | str | None = None,
         when_floating: bool = True,
+        func: Callable | None = None
     ) -> "LazyCall":
-        """Enable call only for given layout(s) and floating state
+        """Enable call only for matching criteria.
 
-        Parameters
+        Positional parameters
+        ---------------------
+        check: a boolean value to determine whether the lazy object should
+            be run.
+
+        Keyword parameters
         ----------
         focused: Match or None
             Match criteria to enable call for the current window.
@@ -117,10 +128,15 @@ class LazyCall:
             If None, enable the call for all layouts.
         when_floating: bool
             Enable call when the current window is floating.
+        func: callable
+            Enable call when the result of the callable evaluates to True
         """
         self._focused = focused
 
         self._if_no_focused = if_no_focused
+
+        self._check = check
+        self._func = func
 
         if layout is not None:
             self._layouts = {layout} if isinstance(layout, str) else set(layout)
@@ -130,6 +146,9 @@ class LazyCall:
 
     def check(self, q) -> bool:
         cur_win_floating = q.current_window and q.current_window.floating
+
+        if self._check is False:
+            return False
 
         if self._focused:
             if q.current_window and not self._focused.compare(q.current_window):
@@ -143,6 +162,16 @@ class LazyCall:
 
         if self._layouts and q.current_layout.name not in self._layouts:
             return False
+
+        if self._func:
+            try:
+                result = self._func()
+            except Exception:
+                logger.exception("Error when running function in lazy call. Ignoring.")
+                result = True
+
+            if not result:
+                return False
 
         return True
 

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -21,9 +21,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from libqtile.backend import CORES
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.command.interface import CommandInterface
+from libqtile.confreader import ConfigError
 
 if TYPE_CHECKING:
     from typing import Iterable
@@ -53,6 +55,7 @@ class LazyCall:
         self._if_no_focused: bool = False
         self._layouts: set[str] = set()
         self._when_floating = True
+        self._backend: str | None = None
 
     def __call__(self, *args, **kwargs):
         """Convenience method to allow users to pass arguments to
@@ -97,6 +100,7 @@ class LazyCall:
         if_no_focused: bool = False,
         layout: Iterable[str] | str | None = None,
         when_floating: bool = True,
+        backend: str | None = None,
     ) -> "LazyCall":
         """Enable call only for given layout(s) and floating state
 
@@ -117,6 +121,8 @@ class LazyCall:
             If None, enable the call for all layouts.
         when_floating: bool
             Enable call when the current window is floating.
+        backend: str ("x11" or "wayland")
+            Only run on specified backend
         """
         self._focused = focused
 
@@ -126,6 +132,12 @@ class LazyCall:
             self._layouts = {layout} if isinstance(layout, str) else set(layout)
 
         self._when_floating = when_floating
+
+        if backend is not None:
+            if backend not in CORES:
+                raise ConfigError(f"Unknown backend used in lazy call: {backend}.")
+            self._backend = backend
+
         return self
 
     def check(self, q) -> bool:
@@ -142,6 +154,9 @@ class LazyCall:
             return False
 
         if self._layouts and q.current_layout.name not in self._layouts:
+            return False
+
+        if self._backend and q.core.name != self._backend:
             return False
 
         return True

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -21,11 +21,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from libqtile.backend import CORES
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.graph import CommandGraphCall, CommandGraphNode
 from libqtile.command.interface import CommandInterface
-from libqtile.confreader import ConfigError
 
 if TYPE_CHECKING:
     from typing import Iterable
@@ -55,7 +53,6 @@ class LazyCall:
         self._if_no_focused: bool = False
         self._layouts: set[str] = set()
         self._when_floating = True
-        self._backend: str | None = None
 
     def __call__(self, *args, **kwargs):
         """Convenience method to allow users to pass arguments to
@@ -100,7 +97,6 @@ class LazyCall:
         if_no_focused: bool = False,
         layout: Iterable[str] | str | None = None,
         when_floating: bool = True,
-        backend: str | None = None,
     ) -> "LazyCall":
         """Enable call only for given layout(s) and floating state
 
@@ -121,8 +117,6 @@ class LazyCall:
             If None, enable the call for all layouts.
         when_floating: bool
             Enable call when the current window is floating.
-        backend: str ("x11" or "wayland")
-            Only run on specified backend
         """
         self._focused = focused
 
@@ -132,12 +126,6 @@ class LazyCall:
             self._layouts = {layout} if isinstance(layout, str) else set(layout)
 
         self._when_floating = when_floating
-
-        if backend is not None:
-            if backend not in CORES:
-                raise ConfigError(f"Unknown backend used in lazy call: {backend}.")
-            self._backend = backend
-
         return self
 
     def check(self, q) -> bool:
@@ -154,9 +142,6 @@ class LazyCall:
             return False
 
         if self._layouts and q.current_layout.name not in self._layouts:
-            return False
-
-        if self._backend and q.core.name != self._backend:
             return False
 
         return True

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -29,7 +29,7 @@ from sys import exit
 from typing import TYPE_CHECKING
 
 import libqtile.backend
-from libqtile import confreader
+from libqtile import confreader, qtile
 from libqtile.utils import get_config_file
 from libqtile.log_utils import logger
 
@@ -55,6 +55,7 @@ def rename_process():
 
 
 def make_qtile(options) -> Qtile | None:
+    qtile.core.name = options.backend
     if missing_deps := libqtile.backend.has_deps(options.backend):
         print(f"Backend '{options.backend}' missing required Python dependencies:")
         for dep in missing_deps:

--- a/test/test_when.py
+++ b/test/test_when.py
@@ -57,12 +57,12 @@ class WhenConfig(Config):
         config.Key(
             ["control"],
             "t",
-            lazy.next_layout().when(True)
+            lazy.next_layout().when(condition=1 + 1 == 2)
         ),
         config.Key(
             ["control"],
             "f",
-            lazy.next_layout().when(False)
+            lazy.next_layout().when(condition=1 + 1 == 3)
         ),
         config.Key(
             ["control", "shift"],

--- a/test/test_when.py
+++ b/test/test_when.py
@@ -54,6 +54,26 @@ class WhenConfig(Config):
                 focused=config.Match(wm_class="TestWindow"), if_no_focused=True
             ),
         ),
+        config.Key(
+            ["control"],
+            "t",
+            lazy.next_layout().when(True)
+        ),
+        config.Key(
+            ["control"],
+            "f",
+            lazy.next_layout().when(False)
+        ),
+        config.Key(
+            ["control", "shift"],
+            "t",
+            lazy.next_layout().when(func=lambda: True)
+        ),
+        config.Key(
+            ["control", "shift"],
+            "f",
+            lazy.next_layout().when(func=lambda: False)
+        ),
     ]
     layouts = [layout.MonadWide(), layout.MonadTall()]
 
@@ -89,4 +109,22 @@ def test_when(manager):
 
     # This does go to the next layout as empty is matched
     manager.c.simulate_keypress(["control"], "m")
+    assert manager.c.layout.info() != prev_layout_info
+
+    # Test boolean argument
+    prev_layout_info = manager.c.layout.info()
+
+    manager.c.simulate_keypress(["control"], "f")
+    assert manager.c.layout.info() == prev_layout_info
+
+    manager.c.simulate_keypress(["control"], "t")
+    assert manager.c.layout.info() != prev_layout_info
+
+    # Test function argument
+    prev_layout_info = manager.c.layout.info()
+
+    manager.c.simulate_keypress(["control", "shift"], "f")
+    assert manager.c.layout.info() == prev_layout_info
+
+    manager.c.simulate_keypress(["control", "shift"], "t")
     assert manager.c.layout.info() != prev_layout_info

--- a/test/test_when.py
+++ b/test/test_when.py
@@ -54,16 +54,6 @@ class WhenConfig(Config):
                 focused=config.Match(wm_class="TestWindow"), if_no_focused=True
             ),
         ),
-        config.Key(
-            ["control"],
-            "w",
-            lazy.next_layout().when(backend="wayland"),
-        ),
-        config.Key(
-            ["control"],
-            "x",
-            lazy.next_layout().when(backend="x11"),
-        ),
     ]
     layouts = [layout.MonadWide(), layout.MonadTall()]
 
@@ -72,7 +62,7 @@ when_config = pytest.mark.parametrize("manager", [WhenConfig], indirect=True)
 
 
 @when_config
-def test_when(manager, backend_name):
+def test_when(manager):
     # Check if the test window is alive and tiled
     one = manager.test_window("one")
     assert not manager.c.window.info()["floating"]
@@ -100,20 +90,3 @@ def test_when(manager, backend_name):
     # This does go to the next layout as empty is matched
     manager.c.simulate_keypress(["control"], "m")
     assert manager.c.layout.info() != prev_layout_info
-
-    # Test backend specific calls...
-    prev_layout_info = manager.c.layout.info()
-    manager.c.simulate_keypress(["control"], "w")
-
-    if backend_name == "wayland":
-        assert manager.c.layout.info() != prev_layout_info
-    else:
-        assert manager.c.layout.info() == prev_layout_info
-
-    prev_layout_info = manager.c.layout.info()
-    manager.c.simulate_keypress(["control"], "x")
-
-    if backend_name == "x11":
-        assert manager.c.layout.info() != prev_layout_info
-    else:
-        assert manager.c.layout.info() == prev_layout_info


### PR DESCRIPTION
We can't use `qtile.core.name` in the default config so one way to have backend specific keybindings is to add a `backend=` option to the `.when` method for lazy calls.