### PR TITLE
Prevent KeyError in third party hook registries

### DIFF
--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -175,6 +175,12 @@ class Registry:
     def fire(self, event, *args, **kwargs):
         if event not in self.subscribe.hooks:
             raise utils.QtileError("Unknown event: %s" % event)
+        # We should check if the registry name is in the subscriptions dict
+        # A name can disappear if the config is reloaded (which clears subscriptions)
+        # but there are no hook subscriptions. This is not an issue for qtile core but
+        # third party libraries will need this to prevent KeyErrors when firing hooks
+        if self.name not in subscriptions:
+            subscriptions[self.name] = dict()
         for i in subscriptions[self.name].get(event, []):
             try:
                 if asyncio.iscoroutinefunction(i):


### PR DESCRIPTION
Reloading the config can cause third party hook registries to raise a KeyError when firing hooks. This is because the `subscriptions` dict is cleared but the regitry key is only created when a hook is subscribed (as the hook module is not reloaded). Therefore, if a user does not subcribe to any hooks from the third party library, this will cause the hook to fail.

Fixes: https://github.com/elParaguayo/qtile-extras/issues/301