### PR TITLE
x11: set qtile's pid

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -119,6 +119,7 @@ class Core(base.Core):
         self._wmname = "qtile"
         self._supporting_wm_check_window = self.conn.create_window(-1, -1, 1, 1)
         self._supporting_wm_check_window.set_property("_NET_WM_NAME", self._wmname)
+        self._supporting_wm_check_window.set_property("_NET_WM_PID", os.getpid())
         self._supporting_wm_check_window.set_property(
             "_NET_SUPPORTING_WM_CHECK", self._supporting_wm_check_window.wid
         )


### PR DESCRIPTION
In support of debugging #3866, I was poking through xrestop, which didn't know about qtile's pid. Let's set it so we get:

1a00000     6   14   77   17  313    12311K     84K  12395K 922160 qtile