### PR TITLE
Fix qtile check raising an exception if mypy is missing

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -151,12 +151,12 @@ def check_config(args):
             except CheckError:
                 valid = False
 
-    if valid:
-        print("Your config can be loaded by Qtile.")
-    else:
-        print(
-            "Your config is valid python but has type checking errors. This may result in unexpected behaviour."
-        )
+        if valid:
+            print("Your config can be loaded by Qtile.")
+        else:
+            print(
+                "Your config is valid python but has type checking errors. This may result in unexpected behaviour."
+            )
 
 
 def add_subcommand(subparsers, parents):


### PR DESCRIPTION
Just a simple fix for an incorrectly indented code block.