### PR TITLE
Use deepcopy to clone widgets

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -400,7 +400,7 @@ class _Widget(CommandObject, configurable.Configurable):
         return Mirror(self, background=self.background)
 
     def clone(self):
-        return copy.copy(self)
+        return copy.deepcopy(self)
 
     def mouse_enter(self, x, y):
         pass


### PR DESCRIPTION
Widgets' `clone` method used `copy.copy`. This causes an issue where widgets defined list and dicts during `__init__` as these are not copied and, instead, the same object is shared between widget instances. Using `copy.deepcopy` should mean these objects are also copied.

Fixes #4668