### PR TITLE
Accurately display mute status when using volume icon or emoji

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -165,7 +165,7 @@ class Volume(base._TextBox):
 
         if self.theme_path:
             self.drawer.clear(self.background or self.bar.background)
-            if self.volume <= 0:
+            if self.volume <= 0 or self.is_mute:
                 img_name = "audio-volume-muted"
             elif self.volume <= 30:
                 img_name = "audio-volume-low"
@@ -183,7 +183,7 @@ class Volume(base._TextBox):
                     "Emoji list given has less than 4 items. Falling back to default emojis."
                 )
 
-            if self.volume <= 0:
+            if self.volume <= 0 or self.is_mute:
                 self.text = self.emoji_list[0]
             elif self.volume <= 30:
                 self.text = self.emoji_list[1]

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -51,6 +51,10 @@ def test_emoji():
     vol._update_drawer()
     assert vol.text == "\U0001f50a"
 
+    vol.is_mute = True
+    vol._update_drawer()
+    assert vol.text == "\U0001f507"
+
 
 def test_text():
     fmt = "Volume: {}"


### PR DESCRIPTION
I noticed that when using emojis/icons in the `Volume` widget, it only displays the mute symbol when the volume level is 0. It disregards the actual mute status of the device altogether and only reacts to the volume level, which I found a bit misleading.

This PR fixes it by checking mute status in addition to volume when updating the widget.

Please let me know if any changes should be done.