### PR TITLE
Escape ESSID in wlan widget

### DIFF
--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -29,6 +29,7 @@
 import iwlib
 
 from libqtile.log_utils import logger
+from libqtile.pangocffi import markup_escape_text
 from libqtile.widget import base
 
 
@@ -99,7 +100,9 @@ class Wlan(base.InLoopPollText):
                         return self.disconnected_message
                 else:
                     return self.disconnected_message
-            return self.format.format(essid=essid, quality=quality, percent=(quality / 70))
+            return self.format.format(
+                essid=markup_escape_text(essid), quality=quality, percent=(quality / 70)
+            )
         except EnvironmentError:
             logger.error(
                 "Probably your wlan device is switched off or "

--- a/test/widgets/test_wlan.py
+++ b/test/widgets/test_wlan.py
@@ -103,6 +103,15 @@ def test_wlan_display(minimal_conf_noscreen, manager_nospawn, patched_wlan, kwar
     assert text == expected
 
 
+def test_wlan_display_escape_essid(
+    minimal_conf_noscreen, manager_nospawn, patched_wlan, monkeypatch
+):
+    """Test escaping of pango markup in ESSID"""
+    monkeypatch.setitem(MockIwlib.DATA["wlan0"], "ESSID", b"A&B")
+    widget = patched_wlan.Wlan(format="{essid}")
+    assert widget.poll() == "A&amp;B"
+
+
 @pytest.mark.parametrize(
     "kwargs,state,expected",
     [


### PR DESCRIPTION
Escape pango markup in ESSID when formatting the output of wlan widget.

Closes: #4943 