### PR TITLE
ci: bump action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
                 python-version: [pypy-3.10, 3.9, '3.10', '3.11', '3.12']
                 backend: ['x11', 'wayland']
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Set up python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Install dependencies


### PR DESCRIPTION
We are getting

    Node.js 16 actions are deprecated. Please update the following actions
    to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For
    more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

in our github actions logs. Let's update.