### PR TITLE
fix(_get_group): group not in list when reloading

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1286,13 +1286,12 @@ class Core(base.Core, wlrq.HasListeners):
                             name = old_group[0]
                             if win.group.name == name:
                                 group = self.qtile.groups[i]
+                if win in win.group.windows:
+                    # Remove window from old group
+                    win.group.remove(win)
             if group is None:
                 # Falling back to current group if none found
                 group = self.qtile.current_group
-            if win.group and win in win.group.windows:
-                # It might not be in win.group.windows depending on how group state
-                # changed across a config reload
-                win.group.remove(win)
             group.add(win)
             if group == self.qtile.current_group:
                 win.unhide()

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -232,6 +232,9 @@ class Core(base.Core):
                 w for w in self.qtile.windows_map.values() if isinstance(w, window.Window)
             ]
             for managed_win in managed_wins:
+                if managed_win.group and managed_win in managed_win.group.windows:
+                    # Remove window from old group
+                    managed_win.group.remove(managed_win)
                 managed_win.set_group()
             return
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -656,20 +656,22 @@ class Screen(CommandObject):
         return dict(index=self.index, width=self.width, height=self.height, x=self.x, y=self.y)
 
     @expose_command()
-    def next_group(self, skip_empty: bool = False, skip_managed: bool = False) -> None:
+    def next_group(
+        self, skip_empty: bool = False, skip_managed: bool = False, warp: bool = True
+    ) -> None:
         """Switch to the next group"""
-        n = self.group.get_next_group(skip_empty, skip_managed)
-        self.set_group(n)
-        return n.name
+        group = self.group.get_next_group(skip_empty, skip_managed)
+        self.set_group(group, warp=warp)
+        return group.name if group is not None else None
 
     @expose_command()
     def prev_group(
         self, skip_empty: bool = False, skip_managed: bool = False, warp: bool = True
     ) -> None:
         """Switch to the previous group"""
-        n = self.group.get_previous_group(skip_empty, skip_managed)
-        self.set_group(n, warp=warp)
-        return n.name
+        group = self.group.get_previous_group(skip_empty, skip_managed)
+        self.set_group(group, warp=warp)
+        return group.name if group is not None else None
 
     @expose_command()
     def toggle_group(self, group_name: str | None = None, warp: bool = True) -> None:

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -425,9 +425,13 @@ class _Group(CommandObject):
                 return False
             return True
 
-        groups = [group for group in self.qtile.groups if match(group)]
-        index = (groups.index(self) + direction) % len(groups)
-        return groups[index]
+        try:
+            groups = [group for group in self.qtile.groups if match(group)]
+            index = (groups.index(self) + direction) % len(groups)
+            return groups[index]
+        except ValueError:
+            # group is not managed
+            return None
 
     def get_previous_group(self, skip_empty=False, skip_managed=False):
         return self._get_group(-1, skip_empty, skip_managed)

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -548,6 +548,23 @@ def test_nextprevgroup(manager):
     assert manager.c.group.info()["name"] == start
 
 
+def test_nextprevgroup_reload(manager_nospawn):
+    manager_nospawn.start(lambda: BareConfig(file_path=configs_dir / "reloading.py"))
+    # Current group will become unmanaged after reloading
+    manager_nospawn.c.eval("self.old_group = self.current_group")
+    manager_nospawn.c.reload_config()
+    # Check that group has become unmanaged
+    manager_nospawn.c.eval("self.new_group = self.current_group")
+    assert "True" == manager_nospawn.c.eval("self.old_group != self.new_group")[1]
+    # Unmanaged group should not change the group in the screen
+    success, message = manager_nospawn.c.eval("self.old_group.screen.next_group()")
+    assert "True" == manager_nospawn.c.eval("self.new_group == self.current_group")[1]
+    assert success, message
+    success, message = manager_nospawn.c.eval("self.old_group.screen.prev_group()")
+    assert "True" == manager_nospawn.c.eval("self.new_group == self.current_group")[1]
+    assert success, message
+
+
 @manager_config
 def test_toggle_group(manager):
     manager.c.group["a"].toscreen()


### PR DESCRIPTION
I have this hook enabled in my config.

```
@hook.subscribe.group_window_remove
def group_window_remove(group, window):
    if not group.windows and group.screen:
        if group.screen.previous_group and group.screen.previous_group.windows:
            group.toscreen(toggle=True)
        else:
            group.screen.next_group(skip_empty=True, skip_managed=False)
```

That started throwing errors when I reload the config having a window in the current group.

```
ERROR libqtile hook.py:fire():L196 Error in hook group_window_remove
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/libqtile/hook.py", line 194, in fire
    i(*args, **kwargs)
  File "/home/shyguy/.config/qtile/config.py", line 342, in group_window_remove
    group.screen.next_group(skip_empty=True, skip_managed=False)
  File "/usr/lib/python3.12/site-packages/libqtile/config.py", line 661, in next_group
    n = self.group.get_next_group(skip_empty, skip_managed)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/libqtile/group.py", line 436, in get_next_group
    return self._get_group(1, skip_empty, skip_managed)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/libqtile/group.py", line 429, in _get_group
    index = (groups.index(self) + direction) % len(groups)
             ^^^^^^^^^^^^^^^^^^
ValueError: <group.Group ('2')> is not in list
```

What I found is that when reloading, all groups are changed for new ones but when the hook is fire the group associated to the window is still the old one and is not in `qtile.groups` which throws the error. This PR should fix this issue.