### PR TITLE
Fix error if an wayland xwindow has unknown wm_type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Qtile 0.24.0, released 2024-01-20:
       - Fix two bugs in stacking transient windows in X11
       - Checking configs containing `qtile.core.name` with `python config.py` don't fail anymore (but `qtile.core.name`
         will be `None`)
+      - Fix an error if a wayland xwindow has unknown wm_type
 
 Qtile 0.23.0, released 2023-09-24:
     !!! Dependency Changes !!!

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -258,9 +258,9 @@ class XWindow(Window[xwayland.Surface]):
         return self.surface.pid
 
     def get_wm_type(self) -> str | None:
-        wm_type = self.surface.window_type
-        if wm_type:
-            return self.core.xwayland_atoms[wm_type[0]]
+        for wm_type in self.surface.window_type:
+            if wm_type in self.core.xwayland_atoms:
+                return self.core.xwayland_atoms[wm_type]
         return None
 
     def get_wm_role(self) -> str | None:


### PR DESCRIPTION
This re-applies a past fix (see #3612) that apparently got lost during a refactoring (see #3704).

If an xwayland window has an unknown type (in my case a slack huddle window), the error appears and the window will not be visible.