### PR TITLE
Fix Notify widget crash on finalise

### DIFF
--- a/libqtile/widget/notify.py
+++ b/libqtile/widget/notify.py
@@ -219,5 +219,6 @@ class Notify(base._TextBox):
             self._invoke()
 
     def finalize(self):
-        notifier.unregister(self.update, on_close=self.on_close)
+        if notifier is not None:
+            notifier.unregister(self.update, on_close=self.on_close)
         base._TextBox.finalize(self)


### PR DESCRIPTION
If `dbus-next` is not installed the `Notify` widget will crash on `finalize` as it tries to call `notifier.unregister` but `notifier` is `None`. This has a knock-on effect of `widgets_map` not being cleared and additional widgets not being finalised.

Thanks to @holocronweaver for identifying this issue.