### PR TITLE
imapwidget: Do not pass None as username to keyring.get_password()

### DIFF
--- a/libqtile/widget/imapwidget.py
+++ b/libqtile/widget/imapwidget.py
@@ -24,6 +24,7 @@ import re
 
 import keyring
 
+from libqtile.confreader import ConfigError
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
@@ -75,6 +76,8 @@ class ImapWidget(base.ThreadPoolText):
     def __init__(self, **config):
         base.ThreadPoolText.__init__(self, "", **config)
         self.add_defaults(ImapWidget.defaults)
+        if self.user is None:
+            raise ConfigError("You must set the 'user' parameter for the IMAP widget.")
         password = keyring.get_password("imapwidget", self.user)
         if password is not None:
             self.password = password

--- a/test/widgets/test_widget_init_configure.py
+++ b/test/widgets/test_widget_init_configure.py
@@ -58,6 +58,7 @@ extras = [
 
 # To skip a test entirely, list the widget class here
 no_test = [widgets.Mirror, widgets.PulseVolume]  # Mirror requires a reflection object
+no_test += [widgets.ImapWidget]  # Requires a configured username
 
 # To test a widget only under one backend, list the widget class here
 exclusive_backend = {


### PR DESCRIPTION
Ensure not to pass `None` as the username to `keyring.get_password()`, as the API requires it to always be a `str` and some backends (particularly `keyrings-alt`) crash on `None`.

Fixes #4609