### PR TITLE
don't cast before free

### DIFF
--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -88,7 +88,6 @@ class PangoLayout:
         self._pointer = pangocairo.pango_cairo_create_layout(cairo_t)
 
         def free(p):
-            p = ffi.cast("gpointer", p)
             gobject.g_object_unref(p)
 
         self._pointer = ffi.gc(self._pointer, free)


### PR DESCRIPTION
we had a recent CI hang in
https://github.com/qtile/qtile/actions/runs/8901596066/job/24445775719 where the last few lines of the stack trace are:

    Current thread 0x7F11FF53CC80 (most recent call first, approximate line numbers):
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/cparser.py", line 307 in _parse
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/cparser.py", line 554 in parse_type_and_quals
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/cparser.py", line 551 in parse_type
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/api.py", line 162 in _typeof_locked
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/api.py", line 180 in _typeof
        File "/opt/hostedtoolcache/PyPy/3.10.13/x64/lib/pypy3.10/cffi/api.py", line 293 in cast
        File "/home/runner/work/qtile/qtile/libqtile/pangocffi.py", line 90 in free

we can drop this cast, since gpointer is just a type alias for `void *`, so any pointer promotes to this. This way we don't have to do lots of extra parsing just to free a pointer.

I doubt this is the source of the hangs, but it is a bunch of stuff we don't need to do, so let's not do it.