### PR TITLE
Don't attempt to reload config if file has been removed

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -115,8 +115,8 @@ class Config:
                     continue
 
                 # Check if the module is in the config folder or subfolder
-                # if so, reload it
-                if folder in subpath.parents:
+                # and the file still exists.  If so, reload it
+                if folder in subpath.parents and subpath.exists():
                     importlib.reload(module)
 
     def load(self):


### PR DESCRIPTION
Currently, if a previously imported file has been deleted in a user's config (eg. due to reorganization), this will break config reloading until qtile is restarted.

This adds a check that the file still exists before attempting to reload.