### PR TITLE
move stack dump handler

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import asyncio
+import faulthandler
 import io
 import logging
 import os
@@ -213,6 +214,12 @@ class Qtile(CommandObject):
         self.core.qtile = self
         self.load_config(initial=True)
         self.core.setup_listener()
+
+        faulthandler.enable(all_threads=True)
+        # This is a bit unfortunate. We use SIGUSR1&2 for reloading config &
+        # restarting qtile, so we overload SIGWINCH here to dump threads.
+        faulthandler.register(signal.SIGWINCH, all_threads=True)
+
         try:
             async with LoopContext(
                 {

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -1,7 +1,5 @@
 import argparse
-import faulthandler
 import logging
-import signal
 import sys
 from pathlib import Path
 
@@ -26,11 +24,6 @@ def check_folder(value):
 
 
 def main():
-    faulthandler.enable(all_threads=True)
-    # This is a bit unfortunate. We use SIGUSR1&2 for reloading config &
-    # restarting qtile, so we overload SIGWINCH here to dump threads.
-    faulthandler.register(signal.SIGWINCH, all_threads=True)
-
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
         "-l",


### PR DESCRIPTION
We set this up in main, but our test suite never calls qtile's main method, so my attempts at logging why tests were hanging would never succeed.

Instead, let's set this up in async_loop() where we set up the other signal handling, which is called by the test suite and hopefully as a result will yield stack traces when our test suite hangs.

Fixes #4778