### PR TITLE
Add :meth:`Spiral.left` and :meth:`Spiral.right` to allow moving left/right on Spiral Layout

### DIFF
--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -378,7 +378,10 @@ class Spiral(_SimpleLayoutBase):
         coords = info["layout_info"]
         focused_x, focused_y, *_ = coords[info["current"]]
 
-        min_x_diff = min(x - focused_x for x, *_ in coords if x > focused_x)
+        diffs = tuple(x - focused_x for x, *_ in coords if x > focused_x)
+        if not diffs:
+            return
+        min_x_diff = min(diffs)
         # find the windows that are a minimal x distance away
         min_x = [
             (idx, x, y) for idx, (x, y, *_) in enumerate(coords) if x - focused_x == min_x_diff

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -343,6 +343,54 @@ class Spiral(_SimpleLayoutBase):
         d["clockwise"] = self.clockwise
         return d
 
+    @expose_command()
+    def left(self) -> None:
+        info = self.info()
+        if not info["focused"]:
+            return
+        # get coordinates of top left corner of windows
+        coords = info["layout_info"]
+        focused_x, focused_y, *_ = coords[info["current"]]
+
+        # if we can't go more left quit early
+        if (focused_x, focused_y) == (0, 0):
+            return
+
+        min_x_diff = min(focused_x - x for x, *_ in coords if x < focused_x)
+        # find the windows that are a minimal x distance away
+        min_x = [
+            (idx, x, y) for idx, (x, y, *_) in enumerate(coords) if focused_x - x == min_x_diff
+        ]
+        # and sort by how close their y value is to the current
+        min_x.sort(key=lambda x: abs(focused_y - coords[x[0]][1]))
+
+        new_idx = min_x[0][0]
+        # go to window by index
+        self.clients.current_index = new_idx
+        self.group.focus(self.clients[new_idx])
+
+    @expose_command()
+    def right(self) -> None:
+        info = self.info()
+        if not info["focused"]:
+            return
+        # get coordinates of top left corner of windows
+        coords = info["layout_info"]
+        focused_x, focused_y, *_ = coords[info["current"]]
+
+        min_x_diff = min(x - focused_x for x, *_ in coords if x > focused_x)
+        # find the windows that are a minimal x distance away
+        min_x = [
+            (idx, x, y) for idx, (x, y, *_) in enumerate(coords) if x - focused_x == min_x_diff
+        ]
+        # and sort by how close their y value is to the current
+        min_x.sort(key=lambda x: abs(focused_y - coords[x[0]][1]))
+
+        new_idx = min_x[0][0]
+        # go to window by index
+        self.clients.current_index = new_idx
+        self.group.focus(self.clients[new_idx])
+
     @expose_command("up")
     def previous(self) -> None:
         _SimpleLayoutBase.previous(self)


### PR DESCRIPTION
The title explains it pretty well what I tried to accomplish. 
Hopefully I can pull out the pieces to reduce the code redundency, and if there are any (better) ways to get things like the layout or the currently focused coordinates please let me know! It's my first time with the codebase so I'm not 100% familiar with everything.

## Algorithm Explanation
I'll explain the left side only, as the right side is almost the exact same.
Consider a spiral like the following
![A spiral layout](https://github.com/qtile/qtile/assets/110117391/45b2bca8-b3ce-4acb-bb9d-295a58da1113)
The way we decide what the window to the left of it is is by ranking the distances of the x coordinate of each window to the x coordinate of the current window. For example for the green window the shortest distance is $1440-960=480$.
Now there are three windows with an x distance of $480$, so we sort them by the *absolute value* of the differences in the $y$ coordinates. The window with the shortest distance in both the $x$ and $y$ directions is the one that gets chosen. In this case the shortest distance in the $y$ direction is obviously black, as they have the same $y$ value.

## Future PRs
Maybe in future PRs a similar idea could be applied to up/down (instead of the current `next`/`previous` renames we seem to have) and there could be some configuration for the way windows are selected based on their $y$ value.
