### PR TITLE
Fix lazy import in Plasma docs

### DIFF
--- a/libqtile/layout/plasma.py
+++ b/libqtile/layout/plasma.py
@@ -753,8 +753,8 @@ class Plasma(Layout):
 
     .. code:: python
 
-        from libqtile.command import lazy
         from libqtile.config import EzKey
+        from libqtile.lazy import lazy
         ...
         keymap = {
             'M-h': lazy.layout.left(),


### PR DESCRIPTION
91d299e6 removed the deprecated wrapper for lazy but the Plasma docs still referred to it.