### PR TITLE
Fix duplicate key message with dgroups_key_binder

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -475,6 +475,9 @@ class Qtile(CommandObject):
         """Grab the given key event"""
         syms = self.core.grab_key(key)
         if syms in self.keys_map:
+            if self.keys_map[syms] == key:
+                # We've already bound this key definition
+                return
             logger.warning("Key spec duplicated, overriding previous: %s", key)
         self.keys_map[syms] = key
 


### PR DESCRIPTION
The dgroups_key_binder creates key bindings for the groups and adds these keys to the config `keys` variable (this was needed to ensure keys were correctly grabbed when exiting a KeyChord - see 9d65ae2e8f0a5283506f7db0d38ee14544fb5067) but this results in multiple attempts to bind the same key. This PR silences warnings when the same key definition is passed.

Fixes #4651