### PR TITLE
pyproject: add more build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = [
+    "cffi>=1.1.0",
+    "cairocffi[xcb]>=1.6.0",
     "setuptools>=60",
     "setuptools-scm>=7.0",
     "wheel",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,6 @@
 [options]
 packages = find_namespace:
 python_requires >= 3.10
-setup_requires =
-  cffi >= 1.1.0
-  cairocffi[xcb] >= 1.6.0
-  setuptools >= 40.5.0
-  setuptools_scm >= 3.2.0
 install_requires =
   cffi >= 1.1.0
   cairocffi[xcb] >= 1.6.0


### PR DESCRIPTION
CI is complaining (but not failing):

    * Building sdist... /tmp/build-env-xomi1h1m/lib/python3.12/site-packages/setuptools_scm/_integration/setuptools.py:31: RuntimeWarning: ERROR: setuptools==0.1.dev1+g59b329a is used in combination with setuptools_scm>=8.x

      Your build configuration is incomplete and previously worked by accident! setuptools_scm requires setuptools>=61

      Suggested workaround if applicable:
       - migrating from the deprecated setup_requires mechanism to pep517/518 and using a pyproject.toml to declare build dependencies which are reliably pre-installed before running the build tools

This seems to fix it.