### PR TITLE
Accept modifiers from distinct keyboards under the wayland environment

### DIFF
--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -21,6 +21,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import reduce
+from operator import or_
 from typing import TYPE_CHECKING
 
 from pywayland.protocol.wayland import WlKeyboard
@@ -279,7 +281,7 @@ class Keyboard(_Device):
                 xkb_keysym,
             )
             keysyms = [xkb_keysym[0][i] for i in range(nsyms)]
-            mods = self.keyboard.modifier
+            mods = reduce(or_, [k.keyboard.modifier for k in self.core.keyboards])
             handled = False
             should_repeat = False
             if event.state == KEY_PRESSED:


### PR DESCRIPTION
This commit tries to apply modifiers from a keyboard to not only the keyboard itself but also the other keyboards under the wayland backend environment.

Background: I use two keyboards at the same time as a primitive manner of split keyboards. That really helps with my posture, and relaxes my shoulders, chest, etc. I noticed that the current master (d13eb3d851fec52d6dc84a5de2de41d2f139d283) as a wayland compositor does not accept key bindings with combination of the super key and any key from distinct keyboards. For example, Super (keyboard 1) + 'w' (keyboard 2) results in only propagation of 'w' key-press into a focused window (showing 'w' if the window is of a text editor) while I expect close of the window with the default key bindings. 

I think this is a natural behavior of WMs. Key bindings outside qtile (e.g. Ctrl-C) from distinct keyboards work well with qtile ( wayland), and additionally, tty, X and Windows to the best of my knowledge.