### PR TITLE
[X11] Bring windows activated by pager to front

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -2135,6 +2135,7 @@ class Window(_Window, base.Window):
                 logger.debug("Focusing window by pager")
                 self.qtile.current_screen.set_group(self.group)
                 self.group.focus(self)
+                self.bring_to_front()
             else:  # XCB_EWMH_CLIENT_SOURCE_TYPE_OTHER
                 focus_behavior = self.qtile.config.focus_on_window_activation
                 if focus_behavior == "focus":


### PR DESCRIPTION
Qtile follows spec for stacking windows. However, this spec itself doesn't provide a way for window switcher to change the stacking order. That's why most EWMH-compatible WMs in response to _NET_ACTIVE_WINDOW not only change focus, but also raise the window to the top of the stack.

Qtile already has code for handling activation by a pager so we can just add code to bring the window to the front.

Closes #4670