### PR TITLE
Allow providing a callback to make when a drag operation finishes.

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -184,7 +184,8 @@ class Drag(Mouse):
     warp_pointer:
         A :class:`bool` indicating if the pointer should be warped to the bottom right of the window
         at the start of dragging. (Default: `False`)
-
+    end:
+        A :class:`LazyCall` object to be evaluated when dragging finishes. (Optional)
     """
 
     def __init__(
@@ -194,9 +195,11 @@ class Drag(Mouse):
         *commands: LazyCall,
         start: LazyCall | None = None,
         warp_pointer: bool = False,
+        end: LazyCall | None = None,
     ) -> None:
         super().__init__(modifiers, button, *commands)
         self.start = start
+        self.end = end
         self.warp_pointer = warp_pointer
 
     def __repr__(self) -> str:
@@ -363,13 +366,20 @@ class EzDrag(EzConfig, Drag):
         A list :class:`LazyCall` objects to evaluate in sequence upon drag.
     start:
         A :class:`LazyCall` object to be evaluated when dragging begins. (Optional)
-
+    end:
+        A :class:`LazyCall` object to be evaluated when dragging finishes. (Optional)
     """
 
-    def __init__(self, btndef: str, *commands: LazyCall, start: LazyCall | None = None) -> None:
+    def __init__(
+        self,
+        btndef: str,
+        *commands: LazyCall,
+        start: LazyCall | None = None,
+        end: LazyCall | None = None,
+    ) -> None:
         modkeys, button = self.parse(btndef)
         button = "Button%s" % button
-        super().__init__(modkeys, button, *commands, start=start)
+        super().__init__(modkeys, button, *commands, start=start, end=end)
 
 
 class ScreenRect:

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -115,8 +115,8 @@ class Config:
                     continue
 
                 # Check if the module is in the config folder or subfolder
-                # if so, reload it
-                if folder in subpath.parents:
+                # and the file still exists.  If so, reload it
+                if folder in subpath.parents and subpath.exists():
                     importlib.reload(module)
 
     def load(self):


### PR DESCRIPTION
This adds a callback that will be invoked when a drag window operation finishes.

The default configuration lets you drag windows between screens / groups as floating windows, but I wanted it to revert the floating status at the end (ie. when the button is released), so it'd snap into the other screens layout rather than needing to re-tile it as a second step.  Adding a callback here allows this to be configurable by something like:

    Drag([mod], "Button1", lazy.window.set_position_floating(),
            start=lazy.window.get_position(), end=lazy.window.toggle_floating() ),

