### PR TITLE
Revert "x11: ignore initial screen change notifications"

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -185,7 +185,10 @@ class Core(base.Core):
         self.conn.finalize()
 
     def get_screen_info(self) -> list[ScreenRect]:
-        return self.conn.pseudoscreens
+        ps = self.conn.pseudoscreens
+        if self.qtile:
+            self._xpoll()
+        return ps
 
     @property
     def wmname(self):
@@ -271,7 +274,6 @@ class Core(base.Core):
 
             self.update_client_lists()
             win.change_layer()
-            self.conn.enable_screen_change_notifications()
 
     def warp_pointer(self, x, y):
         self._root.warp_pointer(x, y)

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -402,6 +402,7 @@ class Xinerama:
 class RandR:
     def __init__(self, conn):
         self.ext = conn.conn(xcffib.randr.key)
+        self.ext.SelectInput(conn.default_screen.root.wid, xcffib.randr.NotifyMask.ScreenChange)
 
     def query_crtcs(self, root):
         infos = []
@@ -410,9 +411,6 @@ class RandR:
 
             infos.append(ScreenRect(crtc_info.x, crtc_info.y, crtc_info.width, crtc_info.height))
         return infos
-
-    def enable_screen_change_notifications(self, conn):
-        self.ext.SelectInput(conn.default_screen.root.wid, xcffib.randr.NotifyMask.ScreenChange)
 
 
 class XFixes:
@@ -496,9 +494,6 @@ class Connection:
             return pseudoscreens
         elif hasattr(self, "randr"):
             return self.randr.query_crtcs(self.screens[0].root.wid)
-
-    def enable_screen_change_notifications(self):
-        self.randr.enable_screen_change_notifications(self)
 
     def finalize(self):
         self.cursors.finalize()


### PR DESCRIPTION
This reverts commit 20f983829aced54a0f7155b43b3cf525e6361c68.

Fixes #4936, Reopens #4818

I am not really sure why this changes things: if people are doing xrandr stuff before they exec qtile, presumably the x11 setup query should return the monitors in that orientation, but it seems like it doesn't, and we're missing randr events somehow. We could "queue" these events, but that also seems like a hack too. Needs more investigation it seems.