### PR TITLE
Fixed typo, "my" -> "by"

### DIFF
--- a/docs/manual/commands/interfaces.rst
+++ b/docs/manual/commands/interfaces.rst
@@ -52,7 +52,7 @@ on how you intend to use it as each interface is suited to different scenarios.
 
 * The ``lazy`` interface is used in config scripts to bind commands to keys and
   mouse callbacks.
-* The ``qtile shell`` is a tool for exploring the graph my presenting it as a
+* The ``qtile shell`` is a tool for exploring the graph by presenting it as a
   file structure. It is not designed to be used for scripting.
 * For users creating shell scripts, the ``qtile cmd-obj`` interface would be
   the recommended choice.


### PR DESCRIPTION
found the typo while reading https://docs.qtile.org/en/stable/manual/commands/interfaces.html