### PR TITLE
docs: drop ubuntu packaging

### DIFF
--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -1,24 +1,10 @@
 ==============================
-Installing on Debian or Ubuntu
+Installing on Ubuntu or Debian 11 (bullseye) or greater
 ==============================
 
-To install the latest stable version of Qtile on Ubuntu (newer than 20.04) and Debian 9:
-
-.. code-block:: bash
-
-   pip install xcffib
-   pip install qtile
-
-To install the git version see :ref:`installing-from-source`
-
-Note: As of Ubuntu 20.04 (Focal Fossa), the package has been outdated
-and removed from the Ubuntu's official package list.
-
-Debian 11 (bullseye)
---------------------
-
-Debian 11 comes with the necessary packages for installing Qtile. Starting 
-from a minimal Debian installation, the following packages are required:
+Ubuntu and Debian >=11 comes with the necessary packages for installing Qtile.
+Starting from a minimal Debian installation, the following packages are
+required:
 
 .. code-block:: bash
 


### PR DESCRIPTION
20.04 is almost end of life, and it doesn't have qtile anyway, which means all supported versions of ubuntu no longer have qtile packages.