### PR TITLE
docs: recommend a synchronous autostart hook

### DIFF
--- a/docs/manual/config/hooks.rst
+++ b/docs/manual/config/hooks.rst
@@ -64,7 +64,7 @@ We can then subscribe to ``startup_once`` to run this script:
     @hook.subscribe.startup_once
     def autostart():
         home = os.path.expanduser('~/.config/qtile/autostart.sh')
-        subprocess.Popen([home])
+        subprocess.call(home)
 
 Accessing the qtile object
 --------------------------


### PR DESCRIPTION
Since we recommend spawning everything in the background here (i.e. "&" at the end), let's also recommend calling this hook synchronously. This way if people do randr things in there, we get a predictable state, since qtile's execution is actually paused during this time.