### PR TITLE
Add returns to lazy.function and qtile.core.function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
         - A Nix flake has been added which can be used by Nix(OS) users to update to the latest version easily
         - Add `group_window_remove` hook when window is removed from group
     * bugfixes
+        - Add returns to lazy.function and qtile.core.function
 
 Qtile 0.28.1, released 2024-08-12:
     * bugfixes

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -336,7 +336,7 @@ class CommandObject(metaclass=abc.ABCMeta):
     def function(self, function, *args, **kwargs) -> None:
         """Call a function with current object as argument"""
         try:
-            function(self, *args, **kwargs)
+            return function(self, *args, **kwargs)
         except Exception:
             error = traceback.format_exc()
             logger.error('Exception calling "%s":\n%s', function, error)


### PR DESCRIPTION
When using `lazy.function` for example to set a start function to a mouse Drag, previously this would result in an error message like this: 
```python
@lazy.function
def get_size(qtile):
    return 10, 10

mouse = [
    Drag([mod], "Button3", lazy.window.set_size_floating(), start=get_size())
]
```
```py
Traceback (most recent call last):
  File "/home/ole/.local/pipx/venvs/qtile/lib/python3.11/site-packages/libqtile/backend/x11/core.py", line 334, in _xpoll
    self.handle_event(event)
  File "/home/ole/.local/pipx/venvs/qtile/lib/python3.11/site-packages/libqtile/backend/x11/core.py", line 301, in handle_event
    ret = target(event)
          ^^^^^^^^^^^^^
  File "/home/ole/.local/pipx/venvs/qtile/lib/python3.11/site-packages/libqtile/backend/x11/core.py", line 682, in handle_ButtonPress
    self.qtile.process_button_click(button_code, state, event.event_x, event.event_y)
  File "/home/ole/.local/pipx/venvs/qtile/lib/python3.11/site-packages/libqtile/core/manager.py", line 856, in process_button_click
    self._drag = (x, y, val[0], val[1], m.commands)
                        ~~~^^^
TypeError: 'NoneType' object is not subscriptable
```

This was because libqtile.command.base.function didn't actually return anything. This commit simply adds a return keyword to it.