### PR TITLE
Fix help subcommand

### DIFF
--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -67,7 +67,9 @@ def main():
     def print_help(options):
         main_parser.print_help()
 
-    help_ = subparsers.add_parser("help", help="Print help message and exit.")
+    help_ = subparsers.add_parser(
+        "help", help="Print help message and exit.", parents=[parent_parser]
+    )
     help_.set_defaults(func=print_help)
 
     options = main_parser.parse_args()

--- a/test/test_qtile_help.py
+++ b/test/test_qtile_help.py
@@ -1,0 +1,47 @@
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import subprocess
+
+
+def run_qtile(args):
+    cmd = os.path.join(os.path.dirname(__file__), "..", "bin", "qtile")
+    argv = [cmd]
+    argv.extend(args)
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+    assert proc.returncode == 0
+    stdout = stdout.decode()
+    stderr = stderr.decode()
+    return (stdout, stderr)
+
+
+def test_cmd_help_subcommand():
+    args = ["help"]
+    stdout, stderr = run_qtile(args)
+    assert "usage: qtile" in stdout
+    assert stderr == ""
+
+
+def test_cmd_help_param():
+    args = ["--help"]
+    stdout, stderr = run_qtile(args)
+    assert "usage: qtile" in stdout
+    assert stderr == ""


### PR DESCRIPTION
The help subcommand on the CLI currently throwas an exception because the log_level property is not available on the options objects.

This PR fixes it by adding the parent parser to the help subparser.

Let me know if you feel the test is too much or need an issues first.

