### PR TITLE
Don't bring static windows to front.

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1345,8 +1345,6 @@ class Core(base.Core, wlrq.HasListeners):
             elif self.qtile.config.bring_front_click == "floating_only":
                 if isinstance(win, base.Window) and win.floating:
                     win.bring_to_front()
-                elif isinstance(win, base.Static):
-                    win.bring_to_front()
 
             if isinstance(win, window.Static):
                 if win.screen is not self.qtile.current_screen:


### PR DESCRIPTION
The Wayland backend raises a Static window when `config.bring_front_click == "floating_only"`.  The x11 backend does not (as far as I can tell), and this doesn't seem like it would be the desired behavior.