### PR TITLE
Add boolean logic to Match objects

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -58,6 +58,7 @@ mix!)
     mouse
     screens
     hooks
+    match
 
 In addition to the above variables, there are several other boolean
 configuration variables that control specific aspects of Qtile's behavior:

--- a/docs/manual/config/match.rst
+++ b/docs/manual/config/match.rst
@@ -1,0 +1,85 @@
+.. _match:
+
+================
+Matching windows
+================
+
+Qtile's config provides a number of situations where the behaviour depends
+on whether the relevant window matches some specified criteria.
+
+These situations include:
+
+  - Defining which windows should be floated by default
+  - Assigning windows to specific groups
+  - Assigning window to a master section of a layout
+
+In each instance, the criteria are defined via a ``Match`` object. The properties
+of the object will be compared to a :class:`~libqtile.base.Window` to determine if
+its properties *match*. It can match by title, wm_class, role, wm_type,
+wm_instance_class, net_wm_pid, or wid. Additionally, a function may be
+passed, which takes in the :class:`~libqtile.base.Window` to be compared
+against and returns a boolean.
+
+A basic rule would therefore look something like:
+
+.. code::  python
+
+    Match(wm_class="mpv")
+
+This would match against any window whose class was ``mpv``.
+
+Where a string is provided as an argument then the value must match exactly. More
+flexibility can be achieved by using regular expressions. For example:
+
+.. code::  python
+
+    import re
+
+    Match(wm_class=re.compile(r"mpv"))
+
+This would still match a window whose class was ``mpv`` but it would also match
+any class starting with ``mpv`` e.g. ``mpvideo``.
+
+.. note::
+
+    When providing a regular expression, qtile applies the ``.match`` method.
+    This matches from the start of the string so, if you want to match any substring,
+    you will need to adapt the regular expression accordingly e.g.
+
+    .. code::  python
+
+        import re
+
+        Match(wm_class=re.compile(r".*mpv"))
+
+    This would match any string containing ``mpv``
+
+Creating advanced rules
+=======================
+
+While the ``func`` parameter allows users to create more complex matches, this requires
+a knowledge of qtile's internal objects. An alternative is to combine Match objects using
+logical operators ``&`` (and), ``|`` (or), ``~`` (not) and ``^`` (xor).
+
+For example, to create rule that matches all windows with a fixed aspect ratio except for
+mpv windows, you would provide the following:
+
+.. code::  python
+
+    Match(func=lambda c: c.has_fixed_ratio()) & ~Match(wm_class="mpv")
+
+It is also possible to use wrappers for ``Match`` objects if you do not want to use the
+operators. The following wrappers are available:
+
+  - ``MatchAll(Match(...), ...)`` equivalent to "and" test. All matches must match.
+  - ``MatchAny(Match(...), ...)`` equivalent to "or" test. At least one match must match.
+  - ``MatchOnlyOne(Match(...), Match(...))`` equivalent to "xor". Only one match must match.
+  - ``InvertMatch(Match(...))`` equivalent to "not". Inverts the result of the match.
+
+So, to recreate the above rule using the wrappers, you would write the following:
+
+.. code::  python
+
+    from libqtile.config import InvertMatch, Match, MatchAll
+
+    MatchAll(Match(func=lambda c: c.has_fixed_ratio()), InvertMatch(Match(wm_class="mpv")))

--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -286,7 +286,7 @@ class Window(_Window, metaclass=ABCMeta):
         """Does this window want to be fullscreen?"""
         return False
 
-    def match(self, match: config.Match) -> bool:
+    def match(self, match: config._Match) -> bool:
         """Compare this window against a Match instance."""
         return match.compare(self)
 

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -604,7 +604,7 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
             fullscreen=self._float_state == FloatStates.FULLSCREEN,
         )
 
