### PR TITLE
drawer: finish() last_surface if it existed

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -123,6 +123,8 @@ class Drawer:
 
     def _create_last_surface(self):
         """Creates a separate RecordingSurface for mirrors to access."""
+        if hasattr(self, "last_surface"):
+            self.last_surface.finish()
         self.last_surface = cairocffi.RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, None)
 
     @property


### PR DESCRIPTION
We call _create_last_surface() on every draw() call. If last_surface previously existed, we will leak its backing resources since we do not finish() it. Let's finish() it.

Found as part of #4821.