### PR TITLE
Remove rogue print statements from tests

### DIFF
--- a/test/extension/test_dmenu.py
+++ b/test/extension/test_dmenu.py
@@ -109,5 +109,4 @@ def test_j4dmenu_configuration_options():
         extension = J4DmenuDesktop(**config)
         extension._configure(None)
         index = extension.configured_command.index(output[0])
-        print(extension.configured_command)
         assert output == extension.configured_command[index : index + len(output)]

--- a/test/layouts/test_ratiotile.py
+++ b/test/layouts/test_ratiotile.py
@@ -298,7 +298,6 @@ def test_ratiotile_alternative_calculation(manager):
 
     for i in range(12):
         manager.test_window(str(i))
-        print(manager.c.layout.info()["layout_info"])
         if i == 0:
             assert manager.c.layout.info()["layout_info"] == [(0, 0, 800, 600)]
         elif i == 4:

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -82,7 +82,6 @@ class MockMPD(ModuleType):
             self._status["state"] = "pause"
 
         def play(self):
-            print("PLAYING")
             self._status["state"] = "play"
 
         def stop(self):


### PR DESCRIPTION
There are some tests that still have print statements but these look intentional. However, the ones removed by this PR were clearly left over from when the tests were being written!