### PR TITLE
Allow customizing battery widget short text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
         - Add `SwayNC` widget to interact with Sway Notification Centre (wayland only)
         - Add `swap` method to Plasma layout
         - New `click_or_drag_only` option for follow_mouse_focus to change the focus to the window under the mouse when click or drag
+        - Customize battery widget "Full" and "Empty" short text with `full_short_text` and `empty_short_text`
     * bugfixes
         - Make MonadWide layout up/down focus navigation behave like MonadTall's left/right
 

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -450,7 +450,21 @@ class Battery(base.ThreadPoolText):
         ("unknown_char", "?", "Character to indicate the battery status is unknown"),
         ("format", "{char} {percent:2.0%} {hour:d}:{min:02d} {watt:.2f} W", "Display format"),
         ("hide_threshold", None, "Hide the text when there is enough energy 0 <= x < 1"),
-        ("show_short_text", True, 'Show "Full" or "Empty" rather than formated text'),
+        (
+            "full_short_text",
+            "Full",
+            "Short text to indicate battery is full; see `show_short_text`",
+        ),
+        (
+            "empty_short_text",
+            "Empty",
+            "Short text to indicate battery is empty; see `show_short_text`",
+        ),
+        (
+            "show_short_text",
+            True,
+            "Show only characters rather than formatted text when battery is full or empty",
+        ),
         ("low_percentage", 0.10, "Indicates when to use the low_foreground color 0 < x < 1"),
         ("low_foreground", "FF0000", "Font color on low battery"),
         ("low_background", None, "Background color on low battery"),
@@ -550,13 +564,13 @@ class Battery(base.ThreadPoolText):
             char = self.discharge_char
         elif status.state == BatteryState.FULL:
             if self.show_short_text:
-                return "Full"
+                return self.full_short_text
             char = self.full_char
         elif status.state == BatteryState.EMPTY or (
             status.state == BatteryState.UNKNOWN and status.percent == 0
         ):
             if self.show_short_text:
-                return "Empty"
+                return self.empty_short_text
             char = self.empty_char
         elif status.state == BatteryState.NOT_CHARGING:
             char = self.not_charging_char

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -82,6 +82,14 @@ def test_text_battery_full(monkeypatch):
     text = batt.poll()
     assert text == "Full"
 
+    full_short_text = "🔋"
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(full_short_text=full_short_text)
+
+    text = batt.poll()
+    assert text == full_short_text
+
     with monkeypatch.context() as manager:
         manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
         batt = Battery(show_short_text=False)
@@ -106,6 +114,14 @@ def test_text_battery_empty(monkeypatch):
 
     text = batt.poll()
     assert text == "Empty"
+
+    empty_short_text = "🪫"
+    with monkeypatch.context() as manager:
+        manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))
+        batt = Battery(empty_short_text=empty_short_text)
+
+    text = batt.poll()
+    assert text == empty_short_text
 
     with monkeypatch.context() as manager:
         manager.setattr(battery, "load_battery", dummy_load_battery(loaded_bat))


### PR DESCRIPTION
Previously the battery widget showed hard-coded short text (`Full` and `Empty`) when the battery is full or empty and "show_short_text" is enabled.

This change allows customizing the full and empty short text using the new `full_short_text` and `empty_short_text` parameters, while retaining the original hard-coded values as defaults.