### PR TITLE
Docs: Small fixes in documentation

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -404,10 +404,10 @@ class ScreenRect:
 
 
 class Screen(CommandObject):
-    """
+    r"""
     A physical screen, and its associated paraphernalia.
 
-    Define a screen with a given set of :class:`Bar`s of a specific geometry. Also,
+    Define a screen with a given set of :class:`Bar`\s of a specific geometry. Also,
     ``x``, ``y``, ``width``, and ``height`` aren't specified usually unless you are
     using 'fake screens'.
 

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -626,7 +626,7 @@ hooks: list[Hook] = [
             from libqtile import hook
             from libqtile.utils import send_notification
 
-            @hook.subscribe.client_killed
+            @hook.subscribe.client_mouse_enter
             def client_mouse_enter(client):
                 send_notification("qtile", f"Mouse has entered {client.name}")
 

--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -52,7 +52,7 @@ class Backlight(base.InLoopPollText):
 
     You can also bind keyboard shortcuts to the backlight widget with:
 
-    .. code-block: python
+    .. code-block:: python
 
         from libqtile.widget import backlight
         Key(


### PR DESCRIPTION
Doc fixes:
- Properly escape role in config.py
- Fix decorator name in client_mouse_enter hook
- Fix invisible code block in Backlight widget