### PR TITLE
drawer: reset ctx if necessary

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -312,6 +312,8 @@ class Drawer:
 
     def clear(self, colour):
         """Clears background of the Drawer and fills with specified colour."""
+        if self.ctx is None:
+            self._reset_surface()
         self.ctx.save()
 
         # Erase the background


### PR DESCRIPTION
we have reports of the stack trace:

    2024-11-05 20:45:41,250 ERROR libqtile hook.py:fire():L196 Error in hook screen_change
    Traceback (most recent call last):
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/hook.py", line 194, in fire
        i(*args, **kwargs)
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/core/manager.py", line 444, in reconfigure_screens
        self._process_screens()
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/core/manager.py", line 415, in _process_screens
        scr._configure(
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/config.py", line 479, in _configure
        i._configure(qtile, self, reconfigure=reconfigure_gaps)
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/bar.py", line 331, in _configure
        self.drawer.clear(self.background)
      File "/home/user/qubes-qtile/trunk/qtile-env/lib64/python3.11/site-packages/libqtile/backend/base/drawer.py", line 315, in clear
        self.ctx.save()
        ^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'save'

if we have finalize()d the drawer, its context may be None, so we need to create a fresh one to draw to.

Fixes #5071