### PR TITLE
Delete non-persistent groups when windows are moved to another group

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.xx.x, released XXXX-XX-XX:
     * features
     * bugfixes
+      - Fix groups marked with `persist=False` not being deleted when their last window is moved to another group.
 
 Qtile 0.24.0, released 2024-01-20:
     !!! config breakage/changes !!!

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -301,7 +301,17 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             if self.group.screen:
                 # for floats remove window offset
                 self.x -= self.group.screen.x
+            group_ref = self.group
             self.group.remove(self)
+            # delete groups with `persist=False`
+            if (
+                not self.qtile.dgroups.groups_map[group_ref.name].persist
+                and len(group_ref.windows) <= 1
+            ):
+                # set back original group so _del() can grab it
+                self.group = group_ref
+                self.qtile.dgroups._del(self)
+                self.group = None
 
         if group.screen and self.x < group.screen.x:
             self.x += group.screen.x

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -2009,7 +2009,16 @@ class Window(_Window, base.Window):
             if self.group.screen:
                 # for floats remove window offset
                 self.x -= self.group.screen.x
+            group_ref = self.group
             self.group.remove(self)
+            if (
+                not self.qtile.dgroups.groups_map[group_ref.name].persist
+                and len(group_ref.windows) <= 1
+            ):
+                # set back original group so _del() can grab it
+                self.group = group_ref
+                self.qtile.dgroups._del(self)
+                self.group = None
 
         if group.screen and self.x < group.screen.x:
             self.x += group.screen.x

--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -254,4 +254,5 @@ class DGroups:
             del self.timeout[client]
 
         logger.debug("Deleting %s in %ss", group, self.delay)
-        self.timeout[client] = self.qtile.call_later(self.delay, delete_client)
+        if client not in self.timeout:
+            self.timeout[client] = self.qtile.call_later(self.delay, delete_client)


### PR DESCRIPTION
Fix #4654

Save a reference to the original group before removing it from the client and set it back before calling `DGroups._del(client)` so it can grab the reference and schedule it for deletion.

Check if the client has already been scheduled for deletion in order to avoid scheduling the same client multiple times and generating a `KeyError`.