### PR TITLE
Renderer API for Wayland.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ MOCK_MODULES = [
     "pywayland.protocol.wayland",
     "pywayland.protocol.wayland.wl_output",
     "pywayland.server",
+    "pywayland.utils",
     "wlroots",
     "wlroots.helper",
     "wlroots.util",

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
 class Output(HasListeners):
     def __init__(self, core: Core, wlr_output: wlrOutput):
         self.core = core
-        self.renderer = core.renderer
         self.wlr_output = wlr_output
         self._reserved_space = (0, 0, 0, 0)
         self.scene_output = SceneOutput.create(core.scene, wlr_output)
@@ -59,7 +58,7 @@ class Output(HasListeners):
         self.y = 0
 
         # Initialise wlr_output
-        wlr_output.init_render(core.allocator, core.renderer)
+        wlr_output.init_render(core.allocator, core.wlr_renderer)
         wlr_output.set_mode(wlr_output.preferred_mode())
         wlr_output.enable()
         wlr_output.commit()
@@ -97,7 +96,7 @@ class Output(HasListeners):
 
     def _on_frame(self, _listener: Listener, _data: Any) -> None:
         try:
-            self.scene_output.commit()
+            self.core.renderer.render(self)
         except RuntimeError:
             # Failed to commit scene output; skip rendering.
             pass

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -51,7 +51,7 @@ class Output(HasListeners):
         self.core = core
         self.wlr_output = wlr_output
         self._reserved_space = (0, 0, 0, 0)
-        self.scene_output = SceneOutput.create(core.scene, wlr_output)
+        self.scene_output: SceneOutput = SceneOutput.create(core.scene, wlr_output)
 
         # These will get updated on the output layout's change event
         self.x = 0

--- a/libqtile/backend/wayland/renderer.py
+++ b/libqtile/backend/wayland/renderer.py
@@ -135,9 +135,9 @@ class WlrootsRenderer(Renderer):
             coord += bw
 
     def destroy_borders(self, window: Window, tree: SceneTree) -> None:
-        for ptr in wl_list_for_each(
+        for ptr in list(wl_list_for_each(
                 "struct wlr_scene_node *", tree._ptr.children, "link", ffi=ffi
-        ):
+        )):
             node = SceneNode(ptr)
             if node.type == SceneNodeType.RECT:
                 node.destroy()

--- a/libqtile/backend/wayland/renderer.py
+++ b/libqtile/backend/wayland/renderer.py
@@ -45,11 +45,17 @@ class Renderer(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def create_borders(self, window: Window) -> None:
+    def create_borders(
+            self,
+            window: Window,
+            tree: SceneTree,
+            colors: ColorsType,
+            width: int
+    ) -> None:
         pass
 
     @abstractmethod
-    def destroy_borders(self, window: Window) -> None:
+    def destroy_borders(self, window: Window, tree: SceneTree) -> None:
         pass
 
     @abstractmethod

--- a/libqtile/backend/wayland/renderer.py
+++ b/libqtile/backend/wayland/renderer.py
@@ -1,21 +1,21 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod, ABCMeta
 import functools
+from abc import abstractmethod, ABCMeta
 from typing import TYPE_CHECKING
 
 from pywayland.utils import wl_list_for_each, wl_container_of
-
 from wlroots.wlr_types.scene import SceneRect, SceneNode, SceneNodeType
 
 from libqtile import utils
 
 if TYPE_CHECKING:
+    from wlroots.wlr_types.scene import SceneTree
     from libqtile.backend.wayland.core import Core
     from libqtile.backend.wayland.output import Output
     from libqtile.backend.wayland.window import Window
-    from libqtile.utils import ColorType
+    from libqtile.utils import ColorType, ColorsType
 
 try:
     # Continue if ffi not built, so that docs can be built without wayland deps.
@@ -60,16 +60,19 @@ class Renderer(metaclass=ABCMeta):
 class WlrootsRenderer(Renderer):
     """This renderer uses the wlroots scene graph renderer."""
 
-    def create_borders(self, window: Window) -> None:
+    def create_borders(
+            self,
+            window: Window,
+            tree: SceneTree,
+            colors: ColorsType,
+            width: int
+    ) -> None:
         # The borders are wlr_scene_rects.
         # They come in groups of four: N, E, S, W edges
         # These groups form the outside-in borders i.e. multiple
         # for multiple borders
-        width = window.borderwidth
-        colors = window.bordercolor
-
         if width == 0:
-            self.destroy_borders(window)
+            self.destroy_borders(window, tree)
             return
 
         if len(colors) > width:
@@ -80,20 +83,16 @@ class WlrootsRenderer(Renderer):
         # We can re-use old border nodes, but let's get rid of any extras.
         borders = []
         for ptr in wl_list_for_each(
-                "struct wlr_scene_node *",
-                window.container._ptr.children,
-                "link",
-                ffi=ffi
+                "struct wlr_scene_node *", tree._ptr.children, "link", ffi=ffi
         ):
             node = SceneNode(ptr)
             if node.type == SceneNodeType.RECT:
-                rect_ptr = wl_container_of(
-                    ptr, "struct wlr_scene_rect *", "node", ffi=ffi)
+                rect_ptr = wl_container_of(ptr, "struct wlr_scene_rect *", "node", ffi=ffi)
                 borders.append(SceneRect(ptr=rect_ptr))
 
-        for rect in borders[num*4:]:
+        for rect in borders[num * 4 :]:
             rect.node.destroy()
-        borders = borders[:num*4]
+        borders = borders[: num * 4]
 
         widths = [width // num] * num
         for i in range(width % num):
@@ -124,22 +123,14 @@ class WlrootsRenderer(Renderer):
                     rect.set_size(w, h)
                     rect.node.set_position(x, y)
                 except IndexError:
-                    rect = SceneRect(window.container, w, h, color_)
+                    rect = SceneRect(tree, w, h, color_)
                     rect.node.set_position(x, y)
 
             coord += bw
 
-        # Ensure the window contents and any nested surfaces are drawn above the
-        # borders.
-        if window.tree:
-            window.tree.node.raise_to_top()
-
-    def destroy_borders(self, window: Window) -> None:
+    def destroy_borders(self, window: Window, tree: SceneTree) -> None:
         for ptr in wl_list_for_each(
-                "struct wlr_scene_node *",
-                window.container._ptr.children,
-                "link",
-                ffi=ffi
+                "struct wlr_scene_node *", tree._ptr.children, "link", ffi=ffi
         ):
             node = SceneNode(ptr)
             if node.type == SceneNodeType.RECT:

--- a/libqtile/backend/wayland/renderer.py
+++ b/libqtile/backend/wayland/renderer.py
@@ -1,0 +1,151 @@
+
+from __future__ import annotations
+
+from abc import abstractmethod, ABCMeta
+import functools
+from typing import TYPE_CHECKING
+
+from pywayland.utils import wl_list_for_each, wl_container_of
+
+from wlroots.wlr_types.scene import SceneRect, SceneNode, SceneNodeType
+
+from libqtile import utils
+
+if TYPE_CHECKING:
+    from libqtile.backend.wayland.core import Core
+    from libqtile.backend.wayland.output import Output
+    from libqtile.backend.wayland.window import Window
+    from libqtile.utils import ColorType
+
+try:
+    # Continue if ffi not built, so that docs can be built without wayland deps.
+    from libqtile.backend.wayland._ffi import ffi
+except ModuleNotFoundError:
+    pass
+
+
+@functools.lru_cache()
+def _rgb(color: ColorType) -> ffi.CData:
+    """Helper to create and cache float[4] arrays for border painting"""
+    if isinstance(color, ffi.CData):
+        return color
+    return ffi.new("float[4]", utils.rgb(color))
+
+
+class Renderer(metaclass=ABCMeta):
+    """This class is responsible for rendering the scene graph.
+
+    This includes painting borders.
+    """
+
+    def __init__(self, core: Core) -> None:
+        self.core = core
+
+    def finalize(self) -> None:
+        pass
+
+    @abstractmethod
+    def create_borders(self, window: Window) -> None:
+        pass
+
+    @abstractmethod
+    def destroy_borders(self, window: Window) -> None:
+        pass
+
+    @abstractmethod
+    def render(self, output: Output) -> None:
+        pass
+
+
+class WlrootsRenderer(Renderer):
+    """This renderer uses the wlroots scene graph renderer."""
+
+    def create_borders(self, window: Window) -> None:
+        # The borders are wlr_scene_rects.
+        # They come in groups of four: N, E, S, W edges
+        # These groups form the outside-in borders i.e. multiple
+        # for multiple borders
+        width = window.borderwidth
+        colors = window.bordercolor
+
+        if width == 0:
+            self.destroy_borders(window)
+            return
+
+        if len(colors) > width:
+            colors = colors[:width]
+
+        num = len(colors)
+
+        # We can re-use old border nodes, but let's get rid of any extras.
+        borders = []
+        for ptr in wl_list_for_each(
+                "struct wlr_scene_node *",
+                window.container._ptr.children,
+                "link",
+                ffi=ffi
+        ):
+            node = SceneNode(ptr)
+            if node.type == SceneNodeType.RECT:
+                rect_ptr = wl_container_of(
+                    ptr, "struct wlr_scene_rect *", "node", ffi=ffi)
+                borders.append(SceneRect(ptr=rect_ptr))
+
+        for rect in borders[num*4:]:
+            rect.node.destroy()
+        borders = borders[:num*4]
+
+        widths = [width // num] * num
+        for i in range(width % num):
+            widths[i] += 1
+
+        outer_w = window.width + width * 2
+        outer_h = window.height + width * 2
+        coord = 0
+
+        for i, color in enumerate(colors):
+            color_ = _rgb(color)
+            bw = widths[i]
+
+            # [x, y, width, height] for N, E, S, W
+            geometries = (
+                (coord, coord, outer_w - coord * 2, bw),
+                (outer_w - bw - coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
+                (coord, outer_h - bw - coord, outer_w - coord * 2, bw),
+                (coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
+            )
+
+            rects = borders[:4]
+            borders = borders[4:]
+            for i, (x, y, w, h) in enumerate(geometries):
+                try:
+                    rect = rects[i]
+                    rect.set_color(color_)
+                    rect.set_size(w, h)
+                    rect.node.set_position(x, y)
+                except IndexError:
+                    rect = SceneRect(window.container, w, h, color_)
+                    rect.node.set_position(x, y)
+
+            coord += bw
+
+        # Ensure the window contents and any nested surfaces are drawn above the
+        # borders.
+        if window.tree:
+            window.tree.node.raise_to_top()
+
+    def destroy_borders(self, window: Window) -> None:
+        for ptr in wl_list_for_each(
+                "struct wlr_scene_node *",
+                window.container._ptr.children,
+                "link",
+                ffi=ffi
+        ):
+            node = SceneNode(ptr)
+            if node.type == SceneNodeType.RECT:
+                node.destroy()
+
+    def render(self, output: Output) -> None:
+        """Render the scene graph to [output]."""
+        # wlroots does all the work
+        output.scene_output.commit()

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -74,6 +74,7 @@ class Config:
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but
     # doing so forces the import, creating a hard dependency for wlroots.
     wl_input_rules: dict[str, Any] | None
+    wl_renderer: type
 
     def __init__(self, file_path=None, **settings):
         """Create a Config() object from settings

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -74,7 +74,7 @@ class Config:
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but
     # doing so forces the import, creating a hard dependency for wlroots.
     wl_input_rules: dict[str, Any] | None
-    wl_renderer: type
+    wl_renderer: type | None
 
     def __init__(self, file_path=None, **settings):
         """Create a Config() object from settings

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -212,6 +212,9 @@ auto_minimize = True
 # When using the Wayland backend, this can be used to configure input devices.
 wl_input_rules = None
 
+# Experimental: this can be used to install a custom renderer under Wayland.
+wl_renderer = None
+
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the
 # mailing lists, GitHub issues, and other WM documentation that suggest setting


### PR DESCRIPTION
This PR is a simple framework for installing a custom renderer in Wayland, as discussed here: https://github.com/qtile/qtile/discussions/4553 .  There's a new abstract class called `Renderer` and an implementation called `WlrootsRenderer` that retains the current behavior.

There are only a few substantive changes:
- Now `wayland.output.Output` calls `core.renderer.render(self)` instead of `scene_output.commit()`.
- Now `wayland.window.Window.paint_borders` calls `core.renderer.create_borders(self)` to allow for custom borders.
- I moved the logic from `Window.paint_borders` to `WlrootsRenderer`.
- There's a new config option `wl_renderer`, which can optionally be set to install a custom renderer. 

I also deleted `wayland.window.Internal.paint_borders`, since it seems never to be used (??).