### PR TITLE
Set `_NET_WM_STATE_SKIP_TASKBAR` for `Scratchpad` windows

### DIFF
--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -173,6 +173,18 @@ class DropDownToggler(WindowVisibilityToggler):
         self.y = ddconfig.y
         self.width = ddconfig.width
         self.height = ddconfig.height
+
+        # add "SKIP_TASKBAR" to _NET_WM_STATE atom (for X11)
+        if window.qtile.core.name == "x11":
+            net_wm_state = list(window.window.get_property("_NET_WM_STATE", "ATOM", unpack=int))
+            skip_taskbar = window.qtile.core.conn.atoms["_NET_WM_STATE_SKIP_TASKBAR"]
+            if net_wm_state:
+                if "_NET_WM_STATE_SKIP_TASKBAR" not in net_wm_state:
+                    net_wm_state.append(skip_taskbar)
+            else:
+                net_wm_state = [skip_taskbar]
+            window.window.set_property("_NET_WM_STATE", net_wm_state)
+
         # Let's add the window to the scratchpad group.
         window.togroup(scratchpad_name)
         window.opacity = ddconfig.opacity
@@ -299,7 +311,7 @@ class ScratchPad(group._Group):
         """
         hook method which is called if window float state is changed.
         If the current associated window is not floated (any more) the window
-        and process is detached from DRopDown, thus the next call to Show
+        and process is detached from DropDown, thus the next call to Show
         will spawn a new process.
         """
         name = None

--- a/test/test_scratchpad.py
+++ b/test/test_scratchpad.py
@@ -321,3 +321,25 @@ def test_stepping_between_groups_should_skip_scratchpads(manager):
     manager.c.screen.prev_group()
     # we should be on b group
     assert manager.c.group.info()["name"] == "b"
+
+
+@scratchpad_config
+def test_skip_taskbar(manager):
+    manager.c.group["SCRATCHPAD"].dropdown_reconfigure("dd-a")
+
+    manager.test_window("one")
+    assert_focused(manager, "one")
+
+    # dd-a has no window associated yet
+    assert "window" not in manager.c.group["SCRATCHPAD"].dropdown_info("dd-a")
+
+    # First toggling: wait for window
+    manager.c.group["SCRATCHPAD"].dropdown_toggle("dd-a")
+    is_spawned(manager, "dd-a")
+    assert_focused(manager, "dd-a")
+    assert manager.c.group["SCRATCHPAD"].dropdown_info("dd-a")["window"]["name"] == "dd-a"
+
+    if manager.c.core.info()["backend"] == "x11":
+        # check that window's _NET_WM_STATE contains _NET_WM_STATE_SKIP_TASKBAR
+        net_wm_state = manager.c.window.eval("self.window.get_net_wm_state()")[1]
+        assert "_NET_WM_STATE_SKIP_TASKBAR" in net_wm_state


### PR DESCRIPTION
`Scratchpad`'s `DropDown` windows do not set that atom currently, so `plank`, `tint2`, `alttab` show it in their open applications.

Let's set it!