### PR TITLE
Fix WindowTabs use of parse_text

### DIFF
--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 from libqtile import bar, hook, pangocffi
+from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
@@ -62,7 +63,11 @@ class WindowTabs(base._TextBox):
     def update(self, *args):
         names = []
         for w in self.bar.screen.group.windows:
-            name = self.parse_text(w.name if w and w.name else " ")
+            try:
+                name = self.parse_text(w.name if w and w.name else "")
+            except:  # noqa: E722
+                logger.exception("parse_text function failed:")
+                name = w.name if w and w.name else "(unnamed)"
             state = ""
             if w.maximized:
                 state = "[] "

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -23,7 +23,6 @@
 # SOFTWARE.
 
 from libqtile import bar, hook, pangocffi
-from libqtile.log_utils import logger
 from libqtile.widget import base
 
 

--- a/libqtile/widget/windowtabs.py
+++ b/libqtile/widget/windowtabs.py
@@ -39,15 +39,10 @@ class WindowTabs(base._TextBox):
         ("selected", ("<b>", "</b>"), "Selected task indicator"),
         (
             "parse_text",
-            None,
-            "Function to parse and modify window names. "
-            "e.g. function in config that removes excess "
-            "strings from window name: "
-            "def my_func(text)"
-            '    for string in [" - Chromium", " - Firefox"]:'
-            '        text = text.replace(string, "")'
-            "   return text"
-            "then set option parse_text=my_func",
+            lambda window_name: window_name,
+            "Function to modify window names. It must accept "
+            "a string argument (original window name) and return "
+            "a string with the modified name.",
         ),
     ]
 
@@ -68,6 +63,7 @@ class WindowTabs(base._TextBox):
     def update(self, *args):
         names = []
         for w in self.bar.screen.group.windows:
+            name = self.parse_text(w.name if w and w.name else " ")
             state = ""
             if w.maximized:
                 state = "[] "
@@ -75,15 +71,9 @@ class WindowTabs(base._TextBox):
                 state = "_ "
             elif w.floating:
                 state = "V "
-            task = "%s%s" % (state, w.name if w and w.name else " ")
-            task = pangocffi.markup_escape_text(task)
+            task = pangocffi.markup_escape_text(state + name)
             if w is self.bar.screen.group.current_window:
                 task = task.join(self.selected)
             names.append(task)
         self.text = self.separator.join(names)
-        if callable(self.parse_text):
-            try:
-                self.text = self.parse_text(self.text)
-            except:  # noqa: E722
-                logger.exception("parse_text function failed:")
         self.bar.draw()

--- a/test/widgets/test_windowtabs.py
+++ b/test/widgets/test_windowtabs.py
@@ -28,6 +28,10 @@ from libqtile.config import Screen
 from libqtile.confreader import Config
 
 
+def custom_text_parser(name):
+    return f"TEST-{name}-TEST"
+
+
 class WindowTabsConfig(Config):
     auto_fullscreen = True
     groups = [libqtile.config.Group("a"), libqtile.config.Group("b")]
@@ -40,6 +44,7 @@ class WindowTabsConfig(Config):
             top=bar.Bar(
                 [
                     widget.WindowTabs(),
+                    widget.WindowTabs(name="customparse", parse_text=custom_text_parser),
                 ],
                 24,
             ),
@@ -136,3 +141,10 @@ def test_escaping_text(manager):
     """
     manager.test_window("Text & Text")
     assert manager.c.widget["windowtabs"].info()["text"] == "<b>Text &amp; Text</b>"
+
+
+@windowtabs_config
+def test_custom_text_parser(manager):
+    """Test the custom text parser function."""
+    manager.test_window("one")
+    assert manager.c.widget["customparse"].info()["text"] == "<b>TEST-one-TEST</b>"


### PR DESCRIPTION
This fixes the issue raised in #3741 by using the parser function for each window title before any state or markup is applied, similarly to what is done for the TaskList widget.

Additionally, instead of checking if the value is callable, it uses a default callable value and also skips the `try...except` block. I believe any raised  errors will be logged anyway, won't they? And with better debug information than only `"parse_text function failed:"`