### PR TITLE
Updates to Extensions

### DIFF
--- a/docs/manual/commands/api/extension.rst
+++ b/docs/manual/commands/api/extension.rst
@@ -1,0 +1,15 @@
+Extension objects
+=================
+
+Extensions are a way to give dmenu direct access to qtile objects as extensions are run
+in process.
+
+.. qtile_graph::
+    :root: extension
+
+|
+
+.. qtile_commands:: libqtile.extension
+    :baseclass: libqtile.extension.base._Extension
+    :object-node: extension
+    :object-selector-name:

--- a/docs/manual/commands/api/index.rst
+++ b/docs/manual/commands/api/index.rst
@@ -18,3 +18,4 @@ for keybindings and mouse callbacks).
     Widgets <widgets>
     Screens <screens>
     Core <backend>
+    Extensions <extension>

--- a/docs/manual/commands/keybindings.rst
+++ b/docs/manual/commands/keybindings.rst
@@ -11,6 +11,7 @@ Default configuration
 .. LS_PNG
 .. image:: /_static/keybindings/mod4.png
 .. image:: /_static/keybindings/mod4-shift.png
+.. image:: /_static/keybindings/control-mod1.png
 .. image:: /_static/keybindings/mod4-control.png
 .. END_LS_PNG
 

--- a/docs/qtile_docs/graph.py
+++ b/docs/qtile_docs/graph.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from dataclasses import dataclass
+from math import cos, pi, sin
 
 from docutils.parsers.rst import Directive, directives
 from qtile_docs.base import SimpleDirectiveMixin
@@ -58,54 +59,80 @@ class Node:
         }
 
 
+def calc_vertex_position(number_nodes, include_origin=True, radius=2, offset=0, rounding=2):
+    """
+    Generator to calculate x, y coordinates for vertices on a regular polygon.
+
+    Use this to set position for nodes on the command object graph map.
+
+    The function has more parameters than are probably needed but this allows flexibility
+    for future changes ;)
+    """
+    if include_origin:
+        yield 0, 0
+        number_nodes -= 1
+
+    theta = 2 * pi / number_nodes
+    for n in range(number_nodes):
+        angle = n * theta
+        x = round(radius * sin(angle + offset), rounding)
+        y = round(radius * cos(angle + offset), rounding)
+        yield x, y
+
+
 ROOT = graph.CommandGraphRoot()
 
+NODE_COUNT = 9  # Includes root
+
+node_position = calc_vertex_position(NODE_COUNT, offset=pi / 2)
 
 # Define our nodes with their positions, colours and link to API docs page.
 NODES = [
-    Node(ROOT, 0, 0, "Gray", "DarkGray", "root.html"),
-    Node(graph._BarGraphNode, -1.94, -0.44, "Violet", "Purple", "bars.html"),
+    Node(ROOT, *next(node_position), "Gray", "DarkGray", "root.html"),
     Node(
         graph._CoreGraphNode,
-        -1.56,
-        1.24,
-        "SlateBlue1",
-        "SlateBlue",
+        *next(node_position),
+        "Violet",
+        "Purple",
         "backend.html",
     ),
+    Node(graph._WindowGraphNode, *next(node_position), "Tomato", "Red", "windows.html"),
     Node(
         graph._GroupGraphNode,
-        1.56,
-        1.24,
+        *next(node_position),
         "Orange",
         "OrangeRed",
         "groups.html",
     ),
     Node(
         graph._LayoutGraphNode,
-        1.94,
-        -0.44,
+        *next(node_position),
         "Gold",
         "Goldenrod",
         "layouts.html",
     ),
     Node(
         graph._ScreenGraphNode,
-        0.86,
-        -1.8,
+        *next(node_position),
         "LimeGreen",
         "DarkGreen",
         "screens.html",
     ),
     Node(
         graph._WidgetGraphNode,
-        -0.86,
-        -1.8,
+        *next(node_position),
         "LightBlue",
         "Blue",
         "widgets.html",
     ),
-    Node(graph._WindowGraphNode, 0, 2, "Tomato", "Red", "windows.html"),
+    Node(
+        graph._ExtensionGraphNode,
+        *next(node_position),
+        "RoyalBlue",
+        "RoyalBlue3",
+        "extension.html",
+    ),
+    Node(graph._BarGraphNode, *next(node_position), "SlateBlue1", "SlateBlue", "bars.html"),
 ]
 
 

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -131,7 +131,7 @@ class CommandGraphRoot(CommandGraphNode):
     @property
     def children(self) -> list[str]:
         """All of the child elements in the root of the command graph"""
-        return ["bar", "group", "layout", "screen", "widget", "window", "core"]
+        return ["bar", "core", "extension", "group", "layout", "screen", "widget", "window"]
 
 
 class CommandGraphObject(CommandGraphNode, metaclass=abc.ABCMeta):
@@ -208,6 +208,11 @@ class _CoreGraphNode(CommandGraphObject):
     children: list[str] = []
 
 
