### PR TITLE
Change the focus to the window under the mouse when click or drag

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * features
         - Add `SwayNC` widget to interact with Sway Notification Centre (wayland only)
         - Add `swap` method to Plasma layout
+        - New `click_or_drag_only` option for follow_mouse_focus to change the focus to the window under the mouse when click or drag
     * bugfixes
         - Make MonadWide layout up/down focus navigation behave like MonadTall's left/right
 

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -135,7 +135,9 @@ configuration variables that control specific aspects of Qtile's behavior:
     * - ``follow_mouse_focus``
       - ``True``
       - Controls whether or not focus follows the mouse around as it moves
-        across windows in a layout.
+        across windows in a layout. Otherwise set this to ``"click_or_drag_only"``
+        to change focus only when doing a :class:`~libqtile.config.Click` or
+        :class:`~libqtile.config.Drag` action.
     * - ``widget_defaults``
       - ``dict(font='sans', fontsize=12, padding=3)``
       - Default settings for bar widgets.

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1133,7 +1133,7 @@ class Core(base.Core, wlrq.HasListeners):
                 hook.fire("client_mouse_enter", win)
 
             if win is not self.qtile.current_window:
-                if motion is not None and self.qtile.config.follow_mouse_focus:
+                if motion is not None and self.qtile.config.follow_mouse_focus is True:
                     if isinstance(win, window.Static):
                         self.qtile.focus_screen(win.screen.index, False)
                     else:
@@ -1695,3 +1695,7 @@ class Core(base.Core, wlrq.HasListeners):
     def get_mouse_position(self) -> tuple[int, int]:
         """Get mouse coordinates."""
         return int(self.cursor.x), int(self.cursor.y)
+
+    @property
+    def hovered_window(self) -> base.WindowType | None:
+        return self._hovered_window

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -946,3 +946,8 @@ class Core(base.Core):
             self.last_focused.change_layer()
 
         self.last_focused = win
+
+    @property
+    def hovered_window(self) -> base.WindowType | None:
+        _hovered_window = self.conn.conn.core.QueryPointer(self._root.wid).reply().child
+        return self.qtile.windows_map.get(_hovered_window)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -2043,7 +2043,7 @@ class Window(_Window, base.Window):
 
     def handle_EnterNotify(self, e):  # noqa: N802
         hook.fire("client_mouse_enter", self)
-        if self.qtile.config.follow_mouse_focus:
+        if self.qtile.config.follow_mouse_focus is True:
             if self.group.current_window != self:
                 self.group.focus(self, False)
             if self.group.screen and self.qtile.current_screen != self.group.screen:

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -219,9 +219,9 @@ class Click(Mouse):
         ``"shift"``, ``"lock"``, ``"control"``, ``"mod1"``, ``"mod2"``, ``"mod3"``,
         ``"mod4"``, ``"mod5"``.
     button:
-        The button used to start dragging e.g. ``"Button1"``.
+        The button used to click e.g. ``"Button1"``.
     commands:
-        A list :class:`LazyCall` objects to evaluate in sequence upon drag.
+        A list :class:`LazyCall` objects to evaluate in sequence upon click.
 
     """
 

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -56,7 +56,7 @@ class Config:
     groups: list[Group]
     dgroups_key_binder: Any
     dgroups_app_rules: list[Rule]
-    follow_mouse_focus: bool
+    follow_mouse_focus: bool | Literal["click_or_drag_only"]
     focus_on_window_activation: Literal["focus", "smart", "urgent", "never"] | FunctionType
     cursor_warp: bool
     layouts: list[Layout]

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -819,6 +819,12 @@ class Qtile(CommandObject):
                 closest_screen = s
         return closest_screen or self.screens[0]
 
+    def _focus_hovered_window(self) -> None:
+        window = self.core.hovered_window
+        if window:
+            if isinstance(window, base.Window):
+                window.focus()
+
     def process_button_click(self, button_code: int, modmask: int, x: int, y: int) -> bool:
         handled = False
         for m in self._mouse_map[button_code]:
@@ -826,6 +832,8 @@ class Qtile(CommandObject):
                 continue
 
             if isinstance(m, Click):
+                if self.config.follow_mouse_focus == "click_or_drag_only":
+                    self._focus_hovered_window()
                 for i in m.commands:
                     if i.check(self):
                         status, val = self.server.call(
@@ -837,6 +845,8 @@ class Qtile(CommandObject):
             elif (
                 isinstance(m, Drag) and self.current_window and not self.current_window.fullscreen
             ):
+                if self.config.follow_mouse_focus == "click_or_drag_only":
+                    self._focus_hovered_window()
                 if m.start:
                     i = m.start
                     status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs, False))


### PR DESCRIPTION
This is useful when in the config you have `follow_mouse_focus = False` and would like to use the window under the mouse when clicking or dragging a window.

P.S. Maybe this should be a global option in the config but I am not sure. If that is the case what name would be good? Maybe `follow_mouse_click_or_drag` or maybe better a new value like `follow_mouse_focus = "click_or_drag_only"`?