### PR TITLE
Wayland Inputs: Allow keybinds to repeat when holding keys

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
         - Add ability to use key codes to bind keys. Will benefit users who change keyboard layouts but
           wish to retain same bindings, irrespective of layout.
         - Wayland: Add support for idle-notify-v1 protocol needed by swayidle.
+        - Wayland: Make keybinds repeat according to the keyboard's repeat rate and delay. Previously the keybinds did not repeat.
 
     * bugfixes
       - Fix `Plasma` layout with `ScreenSplit` by implementing `get_windows`

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -979,7 +979,7 @@ class Qtile(CommandObject):
 
         return self._eventloop.call_soon_threadsafe(f)
 
-    def call_later(self, delay: int, func: Callable, *args: Any) -> asyncio.TimerHandle:
+    def call_later(self, delay: int | float, func: Callable, *args: Any) -> asyncio.TimerHandle:
         """Another event loop proxy, see `call_soon`."""
 
         def f() -> None:


### PR DESCRIPTION
This is a patch to enable keybinds to repeat according to the keyboard's repeat rate and delay. It does this by using asyncio timer's. Other compositors use wayland timers, but using asyncio timers is more qtile-y and seems to work well