### PR TITLE
Trigger `client_killed` hook only for non-internal windows

### DIFF
--- a/libqtile/dgroups.py
+++ b/libqtile/dgroups.py
@@ -253,7 +253,7 @@ class DGroups:
                 self.sort_groups()
             del self.timeout[client]
 
-        if group.persist:
+        if group is not None and group.persist:
             return
 
         logger.debug("Deleting %s in %ss", group, self.delay)

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -35,7 +35,7 @@ import asyncio
 import contextlib
 from typing import TYPE_CHECKING
 
-from libqtile import utils
+from libqtile import backend, utils
 from libqtile.log_utils import logger
 from libqtile.resources.sleep import inhibitor
 
@@ -175,6 +175,9 @@ class Registry:
     def fire(self, event, *args, **kwargs):
         if event not in self.subscribe.hooks:
             raise utils.QtileError("Unknown event: %s" % event)
+        # Do not fire for Internal windows
+        if any(isinstance(arg, backend.base.window.Internal) for arg in args):
+            return
         # We should check if the registry name is in the subscriptions dict
         # A name can disappear if the config is reloaded (which clears subscriptions)
         # but there are no hook subscriptions. This is not an issue for qtile core but
@@ -569,7 +572,8 @@ hooks: list[Hook] = [
     Hook(
         "client_killed",
         """
-        Called after a client has been unmanaged
+        Called after a client has been unmanaged. This hook is not called for
+        internal windows.
 
         **Arguments**
 


### PR DESCRIPTION
As discussed in #4933, this changes the `unmanage` method to only trigger the `client_killed` hook for instances of `Window` and `Static`. Previously, it would also trigger for `Internal` clients. The documentation is updated to bring it in line with other similar hooks which also do not trigger for internal windows. It also adds a `None` check in the `client_killed` hook of the dgroups implementation which should close #4933.

@tych0 [was in favor](https://github.com/qtile/qtile/issues/4933#issuecomment-2258239532) of triggering `client_killed` only for `Window` and not for `Static` and I agree with his reasoning, but my suggestion is to keep it like this for now to a) not risk breaking existing code, b) retain the possibility of keeping track of `Static` windows with hooks, and c) keep this hook in line with other window-handling hooks which also exclude `Internal` windows but still trigger for `Static` windows.

If we want to go the route of exluding both `Internal` and `Static` windows in general, we should change all window-handling hooks to behave the same.

If we want to go the route I suggested (for now), it might be good to update the documentation (for all window-handling hooks) that currently states (under arguments) "`Window` object of the […] window" to "`Window` or `Static` object of the […] window" and maybe add a sentence somewhere that window-handling hook functions can exclude `Static` windows with a simple

```python
# ignore static windows
if isinstance(client, base.Static):
    return
``` 

or something similar.

What do you think?