### PR TITLE
Add `NotAvailble` value to Memory widget

### DIFF
--- a/libqtile/widget/memory.py
+++ b/libqtile/widget/memory.py
@@ -34,6 +34,7 @@ class Memory(base.ThreadPoolText):
     - ``MemTotal``: Total amount of memory.
     - ``MemFree``: Amount of memory free.
     - ``Available``: Amount of memory available.
+    - ``NotAvailable``: Equal to ``MemTotal`` - ``MemAvailable``
     - ``MemPercent``: Memory in use as a percentage.
     - ``Buffers``: Buffer amount.
     - ``Active``: Active memory.
@@ -49,6 +50,7 @@ class Memory(base.ThreadPoolText):
     Widget requirements: psutil_.
 
     .. _psutil: https://pypi.org/project/psutil/
+
     """
 
     defaults = [
@@ -74,6 +76,7 @@ class Memory(base.ThreadPoolText):
         val["MemTotal"] = mem.total / self.calc_mem
         val["MemFree"] = mem.free / self.calc_mem
         val["Available"] = mem.available / self.calc_mem
+        val["NotAvailable"] = (mem.total - mem.available) / self.calc_mem
         val["MemPercent"] = mem.percent
         val["Buffers"] = mem.buffers / self.calc_mem
         val["Active"] = mem.active / self.calc_mem
@@ -85,4 +88,5 @@ class Memory(base.ThreadPoolText):
         val["SwapPercent"] = swap.percent
         val["mm"] = self.measure_mem
         val["ms"] = self.measure_swap
+
         return self.format.format(**val)


### PR DESCRIPTION
Provides a new value, `NotAvailable`, as an alternative to `Used`. The latter takes account of buffers and caches.