### PR TITLE
Centre windows matching float rules

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -257,6 +257,7 @@ class _Group(CommandObject):
             win._float_state = FloatStates.FULLSCREEN
         elif self.floating_layout.match(win) and not win.fullscreen:
             win._float_state = FloatStates.FLOATING
+            win.center()
             if self.qtile.config.floats_kept_above:
                 win.keep_above(enable=True)
         if win.floating and not win.fullscreen:

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -599,15 +599,15 @@ def test_default_float(manager):
     assert manager.c.group.info()["focus"] == "float"
     assert manager.c.window.info()["width"] == 100
     assert manager.c.window.info()["height"] == 100
-    assert manager.c.window.info()["x"] == 350
-    assert manager.c.window.info()["y"] == 240
+    assert manager.c.window.info()["x"] == 350  # (800 - 100) / 2
+    assert manager.c.window.info()["y"] == 250  # (600 - 100) /2
     assert manager.c.window.info()["floating"] is True
 
     manager.c.window.move_floating(10, 20)
     assert manager.c.window.info()["width"] == 100
     assert manager.c.window.info()["height"] == 100
     assert manager.c.window.info()["x"] == 360
-    assert manager.c.window.info()["y"] == 260
+    assert manager.c.window.info()["y"] == 270
     assert manager.c.window.info()["floating"] is True
 
     manager.c.window.set_position_floating(10, 20)


### PR DESCRIPTION
When we float windows matching the user's `float_rules`, let's make sure the window is centred in the screen.

@jwijenbergh let me know if you think there's a better way to do this. I think x11 centres by default but we  get the odd behaviour in wayland where the top-left corner of the window is centred in the screen.