### PR TITLE
[StatusNotifier] fix recursive icon search

### DIFF
--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -243,12 +243,12 @@ class StatusNotifierItem:  # noqa: E303
             return
 
         try:
-            icon_path = Path(await self.item.get_icon_theme_path())
+            icon_path = await self.item.get_icon_theme_path()
         except (AttributeError, DBusError):
             icon_path = None
 
         if icon_path:
-            self.icon = self._get_custom_icon(icon_name, icon_path)
+            self.icon = self._get_custom_icon(icon_name, Path(icon_path))
 
         if not self.icon:
             self.icon = self._get_xdg_icon(icon_name)


### PR DESCRIPTION
Tried to be too cute with previous code. Where there's no IconThemePath, we got an empty `Path` object which is equivalent to `Path('.')` meaning that we'd always do a recursive search on the current folder.

This PR fixes that by only creating a `Path` object if there is a theme path.

Fixes #4959