### PR TITLE
tests: make $DISPLAY available for x11

### DIFF
--- a/test/backend/x11/conftest.py
+++ b/test/backend/x11/conftest.py
@@ -185,6 +185,12 @@ class XBackend(Backend):
         self.core = Core
         self.manager = None
 
+    def configure(self, manager):
+        """This backend needs to get DISPLAY variable."""
+        success, display = manager.c.eval("self.core.display_name")
+        assert success
+        self.env["DISPLAY"] = display
+
     def fake_click(self, x, y):
         """Click at the specified coordinates"""
         conn = Connection(self.env["DISPLAY"])


### PR DESCRIPTION
I am not really sure why this passes in our CI ($DISPLAY wouldn't be set there I wouldn't think?), but hopefully this fixes it.

This is part of #4762