### PR TITLE
Fix static positioning in Wayland.

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -747,6 +747,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         while self._borders:
             for rect in self._borders.pop():
                 rect.node.destroy()
+        if self.tree:
+            self.tree.node.set_position(0, 0)
 
         win = self._to_static()
 


### PR DESCRIPTION
The static was being positioned as if it still had a border.