### PR TITLE
Fix bar positioning when not reserving space

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -273,6 +273,11 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                     else:
                         self.x -= margin[1] + self.border_width[1]
 
+            if screen.bottom is self and not self.reserve:
+                self.y -= self.height + self.margin[2]
+            elif screen.right is self and not self.reserve:
+                self.x -= self.width + self.margin[1]
+
             self._reserved_space_updated = False
 
         width = self.width + (self.border_width[1] + self.border_width[3])


### PR DESCRIPTION
Where a bottom/right bar is used, this was positioned to the bottom/right of the available screen space which had been adjusted to leave space for the bar. However, with the introduction of the `reserve=False` configuration option, this logic fails as the available screen space is not adjusted so the bar ends up being positioned off screen. This PR corrects that logic.