### PR TITLE
Fix bugs in Mirror widget

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -937,6 +937,8 @@ class Mirror(_Widget):
         self.reflects = reflection
         self._length = 0
         self.length_type = self.reflects.length_type
+        if self.length_type is bar.STATIC:
+            self._length = self.reflects._length
 
     def _configure(self, qtile, bar):
         _Widget._configure(self, qtile, bar)
@@ -959,6 +961,8 @@ class Mirror(_Widget):
         self._length = value
 
     def draw(self):
+        if self.length <= 0:
+            return
         self.drawer.clear_rect()
         self.reflects.drawer.paint_to(self.drawer)
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)


### PR DESCRIPTION
The Mirror widget has two bugs:
1) Static width widgets do not have their width copied to the reflection
2) Negative width widgets break the widget.

The use case for point 2 is a bit of a hack: a `Spacer` with a negative width will not be drawn as the widget is only drawn where the width is greater than zero. However, the length is taken into account when positioning other widgets in ths bar.

This PR fixes both issues by setting the width and preventing the widget from drawing when it has a width <= 0.