### PR TITLE
sleep: don't complain about missing dbus-next

### DIFF
--- a/libqtile/resources/sleep.py
+++ b/libqtile/resources/sleep.py
@@ -83,7 +83,6 @@ class Inhibitor:
         for a sleep or wake signal.
         """
         if not has_dbus:
-            logger.warning("dbus-next is not installed. Cannot run inhibitor process.")
             return
 
         if not (self.sleep or self.resume):


### PR DESCRIPTION
This originally started as a patch that looked like this:

    diff --git a/libqtile/hook.py b/libqtile/hook.py
    index c3df2d16..8640cb8d 100644
    --- a/libqtile/hook.py
    +++ b/libqtile/hook.py
    @@ -192,6 +192,9 @@ class Registry:
                 except:  # noqa: E722
                     logger.exception("Error in hook %s", event)

    +    def has_hook(self, event):
    +        return len(subscriptions[self.name].get(event, [])) > 0
    +

     hooks: list[Hook] = [
         Hook(
    @@ -1032,3 +1035,4 @@ qtile_hooks = Registry("qtile", hooks)
     subscribe = qtile_hooks.subscribe
     unsubscribe = qtile_hooks.unsubscribe
     fire = qtile_hooks.fire
    +has_hook = qtile_hooks.has_hook
    diff --git a/libqtile/resources/sleep.py b/libqtile/resources/sleep.py
    index 5038b93d..7618f3be 100644
    --- a/libqtile/resources/sleep.py
    +++ b/libqtile/resources/sleep.py
    @@ -82,7 +82,7 @@ class Inhibitor:
             Will create connection to dbus only if we want to listen out
             for a sleep or wake signal.
             """
    -        if not has_dbus:
    +        if not has_dbus and any(map(hook.has_hook, ["suspend", "resume"])):
                 logger.warning("dbus-next is not installed. Cannot run inhibitor process.")
                 return

but then when testing it, I realized this functionality already exists, via wants_sleep(), which does:

    2024-02-24 08:51:07,524 WARNING libqtile sleep.py:want_sleep():L68 dbus-next must be installed to listen to sleep signals

So let's just drop this message entirely, since it's a duplicate warning in the case where users have hooks installed, and it's a spurious warning in the case when they don't.