### PR TITLE
x11: Add pointer barriers for screen focus

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,7 @@ MOCK_MODULES = [
     "xcffib.render",
     "xcffib.wrappers",
     "xcffib.xfixes",
+    "xcffib.xinput",
     "xcffib.xinerama",
     "xcffib.xproto",
     "xcffib.xtest",

--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -119,3 +119,6 @@ class Core(CommandObject, metaclass=ABCMeta):
     def info(self) -> dict[str, Any]:
         """Get basic information about the running backend."""
         return {"backend": self.name, "display_name": self.display_name}
+
+    def setup_barriers(self, screens: list[config.Screen]) -> None:
+        """Set up pointer barriers to focus screens when moving pointer."""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -822,7 +822,7 @@ class Core(base.Core):
         mouse_y = event.root_y >> 16
 
         if x is not None:
-            if mouse_x >> 16 < x:
+            if mouse_x < x:
                 # Focus screen 2
                 mouse_x += 1
                 screen = screen2
@@ -832,7 +832,7 @@ class Core(base.Core):
                 screen = screen1
 
         else:
-            if event.root_y >> 16 < y:
+            if mouse_y < y:
                 # Focus screen 2
                 mouse_y += 1
                 screen = screen2

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -44,6 +44,7 @@ from libqtile.utils import QtileError
 if TYPE_CHECKING:
     from typing import Callable, Iterator
 
+    from libqtile.config import Screen
     from libqtile.core.manager import Qtile
 
 _IGNORED_EVENTS = {
@@ -809,6 +810,40 @@ class Core(base.Core):
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
         hook.fire("screen_change", event)
 
+    def handle_BarrierHit(self, event):
+        """Warps pointer to other side of barrier and focuses the relevant screen."""
+        barrier = self.conn.xfixes.barriers.get(event.barrier)
+        if barrier is None:
+            logger.warning("Unknown barrier hit event.")
+            return
+
+        x, y, screen1, screen2 = barrier
+        mouse_x = event.root_x >> 16
+        mouse_y = event.root_y >> 16
+
+        if x is not None:
+            if mouse_x >> 16 < x:
+                # Focus screen 2
+                mouse_x += 1
+                screen = screen2
+            else:
+                # Focus screen 1
+                mouse_x -= 1
+                screen = screen1
+
+        else:
+            if event.root_y >> 16 < y:
+                # Focus screen 2
+                mouse_y += 1
+                screen = screen2
+            else:
+                # Focus screen 1
+                mouse_y -= 1
+                screen = screen1
+
+        self.warp_pointer(mouse_x, mouse_y)
+        self.qtile.focus_screen(screen.index, warp=False)
+
     def _fake_input(self, input_type, detail, x=0, y=0) -> None:
         self._xtest.FakeInput(
             input_type,
@@ -952,3 +987,36 @@ class Core(base.Core):
             self.last_focused.change_layer()
 
         self.last_focused = win
+
+    def setup_barriers(self, screens: list[Screen]) -> None:
+        if not (hasattr(self.conn, "xinputextension") and hasattr(self.conn, "xfixes")):
+            logger.warning("Unable to set pointer barriers. Missing extensions.")
+            return
+        self.conn.xinputextension.select_events(self._root.wid)
+
+        if len(screens) < 2:
+            return
+
+        borders = set()
+
+        for screen in screens:
+            for other in [s for s in screens if s is not screen]:
+                border = screen.get_joining_edge(screen, other)
+                if border is None:
+                    continue
+
+                # Vertical border (x coordinate is the same)
+                if border[0] == border[2]:
+                    # We need the leftmost screen first
+                    first = screen if screen.x < other.x else other
+                # Horizontal border
+                else:
+                    # We need higher screen first
+                    first = screen if screen.y < other.y else other
+
+                touching = other if first is screen else screen
+
+                borders.add((*border, first, touching))
+
+        for border in borders:
+            self.conn.xfixes.add_pointer_barrier(self._root.wid, *border)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2019 Aldo Cortesi
 # Copyright (c) 2019 Sean Vig
+# Copyright (c) 2023 elParaguayo
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1001,7 +1002,7 @@ class Core(base.Core):
 
         for screen in screens:
             for other in [s for s in screens if s is not screen]:
-                border = screen.get_joining_edge(screen, other)
+                border = screen.get_joining_edge(other)
                 if border is None:
                     continue
 

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -811,7 +811,7 @@ class Core(base.Core):
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
         hook.fire("screen_change", event)
 
-    def handle_BarrierHit(self, event):
+    def handle_BarrierHit(self, event) -> None:  # noqa: N802
         """Warps pointer to other side of barrier and focuses the relevant screen."""
         barrier = self.conn.xfixes.barriers.get(event.barrier)
         if barrier is None:
@@ -1002,12 +1002,12 @@ class Core(base.Core):
 
         for screen in screens:
             for other in [s for s in screens if s is not screen]:
-                border = screen.get_joining_edge(other)
-                if border is None:
+                edge = screen.get_joining_edge(other)
+                if edge is None:
                     continue
 
                 # Vertical border (x coordinate is the same)
-                if border[0] == border[2]:
+                if edge[0] == edge[2]:
                     # We need the leftmost screen first
                     first = screen if screen.x < other.x else other
                 # Horizontal border
@@ -1017,7 +1017,7 @@ class Core(base.Core):
 
                 touching = other if first is screen else screen
 
-                borders.add((*border, first, touching))
+                borders.add((*edge, first, touching))
 
         for border in borders:
             self.conn.xfixes.add_pointer_barrier(self._root.wid, *border)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -813,6 +813,9 @@ class Core(base.Core):
 
     def handle_BarrierHit(self, event) -> None:  # noqa: N802
         """Warps pointer to other side of barrier and focuses the relevant screen."""
+        assert hasattr(self.conn, "xfixes")
+        assert self.qtile
+
         barrier = self.conn.xfixes.barriers.get(event.barrier)
         if barrier is None:
             logger.warning("Unknown barrier hit event.")

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -11,6 +11,7 @@
 # Copyright (c) 2012, 2014-2015 Tycho Andersen
 # Copyright (c) 2013 Tao Sauvage
 # Copyright (c) 2014-2015 Sean Vig
+# Copyright (c) 2023 elParaguayo
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -48,6 +48,7 @@ import cairocffi.xcb
 import xcffib
 import xcffib.randr
 import xcffib.xinerama
+import xcffib.xinput
 import xcffib.xproto
 from xcffib.xfixes import SelectionEventMask
 from xcffib.xproto import CW, EventMask, WindowClass
@@ -442,10 +443,45 @@ class XFixes:
         self.conn = conn
         self.ext = conn.conn(xcffib.xfixes.key)
         self.ext.QueryVersion(xcffib.xfixes.MAJOR_VERSION, xcffib.xfixes.MINOR_VERSION)
+        self.barriers = {}
 
     def select_selection_input(self, window, selection="PRIMARY"):
         _selection = self.conn.atoms[selection]
         self.conn.xfixes.ext.SelectSelectionInput(window.wid, _selection, self.selection_mask)
+
+    def add_pointer_barrier(self, window, x1, y1, x2, y2, screen1, screen2):
+        barrier = self.conn.conn.generate_id()
+        self.ext.CreatePointerBarrier(barrier, window, x1, y1, x2, y2, 0, 0, [])
+        self.barriers[barrier] = (
+            x1 if x1 == x2 else None,
+            y1 if y1 == y2 else None,
+            screen1,
+            screen2,
+        )
+
+    def remove_pointer_barrier(self, barrier):
+        self.ext.DeletePointerBarrier(barrier)
+        del self.barriers[barrier]
+
+    def remove_pointer_barriers(self):
+        for b in self.barriers.keys():
+            self.remove_pointer_barrier(b)
+
+
+class XInput:
+    def __init__(self, conn):
+        self.conn = conn
+        self.ext = conn.conn(xcffib.xinput.key)
+        self.ext.XIQueryVersion(xcffib.xinput.MAJOR_VERSION, xcffib.xinput.MINOR_VERSION)
+
+    def select_events(self, window):
+        mask = xcffib.xinput.EventMask.synthetic(
+            xcffib.xinput.Device.All,
+            1,
+            [xcffib.xinput.XIEventMask.BarrierHit | xcffib.xinput.XIEventMask.BarrierLeave],
+        )
+        self.ext.XISelectEvents(window, 1, [mask])
+        self.conn.flush()
 
 
 class Connection:
@@ -453,6 +489,7 @@ class Connection:
         "xinerama": Xinerama,
         "randr": RandR,
         "xfixes": XFixes,
+        "xinputextension": XInput,
     }
 
     def __init__(self, display):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -678,6 +678,22 @@ class Screen(CommandObject):
         """Set the wallpaper to the given file."""
         self.paint(path, mode)
 
+    @staticmethod
+    def get_joining_edge(screen1: Screen, screen2: Screen) -> tuple[int, int, int, int] | None:
+        """
+        Returns a tuple of the coordinates of the border where too screens touch.
+
+        Returns None if screens are not adjacent.
+        """
+        x1 = max(screen1.x, screen2.x)
+        y1 = max(screen1.y, screen2.y)
+        x2 = min(screen1.x + screen1.width, screen2.x + screen2.width)
+        y2 = min(screen1.y + screen1.height, screen2.y + screen2.height)
+        if x1 > x2 or y1 > y2:
+            return None
+
+        return (x1, y1, x2, y2)
+
 
 class Group:
     """

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -678,17 +678,16 @@ class Screen(CommandObject):
         """Set the wallpaper to the given file."""
         self.paint(path, mode)
 
-    @staticmethod
-    def get_joining_edge(screen1: Screen, screen2: Screen) -> tuple[int, int, int, int] | None:
+    def get_joining_edge(self, screen2: Screen) -> tuple[int, int, int, int] | None:
         """
-        Returns a tuple of the coordinates of the border where too screens touch.
+        Returns a tuple of the coordinates of the border where the screen touches another screen.
 
         Returns None if screens are not adjacent.
         """
-        x1 = max(screen1.x, screen2.x)
-        y1 = max(screen1.y, screen2.y)
-        x2 = min(screen1.x + screen1.width, screen2.x + screen2.width)
-        y2 = min(screen1.y + screen1.height, screen2.y + screen2.height)
+        x1 = max(self.x, screen2.x)
+        y1 = max(self.y, screen2.y)
+        x2 = min(self.x + self.width, screen2.x + screen2.width)
+        y2 = min(self.y + self.height, screen2.y + screen2.height)
         if x1 > x2 or y1 > y2:
             return None
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -857,7 +857,20 @@ class Qtile(CommandObject):
         if n >= len(self.screens):
             return
         old = self.current_screen
+
+        # If we're dragging a window across screens, we need to remember what the current screen is...
+        if self._drag and self.current_window:
+            cw = self.current_window
+        else:
+            cw = None
+
         self.current_screen = self.screens[n]
+
+        # ... and make it the current window on the next screen.
+        if self._drag and cw is not None:
+            cw.group = self.current_group
+            self.current_group.current_window = cw
+
         if old != self.current_screen:
             hook.fire("current_screen_change")
             hook.fire("setgroup")

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -410,6 +410,8 @@ class Qtile(CommandObject):
 
         self.screens = screens
 
+        self.core.setup_barriers(self.screens)
+
     @expose_command()
     def reconfigure_screens(self, *_: list[Any], **__: dict[Any, Any]) -> None:
         """

--- a/test/backend/x11/test_pointer_barriers.py
+++ b/test/backend/x11/test_pointer_barriers.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2023 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import xcffib.xinput
+import xcffib.xproto
+import xcffib.xtest
+
+from test.conftest import dualmonitor
+
+
+@dualmonitor
+def test_pointer(xmanager):
+    """Two screens should result in 1 pointer barrier."""
+    _, barriers = xmanager.c.eval("len(self.core.conn.xfixes.barriers.keys())")
+    assert int(barriers) == 1
+
+
+def test_no_pointer(xmanager):
+    """One screen should result in 0 pointer barriers."""
+    _, barriers = xmanager.c.eval("len(self.core.conn.xfixes.barriers.keys())")
+    assert int(barriers) == 0
+
+
+@dualmonitor
+def test_screen_focus(xmanager, conn):
+    def current_screen():
+        _, index = xmanager.c.eval("self.current_screen.index")
+        return int(index)
+
+    assert current_screen() == 0
+
+    _, barriers = xmanager.c.eval("len(self.core.conn.xfixes.barriers.keys())")
+
+    xtest = conn.conn(xcffib.xtest.key)
+    # Move to edge of barrier
+    xtest.FakeInput(6, 0, xcffib.xproto.Time.CurrentTime, conn.default_screen.root.wid, 799, 100, 0)
+    # Try to cross barrier
+    xtest.FakeInput(6, 1, xcffib.xproto.Time.CurrentTime, conn.default_screen.root.wid, 1, 0, 0)
+    conn.conn.flush()
+    conn.xsync()
+
+    # Second screen should now be focused
+    assert current_screen() == 1
+
+    # For some reason, FakeInput hits barrier in opposite direction but no barrierhit event is fired :(
+    # So we can't include that part of the test here.

--- a/test/backend/x11/test_pointer_barriers.py
+++ b/test/backend/x11/test_pointer_barriers.py
@@ -49,7 +49,9 @@ def test_screen_focus(xmanager, conn):
 
     xtest = conn.conn(xcffib.xtest.key)
     # Move to edge of barrier
-    xtest.FakeInput(6, 0, xcffib.xproto.Time.CurrentTime, conn.default_screen.root.wid, 799, 100, 0)
+    xtest.FakeInput(
+        6, 0, xcffib.xproto.Time.CurrentTime, conn.default_screen.root.wid, 799, 100, 0
+    )
     # Try to cross barrier
     xtest.FakeInput(6, 1, xcffib.xproto.Time.CurrentTime, conn.default_screen.root.wid, 1, 0, 0)
     conn.conn.flush()


### PR DESCRIPTION
This is draft for now and comments very welcome.

This is an attempt to fix the issue where screens are not focused when the mouse moves to a different screen.

This PR works by creating pointer barriers at the edges where two `Screen`s touch. When the mouse hits one these barriers, an event is fired which allows us to move the mouse to the next screen and focus that screen.

At the moment, this is automatic and not behind a config option.

This probably needs some tests too...