### PR TITLE
[wayland] Add environment variable to configure cursor size

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -108,6 +108,8 @@ if TYPE_CHECKING:
     from libqtile.core.manager import Qtile
 
 
+DEFAULT_CURSOR_SIZE = 24
+
 class ImplicitGrab(wlrq.HasListeners):
     """Keep track of an implicit pointer grab.
 
@@ -226,7 +228,17 @@ class Core(base.Core, wlrq.HasListeners):
 
         # Set up cursor
         self.cursor = Cursor(self.output_layout)
-        self.cursor_manager = XCursorManager(24)
+        size = DEFAULT_CURSOR_SIZE
+        size_str = os.environ.get("XCURSOR_SIZE")
+        if size_str:
+            try:
+                size = int(size_str)
+                if size <= 0:
+                    size = DEFAULT_CURSOR_SIZE
+            except ValueError:
+                logger.info("Failed to use XCURSOR_SIZE.")
+
+        self.cursor_manager = XCursorManager(size)
         self._gestures = PointerGesturesV1(self.display)
         self._pressed_button_count = 0
         self._implicit_grab: ImplicitGrab | None = None


### PR DESCRIPTION
At X11 the way to configure the cursor_size is done by configuring XCURSOR_SIZE https://man.archlinux.org/man/Xcursor.3#XCURSOR_SIZE

There sadly is no standardized way to do that in wayland, the weston-example compositor also does it by XCURSOR_SIZE https://man.archlinux.org/man/weston.1.en#XCURSOR_SIZE
https://gitlab.freedesktop.org/wayland/weston/-/blob/master/clients/window.c#L1338

I added the same approach to qtile with this pr 