### PR TITLE
Move bring_to_front to _Window

### DIFF
--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -218,6 +218,17 @@ class _Window(CommandObject, metaclass=ABCMeta):
         window.
         """
 
+    @abstractmethod
+    @expose_command()
+    def bring_to_front(self) -> None:
+        """
+        Bring the window to the front.
+
+        In X11, `bring_to_front` ignores all other layering rules and brings the
+        window to the very front. When that window loses focus, it will be stacked
+        again according the appropriate rules.
+        """
+
 
 class Window(_Window, metaclass=ABCMeta):
     """
@@ -392,17 +403,6 @@ class Window(_Window, metaclass=ABCMeta):
     @expose_command()
     def disable_fullscreen(self) -> None:
         """Un-fullscreen the window"""
-
-    @abstractmethod
-    @expose_command()
-    def bring_to_front(self) -> None:
-        """
-        Bring the window to the front.
-
-        In X11, `bring_to_front` ignores all other layering rules and brings the
-        window to the very front. When that window loses focus, it will be stacked
-        again according the appropriate rules.
-        """
 
     @abstractmethod
     @expose_command()
@@ -587,11 +587,6 @@ class Static(_Window, metaclass=ABCMeta):
             height=self.height,
             id=self.wid,
         )
-
-    @abstractmethod
-    @expose_command()
-    def bring_to_front(self) -> None:
-        """Bring the window to the front"""
 
 
 WindowType = typing.Union[Window, Internal, Static]

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1489,6 +1489,13 @@ class _Window:
         self.window.set_property("_NET_WM_STATE", reply)
         self.change_layer(up=False)
 
+    @expose_command()
+    def bring_to_front(self):
+        if self.get_wm_type() != "desktop":
+            self.window.configure(stackmode=xcffib.xproto.StackMode.Above)
+            self.raise_children()
+            self.qtile.core.update_client_lists()
+
 
 class Internal(_Window, base.Internal):
     """An internal window, that should not be managed by qtile"""
@@ -1659,13 +1666,6 @@ class Static(_Window, base.Static):
         name = self.qtile.core.conn.atoms.get_name(e.atom)
         if name == "_NET_WM_STRUT_PARTIAL":
             self.update_strut()
-
-    @expose_command()
-    def bring_to_front(self):
-        if self.get_wm_type() != "desktop":
-            self.window.configure(stackmode=xcffib.xproto.StackMode.Above)
-            self.raise_children()
-            self.qtile.core.update_client_lists()
 
 
 class Window(_Window, base.Window):
@@ -2292,13 +2292,6 @@ class Window(_Window, base.Window):
     @expose_command()
     def disable_fullscreen(self):
         self.fullscreen = False
-
-    @expose_command()
-    def bring_to_front(self):
-        if self.get_wm_type() != "desktop":
-            self.window.configure(stackmode=xcffib.xproto.StackMode.Above)
-            self.raise_children()
-            self.qtile.core.update_client_lists()
 
     def _is_in_window(self, x, y, window):
         return window.edges[0] <= x <= window.edges[2] and window.edges[1] <= y <= window.edges[3]


### PR DESCRIPTION
Moving `bring_to_front` to the `base._Window` class. Two reasons:
1) Avoid code duplication
2) Allow Popups (which are Internal windows) to utilise `bring_to_front`.

@jwijenbergh I haven't touched Wayland code. Let me know if we should change it too.