### PR TITLE
Bind keys with keycodes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * features
         - Make default `Plasma` add mode dynamic
         - Add `background` parameter to `Screen` to paint a solid colour background
+        - Add ability to use key codes to bind keys. Will benefit users who change keyboard layouts but
+          wish to retain same bindings, irrespective of layout.
 
     * bugfixes
       - Fix `Plasma` layout with `ScreenSplit` by implementing `get_windows`

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -239,6 +239,7 @@ class Keyboard(_Device):
                 layout=layout, options=options, variant=variant
             )
             self._keymaps[(layout, options, variant)] = keymap
+        self._state = keymap.state_new()
         self.keyboard.set_keymap(keymap)
 
     def _on_modifier(self, _listener: Listener, _data: Any) -> None:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -479,11 +479,17 @@ class Core(base.Core):
 
     def lookup_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Find the keysym and the modifier mask for the given key"""
-        try:
-            keysym = xcbq.get_keysym(key.key)
-            modmask = xcbq.translate_masks(key.modifiers)
-        except xcbq.XCBQError as err:
-            raise utils.QtileError(err)
+        if isinstance(key.key, str):
+            keysym = xcbq.keysyms.get(key.key.lower())
+            if not keysym:
+                raise utils.QtileError("Unknown keysym: %s" % key.key)
+
+        else:
+            keysym = self.conn.code_to_syms[key.key][0]
+            if not keysym:
+                raise utils.QtileError("Unknown keycode: %s" % key.key)
+
+        modmask = xcbq.translate_masks(key.modifiers)
 
         return keysym, modmask
 
@@ -645,7 +651,6 @@ class Core(base.Core):
 
     def handle_KeyPress(self, event, *, simulated=False) -> None:  # noqa: N802
         assert self.qtile is not None
-
         keysym = self.conn.code_to_syms[event.detail][0]
         key, handled = self.qtile.process_key_event(keysym, event.state & self._valid_mask)
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -62,7 +62,8 @@ class Key:
         ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
         ``"mod4"``, ``"mod5"``.
     key:
-        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``.
+        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``. Also accepts
+        an integer value representing a keycode.
     commands:
         One or more :class:`LazyCall` objects to evaluate in sequence upon keypress. Multiple
         commands should be separated by commas.
@@ -76,7 +77,7 @@ class Key:
     def __init__(
         self,
         modifiers: list[str],
-        key: str,
+        key: str | int,
         *commands: LazyCall,
         desc: str = "",
         swallow: bool = True,
@@ -102,7 +103,8 @@ class KeyChord:
         ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
         ``"mod4"``, ``"mod5"``.
     key:
-        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``.
+        A key specification, e.g. ``"a"``, ``"Tab"``, ``"Return"``, ``"space"``. Also accepts
+        an integer value representing a keycode.
     submappings:
         A list of :class:`Key` or :class:`KeyChord` declarations to bind in this chord.
     mode:
@@ -124,7 +126,7 @@ class KeyChord:
     def __init__(
         self,
         modifiers: list[str],
-        key: str,
+        key: str | int,
         submappings: list[Key | KeyChord],
         mode: bool | str = False,
         name: str = "",

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -150,7 +150,7 @@ class Config:
         # because they are dynamically resolved from the default_config. so we
         # need to ignore the errors here about missing attributes.
         for k in self.keys:
-            if k.key.lower() not in valid_keys:
+            if isinstance(k.key, str) and k.key.lower() not in valid_keys:
                 raise ConfigError("No such key: %s" % k.key)
             for m in k.modifiers:
                 if m.lower() not in valid_mods:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -483,8 +483,10 @@ class Qtile(CommandObject):
         Useful when a keyboard mapping event is received.
         """
         self.core.ungrab_keys()
-        for key in self.keys_map.values():
-            self.core.grab_key(key)
+        keys = self.keys_map.copy()
+        self.keys_map.clear()
+        for key in keys.values():
+            self.grab_key(key)
 
     def grab_key(self, key: Key | KeyChord) -> None:
         """Grab the given key event"""
@@ -1085,7 +1087,12 @@ class Qtile(CommandObject):
 
         def walk_binding(k: Key | KeyChord, mode: str) -> None:
             nonlocal rows
-            modifiers, name = ", ".join(k.modifiers), k.key
+            modifiers = ", ".join(k.modifiers)
+            if isinstance(k.key, int):
+                name = hex(k.key)
+            else:
+                name = k.key
+
             if isinstance(k, Key):
                 if not k.commands:
                     return


### PR DESCRIPTION
Draft for now...

Based on the discussion in #933 this is an attempt to allow users to bind keys via keycode rather than keysym.

Keycodes can be bound with:
```python
Key([mod], key_code, lazy...)
```
Where `key_code` is an integer value (compared to keysyms being strings).

Ideally, I need users to test this and report any bugs.

@jwijenbergh @m-col would welcome thoughts on the wayland implementation. I've hardcoded this to match against `self.keyboards[0]` but not sure if that's appropriate or not.

CI will almost certainly fail for the time being too!