### PR TITLE
Pre-commit: Add pyright

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     rev: v2.10
     hooks:
       - id: vulture
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.381
+    hooks:
+    - id: pyright


### PR DESCRIPTION
This patch adds pyright to pre-commit. I am testing this as I find that pyright catches *much* more errors than mypy. Maybe useful to have.