### PR TITLE
improve ratio calculation

### DIFF
--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -83,9 +83,10 @@ class GridInfo:
             sample_width = width / cols
             sample_height = height / rows
             sample_ratio = sample_width / sample_height
-            diff = abs(sample_ratio - self.ratio)
-            if best_ratio is None or diff < best_ratio:
-                best_ratio = diff
+            if sample_ratio < 1:
+                sample_ratio = 1/sample_ratio
+            if best_ratio is None or sample_ratio < best_ratio:
+                best_ratio = sample_ratio
                 best_rows_cols_orientation = (rows, cols, orientation)
 
         return best_rows_cols_orientation


### PR DESCRIPTION
I added a RatioTile(ratio=1) object in my config and noticed that the
layout favored 3 upright elongated windows on a screen that is 1.125 higher than wide.
So they are really really slim, 1.125 tall and  0.333 wide.
The ratio is 1.125/(1/3)=3.375
But I expected them to be 3 wide "landscape" windows because that would be
1.125/3 tall and 1 wide, which is a better ratio because if you see the ratio
as longer_edge_of_window/shorter_edge_of_window then it is
1/(1.125/3)= 2.666
I think if this patch is applied it is needed to also change the default GOLDEN_RATIO value in the code. The golden_ratio value made windows wider and for me they were to high, so maybe it compensated
for this and I wouldn't have noticed it if I hadn't changed the default ratio.