### PR TITLE
Allow setting the exitcode of qtile via shutdown command

### DIFF
--- a/libqtile/core/lifecycle.py
+++ b/libqtile/core/lifecycle.py
@@ -19,6 +19,7 @@ class LifeCycle:
     # referenced here when atexit fires will NOT be finalized properly.
     def __init__(self) -> None:
         self.behavior = Behavior.NONE
+        self.exitcode: int = 0
         self.state_file: str | None = None
         atexit.register(self._atexit)
 
@@ -35,6 +36,10 @@ class LifeCycle:
             os.execv(sys.executable, argv)
         elif self.behavior is Behavior.TERMINATE:
             logger.warning("Qtile will now terminate")
+            # the if statement should be unnecessary, but keeps code coverage working
+            # calling os._exit prevents later injected atexit handlers from running
+            if self.exitcode:
+                os._exit(self.exitcode)
         elif self.behavior is Behavior.NONE:
             pass
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -236,9 +236,10 @@ class Qtile(CommandObject):
             self.finalize()
             self.core.remove_listener()
 
-    def stop(self) -> None:
+    def stop(self, exitcode: int = 0) -> None:
         hook.fire("shutdown")
         lifecycle.behavior = lifecycle.behavior.TERMINATE
+        lifecycle.exitcode = exitcode
         self.core.graceful_shutdown()
         self._stop()
 
@@ -1442,9 +1443,16 @@ class Qtile(CommandObject):
         return dictionary
 
     @expose_command()
-    def shutdown(self) -> None:
-        """Quit Qtile"""
-        self.stop()
+    def shutdown(self, exitcode: int = 0) -> None:
+        """Quit Qtile
+
+        Parameters
+        ==========
+        exitcode :
+            Set exit status of Qtile. Can be e.g. used to make login managers
+            poweroff or restart the system. (default: 0)
+        """
+        self.stop(exitcode)
 
     @expose_command()
     def switch_groups(self, namea: str, nameb: str) -> None:

--- a/test/core/test_exitcode.py
+++ b/test/core/test_exitcode.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2024 Thomas Krug
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import subprocess
+import tempfile
+import threading
+import time
+
+import test
+
+repo_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+socket_path = tempfile.NamedTemporaryFile().name
+
+
+def run_qtile(backend):
+    cmd = os.path.join(repo_path, "bin/qtile")
+    args = [cmd, "start", "-s", socket_path]
+    args.extend(["-b", backend.name])
+
+    env = os.environ.copy()
+    if backend.name == "wayland":
+        env.update(backend.env)
+
+    proc = subprocess.Popen(args, env=env, stdout=subprocess.PIPE)
+    out, err = proc.communicate(timeout=10)
+    exitcode = proc.returncode
+    return exitcode
+
+
+def stop_qtile(code):
+    cmd = os.path.join(repo_path, "bin/qtile")
+    args = [cmd, "cmd-obj", "-o", "cmd", "-s", socket_path, "-f", "shutdown"]
+    if code:
+        args.extend(["-a", str(code)])
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+    proc.communicate(timeout=10)
+    exitcode = proc.returncode
+    return exitcode
+
+
+def deferred_stop(code=0):
+    # wait for qtile process to start
+    wait = 10
+    while not test.helpers.can_connect_qtile(socket_path):
+        time.sleep(1)
+        if not wait:
+            raise Exception("timeout waiting for qtile process")
+        wait -= 1
+
+    stop_qtile(code)
+
+
+# in these testcases there are two qtile instances
+# one started by the helpers.TestManager,
+# which is used to evaluate code coverage
+# and a second instance started by run_qtile,
+# which is used to test the actual exit code behavior
+def test_exitcode_default(manager):
+    thread = threading.Thread(target=deferred_stop)
+    thread.daemon = False
+    thread.start()
+
+    exitcode = run_qtile(manager.backend)
+
+    # shutdown qtile instance started by testmanager
+    manager.c.shutdown()
+
+    assert exitcode == 0
+
+
+def test_exitcode_explicit(manager):
+    code = 23
+
+    thread = threading.Thread(target=deferred_stop, args=(code,))
+    thread.daemon = False
+    thread.start()
+
+    exitcode = run_qtile(manager.backend)
+
+    # shutdown qtile instance started by testmanager
+    manager.c.shutdown()
+
+    assert exitcode == code


### PR DESCRIPTION
I would like to have the possibility to set the exitcode of the Qtile process by specifying it (optionally) using the shutdown command.
This would allow for a communication of poweroff or reboot intents to a login manager.

I'm currently using greetd with gtkgreet as login manager. This feature would make it possible to implement a proper shutdown of the whole system.