### PR TITLE
Fix TaskList calculated size issue

### DIFF
--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -291,7 +291,11 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
     @property
     def max_width(self):
         width = self.bar.width
-        width -= sum(w.width for w in self.bar.widgets if w is not self)
+        width -= sum(
+            w.width
+            for w in self.bar.widgets
+            if w is not self and w.length_type != libqtile.bar.STRETCH
+        )
         return width
 
     def calc_box_widths(self):


### PR DESCRIPTION
TaskList incorrectly calculates the maximum bar space allowed for the widget. By including `STRETCH` widgets which could fill all remaining space, no space was left for the tasklist. This resulted in negative values for the max width causing the widget to break.

Fixes #4996