### PR TITLE
Fix WindowCount widget update on group_window_add

### DIFF
--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -57,6 +57,7 @@ class WindowCount(base._TextBox):
         hook.subscribe.client_killed(self._win_killed)
         hook.subscribe.client_managed(self._wincount)
         hook.subscribe.current_screen_change(self._wincount)
+        hook.subscribe.group_window_add(self._wincount)
         hook.subscribe.setgroup(self._wincount)
 
     def _wincount(self, *args):

--- a/test/widgets/test_window_count.py
+++ b/test/widgets/test_window_count.py
@@ -86,6 +86,10 @@ def test_window_count(manager_nospawn, minimal_conf_noscreen):
     manager_nospawn.c.group["a"].toscreen()
     assert int(manager_nospawn.c.widget["windowcount"].get()) == 2
 
+    # Move a window and check text
+    manager_nospawn.c.window.togroup("b")
+    assert int(manager_nospawn.c.widget["windowcount"].get()) == 1
+
     # Close all windows and check count is 0 and widget not displayed
     manager_nospawn.kill_window(one)
     manager_nospawn.kill_window(two)


### PR DESCRIPTION
Fixes an issue where the WindowCount widget would not update when moving windows to another group using `lazy.window.togroup()` without `switch_group=True`.

It is fixed by subscribing to the `group_window_add` hook in the WindowCount widget.

Closes #4908

Let me know if you want me to add / change any tests.