### PR TITLE
Fix keyboardlayout widget for variants with hyphens

### DIFF
--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -62,7 +62,7 @@ class _BaseLayoutBackend(metaclass=ABCMeta):
 
 class _X11LayoutBackend(_BaseLayoutBackend):
     kb_layout_regex = re.compile(r"layout:\s+(?P<layout>[\w-]+)")
-    kb_variant_regex = re.compile(r"variant:\s+(?P<variant>\w+)")
+    kb_variant_regex = re.compile(r"variant:\s+(?P<variant>[\w-]+)")
 
     def get_keyboard(self) -> str:
         try:


### PR DESCRIPTION
Same fix as #4228 but for variants. Needed for keyboard layouts like "us altgr-intl".