### PR TITLE
Wayland: Refactor output handling

### DIFF
--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -73,7 +73,7 @@ class Output(HasListeners):
 
         # During tests, we want to fix the geometry of the 1 or 2 outputs.
         if wlr_output.is_headless and "PYTEST_CURRENT_TEST" in os.environ:
-            if not core.outputs:
+            if not core.get_enabled_outputs():
                 # First test output
                 state.set_custom_mode(CustomMode(width=800, height=600, refresh=0))
             else:


### PR DESCRIPTION
Output handling was pretty broken still. Custom modes were not working correctly and we were not handling putting output off/on. This patch makes it work well enough in my testing. Unfortunately we have to add a wlroots function in our ffi as this has not been added to pywlroots yet.

The biggest diff in the patch is making sure we use output state everywhere instead of setting wlr_output properties.

Additionally, this also adds adaptive sync.

Note: Most of the logic from this is from DWL