### PR TITLE
Revert "remember to finalize widgets"

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -442,8 +442,6 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         if self.window:
             self.window.kill()
             self.window = None
-        for widget in self.widgets:
-            widget.finalize()
         self.widgets.clear()
 
     def _resize(self, length: int, widgets: list[_Widget]) -> None:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -484,10 +484,6 @@ class Screen(CommandObject):
         elif self.background:
             self.qtile.fill_screen(self, self.background)
 
-    def finalize(self) -> None:
-        for gap in self.gaps:
-            gap.finalize()
-
     def paint(self, path: str, mode: str | None = None) -> None:
         if self.qtile:
             self.qtile.paint_screen(self, path, mode)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -311,6 +311,8 @@ class Qtile(CommandObject):
         shutdown, these are finalized and then regenerated when reloading the config.
         """
         try:
+            for widget in self.widgets_map.values():
+                widget.finalize()
             self.widgets_map.clear()
 
             # For layouts we need to finalize each clone of a layout in each group
@@ -319,7 +321,8 @@ class Qtile(CommandObject):
                     layout.finalize()
 
             for screen in self.screens:
-                screen.finalize()
+                for gap in screen.gaps:
+                    gap.finalize()
         except:  # noqa: E722
             logger.exception("exception during finalize")
         hook.clear()
@@ -419,7 +422,9 @@ class Qtile(CommandObject):
 
         for screen in self.screens:
             if screen not in screens:
-                screen.finalize()
+                for gap in screen.gaps:
+                    if isinstance(gap, bar.Bar) and gap.window:
+                        gap.finalize()
 
         self.screens = screens
 

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -170,8 +170,3 @@ class WidgetBox(base._TextBox):
         """Close the widgetbox."""
         if self.box_is_open:
             self.toggle()
-
-    def finalize(self):
-        for widget in self.widgets:
-            widget.finalize()
-        base._TextBox.finalize(self)


### PR DESCRIPTION
This reverts commit 7c3fbef756c451031e7d822dafed0b54eec0f2ac.

We have a more serious bug (systray windows dying) reported with this commit than the simple memory leak it fixes. We want to do a release to capture other fixes, so let's revert this for now.

See #4897