### PR TITLE
core: use ScreenRect everywhere we represent a screen

### DIFF
--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -5,6 +5,7 @@ import typing
 from abc import ABCMeta, abstractmethod
 
 from libqtile.command.base import CommandObject, expose_command
+from libqtile.config import ScreenRect
 
 if typing.TYPE_CHECKING:
     from typing import Any
@@ -54,7 +55,7 @@ class Core(CommandObject, metaclass=ABCMeta):
         """Set the current desktops of the window manager"""
 
     @abstractmethod
-    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
+    def get_screen_info(self) -> list[ScreenRect]:
         """Get the screen information"""
 
     @abstractmethod

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -87,6 +87,7 @@ from libqtile.backend import base
 from libqtile.backend.wayland import inputs, layer, window, wlrq, xdgwindow, xwindow
 from libqtile.backend.wayland.output import Output
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
 from libqtile.log_utils import logger
 
 try:
@@ -466,7 +467,7 @@ class Core(base.Core, wlrq.HasListeners):
         if not self._current_output:
             self._current_output = output
             self.cursor.set_xcursor(self._cursor_manager, "default")
-            box = Box(*output.get_geometry())
+            box = Box(*output.get_screen_info())
             x = box.x + box.width / 2
             y = box.y + box.height / 2
             self.warp_pointer(x, y)
@@ -1391,9 +1392,9 @@ class Core(base.Core, wlrq.HasListeners):
         logger.warning("Couldn't determine what was under the pointer. Please report.")
         return None
 
-    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
+    def get_screen_info(self) -> list[ScreenRect]:
         """Get the output information"""
-        return [output.get_geometry() for output in self.outputs]
+        return [output.get_screen_info() for output in self.outputs]
 
     def grab_key(self, key: config.Key | config.KeyChord) -> tuple[int, int]:
         """Configure the backend to grab the key event"""

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -34,6 +34,7 @@ from wlroots.wlr_types.layer_shell_v1 import (
 from wlroots.wlr_types.output import CustomMode
 
 from libqtile.backend.wayland.wlrq import HasListeners
+from libqtile.config import ScreenRect
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
@@ -98,7 +99,8 @@ class Output(HasListeners):
         self.scene_output.destroy()
 
     def __repr__(self) -> str:
-        return "<Output (%s, %s, %s, %s)>" % self.get_geometry()
+        i = self.get_screen_info()
+        return f"<Output ({i.x}, {i.y}, {i.width}, {i.height})>"
 
     @property
     def screen(self) -> Screen:
@@ -130,9 +132,9 @@ class Output(HasListeners):
         logger.debug("Signal: output request_state")
         self.wlr_output.commit(request.state)
 
-    def get_geometry(self) -> tuple[int, int, int, int]:
+    def get_screen_info(self) -> ScreenRect:
         width, height = self.wlr_output.effective_resolution()
-        return int(self.x), int(self.y), width, height
+        return ScreenRect(int(self.x), int(self.y), width, height)
 
     def organise_layers(self) -> None:
         """Organise the positioning of layer shell surfaces."""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -38,6 +38,7 @@ from libqtile import config, hook, utils
 from libqtile.backend import base
 from libqtile.backend.x11 import window, xcbq
 from libqtile.backend.x11.xkeysyms import keysyms
+from libqtile.config import ScreenRect
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -183,23 +184,11 @@ class Core(base.Core):
             delattr(self, "qtile")
         self.conn.finalize()
 
-    def get_screen_info(self) -> list[tuple[int, int, int, int]]:
-        info = [(s.x, s.y, s.width, s.height) for s in self.conn.pseudoscreens]
-
-        if not info:
-            info.append(
-                (
-                    0,
-                    0,
-                    self.conn.default_screen.width_in_pixels,
-                    self.conn.default_screen.height_in_pixels,
-                )
-            )
-
+    def get_screen_info(self) -> list[ScreenRect]:
+        ps = self.conn.pseudoscreens
         if self.qtile:
             self._xpoll()
-
-        return info
+        return ps
 
     @property
     def wmname(self):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import os.path
 import re
 import sys
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from libqtile import configurable, hook, utils
@@ -372,21 +373,12 @@ class EzDrag(EzConfig, Drag):
         super().__init__(modkeys, button, *commands, start=start)
 
 
+@dataclass
 class ScreenRect:
-    def __init__(self, x: int, y: int, width: int, height: int) -> None:
-        self.x = x
-        self.y = y
-        self.width = width
-        self.height = height
-
-    def __repr__(self) -> str:
-        return "<%s %d,%d %d,%d>" % (
-            self.__class__.__name__,
-            self.x,
-            self.y,
-            self.width,
-            self.height,
-        )
+    x: int
+    y: int
+    width: int
+    height: int
 
     def hsplit(self, columnwidth: int) -> tuple[ScreenRect, ScreenRect]:
         assert 0 < columnwidth < self.width

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -312,9 +312,11 @@ class RatioTile(_SimpleLayoutBase):
         if new_ratio < 0:
             return
         self.ratio = new_ratio
+        self.dirty = True
         self.group.layout_all()
 
     @expose_command()
     def increase_ratio(self):
         self.ratio += self.ratio_increment
+        self.dirty = True
         self.group.layout_all()

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -359,6 +359,8 @@ class Spiral(_SimpleLayoutBase):
             return
 
         setattr(self, prop, value)
+        # Force layout to be recalculated
+        self.dirty = True
         self.group.layout_all()
 
     @expose_command()
@@ -414,4 +416,6 @@ class Spiral(_SimpleLayoutBase):
         """Reset ratios to values set in config."""
         self.ratio = self.initial_ratio
         self.main_pane_ratio = self.initial_main_pane_ratio
+        # Force layout to be recalculated
+        self.dirty = True
         self.group.layout_all()


### PR DESCRIPTION
We had at least three different classes (all dataclasses without the name) that represented a screen, and additionally open coded them with tuple unpacking in a few places as well. Let's consolidate on one class, use dataclass so we get free __init__ and __repr__, and use it everywhere.

For now this still just contains xywh, but it is where we will eventually add the serial number for the output, and could in the future carry information about DPI, etc.

I don't love the name ScreenRect for this, but this might (?) be user facing, and I don't have a better name, so whatever...

This does fail some layout tests, but I'm really not sure why. I'm also mostly just sending it so @elParaguayo can take a look, maybe we can share this as a place to return both serial and dpi info from get_screen_info().