### PR TITLE
Hook 'client_mouse_enter' consistent in wayland and x11

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1127,12 +1127,12 @@ class Core(base.Core, wlrq.HasListeners):
                     self.cursor.set_xcursor(self._cursor_manager, "default")
                     self.seat.pointer_notify_clear_focus()
 
-            if win is not self.qtile.current_window:
-                if self._hovered_window is not win:
-                    # We only want to fire client_mouse_enter once, so check
-                    # self._hovered_window.
-                    hook.fire("client_mouse_enter", win)
+            if self._hovered_window is not win:
+                # We only want to fire client_mouse_enter once, so check
+                # self._hovered_window.
+                hook.fire("client_mouse_enter", win)
 
+            if win is not self.qtile.current_window:
                 if motion is not None and self.qtile.config.follow_mouse_focus:
                     if isinstance(win, window.Static):
                         self.qtile.focus_screen(win.screen.index, False)

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -579,15 +579,12 @@ def test_client_focus(manager_nospawn):
 @pytest.mark.usefixtures("hook_fixture")
 def test_client_mouse_enter(manager_nospawn):
     class ClientMouseEnterConfig(BareConfig):
-        cursor_warp = True  # wayland backend
         test = CallWindow()
         hook.subscribe.client_mouse_enter(test)
 
     manager_nospawn.start(ClientMouseEnterConfig)
     manager_nospawn.test_window("Test Client")
-    manager_nospawn.test_window("Test MouseEnter")  # wayland backend
-    manager_nospawn.c.next_layout()  # wayland backend
-    manager_nospawn.backend.fake_click(0, 0)  # x11 backend
+    manager_nospawn.backend.fake_click(0, 0)
     assert_window(manager_nospawn, "Test Client")
 
 


### PR DESCRIPTION
Hook `client_mouse_enter` now is fired regardless of the focus window.