### PR TITLE
Groupbox: Set spacing to margin_x in configure

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -243,8 +243,6 @@ class GroupBox(_GroupBase):
     def __init__(self, **config):
         _GroupBase.__init__(self, **config)
         self.add_defaults(GroupBox.defaults)
-        if self.spacing is None:
-            self.spacing = self.margin_x
         self.clicked = None
         self.click = None
 
@@ -257,6 +255,11 @@ class GroupBox(_GroupBase):
                 }
             )
         self.add_callbacks(default_callbacks)
+
+    def _configure(self, qtile, bar):
+        _GroupBase._configure(self, qtile, bar)
+        if self.spacing is None:
+            self.spacing = self.margin_x
 
     @property
     def groups(self):


### PR DESCRIPTION
`widget_defaults` is not picked up in `__init__`, which means that after a config reload we get different spacing (`margin_x` will be different).

discussed on discord