### PR TITLE
check_update widget uses a FreeBSD deprecated command

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -37,7 +37,7 @@ CMD_DICT = {
     "Guix": ("guix upgrade --dry-run", 0),
     "Ubuntu": ("aptitude search ~U", 0),
     "Fedora": ("dnf list updates -q", 1),
-    "FreeBSD": ("pkg_version -I -l '<'", 0),
+    "FreeBSD": ("pkg upgrade -n | awk '/\t/ { print $0 }'", 0),
     "Mandriva": ("urpmq --auto-select", 0),
     "Void": ("xbps-install -nuMS", 0),
 }


### PR DESCRIPTION
To fix the issue #4907 the check command it's changed
the widget use the new command and the output is filtered using awk to get a line for each packates. This lines begin with a tab
