### PR TITLE
x11: don't query offline CRTCs

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -406,9 +406,8 @@ class RandR:
 
     def query_crtcs(self, root):
         infos = []
-        for output in self.ext.GetScreenResources(root).reply().outputs:
-            output_info = self.ext.GetOutputInfo(output, xcffib.CurrentTime).reply()
-            crtc_info = self.ext.GetCrtcInfo(output_info.crtc, xcffib.CurrentTime).reply()
+        for crtc in self.ext.GetScreenResources(root).reply().crtcs:
+            crtc_info = self.ext.GetCrtcInfo(crtc, xcffib.CurrentTime).reply()
 
             infos.append(ScreenRect(crtc_info.x, crtc_info.y, crtc_info.width, crtc_info.height))
         return infos


### PR DESCRIPTION
otherwise we'll end up with:

2024-05-26 15:20:45,432 ERROR libqtile manager.py:load_config():L116 Configuration error: Traceback (most recent call last):
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/core/manager.py", line 113, in load_config
    self.config.load()
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/confreader.py", line 134, in load
    config = importlib.import_module(name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/tycho/.qtile/config.py", line 199, in <module>
    screens = screen_setup()
  File "/home/tycho/.qtile/config.py", line 196, in screen_setup
    return setup.get(current_screens(), one_screen)()
  File "/home/tycho/.qtile/config.py", line 24, in current_screens
    screens = len(conn.pseudoscreens)
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/backend/x11/xcbq.py", line 488, in pseudoscreens
    return self.randr.query_crtcs(self.screens[0].root.wid)
  File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/backend/x11/xcbq.py", line 412, in query_crtcs
    crtc_info = self.ext.GetCrtcInfo(output_info.crtc, xcffib.CurrentTime).reply()
  File "/home/tycho/.local/lib/python3.10/site-packages/xcffib/__init__.py", line 330, in reply
    data = self.conn.wait_for_reply(self.sequence)
  File "/home/tycho/.local/lib/python3.10/site-packages/xcffib/__init__.py", line 579, in wrapper
    return f(*args)
  File "/home/tycho/.local/lib/python3.10/site-packages/xcffib/__init__.py", line 666, in wait_for_reply
    self._process_error(error_p[0])
  File "/home/tycho/.local/lib/python3.10/site-packages/xcffib/__init__.py", line 657, in _process_error
    raise error(buf)
xcffib.randr.BadCrtcError