### PR TITLE
Mpris2 widget - add player name field

### DIFF
--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -128,7 +128,8 @@ class Mpris2(base._TextBox):
             "{xesam:title} - {xesam:album} - {xesam:artist}",
             "Format string for displaying metadata. "
             "See http://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#index5h3 "
-            "for available values",
+            "for available values. The special filed '{qtile:player}' can be used to display the "
+            "player name.",
         ),
         ("separator", ", ", "Separator for metadata fields that are a list."),
         (
@@ -379,6 +380,8 @@ class Mpris2(base._TextBox):
                 self.metadata[new_key] = val
             elif isinstance(val, list):
                 self.metadata[new_key] = self.separator.join(y for y in val if isinstance(y, str))
+        if self.player is not None:
+            self.metadata["qtile:player"] = self.player
 
         return self._formatter.format(self.format, **self.metadata).replace("\n", "")
 


### PR DESCRIPTION
Adds the ability to display the player name by using the `"{qtile:player}"` field in the format string.