### PR TITLE
tests: make the Retry helper's output more useful

### DIFF
--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -195,11 +195,11 @@ def test_togroup(manager):
 def test_resize(manager):
     manager.c.screen[0].resize(x=10, y=10, w=100, h=100)
 
-    @Retry(ignore_exceptions=(AssertionError), fail_msg="Screen didn't resize")
+    @Retry(ignore_exceptions=(AssertionError))
     def run():
         d = manager.c.screen[0].info()
-        assert d["width"] == 100
-        assert d["height"] == 100
+        assert d["width"] == 100, "screen did not resize"
+        assert d["height"] == 100, "screen did not resize"
         return d
 
     d = run()


### PR DESCRIPTION
The existing output looks like:

    manager_nospawn = <test.helpers.TestManager object at 0x7f83f416ba10>

      @pytest.mark.usefixtures("hook_fixture")
      def test_screen_change(manager_nospawn):
	  @Retry(ignore_exceptions=(AssertionError))
	  def assert_inc_calls(num: int):
	      assert manager_nospawn.screen_change_calls.value == num

	  def inc_screen_change_calls(event):
	      manager_nospawn.screen_change_calls.value += 1

	  manager_nospawn.screen_change_calls = Value("i", 0)
	  hook.subscribe.screen_change(inc_screen_change_calls)

	  manager_nospawn.start(BareConfig)
    >       assert_inc_calls(1)

    test/test_hook.py:695:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    args = (1,), kwargs = {}, tmax = 1730476837.01283, dt = 3.8443359375000004
    ignore_exceptions = <class 'AssertionError'>

      @functools.wraps(fn)
      def wrapper(*args, **kwargs):
	  tmax = time.time() + self.tmax
	  dt = self.dt
	  ignore_exceptions = self.ignore_exceptions

	  while time.time() <= tmax:
	      try:
		  return fn(*args, **kwargs)
	      except ignore_exceptions:
		  pass
	      except AssertionError:
		  break
	      time.sleep(dt)
	      dt *= 1.5
	  if self.return_on_fail:
	      return False
	  else:
    >         raise AssertionError(self.fail_msg)
    E         AssertionError: retry failed!

but it doesn't tell you *which* assertion failed inside of the retry function. This is also useful because it expands the values at the assertion, which can be helpful in reasoning about why a retry failed. Instead, let's re-raise the last exception that failed, which renders messages like this:

    manager_nospawn = <test.helpers.TestManager object at 0x7f1d03f41250>

      @pytest.mark.usefixtures("hook_fixture")
      def test_screen_change(manager_nospawn):
	  @Retry(ignore_exceptions=(AssertionError))
	  def assert_inc_calls(num: int):
	      assert manager_nospawn.screen_change_calls.value == num

	  def inc_screen_change_calls(event):
	      manager_nospawn.screen_change_calls.value += 1

	  manager_nospawn.screen_change_calls = Value("i", 0)
	  hook.subscribe.screen_change(inc_screen_change_calls)

	  manager_nospawn.start(BareConfig)
    >       assert_inc_calls(1)

    test/test_hook.py:695:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    test/helpers.py:71: in wrapper
      raise self.last_failure
    test/helpers.py:61: in wrapper
      return fn(*args, **kwargs)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    num = 1

      @Retry(ignore_exceptions=(AssertionError))
      def assert_inc_calls(num: int):
    >       assert manager_nospawn.screen_change_calls.value == num
    E       assert 0 == 1
    E        +  where 0 = <Synchronized wrapper for c_int(0)>.value
    E        +    where <Synchronized wrapper for c_int(0)> = <test.helpers.TestManager object at 0x7f1d03f41250>.screen_change_calls

    test/helpers.py:72: AssertionError

In addition, I dropped the `fail_msg` parameter, in favor of annotating the relevant assertions with the fail message, so that it shows up the same as it did before.