### PR TITLE
Ethernet functionality on the Wlan widget

### DIFF
--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -73,12 +73,11 @@ class Wlan(base.InLoopPollText):
             essid, quality = get_status(self.interface)
             disconnected = essid is None
             if disconnected:
-                statfile = open("/sys/class/net/"+self.ethint+"/operstate", "r")
-                if (statfile.read().strip() == 'up'):
-                    return self.ethernet_message
-                else:
-                    return self.disconnected_message
-
+                with open(f"/sys/class/net/{self.ethint}/operstate", "r") as statfile:
+                    if (statfile.read().strip() == 'up'):
+                        return self.ethernet_message
+                    else:
+                        return self.disconnected_message
             return self.format.format(essid=essid, quality=quality, percent=(quality / 70))
         except EnvironmentError:
             logger.error(

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -68,6 +68,7 @@ class Wlan(base.InLoopPollText):
     def __init__(self, **config):
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(Wlan.defaults)
+        self.ethernetInterfaceNotFound = False
 
     def poll(self):
         try:
@@ -82,17 +83,17 @@ class Wlan(base.InLoopPollText):
                             else:
                                 return self.disconnected_message
                     except FileNotFoundError:
-                        logger.error(
-                            "%s: Ethernet interface has not been found!",
-                            self.__class__.__name__,
-                        )
+                        if not self.ethernetInterfaceNotFound:
+                            logger.error(
+                                "Ethernet interface has not been found!"
+                            )
+                            self.ethernetInterfaceNotFound = True
                         return self.disconnected_message
                 else:
                     return self.disconnected_message
             return self.format.format(essid=essid, quality=quality, percent=(quality / 70))
         except EnvironmentError:
             logger.error(
-                "%s: Probably your wlan device is switched off or "
-                " otherwise not present in your system.",
-                self.__class__.__name__,
+                "Probably your wlan device is switched off or "
+                " otherwise not present in your system."
             )

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -73,11 +73,18 @@ class Wlan(base.InLoopPollText):
             essid, quality = get_status(self.interface)
             disconnected = essid is None
             if disconnected:
-                with open(f"/sys/class/net/{self.ethernet_interface}/operstate", "r") as statfile:
-                    if (statfile.read().strip() == 'up'):
-                        return self.ethernet_message
-                    else:
-                        return self.disconnected_message
+                try:
+                    with open(f"/sys/class/net/{self.ethernet_interface}/operstate", "r") as statfile:
+                        if (statfile.read().strip() == 'up'):
+                            return self.ethernet_message
+                        else:
+                            return self.disconnected_message
+                except FileNotFoundError:
+                    logger.error(
+                        "%s: Ethernet interface has not been found!",
+                        self.__class__.__name__,
+                    )
+                    return self.disconnected_message
             return self.format.format(essid=essid, quality=quality, percent=(quality / 70))
         except EnvironmentError:
             logger.error(

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -27,6 +27,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import iwlib
+import os
 
 from libqtile.log_utils import logger
 from libqtile.widget import base
@@ -53,8 +54,10 @@ class Wlan(base.InLoopPollText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("interface", "wlan0", "The interface to monitor"),
+        ("ethint", "eth0", "The ethernet interface to monitor"),
         ("update_interval", 1, "The update interval."),
         ("disconnected_message", "Disconnected", "String to show when the wlan is diconnected."),
+        ("ethernet_message", "Ethernet", "String to show when ethernet is being used"),
         (
             "format",
             "{essid} {quality}/70",
@@ -71,7 +74,10 @@ class Wlan(base.InLoopPollText):
             essid, quality = get_status(self.interface)
             disconnected = essid is None
             if disconnected:
-                return self.disconnected_message
+                if (os.popen("cat /sys/class/net/"+self.ethint+"/operstate").read().strip() == 'up'):
+                    return self.ethernet_message
+                else:
+                    return self.disconnected_message
 
             return self.format.format(essid=essid, quality=quality, percent=(quality / 70))
         except EnvironmentError:

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -53,11 +53,19 @@ class Wlan(base.InLoopPollText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("interface", "wlan0", "The interface to monitor"),
-        ("ethernet_interface", "eth0", "The ethernet interface to monitor, NOTE: If you do not have a wlan device in your system, ethernet functionality will not work, use the Net widget instead"),
+        (
+            "ethernet_interface",
+            "eth0",
+            "The ethernet interface to monitor, NOTE: If you do not have a wlan device in your system, ethernet functionality will not work, use the Net widget instead",
+        ),
         ("update_interval", 1, "The update interval."),
         ("disconnected_message", "Disconnected", "String to show when the wlan is diconnected."),
         ("ethernet_message", "eth", "String to show when ethernet is being used"),
-        ("use_ethernet", False, "Activate or deactivate checking for ethernet when no wlan connection is detected"),
+        (
+            "use_ethernet",
+            False,
+            "Activate or deactivate checking for ethernet when no wlan connection is detected",
+        ),
         (
             "format",
             "{essid} {quality}/70",
@@ -77,16 +85,16 @@ class Wlan(base.InLoopPollText):
             if disconnected:
                 if self.use_ethernet:
                     try:
-                        with open(f"/sys/class/net/{self.ethernet_interface}/operstate", "r") as statfile:
-                            if (statfile.read().strip() == 'up'):
+                        with open(
+                            f"/sys/class/net/{self.ethernet_interface}/operstate", "r"
+                        ) as statfile:
+                            if statfile.read().strip() == "up":
                                 return self.ethernet_message
                             else:
                                 return self.disconnected_message
                     except FileNotFoundError:
                         if not self.ethernetInterfaceNotFound:
-                            logger.error(
-                                "Ethernet interface has not been found!"
-                            )
+                            logger.error("Ethernet interface has not been found!")
                             self.ethernetInterfaceNotFound = True
                         return self.disconnected_message
                 else:

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -53,7 +53,7 @@ class Wlan(base.InLoopPollText):
     orientations = base.ORIENTATION_HORIZONTAL
     defaults = [
         ("interface", "wlan0", "The interface to monitor"),
-        ("ethint", "eth0", "The ethernet interface to monitor"),
+        ("ethernet_interface", "eth0", "The ethernet interface to monitor, it will only scan for it when no wlan connection is detected. NOTE: If you do not have a wlan device in your system ethernet functionality will not work, use the Net widget instead"),
         ("update_interval", 1, "The update interval."),
         ("disconnected_message", "Disconnected", "String to show when the wlan is diconnected."),
         ("ethernet_message", "eth", "String to show when ethernet is being used"),
@@ -73,7 +73,7 @@ class Wlan(base.InLoopPollText):
             essid, quality = get_status(self.interface)
             disconnected = essid is None
             if disconnected:
-                with open(f"/sys/class/net/{self.ethint}/operstate", "r") as statfile:
+                with open(f"/sys/class/net/{self.ethernet_interface}/operstate", "r") as statfile:
                     if (statfile.read().strip() == 'up'):
                         return self.ethernet_message
                     else:

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -27,7 +27,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import iwlib
-import os
 
 from libqtile.log_utils import logger
 from libqtile.widget import base
@@ -57,7 +56,7 @@ class Wlan(base.InLoopPollText):
         ("ethint", "eth0", "The ethernet interface to monitor"),
         ("update_interval", 1, "The update interval."),
         ("disconnected_message", "Disconnected", "String to show when the wlan is diconnected."),
-        ("ethernet_message", "Ethernet", "String to show when ethernet is being used"),
+        ("ethernet_message", "eth", "String to show when ethernet is being used"),
         (
             "format",
             "{essid} {quality}/70",
@@ -74,7 +73,8 @@ class Wlan(base.InLoopPollText):
             essid, quality = get_status(self.interface)
             disconnected = essid is None
             if disconnected:
-                if (os.popen("cat /sys/class/net/"+self.ethint+"/operstate").read().strip() == 'up'):
+                statfile = open("/sys/class/net/"+self.ethint+"/operstate", "r")
+                if (statfile.read().strip() == 'up'):
                     return self.ethernet_message
                 else:
                     return self.disconnected_message

--- a/test/widgets/test_wlan.py
+++ b/test/widgets/test_wlan.py
@@ -20,6 +20,7 @@
 
 # Widget specific tests
 
+import builtins
 import sys
 from importlib import reload
 from types import ModuleType
@@ -33,6 +34,21 @@ from libqtile.bar import Bar
 def no_op(*args, **kwargs):
     pass
 
+def mock_open(output):
+    class MockOpen:
+        def __init__(self, *args):
+            self.output = output
+
+        def __enter__(self):
+            return self
+
+        def __exit__(*exc):
+            return None
+
+        def read(self):
+            return self.output
+
+    return MockOpen
 
 class MockIwlib(ModuleType):
     DATA = {
@@ -44,7 +60,10 @@ class MockIwlib(ModuleType):
             "ESSID": b"QtileNet",
             "Mode": b"Managed",
             "stats": {"quality": 49, "level": 190, "noise": 0, "updated": 75},
-        }
+        },
+        "wlan1": {
+            "ESSID": None,
+        },
     }
 
     @classmethod
@@ -80,3 +99,22 @@ def test_wlan_display(minimal_conf_noscreen, manager_nospawn, patched_wlan, kwar
 
     text = manager_nospawn.c.bar["top"].info()["widgets"][0]["text"]
     assert text == expected
+
+@pytest.mark.parametrize(
+    "kwargs,state,expected",
+    [
+        ({"interface": "wlan1", "use_ethernet": True}, "up", "eth"),
+        ({"interface": "wlan1", "use_ethernet": True}, "down", "Disconnected"),
+        (
+            {"interface": "wlan1", "use_ethernet": True, "ethernet_message": "Wired"},
+            "up",
+            "Wired",
+        ),
+    ],
+)
+def test_ethernet(
+    minimal_conf_noscreen, manager_nospawn, patched_wlan, kwargs, state, expected, monkeypatch
+):
+    monkeypatch.setattr(builtins, "open", mock_open(state))
+    widget = patched_wlan.Wlan(**kwargs)
+    assert widget.poll() == expected

--- a/test/widgets/test_wlan.py
+++ b/test/widgets/test_wlan.py
@@ -34,6 +34,7 @@ from libqtile.bar import Bar
 def no_op(*args, **kwargs):
     pass
 
+
 def mock_open(output):
     class MockOpen:
         def __init__(self, *args):
@@ -49,6 +50,7 @@ def mock_open(output):
             return self.output
 
     return MockOpen
+
 
 class MockIwlib(ModuleType):
     DATA = {
@@ -99,6 +101,7 @@ def test_wlan_display(minimal_conf_noscreen, manager_nospawn, patched_wlan, kwar
 
     text = manager_nospawn.c.bar["top"].info()["widgets"][0]["text"]
     assert text == expected
+
 
 @pytest.mark.parametrize(
     "kwargs,state,expected",


### PR DESCRIPTION
Using `os.popen()` and a simple `cat` command it is possible to check the status of the ethernet interface that can be defined using the `ethint` parameter and then output a message that can also be changed by modifying the `ethernet_message` parameter.
I did not include this check in the case the wlan device is not detected because if the user does not have a wlan device why would they be using the `Wlan` widget in the first place? I also did not include an `ssid` parameter or `quality` parameter since those do not apply to ethernet.