### PR TITLE
pangocffi: don't cast to "cairo_t *"

### DIFF
--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -56,14 +56,12 @@ pangocairo = ffi.dlopen("libpangocairo-1.0.so.0")  # type: ignore
 
 def patch_cairo_context(cairo_t):
     def create_layout():
-        return PangoLayout(ffi.cast("struct _cairo *", cairo_t._pointer))
+        return PangoLayout(cairo_t._pointer)
 
     cairo_t.create_layout = create_layout
 
     def show_layout(layout):
-        pangocairo.pango_cairo_show_layout(
-            ffi.cast("struct _cairo *", cairo_t._pointer), layout._pointer
-        )
+        pangocairo.pango_cairo_show_layout(cairo_t._pointer, layout._pointer)
 
     cairo_t.show_layout = show_layout
 


### PR DESCRIPTION
Similar to d10c3bb41254 ("don't cast before free"), we do not actually need these casts: the _pointer member of CairoContext is a cairo_t * already. I have no real memory of why I thought these were needed initially and didn't look through the git logs to figure it out, but I can if we want. I have been running a branch with this change for a bit and haven't seen any weirdness.

These are the last two casts in the tree, so hopefully this will be the last version of this patch.

Finally, looking at the code, there's no real reason we do this weird monkey-patching of the cairo context I don't think. We could split this out into separate function calls in our own object and it would work just fine. Maybe I'll do that if people think it's reasonable.