### PR TITLE
switch semantics of sigusr2 to stack dumping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Qtile x.xx.x, released XXXX-XX-XX:
     !!! breaking changes !!!
       - this release drops support for python 3.9
       - deleted the (very old) libqtile/command_* deprecation wrappers
+      - SIGUSR2 no longer restarts qtile, instead it dumps stack traces
     * features
       - automatically lift types to their annotated type when specified via
         the `qtile cmd-obj` command line

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -216,9 +216,7 @@ class Qtile(CommandObject):
         self.core.setup_listener()
 
         faulthandler.enable(all_threads=True)
-        # This is a bit unfortunate. We use SIGUSR1&2 for reloading config &
-        # restarting qtile, so we overload SIGWINCH here to dump threads.
-        faulthandler.register(signal.SIGWINCH, all_threads=True)
+        faulthandler.register(signal.SIGUSR2, all_threads=True)
 
         try:
             async with LoopContext(
@@ -227,7 +225,6 @@ class Qtile(CommandObject):
                     signal.SIGINT: self.stop,
                     signal.SIGHUP: self.stop,
                     signal.SIGUSR1: self.reload_config,
-                    signal.SIGUSR2: self.restart,
                 }
             ), ipc.Server(
                 self._prepare_socket_path(self.socket_path),

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -230,7 +230,7 @@ class TestManager:
             if self.proc.is_alive():
                 # uh oh, we're hung somewhere. give it another second to print
                 # some stack traces
-                os.kill(self.proc.pid, signal.SIGWINCH)
+                os.kill(self.proc.pid, signal.SIGUSR2)
                 self.proc.join(1)
                 print("Killing qtile forcefully", file=sys.stderr)
                 # desperate times... this probably messes with multiprocessing...


### PR DESCRIPTION
people can restart qtile via IPC, whereas this stack trace dump may not be possible via IPC if qtile is super wedged, so let's comandeer SIGUSR2 for this. Hopefully people weren't using this too much.