+class _ExtensionGraphNode(CommandGraphObject):
+    object_type = "extension"
+    children: list[str] = []
+
+
 _COMMAND_GRAPH_MAP: dict[str, Type[CommandGraphObject]] = {
     "bar": _BarGraphNode,
     "group": _GroupGraphNode,
@@ -216,6 +221,7 @@ _COMMAND_GRAPH_MAP: dict[str, Type[CommandGraphObject]] = {
     "window": _WindowGraphNode,
     "screen": _ScreenGraphNode,
     "core": _CoreGraphNode,
+    "extension": _ExtensionGraphNode,
 }
 
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -125,7 +125,7 @@ class Qtile(CommandObject):
         _Widget.global_defaults = self.config.widget_defaults
         _Extension.global_defaults = self.config.extension_defaults
 
-        for installed_extension in _Extension.installed_extensions:
+        for installed_extension in _Extension.installed_extensions.values():
             installed_extension._configure(self)
 
         for i in self.groups:
@@ -898,6 +898,8 @@ class Qtile(CommandObject):
             return True, list(range(len(self.screens)))
         elif name == "core":
             return True, []
+        elif name == "extension":
+            return False, [name for name in _Extension.installed_extensions.keys()]
         return None
 
     def _select(self, name: str, sel: str | int | None) -> CommandObject | None:
@@ -935,6 +937,8 @@ class Qtile(CommandObject):
                 return lget(self.screens, int(sel))
         elif name == "core":
             return self.core
+        elif name == "extension":
+            return _Extension.installed_extensions.get(sel)
         return None
 
     def call_soon(self, func: Callable, *args: Any) -> asyncio.Handle:

--- a/libqtile/extension/dmenu.py
+++ b/libqtile/extension/dmenu.py
@@ -21,6 +21,7 @@
 import shlex
 
 from libqtile.extension import base
+from libqtile.utils import create_task
 
 
 class Dmenu(base.RunCommand):
@@ -97,11 +98,16 @@ class Dmenu(base.RunCommand):
             lines = min(len(items), int(self.dmenu_lines))
             self.configured_command.extend(("-l", str(lines)))
 
-        proc = super().run()
+        task = create_task(self._run(items))
+        return task
+
+    async def _run(self, items):
+        proc = await super().run()
 
         if items:
             input_str = "\n".join([i for i in items]) + "\n"
-            return proc.communicate(str.encode(input_str))[0].decode("utf-8")
+            stdout, _stderr = await proc.communicate(str.encode(input_str))
+            return stdout.decode("utf-8")
 
         return proc
 

--- a/libqtile/extension/window_list.py
+++ b/libqtile/extension/window_list.py
@@ -61,7 +61,11 @@ class WindowList(Dmenu):
 
     def run(self):
         self.list_windows()
-        out = super().run(items=self.item_to_win.keys())
+        task = super().run(items=self.item_to_win.keys())
+        task.add_done_callback(self._process_result)
+
+    def _process_result(self, task):
+        out = task.result()
 
         try:
             sout = out.rstrip("\n")

--- a/test/extension/test_base.py
+++ b/test/extension/test_base.py
@@ -17,6 +17,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import asyncio
+
 import pytest
 
 from libqtile.extension.base import RunCommand, _Extension
@@ -73,12 +75,15 @@ def test_base_methods():
 
 
 def test_run_command(monkeypatch):
-    def fake_popen(cmd, *args, **kwargs):
-        return cmd
+    async def fake_async_proc(*args, **kwargs):
+        return args
 
-    monkeypatch.setattr("libqtile.extension.base.Popen", fake_popen)
+    monkeypatch.setattr("libqtile.extension.base.asyncio.create_subprocess_exec", fake_async_proc)
 
-    extension = RunCommand(command="command --arg1 --arg2")
+    async def t():
+        extension = RunCommand(cmd="command --arg1 --arg2")
 
-    assert extension.command == "command --arg1 --arg2"
-    assert extension.run() == "command --arg1 --arg2"
+        assert extension.cmd == "command --arg1 --arg2"
+        assert await extension.run() == ("command", "--arg1", "--arg2")
+
+    asyncio.run(t())

--- a/test/extension/test_window_list.py
+++ b/test/extension/test_window_list.py
@@ -32,14 +32,16 @@ def extension_manager(monkeypatch, manager_nospawn):
     extension = WindowList()
 
     # We want the value returned immediately
-    def fake_popen(cmd, *args, **kwargs):
-        class PopenObj:
-            def communicate(self, value_in, *args):
+    async def fake_async_subprocess(cmd, *args, **kwargs):
+        class AsyncProc:
+            async def communicate(self, value_in, *args):
                 return [value_in, None]
 
-        return PopenObj()
+        return AsyncProc()
 
-    monkeypatch.setattr("libqtile.extension.base.Popen", fake_popen)
+    monkeypatch.setattr(
+        "libqtile.extension.base.asyncio.create_subprocess_exec", fake_async_subprocess
+    )
 
     class ManagerConfig(Config):
         groups = [

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -66,8 +66,14 @@ def test_ls(manager):
     client = ipc.Client(manager.sockfile)
     command = IPCCommandInterface(client)
     sh = QSh(command)
-    assert sh.do_ls(None) == "bar/     group/   layout/  screen/  widget/  window/  core/  "
-    assert sh.do_ls("") == "bar/     group/   layout/  screen/  widget/  window/  core/  "
+    assert sh.do_ls(None) == (
+        "bar/        core/       extension/  group/      layout/     screen/   \n"
+        "widget/     window/   "
+    )
+    assert sh.do_ls("") == (
+        "bar/        core/       extension/  group/      layout/     screen/   \n"
+        "widget/     window/   "
+    )
     assert sh.do_ls("layout") == "layout/group/   layout/window/  layout/screen/  layout[0]/    "
 
     assert sh.do_cd("layout") == "layout"


### PR DESCRIPTION
Draft for now.

This PR makes a few changes to extensions:
- extensions are now `CommandObject`s i.e. they can be accessed via qtile's command graph so we can do `lazy.extension["extensionname"].run()`
- extensions are run asynchronously which prevents the IPC server from timing out
- docs are updated to show extensions on the command graph
- tests are updated

Outstanding:
- Need to think of best way to have extensions defined in the config.
- Needs migrations to fix property name clashes