### PR TITLE
Updated fedora.rst

### DIFF
--- a/docs/manual/install/fedora.rst
+++ b/docs/manual/install/fedora.rst
@@ -1,5 +1,12 @@
 ====================
-Installing on Fedora
+Installing on Fedora 40 or later.
 ====================
+Both Qtile X11 and Wayland stable versions can be installed via the DNF Package Manager.
 
-Stable versions of Qtile are not currently packaged for the current version of Fedora. Users are advised to follow the instructions of :ref:`installing-from-source`.
+If you want to pick a specific version(Such as the wayland version) then double-click Tab after "qtile".
+
+.. code-block:: bash
+
+   dnf install qtile
+
+


### PR DESCRIPTION
Removed the outdated recommendation to install from source as it's no longer necessary due to qtile stable versions now being available in the Fedora Repository as of Fedora 40.

Added instructions on how to install qtile from the built in package manager.