### PR TITLE
Add Minimum Brightness to Backlight

### DIFF
--- a/libqtile/widget/backlight.py
+++ b/libqtile/widget/backlight.py
@@ -82,6 +82,7 @@ class Backlight(base.InLoopPollText):
         ("step", 10, "Percent of backlight every scroll changed"),
         ("format", "{percent:2.0%}", "Display format"),
         ("change_command", "xbacklight -set {0}", "Execute command to change value"),
+        ("min_brightness", 0, "Minimum brightness percentage"),
     ]
 
     def __init__(self, **config):
@@ -154,7 +155,7 @@ class Backlight(base.InLoopPollText):
             return
         new = now = self._get_info() * 100
         if direction is ChangeDirection.DOWN:
-            new = max(now - step, 0)
+            new = max(now - step, self.min_brightness)
         elif direction is ChangeDirection.UP:
             new = min(now + step, 100)
         if new != now:


### PR DESCRIPTION
After totally turning off my screen by scrolling too far, I figured it would be a good idea to add a minimum brightness option to the Backlight widget. I set the default to zero for backwards compatibility.

I also thought about checking to see if the brightness was less than the minimum after polling, but decided against it. If the brightness was set below the minimum through some other method than qtile, that user likely does not want qtile to change it.