### PR TITLE
XWayland: Fake a fullscreen request on map event

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * bugfixes
       - Fix `Plasma` layout with `ScreenSplit` by implementing `get_windows`
       - Fix border bug in fullscreening/maximizing wayland windows
+      - Fix automatic fullscreening for many XWayland applications (e.g. games) by checking if they want to fullscreen on map
 
 Qtile 0.26.0, released 2024-05-21:
     !!! breaking changes !!!


### PR DESCRIPTION
Some games request fullscreen *before* they are mapped. Other
compositors handle this by checking if the surface wants to be
fullscreened on first map. I have added this workaround to Qtile. Fixes https://github.com/qtile/qtile/issues/4900