### PR TITLE
Wayland: Fix self.qtile startup logic

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -446,7 +446,7 @@ class Core(base.Core, wlrq.HasListeners):
         self.seat.set_capabilities(capabilities)
 
         logger.info("New device: %s %s", *device.get_info())
-        if self.qtile:
+        if hasattr(self, "qtile"):
             if self.qtile.config.wl_input_rules:
                 device.configure(self.qtile.config.wl_input_rules)
         else:

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -207,7 +207,6 @@ class _Device(ABC, HasListeners):
 class Keyboard(_Device):
     def __init__(self, core: Core, wlr_device: InputDevice, keyboard: WlrKeyboard):
         super().__init__(core, wlr_device)
-        self.qtile = core.qtile
         self.seat = core.seat
         self.keyboard = keyboard
         self.grabbed_keys = core.grabbed_keys


### PR DESCRIPTION
In #4757 we have fixed some of the logic with regards to setting self.qtile. This means that in certain scenarios the self.qtile attribute does not exist, e.g. when we're adding keyboards before the config is loaded.

We already mark these devices as "pending" if
self.qtile is `None`, but this now does not work as the attribute is not set in the first place. Let's check with hasattr and remove the unneeded self.qtile setting inside of the keyboard constructor.

This fixes #4767