### PR TITLE
Fix background bug for mirrored widgets

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -959,7 +959,7 @@ class Mirror(_Widget):
         self._length = value
 
     def draw(self):
-        self.drawer.clear(self.reflects.background or self.bar.background)
+        self.drawer.clear_rect()
         self.reflects.drawer.paint_to(self.drawer)
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
 


### PR DESCRIPTION
Since the refactoring of the `Drawer` class, widget backgrounds are now drawn to the drawer's RecordingSurface. However, `Mirror.draw` paints the widget background with the background colour before copying the contents of the recording surface. This means that the background is painted twice, causing issues where widgets had semi translucent backgrounds.

This PR fixes the issue by clearing the drawer before copying the recording surface.

Fixes #4589