### PR TITLE
Add `group_window_remove` hook when window is removed from group

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
         - A Nix flake has been added which can be used by Nix(OS) users to update to the latest version easily
+        - Add `group_window_remove` hook when window is removed from group
     * bugfixes
 
 Qtile 0.28.1, released 2024-08-12:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -271,6 +271,7 @@ class _Group(CommandObject):
 
     def remove(self, win, force=False):
         self.windows.remove(win)
+        hook.fire("group_window_remove", self, win)
         hadfocus = self._remove_from_focus_history(win)
         win.group = None
 

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -517,6 +517,29 @@ hooks: list[Hook] = [
         """,
     ),
     Hook(
+        "group_window_remove",
+        """Called when a window is removed from a group
+
+        **Arguments**
+
+            * ``Group`` removing the window
+            * ``Window`` removed from the group
+
+        Example:
+
+        .. code:: python
+
+          from libqtile import hook
+          from libqtile.utils import send_notification
+
+
+          @hook.subscribe.group_window_remove
+          def group_window_remove(group, window):
+              send_notification("qtile", f"Window {window.name} removed from {group.name}")
+
+        """,
+    ),
+    Hook(
         "client_new",
         """
         Called before Qtile starts managing a new client

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -30,6 +30,7 @@ import libqtile.utils
 from libqtile import hook
 from libqtile.resources import default_config
 from test.conftest import BareConfig
+from test.helpers import Retry
 
 # TODO: more tests required.
 # 1. Check all hooks that can be fired
@@ -267,6 +268,12 @@ class CallGroupname:
         self.groupname = groupname
 
 
+@Retry(ignore_exceptions=(AssertionError))
+def assert_groupname(mgr_nospawn, groupname):
+    _, _groupname = mgr_nospawn.c.eval("self.config.test.groupname")
+    assert _groupname == groupname
+
+
 @pytest.mark.usefixtures("hook_fixture")
 def test_addgroup(manager_nospawn):
     class AddgroupConfig(BareConfig):
@@ -274,8 +281,7 @@ def test_addgroup(manager_nospawn):
         hook.subscribe.addgroup(test)
 
     manager_nospawn.start(AddgroupConfig)
-    _, groupname = manager_nospawn.c.eval("self.config.test.groupname")
-    assert groupname == "d"
+    assert_groupname(manager_nospawn, "d")
 
 
 @pytest.mark.usefixtures("hook_fixture")
@@ -286,8 +292,7 @@ def test_delgroup(manager_nospawn):
 
     manager_nospawn.start(DelgroupConfig)
     manager_nospawn.c.delgroup("d")
-    _, groupname = manager_nospawn.c.eval("self.config.test.groupname")
-    assert groupname == "d"
+    assert_groupname(manager_nospawn, "d")
 
 
 class CallGroupWindow:
@@ -300,6 +305,14 @@ class CallGroupWindow:
         self.window = win.name
 
 
+@Retry(ignore_exceptions=(AssertionError))
+def assert_group_window(mgr_nospawn, group, window):
+    _, _group = mgr_nospawn.c.eval("self.config.test.group")
+    _, _window = mgr_nospawn.c.eval("self.config.test.window")
+    assert _group == group
+    assert _window == window
+
+
 @pytest.mark.usefixtures("hook_fixture")
 def test_group_window_add(manager_nospawn):
     class AddGroupWindowConfig(BareConfig):
@@ -308,10 +321,7 @@ def test_group_window_add(manager_nospawn):
 
     manager_nospawn.start(AddGroupWindowConfig)
     manager_nospawn.test_window("Test Window")
-    _, group = manager_nospawn.c.eval("self.config.test.group")
-    _, window = manager_nospawn.c.eval("self.config.test.window")
-    assert group == "a"
-    assert window == "Test Window"
+    assert_group_window(manager_nospawn, "a", "Test Window")
 
 
 @pytest.mark.usefixtures("hook_fixture")
@@ -323,10 +333,7 @@ def test_group_window_remove(manager_nospawn):
     manager_nospawn.start(RemoveGroupWindowConfig)
     manager_nospawn.test_window("Test Window")
     manager_nospawn.c.window.kill()
-    _, group = manager_nospawn.c.eval("self.config.test.group")
-    _, window = manager_nospawn.c.eval("self.config.test.window")
-    assert group == "a"
-    assert window == "Test Window"
+    assert_group_window(manager_nospawn, "a", "Test Window")
 
 
 class CallClient:
@@ -337,6 +344,12 @@ class CallClient:
         self.client = client.name
 
 
+@Retry(ignore_exceptions=(AssertionError))
+def assert_client(mgr_nospawn, client):
+    _, _client = mgr_nospawn.c.eval("self.config.test.client")
+    assert _client == client
+
+
 @pytest.mark.usefixtures("hook_fixture")
 def test_client_new(manager_nospawn):
     class ClientNewConfig(BareConfig):
@@ -345,8 +358,7 @@ def test_client_new(manager_nospawn):
 
     manager_nospawn.start(ClientNewConfig)
     manager_nospawn.test_window("Test Client")
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")
 
 
 @pytest.mark.usefixtures("hook_fixture")
@@ -357,13 +369,11 @@ def test_client_managed(manager_nospawn):
 
     manager_nospawn.start(ClientManagedConfig)
     manager_nospawn.test_window("Test Client")
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")
     manager_nospawn.test_window("Test Static")
     manager_nospawn.c.group.focus_back()
     manager_nospawn.c.window.static()
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")
 
 
 @pytest.mark.usefixtures("hook_fixture")
@@ -375,8 +385,7 @@ def test_client_killed(manager_nospawn):
     manager_nospawn.start(ClientKilledConfig)
     manager_nospawn.test_window("Test Client")
     manager_nospawn.c.window.kill()
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")
 
 
 @pytest.mark.usefixtures("hook_fixture")
@@ -387,9 +396,7 @@ def test_client_focus(manager_nospawn):
 
     manager_nospawn.start(ClientFocusConfig)
     manager_nospawn.test_window("Test Client")
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")
     manager_nospawn.test_window("Test Focus")
     manager_nospawn.c.group.focus_back()
-    _, client = manager_nospawn.c.eval("self.config.test.client")
-    assert client == "Test Client"
+    assert_client(manager_nospawn, "Test Client")


### PR DESCRIPTION
This hook serves as a complement of the already existing [group_window_add](https://github.com/qtile/qtile/blob/b1e5cd703024cd8202c149ff8d645bd8766e2e82/libqtile/hook.py#L497) hook but works when window is removed from group.

PS. In my case is helpful if doing this in the config.py.

```
# Move to group where window spawn
@hook.subscribe.group_window_add
def group_window_add(group, window):
    group.toscreen()

# Revert to last group after all windows close
@hook.subscribe.group_window_remove
def group_window_remove(group, window):
    if not group.windows:
        group.toscreen(toggle=True)
```