### PR TITLE
Make stretch optional for TaskList

### DIFF
--- a/test/widgets/test_tasklist.py
+++ b/test/widgets/test_tasklist.py
@@ -211,3 +211,15 @@ def test_tasklist_bad_theme_mode(tasklist_manager, logger):
 def test_tasklist_no_xdg(tasklist_manager, logger):
     msgs = [rec.msg for rec in logger.get_records("setup")]
     assert "You must install pyxdg to use theme icons." in msgs
+
+
+@configure_tasklist(stretch=False)
+def test_tasklist_no_stretch(tasklist_manager):
+    widget = tasklist_manager.c.widget["tasklist"]
+    tasklist_manager.test_window("One")
+    width_one = widget.info()["width"]
+
+    tasklist_manager.test_window("Two")
+    width_two = widget.info()["width"]
+
+    assert width_one != width_two


### PR DESCRIPTION
Adds ability to disable strech behaviour for the TaskList widget. This is helpful for users who wish to give the widget a background colour but don't want the widget to fill all available space.

Closes #3854