### PR TITLE
Wayland {Xdg,X}Window: Fix position placing with multi monitors

### DIFF
--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -283,7 +283,7 @@ class XdgWindow(Window[XdgSurface]):
             [
                 self._geom.x != geom.x,
                 self._geom.y != geom.y,
-                self._geom.width != width,
+                self._geom.width != geom.width,
                 self._geom.height != geom.height,
             ]
         )
@@ -298,8 +298,8 @@ class XdgWindow(Window[XdgSurface]):
         self._width = width
         self._height = height
 
+        self.container.node.set_position(x, y)
         if needs_repos:
-            self.container.node.set_position(x, y)
             self.surface.set_size(width, height)
             self.surface.set_bounds(width, height)
             self.clip()

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -363,9 +363,9 @@ class XWindow(Window[xwayland.Surface]):
         self._width = width
         self._height = height
 
+        self.container.node.set_position(x, y)
+        self.surface.configure(x, y, width, height)
         if needs_repos:
-            self.container.node.set_position(x, y)
-            self.surface.configure(x, y, width, height)
             self.clip()
 
         if needs_repos or has_border_changed:


### PR DESCRIPTION
Seems like we need to do set_position more often as needs_repos doesn't report if we just switched mons. Let's always do it and only do the methods that we are absolutely sure do not need a change.

Borders only need to be changed if the borderwidth or color has changed.