### PR TITLE
[x11] Fix focus event on `Window.focus()`

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -267,8 +267,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
                 self.y + self._height / 2,
             )
 
-        if self.group:
-            self.group.current_window = self
+        if self.group and self.group.current_window is not self:
+            self.group.focus(self)
 
         hook.fire("client_focus", self)
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1327,11 +1327,11 @@ class _Window:
         self.qtile.core._root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
         self._ungrab_click()
 
-        if self.group:
-            self.group.current_window = self
-
         # Check if we need to restack a previously focused fullscreen window
         self.qtile.core.check_stacking(self)
+
+        if self.group and self.group.current_window is not self:
+            self.group.focus(self)
 
         hook.fire("client_focus", self)
 

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -1,6 +1,6 @@
 import pytest
 
-from libqtile import config, layout, resources
+from libqtile import bar, config, layout, resources, widget
 from libqtile.confreader import Config
 from test.conftest import BareConfig, dualmonitor
 from test.layouts.layout_utils import assert_focused
@@ -305,3 +305,31 @@ def test_set_position(manager):
 
     # Also check if there is only one client now
     assert len(manager.c.layout.info()["clients"]) == 1
+
+
+class WindowNameConfig(BareConfig):
+    screens = [
+        config.Screen(
+            bottom=bar.Bar(
+                [
+                    widget.WindowName(),
+                ],
+                20,
+            ),
+        ),
+    ]
+    layouts = [layout.Columns()]
+
+
+@pytest.mark.parametrize("manager", [WindowNameConfig], indirect=True)
+def test_focus_switch(manager):
+    def _wnd(name):
+        return manager.c.window[{w["name"]: w["id"] for w in manager.c.windows()}[name]]
+
+    manager.test_window("One")
+    manager.test_window("Two")
+
+    assert manager.c.widget["windowname"].info()["text"] == "Two"
+
+    _wnd("One").focus()
+    assert manager.c.widget["windowname"].info()["text"] == "One"


### PR DESCRIPTION
When calling `Window.focus()` the borders did not update on the focused window and the `WindowName` widget did not reflect the change.

Fixes #3751

I believe this works because the existing code set the current window in the group but, by doing that, it bypassed all the logic updating the layouts. Then, when the hook was called, because the window was already the `current_window` no changes were required. So, by removing the setting line, the hook then triggers all the relevant updates.