### PR TITLE
Cleanup some grammar, spelling, and layout issues in docstring

### DIFF
--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -37,7 +37,7 @@ class VerticalTile(_SimpleLayoutBase):
 
     The available height gets divided by the number of panes, if no pane is
     maximized. If one pane has been maximized, the available height gets split
-    in master- and secondary area. The maximized pane (master pane) gets the
+    in master and secondary area. The maximized pane (master pane) gets the
     full height of the master area and the other panes (secondary panes) share
     the remaining space.  The master area (at default 75%) can grow and shrink
     via keybindings.
@@ -62,17 +62,17 @@ class VerticalTile(_SimpleLayoutBase):
         |               |                |       3       |   |
         -----------------                -----------------  ---
 
-    Normal behavior. No              One maximized pane in the master area
-    maximized pane. No               and two secondary panes in the
-    specific areas.                  secondary area.
+        Normal behavior.                 One maximized pane in the master area
+        No maximized pane.               and two secondary panes in the
+        No specific areas.               secondary area.
 
     ::
 
-        -----------------------------------  In some cases VerticalTile can be
+        -----------------------------------  In some cases, VerticalTile can be
         |                                 |  useful on horizontal mounted
-        |                1                |  monitors two.
-        |                                 |  For example if you want to have a
-        |---------------------------------|  webbrowser and a shell below it.
+        |                1                |  monitors too.
+        |                                 |  For example, if you want to have a
+        |---------------------------------|  web browser and a shell below it.
         |                                 |
         |                2                |
         |                                 |


### PR DESCRIPTION
(I'm not sure how rigorous the guidelines are when they come to simple documentation/docstring changes. Apologies in advance if this violates the rules of contribution.)

The indentation was wrong under the ASCII diagrams for regular vs. maximized verticaltile, so the text was rendered as HTML which messed up the formatting of the text (instead of a more columnar text layout) and made it very confusing. 

I also cleaned up a misspelling or two, a typo, and some basic grammar corrections.
