### PR TITLE
feat: Add options to set initial state for caps lock and num lock

### DIFF
--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from pywayland.protocol.wayland import WlKeyboard
+from wlroots.wlr_types.keyboard import ModifiersMask
 from xkbcommon import xkb
 
 from libqtile import configurable
@@ -143,6 +144,8 @@ class InputConfig(configurable.Configurable):
         ("kb_variant", None, "Keyboard variant i.e. ``XKB_DEFAULT_VARIANT``"),
         ("kb_repeat_rate", 25, "Keyboard key repeats made per second"),
         ("kb_repeat_delay", 600, "Keyboard delay in milliseconds before repeating"),
+        ("kb_numlock", None, "``True`` or ``False`` Enable numlock on startup"),
+        ("kb_capslock", None, "``True`` or ``False`` Enable capslock on startup"),
     ]
 
     def __init__(self, **config: Any) -> None:
@@ -313,6 +316,15 @@ class Keyboard(_Device):
 
         self.seat.keyboard_notify_key(event)
 
+    def _set_num_caps_lock(self, numlock: bool | None, capslock: bool | None) -> None:
+        """Set the initial num/caps lock state of the keyboard."""
+        mask = ModifiersMask(self.keyboard)
+        if numlock:
+            mask.add("Mod2")
+        if capslock:
+            mask.add("Lock")
+        self.keyboard.notify_modifiers(mask)
+
     def configure(self, configs: dict[str, InputConfig]) -> None:
         """Applies ``InputConfig`` rules to this keyboard device."""
         config = self._match_config(configs)
@@ -320,6 +332,7 @@ class Keyboard(_Device):
         if config:
             self.keyboard.set_repeat_info(config.kb_repeat_rate, config.kb_repeat_delay)
             self.set_keymap(config.kb_layout, config.kb_options, config.kb_variant)
+            self._set_num_caps_lock(config.kb_numlock, config.kb_capslock)
 
 
 class Pointer(_Device):

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -144,8 +144,8 @@ class InputConfig(configurable.Configurable):
         ("kb_variant", None, "Keyboard variant i.e. ``XKB_DEFAULT_VARIANT``"),
         ("kb_repeat_rate", 25, "Keyboard key repeats made per second"),
         ("kb_repeat_delay", 600, "Keyboard delay in milliseconds before repeating"),
-        ("kb_numlock", None, "``True`` or ``False`` Enable numlock on startup"),
-        ("kb_capslock", None, "``True`` or ``False`` Enable capslock on startup"),
+        ("kb_numlock", False, "``True`` or ``False`` Enable numlock on startup"),
+        ("kb_capslock", False, "``True`` or ``False`` Enable capslock on startup"),
     ]
 
     def __init__(self, **config: Any) -> None:

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -25,7 +25,6 @@
 # SOFTWARE.
 
 from libqtile import bar, layout, qtile, widget
-from libqtile.backend.wayland.inputs import InputConfig
 from libqtile.config import Click, Drag, Group, Key, Match, Screen
 from libqtile.lazy import lazy
 from libqtile.utils import guess_terminal
@@ -212,9 +211,13 @@ auto_minimize = True
 
 # When using the Wayland backend, this can be used to configure input devices.
 # By default the numlock is on by default.
-wl_input_rules = {
-    "type:keyboard": InputConfig(kb_numlock=True),
-}
+wl_input_rules = None
+if qtile.core.name == "wayland":
+    from libqtile.backend.wayland.inputs import InputConfig
+
+    wl_input_rules = {
+        "type:keyboard": InputConfig(kb_numlock=True),
+    }
 
 # xcursor theme (string or None) and size (integer) for Wayland backend
 wl_xcursor_theme = None

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -25,6 +25,7 @@
 # SOFTWARE.
 
 from libqtile import bar, layout, qtile, widget
+from libqtile.backend.wayland.inputs import InputConfig
 from libqtile.config import Click, Drag, Group, Key, Match, Screen
 from libqtile.lazy import lazy
 from libqtile.utils import guess_terminal
@@ -210,7 +211,10 @@ reconfigure_screens = True
 auto_minimize = True
 
 # When using the Wayland backend, this can be used to configure input devices.
-wl_input_rules = None
+# By default the numlock is on by default.
+wl_input_rules = {
+    "type:keyboard": InputConfig(kb_numlock=True),
+}
 
 # xcursor theme (string or None) and size (integer) for Wayland backend
 wl_xcursor_theme = None


### PR DESCRIPTION
This adds the ability set an initial state for
caps lock and num lock using kb_capslock and
kb_numlock InputConfig options.

Closes:
https://github.com/qtile/qtile/issues/4225