### PR TITLE
[x11 stacking] filter unknown windows

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1040,6 +1040,9 @@ class _Window:
             )
         )
 
+        # Remove any windows that aren't in the server's stack
+        windows = list(filter(lambda w: w[0].wid in stack, windows))
+
         # Sort this list to match stacking order reported by server
         windows.sort(key=lambda w: stack.index(w[0].wid))
 


### PR DESCRIPTION
There have been two recent reports of users seeing an error where stacking fails because a window cannot be found in the X server's stack. This shouldn't happen but let's filter out unknown windows.