### PR TITLE
Fix volume widget ignoring default foreground

### DIFF
--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -110,7 +110,6 @@ class Volume(base._TextBox):
         self.surfaces = {}
         self.volume = None
         self.is_mute = False
-        self.unmute_foreground = self.foreground
 
         self.add_callbacks(
             {
@@ -126,6 +125,7 @@ class Volume(base._TextBox):
             self.length_type = bar.STATIC
             self.length = 0
         base._TextBox._configure(self, qtile, parent_bar)
+        self.unmute_foreground = self.foreground
 
     def timer_setup(self):
         self.timeout_add(self.update_interval, self.update)

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -3,7 +3,7 @@ import pytest
 
 from libqtile import bar, images
 from libqtile.widget import Volume
-from test.widgets.conftest import TEST_DIR
+from test.widgets.conftest import TEST_DIR, FakeBar
 
 
 def test_images_fail():
@@ -81,10 +81,14 @@ def test_formats():
     assert vol.text == "Volume: 50% M"
 
 
-def test_foregrounds():
+def test_foregrounds(fake_qtile, fake_window):
     foreground = "#dddddd"
     mute_foreground = None
+
     vol = Volume(foreground=foreground, mute_foreground=mute_foreground)
+    fakebar = FakeBar([vol], window=fake_window)
+    vol._configure(fake_qtile, fakebar)
+
     vol.volume = 50
     vol._update_drawer()
     assert vol.foreground == foreground


### PR DESCRIPTION
This fixes an issue in the volume widget where the foreground color in widget_defaults would be ignored because unmute_foreground is initialized in `__init__()`.

This is fixed by moving the initialization of unmute_foreground into `_configure()`.

Let me know if you want me to add a test. (Also, I hope it is fine to create PRs without related issues if the problem and solution are properly explained? If not I can create an issue of course.)