### PR TITLE
Always use `decode_to_image_surface` for images

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -18,7 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import io
 import os
 from collections import namedtuple
 
@@ -35,7 +34,7 @@ class LoadingError(Exception):
 _SurfaceInfo = namedtuple("_SurfaceInfo", ("surface", "file_type"))
 
 
-def _decode_to_image_surface(bytes_img, width=None, height=None):
+def get_cairo_surface(bytes_img, width=None, height=None):
     try:
         surf, fmt = cairocffi.pixbuf.decode_to_image_surface(bytes_img, width, height)
         return _SurfaceInfo(surf, fmt)
@@ -49,15 +48,6 @@ def _decode_to_image_surface(bytes_img, width=None, height=None):
         )
         surf, fmt = cairocffi.pixbuf.decode_to_image_surface(bytes_img)
         return _SurfaceInfo(surf, fmt)
-
-
-def get_cairo_surface(bytes_img, width=None, height=None):
-    try:
-        surf = cairocffi.ImageSurface.create_from_png(io.BytesIO(bytes_img))
-        return _SurfaceInfo(surf, "png")
-    except (MemoryError, OSError):
-        pass
-    return _decode_to_image_surface(bytes_img, width, height)
 
 
 def get_cairo_pattern(surface, width=None, height=None, theta=0.0):

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -122,18 +122,15 @@ class TestImg:
         img = images.Img(bytes_image)
         assert isinstance(img.pattern, cairocffi.SurfacePattern)
 
-    def test_pattern_resize(self, path_n_bytes_image_pngs):
+    def test_surface_resize(self, path_n_bytes_image_pngs):
         path, bytes_image = path_n_bytes_image_pngs
         img = images.Img.from_path(path)
-        assert isinstance(img.pattern, cairocffi.SurfacePattern)
-        t_matrix = img.pattern.get_matrix().as_tuple()
-        assert_approx_equal(t_matrix, (1.0, 0.0, 0.0, 1.0))
+        original_width = img.width
+        original_height = img.height
         img.width = 2.0 * img.default_size.width
-        t_matrix = img.pattern.get_matrix().as_tuple()
-        assert_approx_equal(t_matrix, (0.5, 0.0, 0.0, 1.0))
+        assert img.surface.get_width() == 2 * original_width
         img.height = 3.0 * img.default_size.height
-        t_matrix = img.pattern.get_matrix().as_tuple()
-        assert_approx_equal(t_matrix, (0.5, 0.0, 0.0, 1.0 / 3.0))
+        assert img.surface.get_height() == 3 * original_height
 
     def test_pattern_rotate(self, path_n_bytes_image):
         path, bytes_image = path_n_bytes_image


### PR DESCRIPTION
cairo 1.18.2 broke the `Img` object as we tried to create images using `ImageSurface.create_from_png` first. However,
`cairocffi.pixbuf.decode_to_image_surface` seems to work for all formats so we can just use that.

Fixed #4987