### PR TITLE
GenPollUrl: catch http.client exceptions

### DIFF
--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from http.client import HTTPException
 from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
@@ -85,6 +86,8 @@ class GenPollUrl(base.ThreadPoolText):
             body = self.fetch()
         except URLError:
             return "No network"
+        except HTTPException:
+            return "Request failed"
 
         try:
             text = self.parse(body)


### PR DESCRIPTION
This catches exceptions from the HTTP protocol client used in urllib which can be raised in GenPollUrl.fetch.

Some context: I've been using the OpenWeather widget for a while now and recently (possibly due to issues with my Internet connection or the API) I've been seeing uncaught  [`http.client.RemoteDisconnected`](https://docs.python.org/3/library/http.client.html#http.client.RemoteDisconnected) exceptions in the log, which, after some hours of marvelling at the stable temperatures outside, led to the eventual realization that the widget was not updating (since uncaught exceptions lead to `poll()` not being rescheduled).

To fix this, I added another `except` in the `GenPollUrl` widget which catches `http.client` exceptions.