### PR TITLE
add support for dumping current threads

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -1,5 +1,7 @@
 import argparse
+import faulthandler
 import logging
+import signal
 import sys
 from pathlib import Path
 
@@ -24,6 +26,11 @@ def check_folder(value):
 
 
 def main():
+    faulthandler.enable(all_threads=True)
+    # This is a bit unfortunate. We use SIGUSR1&2 for reloading config &
+    # restarting qtile, so we overload SIGWINCH here to dump threads.
+    faulthandler.register(signal.SIGWINCH, all_threads=True)
+
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
         "-l",


### PR DESCRIPTION
We are seeing some strange hangs in CI, e.g.

https://github.com/qtile/qtile/actions/runs/8239452558/job/22532678205

which prints lots of stacks, but they are only the test stacks, and not qtile's stacks. However, you can see the test suite waiting and eventually SIGKILLING qtile,

        Killing qtile forcefully
        qtile exited with exitcode: -9

so clearly qtile is deadlocked somewhere, but we have no idea where.

Python since 3.3 has a nice thing where you can print all the threads of a currently running qtile, which might give us a clue where it's deadlocked. The output looks like:

    Thread 0x00007f5e1bfff640 (most recent call first):
      File "/usr/lib/python3.10/concurrent/futures/thread.py", line 81 in _worker
      File "/usr/lib/python3.10/threading.py", line 953 in run
      File "/usr/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
      File "/usr/lib/python3.10/threading.py", line 973 in _bootstrap

    Thread 0x00007f5e2892a640 (most recent call first):
      File "/usr/lib/python3.10/concurrent/futures/thread.py", line 81 in _worker
      File "/usr/lib/python3.10/threading.py", line 953 in run
      File "/usr/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
      File "/usr/lib/python3.10/threading.py", line 973 in _bootstrap

    Thread 0x00007f5e29b91640 (most recent call first):
      File "/usr/lib/python3.10/concurrent/futures/thread.py", line 81 in _worker
      File "/usr/lib/python3.10/threading.py", line 953 in run
      File "/usr/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
      File "/usr/lib/python3.10/threading.py", line 973 in _bootstrap

    Thread 0x00007f5e29280640 (most recent call first):
      File "/usr/lib/python3.10/concurrent/futures/thread.py", line 81 in _worker
      File "/usr/lib/python3.10/threading.py", line 953 in run
      File "/usr/lib/python3.10/threading.py", line 1016 in _bootstrap_inner
      File "/usr/lib/python3.10/threading.py", line 973 in _bootstrap

    Current thread 0x00007f5e2cebb1c0 (most recent call first):
      File "/usr/lib/python3.10/selectors.py", line 469 in select
      File "/usr/lib/python3.10/asyncio/base_events.py", line 1871 in _run_once
      File "/usr/lib/python3.10/asyncio/base_events.py", line 603 in run_forever
      File "/usr/lib/python3.10/asyncio/base_events.py", line 636 in run_until_complete
      File "/usr/lib/python3.10/asyncio/runners.py", line 44 in run
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/core/manager.py", line 204 in loop
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/scripts/start.py", line 109 in start
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/scripts/main.py", line 83 in main
      File "/home/tycho/.local/bin/qtile", line 8 in <module>

Hopefully this will help us debug some of these random failures.