### PR TITLE
Update build process - make Wayland build optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Build wheels
         run: |
           python -m pip install cffi build auditwheel
-          python -m build --wheel .
+          python -m build --config-setting backend=wayland --wheel .
           ls dist/
           auditwheel show dist/qtile-*.whl
           auditwheel repair --plat manylinux_2_28_x86_64 -w output_wheels dist/qtile-*.whl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include README.rst
 include MANIFEST.in
 include CONTRIBUTING.md
 include .pre-commit-config.yaml
+include builder.py
 
 exclude .coveragerc
 exclude .pylintrc

--- a/builder.py
+++ b/builder.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023, elParaguayo. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import sys
+
+from setuptools import build_meta as _orig
+from setuptools.build_meta import *  # noqa: F401,F403
+
+WAYLAND_DEPENDENCIES = ["pywlroots>=0.16.4,<0.17.0"]
+
+
+def wants_wayland(config_settings):
+    if config_settings:
+        for key in ["Backend", "backend"]:
+            if config_settings.get(key, "").lower() == "wayland":
+                return True
+
+    return False
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    """Inject pywlroots into build dependencies if wayland requested."""
+    reqs = _orig.get_requires_for_build_wheel(config_settings)
+    if wants_wayland(config_settings):
+        reqs += WAYLAND_DEPENDENCIES
+
+    return reqs
+
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    """Stop building if wayland requested but pywlroots is not installed."""
+    if wants_wayland(config_settings):
+        try:
+            import wlroots  # noqa: F401
+        except ImportError:
+            sys.exit("Wayland backend requested but pywlroots is not installed.")
+
+    return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)

--- a/docs/manual/faq.rst
+++ b/docs/manual/faq.rst
@@ -172,36 +172,6 @@ Where are the log files for Qtile?
 
 The log files for qtile are at ``~/.local/share/qtile/qtile.log``.
 
-Why do I get an ``AttributeError`` when building Qtile?
-=======================================================
-
-If you see this message:
-``AttributeError: cffi library 'libcairo.so.2' has no function, constant or global variable named 'cairo_xcb_surface_create'``
-when building Qtile then your Cairo version lacks XCB support.
-
-If it happens, it might be because the ``cairocffi`` and ``xcffib`` dependencies
-were installed in the wrong order.
-
-To fix this:
-
-1. uninstall them from your environment: with ``pip uninstall cairocffi xcffib``
-   if using a virtualenv, or with your system package-manager if you installed
-   the development version of Qtile system-wide.
-#. re-install them sequentially (again, with pip or with your package-manager)::
-
-    pip install xcffib
-    pip install --no-cache-dir cairocffi
-
-See `this issue comment`_ for more information.
-
-.. _`this issue comment`: https://github.com/qtile/qtile/issues/994#issuecomment-497984551
-
-If you are using your system package-manager and the issue still happens,
-the packaging of ``cairocffi`` might be broken for your distribution.
-Try to contact the persons responsible for ``cairocffi``'s packaging
-on your distribution, or to install it from the sources with ``xcffib``
-available.
-
 How can I match the bar with picom?
 ===================================
 

--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -57,9 +57,7 @@ only the dependencies of one of these is required.
 +-------------------+-------------------------+-----------------------------------------+
 | CFFI_             | python3-cffi            | Bars and popups                         |
 +-------------------+-------------------------+-----------------------------------------+
-| cairocffi_        | python3-cairocffi       | Drawing on bars and popups (if using    |
-|                   |                         | X11 install xcffib BEFORE installing    |
-|                   |                         | cairocffi, see below)                   |
+| cairocffi_        | python3-cairocffi       | Drawing on bars and popups              |
 +-------------------+-------------------------+-----------------------------------------+
 | libpangocairo     | libpangocairo-1.0-0     | Writing on bars and popups              |
 +-------------------+-------------------------+-----------------------------------------+
@@ -93,20 +91,6 @@ only the dependencies of one of these is required.
 .. _dbus-next: https://python-dbus-next.readthedocs.io/en/latest/index.html
 
 
-cairocffi
----------
-
-Qtile uses cairocffi_ for drawing on status bars and popup windows. Under X11,
-cairocffi requires XCB support via xcffib, which you should be sure to have
-installed **before** installing cairocffi; otherwise, the needed cairo-xcb
-bindings will not be built. Once you've got the dependencies installed, you can
-use the latest version on PyPI:
-
-.. code-block:: bash
-
-    pip install --no-cache-dir cairocffi
-
-
 Qtile
 -----
 
@@ -131,11 +115,7 @@ Or install qtile-git with:
     git clone https://github.com/qtile/qtile.git
     cd qtile
     pip install .
-
-As long as the necessary libraries are in place, this can be done at any point,
-however, it is recommended that you first install xcffib to ensure the
-cairo-xcb bindings are built (X11 only) (see above).
-
+    pip install --config-setting backend=wayland .  # adds wayland dependencies
 
 .. _starting-qtile:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = [
     "setuptools>=60",
     "setuptools-scm>=7.0",
     "wheel",
-    "pywlroots>=0.16.4,<0.17.0"
 ]
-build-backend = "setuptools.build_meta"
+backend-path=["."]
+build-backend = "builder"
 
 [project]
 name = "qtile"


### PR DESCRIPTION
This is an attempt to fix some issues that users are having with building qtile and not wanting the Wayland backend.

The PR removes `pywlroots` from the build dependencies and uses a custom build backend to inject the requirement if the wayland backend is specifically requested.

The builder will also raise an error if the backend is requested but `pywroots` is not installed. This is useful for `--no-build-isolation` flag as that builds against pre-installed libraries.

Comments welcome.