### PR TITLE
bump python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
                 # If you change one of these, be sure to update:
                 # - /tox.ini:[gh-actions]
                 # - /setup.cfg:[mypy]
-                # - /libqtile/scripts/check.py mypy argument
                 # If adding new python versions, consider also updating
                 # python version in .readthedocs.yaml
-                python-version: [pypy-3.9, 3.9, '3.10', '3.11']
+                python-version: [pypy-3.10, 3.9, '3.10', '3.11', '3.12']
                 backend: ['x11', 'wayland']
         steps:
             - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist=True
 minversion = 4.0.12
 envlist =
     # Python environments with specific backend
-    py{py3,39,310,311}-{x11,wayland}
+    py{py3,39,310,311,312}-{x11,wayland}
     docs,
     packaging,
     # For running pytest locally
@@ -120,7 +120,7 @@ commands =
 
 [gh-actions]
 python =
-    pypy-3.9: pypy3
+    pypy-3.10: pypy3
     3.9: py39
     3.10: py310
     3.11: py311, packaging


### PR DESCRIPTION
here's a somewhat science experiment to see if we can move to pypy 3.10 and python 3.12.

As far as I can tell, we don't need (or at least, we don't) pass mypy's --python-version flag any more, so I dropped that from the list of places to update.