### PR TITLE
Wayland {X,Xdg}Window: Remove all position checks in place

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * features
         * Make default `Plasma` add mode dynamic
     * bugfixes
-        * Fix `Plasma` layout with `ScreenSplit` by implementing `get_windows`
+      - Fix `Plasma` layout with `ScreenSplit` by implementing `get_windows`
+      - Fix border bug in fullscreening/maximizing wayland windows
 
 Qtile 0.26.0, released 2024-05-21:
     !!! breaking changes !!!

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -63,7 +63,6 @@ class XdgWindow(Window[XdgSurface]):
         Window.__init__(self, core, qtile, surface)
 
         self._wm_class = surface.toplevel.app_id
-        self._geom = Box(0, 0, 0, 0)
         surface.set_wm_capabilities(WM_CAPABILITIES)
         surface.data = self.data_handle
         self.tree = core.scene.xdg_surface_create(self.container, surface)
@@ -230,9 +229,8 @@ class XdgWindow(Window[XdgSurface]):
             return
         if next(self.tree.children, None) is None:
             return
-        self.tree.node.subsurface_tree_set_clip(
-            Box(self._geom.x, self._geom.y, self.width, self.height)
-        )
+        geom = self.surface.get_geometry()
+        self.tree.node.subsurface_tree_set_clip(Box(geom.x, geom.y, self.width, self.height))
 
     def place(
         self,
@@ -275,37 +273,17 @@ class XdgWindow(Window[XdgSurface]):
         if height < 1:
             height = 1
 
-        geom = self.surface.get_geometry()
-        place_changed = any(
-            [self.x != x, self.y != y, self._width != width, self._height != height]
-        )
-        geom_changed = any(
-            [
-                self._geom.x != geom.x,
-                self._geom.y != geom.y,
-                self._geom.width != geom.width,
-                self._geom.height != geom.height,
-            ]
-        )
-        needs_repos = place_changed or geom_changed
-        has_border_changed = any(
-            [borderwidth != self.borderwidth, bordercolor != self.bordercolor]
-        )
-
-        self._geom = geom
         self.x = x
         self.y = y
         self._width = width
         self._height = height
 
         self.container.node.set_position(x, y)
-        if needs_repos:
-            self.surface.set_size(width, height)
-            self.surface.set_bounds(width, height)
-            self.clip()
+        self.surface.set_size(width, height)
+        self.surface.set_bounds(width, height)
+        self.clip()
 
-        if needs_repos or has_border_changed:
-            self.paint_borders(bordercolor, borderwidth)
+        self.paint_borders(bordercolor, borderwidth)
 
         if above:
             self.bring_to_front()

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -342,22 +342,6 @@ class XWindow(Window[xwayland.Surface]):
         if height < 1:
             height = 1
 
-        place_changed = any(
-            [self.x != x, self.y != y, self._width != width, self._height != height]
-        )
-        geom_changed = any(
-            [
-                self.surface.x != x,
-                self.surface.y != y,
-                self.surface.width != width,
-                self.surface.height != height,
-            ]
-        )
-        needs_repos = place_changed or geom_changed
-        has_border_changed = any(
-            [borderwidth != self.borderwidth, bordercolor != self.bordercolor]
-        )
-
         self.x = x
         self.y = y
         self._width = width
@@ -365,11 +349,9 @@ class XWindow(Window[xwayland.Surface]):
 
         self.container.node.set_position(x, y)
         self.surface.configure(x, y, width, height)
-        if needs_repos:
-            self.clip()
+        self.clip()
 
-        if needs_repos or has_border_changed:
-            self.paint_borders(bordercolor, borderwidth)
+        self.paint_borders(bordercolor, borderwidth)
 
         if above:
             self.bring_to_front()


### PR DESCRIPTION
Previously I checked if border needs to change or the window needs to be repositioned, instead of calling configure and setting sizes every time `place()` is called. However, this has too many edge cases. Let's not do premature optimization here because it leads to issues such as #4838