### PR TITLE
bar: fix finalize() and re-initialization

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -439,6 +439,7 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         if self.future:
             self.future.cancel()
         self.drawer.finalize()
+        del self.drawer
         if self.window:
             self.window.kill()
             self.window = None


### PR DESCRIPTION
I just got the stack trace:

    2024-11-03 18:50:41,798 ERROR libqtile hook.py:fire():L196 Error in hook screen_change
    Traceback (most recent call last):
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/hook.py", line 194, in fire
        i(*args, **kwargs)
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/core/manager.py", line 446, in reconfigure_screens
        self._process_screens()
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/core/manager.py", line 417, in _process_screens
        scr._configure(
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/config.py", line 479, in _configure
        i._configure(qtile, self, reconfigure=reconfigure_gaps)
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/bar.py", line 331, in _configure
        self.drawer.clear(self.background)
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/backend/base/drawer.py", line 318, in clear
        self.clear_rect()
      File "/home/tycho/.local/lib/python3.10/site-packages/libqtile/backend/x11/drawer.py", line 234, in clear_rect
        with cairocffi.Context(self._xcb_surface) as ctx:
      File "/home/tycho/.local/lib/python3.10/site-packages/cairocffi/context.py", line 100, in __init__
        self._init_pointer(cairo.cairo_create(target._pointer))
    AttributeError: 'NoneType' object has no attribute '_pointer'

it looks like this is because the drawer's finalize() has been called, so the underlying x11 drawer freed the xcb_surface, but then bar's _configure() does:

    if hasattr(self, "drawer"):
        self.drawer.width = width
        self.drawer.height = height
    else:
        self.drawer = self.window.create_drawer(width, height)

which means we never reinitialize the drawer, since we still hasattr() it. To fix that, let's delete the drawer as well, so we create a new drawer.