### PR TITLE
Implement move_to_{top,bottom} in Wayland

### DIFF
--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -197,7 +197,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         """
 
     @expose_command()
-    def move_to_top(self) -> None:
+    def move_to_top(self, force: bool = False) -> None:
         """
         Move this window above all windows in the current layer
         e.g. if you have 3 windows all with "keep_above" set, calling
@@ -205,10 +205,13 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
         Calling this on a "normal" window will not raise it above a "kept_above"
         window.
+
+        Will not raise a window where "keep_below" is True unless
+        force is set to True.
         """
 
     @expose_command()
-    def move_to_bottom(self) -> None:
+    def move_to_bottom(self, force: bool = False) -> None:
         """
         Move this window below all windows in the current layer
         e.g. if you have 3 windows all with "keep_above" set, calling
@@ -216,6 +219,9 @@ class _Window(CommandObject, metaclass=ABCMeta):
 
         Calling this on a "normal" window will not raise it below a "kept_below"
         window.
+
+        Will not lower a window where "keep_above" is True unless
+        force is set to True.
         """
 
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -776,6 +776,16 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     def is_visible(self) -> bool:
         return self.container.node.enabled
 
+    @expose_command()
+    def move_to_top(self) -> None:
+        if self.tree:
+            self.tree.node.raise_to_top()
+
+    @expose_command()
+    def move_to_bottom(self) -> None:
+        if self.tree:
+            self.tree.node.lower_to_bottom()
+
     @abc.abstractmethod
     def _to_static(
         self, x: int | None, y: int | None, width: int | None, height: int | None
@@ -904,6 +914,14 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
     @expose_command()
     def bring_to_front(self) -> None:
         self.container.node.raise_to_top()
+
+    @expose_command()
+    def move_to_top(self) -> None:
+        self.container.node.raise_to_top()
+
+    @expose_command()
+    def move_to_bottom(self) -> None:
+        self.container.node.lower_to_bottom()
 
     @expose_command()
     def info(self) -> dict:
@@ -1108,6 +1126,14 @@ class Internal(_Base, base.Internal):
     @expose_command()
     def bring_to_front(self) -> None:
         self.tree.node.raise_to_top()
+
+    @expose_command()
+    def move_to_top(self) -> None:
+        self.tree.node.raise_to_top()
+
+    @expose_command()
+    def move_to_bottom(self) -> None:
+        self.tree.node.lower_to_bottom()
 
 
 WindowType = typing.Union[Window, Static, Internal]

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -777,12 +777,12 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
         return self.container.node.enabled
 
     @expose_command()
-    def move_to_top(self) -> None:
+    def move_to_top(self, force=False) -> None:
         if self.tree:
             self.tree.node.raise_to_top()
 
     @expose_command()
-    def move_to_bottom(self) -> None:
+    def move_to_bottom(self, force=False) -> None:
         if self.tree:
             self.tree.node.lower_to_bottom()
 
@@ -916,11 +916,11 @@ class Static(typing.Generic[S], _Base, base.Static, HasListeners):
         self.container.node.raise_to_top()
 
     @expose_command()
-    def move_to_top(self) -> None:
+    def move_to_top(self, force=False) -> None:
         self.container.node.raise_to_top()
 
     @expose_command()
-    def move_to_bottom(self) -> None:
+    def move_to_bottom(self, force=False) -> None:
         self.container.node.lower_to_bottom()
 
     @expose_command()
@@ -1128,11 +1128,11 @@ class Internal(_Base, base.Internal):
         self.tree.node.raise_to_top()
 
     @expose_command()
-    def move_to_top(self) -> None:
+    def move_to_top(self, force=False) -> None:
         self.tree.node.raise_to_top()
 
     @expose_command()
-    def move_to_bottom(self) -> None:
+    def move_to_bottom(self, force=False) -> None:
         self.tree.node.lower_to_bottom()
 
 


### PR DESCRIPTION
This adds `move_to_top()` and `move_to_bottom()` to Wayland windows.  The `bring_to_front()` command had already been implemented, and these do essentially the same thing.  (Before there was no command to lower a Wayland window.)