### PR TITLE
x11: ignore initial screen change notifications

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -185,10 +185,7 @@ class Core(base.Core):
         self.conn.finalize()
 
     def get_screen_info(self) -> list[ScreenRect]:
-        ps = self.conn.pseudoscreens
-        if self.qtile:
-            self._xpoll()
-        return ps
+        return self.conn.pseudoscreens
 
     @property
     def wmname(self):
@@ -274,6 +271,7 @@ class Core(base.Core):
 
             self.update_client_lists()
             win.change_layer()
+            self.conn.enable_screen_change_notifications()
 
     def warp_pointer(self, x, y):
         self._root.warp_pointer(x, y)

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -402,7 +402,6 @@ class Xinerama:
 class RandR:
     def __init__(self, conn):
         self.ext = conn.conn(xcffib.randr.key)
-        self.ext.SelectInput(conn.default_screen.root.wid, xcffib.randr.NotifyMask.ScreenChange)
 
     def query_crtcs(self, root):
         infos = []
@@ -411,6 +410,9 @@ class RandR:
 
             infos.append(ScreenRect(crtc_info.x, crtc_info.y, crtc_info.width, crtc_info.height))
         return infos
+
+    def enable_screen_change_notifications(self, conn):
+        self.ext.SelectInput(conn.default_screen.root.wid, xcffib.randr.NotifyMask.ScreenChange)
 
 
 class XFixes:
@@ -494,6 +496,9 @@ class Connection:
             return pseudoscreens
         elif hasattr(self, "randr"):
             return self.randr.query_crtcs(self.screens[0].root.wid)
+
+    def enable_screen_change_notifications(self):
+        self.randr.enable_screen_change_notifications(self)
 
     def finalize(self):
         self.cursors.finalize()


### PR DESCRIPTION
...and drop our _xpoll() hack. Fixes #4818.

Instead of swallowing these manually by invoking an _xpoll() before the on_screen_change hook is registered, let's just leave that event masked until we are ready to handle it.