### PR TITLE
Fix playback status text color issue in Cmus widget

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -509,6 +509,7 @@ class _TextBox(_Widget):
         self._scroll_queued = False
         self._scroll_timer = None
         self._scroll_width = width
+        self._force_redraw = False
 
     @property
     def text(self):
@@ -748,8 +749,10 @@ class _TextBox(_Widget):
         if not self.can_draw():
             return
 
-        if self.text == text:
+        if self.text == text and not self._force_redraw:
             return
+        self._force_redraw = False
+
         if text is None:
             text = ""
 

--- a/libqtile/widget/cmus.py
+++ b/libqtile/widget/cmus.py
@@ -100,6 +100,7 @@ class Cmus(base.ThreadPoolText):
         if info:
             status = info["status"]
             if self.status != status:
+                self._force_redraw = True
                 self.status = status
                 if self.status == "playing":
                     self.layout.colour = self.play_color


### PR DESCRIPTION
This fixes an issue in the Cmus widget where the text color would not change to reflect the current playback status unless the song was changed (#4904).

The reason for the issue is that the TextBox widget only redraws the widget if the text changes without checking if layout information like text color have changed.

We use the `_force_redraw` flag of the `TextWidget` to force a redraw if the playback status changes to fix this.

Closes #4904.