### PR TITLE
tests: reorder SIGWINCH to be after sleep

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -230,8 +230,8 @@ class TestManager:
             if self.proc.is_alive():
                 # uh oh, we're hung somewhere. give it another second to print
                 # some stack traces
-                self.proc.join(1)
                 os.kill(self.proc.pid, signal.SIGWINCH)
+                self.proc.join(1)
                 print("Killing qtile forcefully", file=sys.stderr)
                 # desperate times... this probably messes with multiprocessing...
                 try:


### PR DESCRIPTION
It looks like in a recent run:
https://github.com/qtile/qtile/actions/runs/8321862376/job/22786549176 which had my previous patch we didn't get the stack traces. Presumably that's because we sent SIGWINCH and then immediately sent SIGKILL. I meant to put this sleep *after* SIGWINCH to give python time to walk its stack, but put it before. derp.