### PR TITLE
test: do not actually call set_font() in migration

### DIFF
--- a/libqtile/scripts/migrations/rename_unspecified.py
+++ b/libqtile/scripts/migrations/rename_unspecified.py
@@ -89,8 +89,9 @@ class RenameUnspecified(_QtileMigrator):
             tb = TextBox(text="hello")
             # just to use ORIENTATION_BOTH and force us to delete only the
             # right thing
-            tb.orientations = ORIENTATION_BOTH
-            tb.set_font(font=UNSPECIFIED, fontsize=12)
+            if False:
+                tb.orientations = ORIENTATION_BOTH
+                tb.set_font(font=UNSPECIFIED, fontsize=12)
             """,
             """
             from libqtile.widget.base import ORIENTATION_BOTH
@@ -100,8 +101,9 @@ class RenameUnspecified(_QtileMigrator):
             tb = TextBox(text="hello")
             # just to use ORIENTATION_BOTH and force us to delete only the
             # right thing
-            tb.orientations = ORIENTATION_BOTH
-            tb.set_font(fontsize=12)
+            if False:
+                tb.orientations = ORIENTATION_BOTH
+                tb.set_font(fontsize=12)
             """,
         )
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ testdeps =
     libcst >= 1.0.0
     PyGObject   
     isort
+    mypy
 commands =
     !x11: pip install pywlroots==0.17.0
     pip install .


### PR DESCRIPTION
We have reports of the stack trace:

[ 1845s] Checking Qtile config at: /tmp/tmpmddmh3ov/config.py [ 1845s] Checking if config is valid python...
[ 1845s] Traceback (most recent call last):
[ 1845s]   File "/home/abuild/rpmbuild/BUILD/qtile-0.26.0/libqtile/scripts/check.py", line 122, in check_config
[ 1845s]     config.load()
[ 1845s]   File "/home/abuild/rpmbuild/BUILD/qtile-0.26.0/libqtile/confreader.py", line 134, in load
[ 1845s]     config = importlib.import_module(name)
[ 1845s]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ 1845s]   File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
[ 1845s]     return _bootstrap._gcd_import(name[level:], package, level)
[ 1845s]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ 1845s]   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
[ 1845s]   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
[ 1845s]   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
[ 1845s]   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
[ 1845s]   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
[ 1845s]   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
[ 1845s]   File "/tmp/tmpmddmh3ov/config.py", line 10, in <module>
[ 1845s]     tb.set_font(fontsize=12)
[ 1845s]   File "/home/abuild/rpmbuild/BUILD/qtile-0.26.0/libqtile/widget/base.py", line 733, in set_font
[ 1845s]     self.bar.draw()
[ 1845s]     ^^^^^^^^
[ 1845s]   File "/home/abuild/rpmbuild/BUILD/qtile-0.26.0/libqtile/command/base.py", line 281, in __getattr__
[ 1845s]     raise AttributeError(f"{self.__class__} has no attribute {name}")
[ 1845s] AttributeError: <class 'libqtile.widget.textbox.TextBox'> has no attribute bar

the problem here is that the test actually calls set_font() when imported, which we can't do since we haven't actually configured a bar yet.

This is part of #4868 and suggests that we are somehow not running the migration tests correctly in our CI.