### PR TITLE
don't fail on coveralls upload failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     build:
         runs-on: ubuntu-22.04
         name: "python ${{ matrix.python-version }} on ${{ matrix.backend }}"
+        # https://github.com/pypy/pypy/issues/4956
+        continue-on-error: "${{ matrix.python-version == 'pypy-3.10' }}"
         strategy:
             matrix:
                 # If you change one of these, be sure to update:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
               env:
                 BACKEND: ${{ matrix.backend }}
             - name: Upload coverage data to coveralls.io
+              continue-on-error: true
               run: |
                 pip -q install coveralls >=3.3.0
                 coveralls --service=github


### PR DESCRIPTION
I don't know what other consequences this will have if coveralls fails (will it list our coverage as 0%?). I'm also a little weary of this, because if we break it somehow for real, it feels like it'll take a while for someone to notice.

Ideally, there would be some coveralls --fail-only-if-upload-500s. Maybe we should grep output for error strings? That also feels brittle, and it's not clear whether the coveralls error from [1] goes to stdout or stderr, etc. etc.

I don't know. Maybe we shouldn't merge this? coveralls doesn't fail that often.

Fixes: #4815

[1]: https://github.com/qtile/qtile/actions/runs/9091975351/job/24992594703