### PR TITLE
battery: add "fancy" charge control

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Qtile x.xx.x, released XXXX-XX-XX:
     * features
+      - The Battery widget now supports dynamic charge control, allowing for
+        protecting battery life.
     * bugfixes
 
 Qtile 0.24.0, released 2024-01-20:

--- a/test/widgets/docs_screenshots/ss_battery.py
+++ b/test/widgets/docs_screenshots/ss_battery.py
@@ -32,6 +32,8 @@ def widget(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
     monkeypatch.setattr("libqtile.widget.battery.load_battery", dummy_load_battery(loaded_bat))
     yield libqtile.widget.battery.Battery

--- a/test/widgets/docs_screenshots/ss_batteryicon.py
+++ b/test/widgets/docs_screenshots/ss_batteryicon.py
@@ -32,6 +32,8 @@ def widget(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     monkeypatch.setattr("libqtile.widget.battery.load_battery", dummy_load_battery(loaded_bat))

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -35,6 +35,8 @@ def test_text_battery_charging(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -51,6 +53,8 @@ def test_text_battery_discharging(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -67,6 +71,8 @@ def test_text_battery_full(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -90,6 +96,8 @@ def test_text_battery_empty(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -111,6 +119,8 @@ def test_text_battery_empty(monkeypatch):
         percent=0.0,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -127,6 +137,8 @@ def test_text_battery_not_charging(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -143,6 +155,8 @@ def test_text_battery_unknown(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -159,6 +173,8 @@ def test_text_battery_hidden(monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     with monkeypatch.context() as manager:
@@ -233,12 +249,16 @@ def test_battery_background(fake_qtile, fake_window, monkeypatch):
         percent=0.5,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
     low = BatteryStatus(
         state=BatteryState.DISCHARGING,
         percent=0.1,
         power=15.0,
         time=1729,
+        charge_start_threshold=0,
+        charge_end_threshold=100,
     )
 
     low_background = "ff0000"
@@ -258,3 +278,74 @@ def test_battery_background(fake_qtile, fake_window, monkeypatch):
     batt._battery._status = ok
     batt.poll()
     assert batt.background == background
+
+
+def test_charge_control(fake_qtile, fake_window, monkeypatch):
+    start = 0
+    end = 100
+
+    def save_battery_percentage(self, charge_start_threshold, charge_end_threshold):
+        nonlocal start
+        nonlocal end
+
+        start = charge_start_threshold
+        end = charge_end_threshold
+
+    with monkeypatch.context() as manager:
+        manager.setattr(
+            battery._LinuxBattery, "set_battery_charge_thresholds", save_battery_percentage
+        )
+        batt = Battery(charge_controller=lambda: (5, 10))
+
+        fakebar = FakeBar([batt], window=fake_window)
+        batt._configure(fake_qtile, fakebar)
+        batt.poll()
+
+        assert start == 5
+        assert end == 10
+
+
+def test_charge_control_disabled(fake_qtile, fake_window, monkeypatch):
+    start = 4
+    end = 7
+
+    def save_battery_percentage(self, charge_start_threshold, charge_end_threshold):
+        raise "should not be called"
+
+    with monkeypatch.context() as manager:
+        manager.setattr(
+            battery._LinuxBattery, "set_battery_charge_thresholds", save_battery_percentage
+        )
+        batt = Battery(charge_controller=None)
+
+        fakebar = FakeBar([batt], window=fake_window)
+        batt._configure(fake_qtile, fakebar)
+        batt.poll()
+
+        assert start == 4
+        assert end == 7
+
+
+def test_charge_control_force_charge(fake_qtile, fake_window, monkeypatch):
+    start = 4
+    end = 7
+
+    def save_battery_percentage(self, charge_start_threshold, charge_end_threshold):
+        nonlocal start
+        nonlocal end
+
+        start = charge_start_threshold
+        end = charge_end_threshold
+
+    with monkeypatch.context() as manager:
+        manager.setattr(
+            battery._LinuxBattery, "set_battery_charge_thresholds", save_battery_percentage
+        )
+        batt = Battery(charge_controller=lambda: (0, 90), force_charge=True)
+
+        fakebar = FakeBar([batt], window=fake_window)
+        batt._configure(fake_qtile, fakebar)
+        batt.poll()
+
+        assert start == 0
+        assert end == 100


### PR DESCRIPTION
Inspired by this talk at FOSDEM:

https://fosdem.org/2024/schedule/event/fosdem-2024-2123-from-kernel-api-to-desktop-integration-how-do-we-integrate-battery-charge-limiting-in-the-desktop/

I wrote some "smart charge" logic for qtile. It probably needs better detection of other kinds of docking stations, since all I have is a thunderbolt one. But at least this is a start.