### PR TITLE
 Config: Support lists in Match for backwards compatibility 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.xx.x, released XXXX-XX-XX:
     !!! config breakage/changes !!!
       - Matches no longer use "include/substring" style matching. But match the string exactly. Previously on X11, if the WM_TYPE of a spawned window is e.g. dialog a match with wm_type dialognoonereadschangelogs would return true. Additionally a window with an empty WM_CLASS (which can happen) would match anything. If you rely this style of substring matching, pass a regex to your match or use a function with func=.
+        Using a list of strings inside Match with role, title, wm_class, wm_instance_class, wm_type are also deprecated, use a regex. Right now we replace the property with a regex if it's a list and warn with a deprecation message. You can use "qtile migrate" to migrate your config to this.
     * features
       - Change how `tox` runs tests. See https://docs.qtile.org/en/latest/manual/contributing.html#running-tests-locally
       for more information on how to run tests locally.

--- a/docs/manual/config/groups.rst
+++ b/docs/manual/config/groups.rst
@@ -22,7 +22,7 @@ Example
     groups = [
         Group("a"),
         Group("b"),
-        Group("c", matches=[Match(wm_class=["Firefox"])]),
+        Group("c", matches=[Match(wm_class="Firefox")]),
     ]
 
     # allow mod3+1 through mod3+0 to bind to groups; if you bind your groups

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -851,7 +851,7 @@ class Match:
     title:
         Match against the WM_NAME atom (X11) or title (Wayland).
     wm_class:
-        Match against the second string in WM_CLASS atom (X11) or app ID (Wayland).
+        Match against any value in the whole WM_CLASS atom (X11) or app ID (Wayland).
     role:
         Match against the WM_ROLE atom (X11 only).
     wm_type:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -28,6 +28,7 @@
 from __future__ import annotations
 
 import os.path
+import re
 import sys
 from typing import TYPE_CHECKING
 
@@ -37,7 +38,6 @@ from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    import re
     from typing import Any, Callable, Iterable
 
     from libqtile.backend import base
@@ -818,6 +818,20 @@ class ScratchPad(Group):
         )
 
 