-    def match(self, match: config.Match) -> bool:
+    def match(self, match: config._Match) -> bool:
         return match.compare(self)
 
     def add_idle_inhibitor(

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from libqtile.command.base import expose_command
-from libqtile.config import Match
+from libqtile.config import Match, _Match
 from libqtile.layout.base import Layout
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ class Floating(Layout):
     Floating layout, which does nothing with windows but handles focus order
     """
 
-    default_float_rules = [
+    default_float_rules: list[_Match] = [
         Match(wm_type="utility"),
         Match(wm_type="notification"),
         Match(wm_type="toolbar"),
@@ -74,7 +74,7 @@ class Floating(Layout):
     ]
 
     def __init__(
-        self, float_rules: list[Match] | None = None, no_reposition_rules=None, **config
+        self, float_rules: list[_Match] | None = None, no_reposition_rules=None, **config
     ):
         """
         If you have certain apps that you always want to float you can provide

--- a/libqtile/layout/screensplit.py
+++ b/libqtile/layout/screensplit.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import hook
 from libqtile.command.base import expose_command
-from libqtile.config import Match, ScreenRect
+from libqtile.config import ScreenRect, _Match
 from libqtile.layout import Columns, Max
 from libqtile.layout.base import Layout
 from libqtile.log_utils import logger
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 class Split:
     def __init__(
-        self, *, name: str, rect: Rect, layout: Layout, matches: list[Match] = list()
+        self, *, name: str, rect: Rect, layout: Layout, matches: list[_Match] = list()
     ) -> None:
         # Check that rect is correctly defined
         if not isinstance(rect, (tuple, list)):
@@ -53,7 +53,7 @@ class Split:
 
         if matches:
             if isinstance(matches, list):
-                if not all(isinstance(m, Match) for m in matches):
+                if not all(isinstance(m, _Match) for m in matches):
                     raise ValueError("Invalid object in 'matches'.")
             else:
                 raise ValueError("'matches' must be a list of 'Match' objects.")

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from libqtile.command.base import expose_command
-from libqtile.config import Match
+from libqtile.config import _Match
 from libqtile.layout.base import _SimpleLayoutBase
 
 if TYPE_CHECKING:
@@ -150,7 +150,7 @@ class Tile(_SimpleLayoutBase):
             return
         if self.clients:
             master_match = match or self.master_match
-            if isinstance(master_match, Match):
+            if isinstance(master_match, _Match):
                 master_match = [master_match]
             masters = []
             for c in self.clients:

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from typing import Callable, Iterable
 
     from libqtile.command.graph import SelectorType
-    from libqtile.config import Match
+    from libqtile.config import _Match
 
 
 class LazyCall:
@@ -50,7 +50,7 @@ class LazyCall:
         self._args = args
         self._kwargs = kwargs
 
-        self._focused: Match | None = None
+        self._focused: _Match | None = None
         self._if_no_focused: bool = False
         self._layouts: set[str] = set()
         self._when_floating = True
@@ -96,7 +96,7 @@ class LazyCall:
 
     def when(
         self,
-        focused: Match | None = None,
+        focused: _Match | None = None,
         if_no_focused: bool = False,
         layout: Iterable[str] | str | None = None,
         when_floating: bool = True,

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 from libqtile import config, group, hook
 from libqtile.backend.base import FloatStates
 from libqtile.command.base import expose_command
-from libqtile.config import Match
+from libqtile.config import Match, _Match
 
 if TYPE_CHECKING:
     from libqtile.backend.base import Window
@@ -243,7 +243,7 @@ class ScratchPad(group._Group):
         group._Group.__init__(self, name, label=label)
         self._dropdownconfig = {dd.name: dd for dd in dropdowns} if dropdowns is not None else {}
         self.dropdowns: dict[str, DropDownToggler] = {}
-        self._spawned: dict[str, Match] = {}
+        self._spawned: dict[str, _Match] = {}
         self._to_hide: list[str] = []
         self._single = single
 

--- a/test/test_match.py
+++ b/test/test_match.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2024 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import re
+
+import pytest
+
+from libqtile import layout
+from libqtile.config import Match, Screen
+from libqtile.confreader import Config
+
+
+@pytest.fixture(scope="function")
+def manager(manager_nospawn, request):
+    class MatchConfig(Config):
+        rules = getattr(request, "param", list())
+        if not isinstance(rules, (list, tuple)):
+            rules = [rules]
+
+        screens = [Screen()]
+        floating_layout = layout.Floating(float_rules=[*rules])
+
+    manager_nospawn.start(MatchConfig)
+
+    yield manager_nospawn
+
+
+def configure_rules(*args):
+    return pytest.mark.parametrize("manager", [args], indirect=True)
+
+
+def assert_float(manager, name, floating=True):
+    manager.test_window(name)
+    assert manager.c.window.info()["floating"] is floating
+    manager.c.window.kill()
+
+
+@configure_rules(Match(title="floatme"))
+@pytest.mark.parametrize(
+    "name,result", [("normal", False), ("floatme", True), ("floatmetoo", False)]
+)
+def test_single_rule(manager, name, result):
+    """Single string must be exact match"""
+    assert_float(manager, name, result)
+
+
+@configure_rules(Match(title=re.compile(r"floatme")))
+@pytest.mark.parametrize(
+    "name,result", [("normal", False), ("floatme", True), ("floatmetoo", True)]
+)
+def test_single_regex_rule(manager, name, result):
+    """Regex to match substring"""
+    assert_float(manager, name, result)
+
+
+@configure_rules(~Match(title="floatme"))
+@pytest.mark.parametrize(
+    "name,result", [("normal", True), ("floatme", False), ("floatmetoo", True)]
+)
+def test_not_rule(manager, name, result):
+    """Invert match rule"""
+    assert_float(manager, name, result)
+
+
+@configure_rules(Match(title="floatme") | Match(title="floating"))
+@pytest.mark.parametrize(
+    "name,result",
+    [("normal", False), ("floatme", True), ("floating", True), ("floatmetoo", False)],
+)
+def test_or_rule(manager, name, result):
+    """Invert match rule"""
+    assert_float(manager, name, result)
+
+
+@configure_rules(Match(title=re.compile(r"^floatme")) & Match(title=re.compile(r".*too$")))
+@pytest.mark.parametrize(
+    "name,result", [("normal", False), ("floatme", False), ("floatmetoo", True)]
+)
+def test_and_rule(manager, name, result):
+    """Combine match rules"""
+    assert_float(manager, name, result)
+
+
+@configure_rules(Match(title=re.compile(r"^floatme")) ^ Match(title=re.compile(r".*too$")))
+@pytest.mark.parametrize(
+    "name,result",
+    [("normal", False), ("floatme", True), ("floatmetoo", False), ("thisfloatstoo", True)],
+)
+def test_xor_rule(manager, name, result):
+    """Combine match rules"""
+    assert_float(manager, name, result)


### PR DESCRIPTION
This PR adds the ability to use bitwise operators on `Match` objects in order to build more complex rules.

Match objects now support `|`, `&`, `~` and `^` operators.

This allows you to define more complex rules. For example, the following rule would match all windows with a fixed aspect ratio *except* an `mpv` instance:
```python
Match(func=lambda c: c.has_fixed_ratio()) & ~Match(wm_class="mpv")
```

I should update the docs for this but would welcome thoughts.