### PR TITLE
Add ability to override floating rules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
         the `qtile cmd-obj` command line
       - Add `Plasma` layout. The original layout (https://github.com/numirias/qtile-plasma) appears to be unmaintained
         so we have added this to the main codebase.
+      - Add ability to define exceptions to rules for floating windows.
     * bugfixes
 
 Qtile 0.25.0, released 2024-04-06:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -27,6 +27,7 @@
 # SOFTWARE.
 
 import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -69,7 +70,9 @@ class ManagerConfig(Config):
             *libqtile.layout.floating.Floating.default_float_rules,
             Match(wm_class="float"),
             Match(title="float"),
-        ]
+            Match(title=re.compile(r"^floatthis")),
+        ],
+        override_rules=[Match(title=re.compile(r".*nofloat$"))],
     )
     keys = [
         libqtile.config.Key(
@@ -916,6 +919,15 @@ def test_move_floating(manager):
     assert manager.c.window.info()["height"] == 20
     assert manager.c.window.info()["x"] == 10
     assert manager.c.window.info()["y"] == 20
+
+
+@manager_config
+def test_float_overrides(manager):
+    manager.test_window("floatthiswindow-nofloat")
+    assert manager.c.window.info()["floating"] is False
+
+    manager.test_window("floatthiswindow")
+    assert manager.c.window.info()["floating"] is True
 
 
 @manager_config


### PR DESCRIPTION
Some float rules (e.g. fixed size/aspect ratio) can be too broad and users may want exceptions to these rules. It is possible to do this with hooks but they can become unwieldy with multiple exceptions.

This PR adds an `override_rules` argument to the floating layout. Where a window matches one of these rules then window will not be floated.

Question for @tych0 - any idea where the test fails if the windows are added in the other order? i.e. if I open the `nofloat` window second, the focus remains on the first one so `manager.c.window` points to the wrong window.