### PR TITLE
Change focus_on_window_activation var to allow functions

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -118,7 +118,7 @@ configuration variables that control specific aspects of Qtile's behavior:
       - Floating windows are kept above tiled windows (Currently x11 only. Wayland support coming soon.)
     * - ``focus_on_window_activation``
       - ``'smart'``
-      - Behavior of the _NET_ACTIVATE_WINDOW message sent by applications
+      - Behavior of the _NET_ACTIVE_WINDOW message sent by applications
 
         - urgent: urgent flag is set for the window
 
@@ -127,6 +127,11 @@ configuration variables that control specific aspects of Qtile's behavior:
         - smart: automatically focus if the window is in the current group
 
         - never: never automatically focus any window that requests it
+
+        - can also be a function which takes the window as an argument:
+            - returns True: focus window
+
+            - returns False: doesn't do anything
     * - ``follow_mouse_focus``
       - ``True``
       - Controls whether or not focus follows the mouse around as it moves

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -5,6 +5,7 @@ import contextlib
 import inspect
 import traceback
 from itertools import islice
+from types import FunctionType
 from typing import TYPE_CHECKING
 
 import xcffib
@@ -2147,7 +2148,11 @@ class Window(_Window, base.Window):
                 self.bring_to_front()
             else:  # XCB_EWMH_CLIENT_SOURCE_TYPE_OTHER
                 focus_behavior = self.qtile.config.focus_on_window_activation
-                if focus_behavior == "focus":
+                if (
+                    focus_behavior == "focus"
+                    or type(focus_behavior) is FunctionType
+                    and focus_behavior(self)
+                ):
                     logger.debug("Focusing window")
                     # Windows belonging to a scratchpad need to be toggled properly
                     if isinstance(self.group, ScratchPad):

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from types import FunctionType
     from typing import Any, Literal
 
     from libqtile.config import Group, Key, Mouse, Rule, Screen
@@ -56,7 +57,7 @@ class Config:
     dgroups_key_binder: Any
     dgroups_app_rules: list[Rule]
     follow_mouse_focus: bool
-    focus_on_window_activation: Literal["focus", "smart", "urgent", "never"]
+    focus_on_window_activation: Literal["focus", "smart", "urgent", "never"] | FunctionType
     cursor_warp: bool
     layouts: list[Layout]
     floating_layout: Layout


### PR DESCRIPTION
When the _NET_ACTIVE_WINDOW message is send the focus_on_window_activation config variable is checked.
If it is a function (that takes the window as an argument) and returns True the window is focused. If it is a string then the old behaviors are used.
This could for example be used if you only want to focus the browser when you open a link, and it's in a different group.

This is how you could set that up:
```py
def focus_behavior(client: Window):
    return "Firefox-esr" in client.get_wm_class() or client.group.screen == qtile.current_screen
focus_on_window_activation = focus_behavior
```