### PR TITLE
use typing instead of typing_extensions

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -29,9 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any
-
-    from typing_extensions import Literal
+    from typing import Any, Literal
 
     from libqtile.config import Group, Key, Mouse, Rule, Screen
     from libqtile.layout.base import Layout
@@ -43,7 +41,7 @@ class ConfigError(Exception):
 
 config_pyi_header = """
 from typing import Any
-from typing_extensions import Literal
+from typing import Literal
 from libqtile.config import Group, Key, Mouse, Rule, Screen
 from libqtile.layout.base import Layout
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -59,9 +59,7 @@ from libqtile.utils import cancel_tasks, get_cache_dir, lget, remove_dbus_rules,
 from libqtile.widget.base import _Widget
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
-
-    from typing_extensions import Literal
+    from typing import Any, Callable, Literal
 
     from libqtile.command.base import ItemT
     from libqtile.confreader import Config


### PR DESCRIPTION
The only thing we use from typing_extensions is Litral, which was stabilized in python 3.8: https://peps.python.org/pep-0586/

This was a third party module and an undocumented dependency, so probably good to get rid of it :)