### PR TITLE
Fix packaging test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include README.rst
 include MANIFEST.in
 include CONTRIBUTING.md
+include .pre-commit-config.yaml
 
 exclude .coveragerc
 exclude .pylintrc

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     # Python environments with specific backend
     py{py3,39,310,311}-{x11,wayland}
     docs,
-    packaging,
+    packaging-{x11,wayland},
     # For running pytest locally
     test-{x11,wayland,both}
 
@@ -102,7 +102,7 @@ commands =
     wayland: python -m pytest --backend=wayland {posargs}
     both: python -m pytest --backend=wayland --backend=x11 {posargs}
 
-[testenv:packaging]
+[testenv:packaging-{x11,wayland}]
 deps =
     check-manifest
     twine


### PR DESCRIPTION
The packaging test has not been running since splitting x11 and wayland backends in CI. This PR should address that by adding the backends to test in `tox.ini`.