### PR TITLE
Nix test fixes

### DIFF
--- a/test/migrate/conftest.py
+++ b/test/migrate/conftest.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 import subprocess
+import sys
 import tempfile
 import textwrap
 from pathlib import Path
@@ -53,7 +54,16 @@ class MigrationTester:
     def assert_migrate(self):
         if not self.test.source:
             assert False, f"{self.test_id} has no tests."
-        argv = [self.cmd, "migrate", "--yes", "-r", self.test_id, "-c", self.test.source_path]
+        argv = [
+            sys.executable,
+            self.cmd,
+            "migrate",
+            "--yes",
+            "-r",
+            self.test_id,
+            "-c",
+            self.test.source_path,
+        ]
         try:
             subprocess.check_call(argv)
         except subprocess.CalledProcessError:
@@ -63,7 +73,16 @@ class MigrationTester:
         assert updated == self.test.expected
 
     def assert_lint(self):
-        argv = [self.cmd, "migrate", "--lint", "-r", self.test_id, "-c", self.test.source_path]
+        argv = [
+            sys.executable,
+            self.cmd,
+            "migrate",
+            "--lint",
+            "-r",
+            self.test_id,
+            "-c",
+            self.test.source_path,
+        ]
         try:
             output = subprocess.run(argv, capture_output=True, check=True)
         except subprocess.CalledProcessError:

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 
@@ -152,7 +153,7 @@ def test_prompt(manager, monkeypatch):
     manager.c.widget["prompt"].fake_keypress("Tab")
 
     script = Path(__file__).parent / "scripts" / "window.py"
-    manager.c.spawncmd(":", aliases={"w": script.as_posix()})
+    manager.c.spawncmd(":", aliases={"w": f"{sys.executable} {script.as_posix()}"})
     manager.c.widget["prompt"].fake_keypress("w")
     manager.c.widget["prompt"].fake_keypress("Return")
 

--- a/test/widgets/test_mpd2widget.py
+++ b/test/widgets/test_mpd2widget.py
@@ -105,8 +105,8 @@ class MockMPD(ModuleType):
 
 @pytest.fixture
 def mpd2_manager(manager_nospawn, monkeypatch, minimal_conf_noscreen, request):
-    # monkeypatch.setattr("libqtile.widget.mpd2widget.MPDClient", MockMPDClient)
     monkeypatch.setitem(sys.modules, "mpd", MockMPD("mpd"))
+    monkeypatch.setattr("libqtile.widget.mpd2widget.MPDClient", MockMPD.MPDClient)
 
     config = minimal_conf_noscreen
     config.screens = [


### PR DESCRIPTION
- Do not assume python interpreter path, but use sys.executable
- Make MPD mocking work

If this is green in the CI here I propose these patches are wanted because they also make our tests work with Nix