### PR TITLE
Allow third party code to register hooks

### DIFF
--- a/docs/manual/config/hooks.rst
+++ b/docs/manual/config/hooks.rst
@@ -87,3 +87,22 @@ will run them asynchronously in the event loop:
     @hook.subscribe.focus_change
     async def _():
         ...
+
+
+Registering additional hooks
+============================
+
+Third party code (widgets, layouts etc.) are able to register their own hooks which users
+can then subscribe to:
+
+.. code-block:: python
+
+    hook.register_hook("my_widget_hook")
+
+Users then subscribe to the hook as normal:
+
+.. code-block:: python
+
+    @hook.subscribe.my_widget_hook
+    def _():
+        ...

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -53,6 +53,13 @@ class Subscribe:
                 hooks.add(i)
         self.hooks = hooks
 
+    def _register(self, hook_name):
+        def _hook_func(func):
+            return self._subscribe(hook_name, func)
+
+        self.hooks.add(hook_name)
+        setattr(self, hook_name, _hook_func)
+
     def _subscribe(self, event, func):
         lst = subscriptions.setdefault(event, [])
         if func not in lst:
@@ -901,3 +908,14 @@ def fire(event, *args, **kwargs):
                 i(*args, **kwargs)
         except:  # noqa: E722
             logger.exception("Error in hook %s", event)
+
+
+def register_hook(hook_name):
+    if hook_name in dir(subscribe):
+        raise utils.QtileError(
+            f"Unable to register hook. A hook with that name already exists: {hook_name}"
+        )
+
+    logger.debug("Registered new hook: '%s'.", hook_name)
+    subscribe._register(hook_name)
+    unsubscribe._register(hook_name)

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -197,3 +197,30 @@ def test_resume_hook(manager):
     hook.subscribe.resume(test)
     hook.fire("resume")
     assert test.val == 1
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_register_new_hooks():
+    test = NoArgCall(0)
+
+    # Create a new hook and attach a subscription
+    hook.register_hook("test_hook")
+    hook.subscribe.test_hook(test)
+
+    assert "test_hook" in hook.subscriptions
+    assert hook.subscriptions["test_hook"]
+
+    # Fire the hook and check callback worked
+    hook.fire("test_hook")
+    assert test.val == 1
+
+    # Unsubscribing should also work
+    hook.unsubscribe.test_hook(test)
+    assert not hook.subscriptions["test_hook"]
+
+    # Should get errors if you try to register a hook with an existing name
+    with pytest.raises(libqtile.utils.QtileError):
+        hook.register_hook("test_hook")
+
+    with pytest.raises(libqtile.utils.QtileError):
+        hook.register_hook("client_managed")


### PR DESCRIPTION
Adds a new `hook.register_hook` function to allow third party layouts, widgets etc to create new hooks.