### PR TITLE
Test Clock: Fix timezone offset

### DIFF
--- a/test/widgets/test_clock.py
+++ b/test/widgets/test_clock.py
@@ -43,6 +43,11 @@ class MockDatetime(datetime.datetime):
     def now(cls, *args, **kwargs):
         return cls(2021, 1, 1, 10, 20, 30)
 
+    def astimezone(self, tzone=None):
+        if tzone is None:
+            return self
+        return self + tzone.utcoffset(None)
+
 
 @pytest.fixture
 def patched_clock(monkeypatch):


### PR DESCRIPTION
This was previously removed, and now this test seems to depend on the environment it is being ran (?). This adds back the UTC offset of the timezone such that the delta is taken into account. Fixes #4762

Hopefully CI passes too. It works for me locally now

Can't say I can fully understand it though