### PR TITLE
Make MonadWide up/down focus navigation behave like MonadTall left/right

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
     * bugfixes
+        - Make MonadWide layout up/down focus navigation behave like MonadTall's left/right
 
 Qtile 0.29.0, released 2024-10-19:
     * features

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -756,11 +756,11 @@ class MonadTall(_SimpleLayoutBase):
         # shrink client by total change
         self.relative_sizes[self.focused - 1] -= self._get_relative_size_from_absolute(change)
 
-    @expose_command("down")
+    @expose_command()
     def next(self) -> None:
         _SimpleLayoutBase.next(self)
 
-    @expose_command("up")
+    @expose_command()
     def previous(self) -> None:
         _SimpleLayoutBase.previous(self)
 
@@ -857,6 +857,16 @@ class MonadTall(_SimpleLayoutBase):
         candidates = [c for c in self.clients if c.info()["x"] > x]
         self.clients.current_client = self._get_closest(x, y, candidates)
         self.group.focus(self.clients.current_client)
+
+    @expose_command()
+    def up(self):
+        """Focus on the closest window above the current window"""
+        self.previous()
+
+    @expose_command()
+    def down(self):
+        """Focus on the closest window below the current window"""
+        self.next()
 
 
 class MonadWide(MonadTall):
@@ -1122,6 +1132,34 @@ class MonadWide(MonadTall):
             self.swap_right()
         elif self.align == self._down:
             self.swap_left()
+
+    @expose_command()
+    def left(self):
+        """Focus on the closest window to the left of the current window"""
+        self.previous()
+
+    @expose_command()
+    def right(self):
+        """Focus on the closest window to the right of the current window"""
+        self.next()
+
+    @expose_command()
+    def up(self):
+        """Focus on the closest window above the current window"""
+        win = self.clients.current_client
+        x, y = win.x, win.y
+        candidates = [c for c in self.clients if c.info()["y"] < y]
+        self.clients.current_client = self._get_closest(x, y, candidates)
+        self.group.focus(self.clients.current_client)
+
+    @expose_command()
+    def down(self):
+        """Focus on the closest window below the current window"""
+        win = self.clients.current_client
+        x, y = win.x, win.y
+        candidates = [c for c in self.clients if c.info()["y"] > y]
+        self.clients.current_client = self._get_closest(x, y, candidates)
+        self.group.focus(self.clients.current_client)
 
 
 class MonadThreeCol(MonadTall):

--- a/test/layouts/test_xmonad.py
+++ b/test/layouts/test_xmonad.py
@@ -925,6 +925,90 @@ def test_wide_window_focus_cycle(manager):
     assert_focus_path(manager, "float1", "float2", "one", "two", "three")
 
 
+@monadtall_config
+def test_tall_window_directional_focus(manager):
+    # setup 3 tiled and two floating clients
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
+
+    # test preconditions
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    # last added window has focus
+    assert_focused(manager, "three")
+
+    # starting from the last tiled client, test that left/right focus changes go
+    # to the closest window in that direction (no cycling), and up/down cycles
+    # focus
+    manager.c.layout.left()
+    assert_focused(manager, "one")
+    manager.c.layout.left()
+    assert_focused(manager, "one")
+    manager.c.layout.right()
+    assert_focused(manager, "two")
+    manager.c.layout.right()
+    assert_focused(manager, "two")
+
+    manager.c.layout.down()
+    assert_focused(manager, "three")
+    manager.c.layout.down()
+    assert_focused(manager, "one")
+    manager.c.layout.down()
+    assert_focused(manager, "two")
+    manager.c.layout.up()
+    assert_focused(manager, "one")
+    manager.c.layout.up()
+    assert_focused(manager, "three")
+    manager.c.layout.up()
+    assert_focused(manager, "two")
+
+
+@monadwide_config
+def test_wide_window_directional_focus(manager):
+    # setup 3 tiled and two floating clients
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("float1")
+    manager.c.window.toggle_floating()
+    manager.test_window("float2")
+    manager.c.window.toggle_floating()
+    manager.test_window("three")
+
+    # test preconditions
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+    # last added window has focus
+    assert_focused(manager, "three")
+
+    # starting from the last tiled client, test that up/down focus changes go to
+    # the closest window in that direction (no cycling), and left/right cycles
+    # focus
+    manager.c.layout.up()
+    assert_focused(manager, "one")
+    manager.c.layout.up()
+    assert_focused(manager, "one")
+    manager.c.layout.down()
+    assert_focused(manager, "two")
+    manager.c.layout.down()
+    assert_focused(manager, "two")
+
+    manager.c.layout.left()
+    assert_focused(manager, "one")
+    manager.c.layout.left()
+    assert_focused(manager, "three")
+    manager.c.layout.left()
+    assert_focused(manager, "two")
+    manager.c.layout.right()
+    assert_focused(manager, "three")
+    manager.c.layout.right()
+    assert_focused(manager, "one")
+    manager.c.layout.right()
+    assert_focused(manager, "two")
+
+
 # MonadThreeCol
 class MonadThreeColConfig(Config):
     auto_fullscreen = True


### PR DESCRIPTION
MonadTall exposes left/right commands to focus the closest window to the left/right, allowing easy navigation between columns. MonadWide had no similar override for up/down focus commands, instead it inherited the next/previous = down/up overrides of MonadTall, making directional navigation between rows more cumbersome by requiring cycling amongst all windows. The result is inconsistent window navigation between MonadTall and MonadWide.

This change retains the original navigation commands and behavior of MonadTall (including left/right), while adding a symmetric up/down command to MonadWide.

---

Besides manually testing the Qtile directional focus navigation behavior for both MonadTall and Wide layouts, I added unit tests, and have verified the full test suite passes locally (except for one related to migration that seems unrelated to my changes). I also verified that my unit tests for MonadTall pass without my layout code changes (implying no behavior change), while those for MonadWide fail (implying I fixed the inconsistency).