### PR TITLE
don't use wayland backend in x11 tests

### DIFF
--- a/test/backend/x11/conftest.py
+++ b/test/backend/x11/conftest.py
@@ -170,6 +170,21 @@ def xmanager(request, xephyr):
 
 
 @pytest.fixture(scope="function")
+def xmanager_nospawn(request, xephyr):
+    """
+    This replicates the `manager` fixture except that the x11 backend is hard-coded. We
+    cannot simply parametrize the `backend_name` fixture module-wide because it gets
+    parametrized by `pytest_generate_tests` in test/conftest.py and only one of these
+    parametrize calls can be used.
+    """
+    backend = XBackend({"DISPLAY": xephyr.display}, args=[xephyr.display])
+
+    with TestManager(backend, request.config.getoption("--debuglog")) as manager:
+        manager.display = xephyr.display
+        yield manager
+
+
+@pytest.fixture(scope="function")
 def conn(xmanager):
     conn = Connection(xmanager.display)
     yield conn

--- a/test/backend/x11/test_window.py
+++ b/test/backend/x11/test_window.py
@@ -71,21 +71,21 @@ class SmartConfig(BareConfig):
 
 
 @dualmonitor
-def test_urgent_hook_fire(manager_nospawn):
-    manager_nospawn.display = manager_nospawn.backend.env["DISPLAY"]
-    conn = Connection(manager_nospawn.display)
+def test_urgent_hook_fire(xmanager_nospawn):
+    xmanager_nospawn.display = xmanager_nospawn.backend.env["DISPLAY"]
+    conn = Connection(xmanager_nospawn.display)
 
-    manager_nospawn.hook_fired = Value("i", 0)
+    xmanager_nospawn.hook_fired = Value("i", 0)
 
     def _hook_test(val):
-        manager_nospawn.hook_fired.value += 1
+        xmanager_nospawn.hook_fired.value += 1
 
     hook.subscribe.client_urgent_hint_changed(_hook_test)
 
-    manager_nospawn.start(UrgentConfig)
+    xmanager_nospawn.start(UrgentConfig)
 
-    manager_nospawn.test_window("one")
-    window_info = manager_nospawn.c.window.info()
+    xmanager_nospawn.test_window("one")
+    window_info = xmanager_nospawn.c.window.info()
 
     # send activate window message
     data = xcffib.xproto.ClientMessageData.synthetic([0, 0, 0, 0, 0], "IIIII")
@@ -95,15 +95,15 @@ def test_urgent_hook_fire(manager_nospawn):
     conn.default_screen.root.send_event(ev, mask=xcffib.xproto.EventMask.SubstructureRedirect)
     conn.xsync()
 
-    manager_nospawn.terminate()
-    assert manager_nospawn.hook_fired.value == 1
+    xmanager_nospawn.terminate()
+    assert xmanager_nospawn.hook_fired.value == 1
 
     # test that focus_on_window_activation = "smart" also fires the hook
-    manager_nospawn.start(SmartConfig, no_spawn=True)
+    xmanager_nospawn.start(SmartConfig, no_spawn=True)
 
-    manager_nospawn.test_window("one")
-    window_info = manager_nospawn.c.window.info()
-    manager_nospawn.c.window.toscreen(1)
+    xmanager_nospawn.test_window("one")
+    window_info = xmanager_nospawn.c.window.info()
+    xmanager_nospawn.c.window.toscreen(1)
 
     # send activate window message
     ev = xcffib.xproto.ClientMessageEvent.synthetic(
@@ -111,9 +111,9 @@ def test_urgent_hook_fire(manager_nospawn):
     )
     conn.default_screen.root.send_event(ev, mask=xcffib.xproto.EventMask.SubstructureRedirect)
     conn.xsync()
-    manager_nospawn.terminate()
+    xmanager_nospawn.terminate()
 
-    assert manager_nospawn.hook_fired.value == 2
+    assert xmanager_nospawn.hook_fired.value == 2
 
 
 @manager_config


### PR DESCRIPTION
We were previously using `manager_nospawn`, which is a fixture that enables the test for both backends, even though this test is x11 specific. You can see this with the failed test name+params here:

    FAILED test/backend/x11/test_window.py::test_urgent_hook_fire[wayland-2]

instead, let's introduce our own xmanager_nospawn, and use that.

This is the other half of #4762