### PR TITLE
Fix wayland cpu usage

### DIFF
--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -255,8 +255,8 @@ class XdgWindow(Window[XdgSurface]):
             width -= margin[1] + margin[3]
             height -= margin[0] + margin[2]
 
+        state = self.surface.toplevel._ptr.current
         if respect_hints:
-            state = self.surface.toplevel._ptr.current
             width = max(width, state.min_width)
             height = max(height, state.min_height)
             if state.max_width:
@@ -276,15 +276,22 @@ class XdgWindow(Window[XdgSurface]):
             height = 1
 
         geom = self.surface.get_geometry()
-        place_changed = any(
-            [self.x != x, self.y != y, self._width != width, self._height != height]
-        )
         geom_changed = any(
             [
                 self._geom.x != geom.x,
                 self._geom.y != geom.y,
                 self._geom.width != geom.width,
                 self._geom.height != geom.height,
+            ]
+        )
+        place_changed = any(
+            [
+                self.x != x,
+                self.y != y,
+                self._width != width,
+                self._height != height,
+                state.width != width,
+                state.height != height,
             ]
         )
         needs_repos = place_changed or geom_changed

--- a/libqtile/backend/wayland/xwindow.py
+++ b/libqtile/backend/wayland/xwindow.py
@@ -342,6 +342,22 @@ class XWindow(Window[xwayland.Surface]):
         if height < 1:
             height = 1
 
+        place_changed = any(
+            [self.x != x, self.y != y, self._width != width, self._height != height]
+        )
+        geom_changed = any(
+            [
+                self.surface.x != x,
+                self.surface.y != y,
+                self.surface.width != width,
+                self.surface.height != height,
+            ]
+        )
+        needs_repos = place_changed or geom_changed
+        has_border_changed = any(
+            [borderwidth != self.borderwidth, bordercolor != self.bordercolor]
+        )
+
         self.x = x
         self.y = y
         self._width = width
@@ -349,9 +365,11 @@ class XWindow(Window[xwayland.Surface]):
 
         self.container.node.set_position(x, y)
         self.surface.configure(x, y, width, height)
-        self.clip()
+        if needs_repos:
+            self.clip()
 
-        self.paint_borders(bordercolor, borderwidth)
+        if needs_repos or has_border_changed:
+            self.paint_borders(bordercolor, borderwidth)
 
         if above:
             self.bring_to_front()


### PR DESCRIPTION
This patch reverts an optimization that was removed, so in english: it adds back an optimization :^)

Previously this optimization had issues with fullscreen/max window toggle but this patch fixes that by checking the toplevel width/height.

This optimization is needed in the wlr 0.17 codebase because we `place()` on each commit. Which is what other compositors also do and they also check for geometry changes

Fixes: #4865 #4878 