### PR TITLE
x11: more drawer finalize cleanup

### DIFF
--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -229,6 +229,8 @@ class Drawer(drawer.Drawer):
         if height <= 0:
             height = self.height
 
+        self._check_xcb()
+
         # Using OPERATOR_CLEAR in a RecordingSurface does not clear the
         # XCBSurface so we clear the XCBSurface directly.
         with cairocffi.Context(self._xcb_surface) as ctx:


### PR DESCRIPTION
Probably I fixed the wayland version of this bug in f642d3aa80f5 ("bar: fix finalize() and re-initialization"), but I didn't realize x11 had totally custom workarounds for OPERATOR_CLEAR. This means we explicitly need to initialize the surface before we clear it.

This again Fixes #5071, for the *third* time? :)