### PR TITLE
Wayland Core: NULL check xdg_surface in request activate

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -847,6 +847,9 @@ class Core(base.Core, wlrq.HasListeners):
         surface = event.surface
         if surface and surface.is_xdg_surface:
             xdg_surface = XdgSurface.from_surface(surface)
+            if not xdg_surface:
+                logger.debug("Failed to find a non-NULL xdg_surface. Ignoring request.")
+                return
             if win := xdg_surface.data:
                 win.handle_activation_request(focus_on_window_activation)
             else:


### PR DESCRIPTION
In theory this could be null I think, even if we check if it's an xdg surface. MIGHT fix #4562 and helps #4568 