+def convert_deprecated_list(vals: list[str], name: str) -> re.Pattern:
+    # make a regex with OR on word boundaries
+    regex_input = r"^({})$".format("|".join(map(re.escape, vals)))
+    logger.warning(
+        "Your Match with the %s property is using lists which are deprecated, replace Match(%s=%s) with Match(%s=re.compile(r\"%s\")) after importing the 're' module",
+        name,
+        name,
+        vals,
+        name,
+        regex_input,
+    )
+    return re.compile(regex_input)
+
+
 class Match:
     """
     Window properties to compare (match) with a window.
@@ -868,10 +882,18 @@ class Match:
         self._rules: dict[str, Any] = {}
 
         if title is not None:
+            if isinstance(title, list):  # type: ignore
+                title = convert_deprecated_list(title, "title")  # type: ignore
             self._rules["title"] = title
         if wm_class is not None:
+            if isinstance(wm_class, list):  # type: ignore
+                wm_class = convert_deprecated_list(wm_class, "wm_class")  # type: ignore
             self._rules["wm_class"] = wm_class
         if wm_instance_class is not None:
+            if isinstance(wm_instance_class, list):  # type: ignore
+                wm_instance_class = convert_deprecated_list(  # type: ignore
+                    wm_instance_class, "wm_instance_class"
+                )
             self._rules["wm_instance_class"] = wm_instance_class
         if wid is not None:
             self._rules["wid"] = wid
@@ -885,8 +907,12 @@ class Match:
             self._rules["func"] = func
 
         if role is not None:
+            if isinstance(role, list):  # type: ignore
+                role = convert_deprecated_list(role, "role")  # type: ignore
             self._rules["role"] = role
         if wm_type is not None:
+            if isinstance(wm_type, list):  # type: ignore
+                wm_type = convert_deprecated_list(wm_type, "wm_type")  # type: ignore
             self._rules["wm_type"] = wm_type
 
     @staticmethod

--- a/libqtile/scripts/migrations/match_list_regex.py
+++ b/libqtile/scripts/migrations/match_list_regex.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023, elParaguayo. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import libcst as cst
+import libcst.matchers as m
+from libcst import codemod
+from libcst.codemod.visitors import AddImportsVisitor
+
+from libqtile.scripts.migrations._base import (
+    Check,
+    MigrationTransformer,
+    _QtileMigrator,
+    add_migration,
+)
+
+try:
+    import isort
+
+    can_sort = True
+except ImportError:
+    can_sort = False
+
+
+class MatchRegexTransformer(MigrationTransformer):
+    def __init__(self, *args, **kwargs):
+        self.needs_import = False
+        MigrationTransformer.__init__(self, *args, **kwargs)
+
+    @m.call_if_inside(
+        m.Call(func=m.Name("Match")) | m.Call(func=m.Attribute(attr=m.Name("Match")))
+    )
+    @m.leave(m.Arg(value=m.List(), keyword=m.Name()))
+    def update_match_args(self, original_node, updated_node) -> cst.Arg:
+        """Changes positional  argumentto 'widgets' kwargs."""
+        name = original_node.keyword.value
+        if not (all(isinstance(e.value, cst.SimpleString) for e in original_node.value.elements)):
+            self.lint(
+                original_node,
+                f"The {name} keyword uses a list but the migrate script can not fix this as "
+                f"not all elements are strings.",
+            )
+            return updated_node
+
+        joined_text = "|".join(e.value.value.strip("'\"") for e in original_node.value.elements)
+        regex = cst.parse_expression(f"""re.compile(r"^({joined_text})$")""")
+        self.lint(
+            original_node,
+            f"The use of a list for the {name} argument is deprecated. "
+            f"Please replace with 're.compile(r\"^({joined_text})$\")'.",
+        )
+        self.needs_import = True
+        return updated_node.with_changes(value=regex)
+
+
+class MatchListRegex(_QtileMigrator):
+    ID = "MatchListRegex"
+
+    SUMMARY = "Updates Match objects using lists"
+
+    HELP = """
+    The use of lists in ``Match`` objects is deprecated and should be
+    replaced with a regex.
+
+    For example:
+
+    .. code:: python
+
+        Match(wm_class=["one", "two"])
+
+    should be changed to:
+
+    .. code::
+
+        Match(wm_class=re.compile(r"^(one|two)$"))
+
+    """
+
+    AFTER_VERSION = "0.23.0"
+
+    TESTS = [
+        Check(
+            """
+            from libqtile.config import Match
+
+            Match(wm_class=["one", "two"])
+            """,
+            """
+            import re
+
+            from libqtile.config import Match
+
+            Match(wm_class=re.compile(r"^(one|two)$"))
+            """,
+        ),
+    ]
+
+    def run(self, original_node):
+        # Run the base transformer first...
+        # This fixes simple replacements
+        transformer = MatchRegexTransformer()
+        updated = original_node.visit(transformer)
+
+        # Update details of linting
+        self.update_lint(transformer)
+
+        # Check if we replaced any lists and now need to add re import
+        if transformer.needs_import:
+            # Create a context to store details of changes
+            context = codemod.CodemodContext()
+            AddImportsVisitor.add_needed_import(context, "re")
+            add_visitor = AddImportsVisitor(context)
+
+            # Run the transformations
+            updated = add_visitor.transform_module(updated)
+
+            if can_sort:
+                updated = cst.parse_module(isort.code(updated.code))
+            else:
+                print("Unable to sort import lines.")
+
+        return original_node, updated
+
+
+add_migration(MatchListRegex)

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ testdeps =
     {wayland,x11}: coverage
     libcst >= 1.0.0
     PyGObject   
+    isort
 commands =
     !x11: pip install pywlroots==0.16.4
     pip install .


### PR DESCRIPTION
This was broken in https://github.com/qtile/qtile/pull/4603

IMO we should only support regexes and strings going forwards, like the docstring already says. I have replaced the existing lists with regexes. See https://github.com/search?q=wm_class%3D%5B%22&type=code, it's still widely used

I could also remove the deprecation notice as supporting this is pretty trivial, thoughts?