### PR TITLE
x11: look at all the wm type atoms

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -281,8 +281,16 @@ class XWindow:
         """
         r = self.get_property("_NET_WM_WINDOW_TYPE", "ATOM", unpack=int)
         if r:
-            name = self.conn.atoms.get_name(r[0])
-            return xcbq.WindowTypes.get(name, name)
+            first_name = None
+            for i, a in enumerate(r):
+                name = self.conn.atoms.get_name(a)
+                if i == 0:
+                    first_name = name
+                qtile_type = xcbq.WindowTypes.get(name, None)
+                if qtile_type is not None:
+                    return qtile_type
+            return first_name
+        return None
 
     def get_net_wm_state(self):
         r = self.get_property("_NET_WM_STATE", "ATOM", unpack=int)

--- a/test/backend/x11/test_window.py
+++ b/test/backend/x11/test_window.py
@@ -1053,3 +1053,12 @@ def test_move_float_above_tiled(xmanager):
 
     _wnd("two").toggle_floating()
     assert _clients() == ["one", "three", "two"]
+
+
+def test_multiple_wm_types(xmanager):
+    conn = xcbq.Connection(xmanager.display)
+    w = conn.create_window(50, 50, 50, 50)
+    normal = conn.atoms["_NET_WM_WINDOW_TYPE_NORMAL"]
+    kde_override = conn.atoms["_KDE_NET_WM_WINDOW_TYPE_OVERRIDE"]
+    w.set_property("_NET_WM_WINDOW_TYPE", [kde_override, normal])
+    assert w.get_wm_type() == "normal"


### PR DESCRIPTION
_NET_WM_WINDOW_TYPE is really a *list*, not a single atom. We were previously using just the first element to distinguish types, but at least one application (Zoom, see #5065) set multiple _NET_WM_WINDOW_TYPE atoms, and the first one is not one that we understand natively:

    _NET_WM_WINDOW_TYPE(ATOM) = _KDE_NET_WM_WINDOW_TYPE_OVERRIDE, _NET_WM_WINDOW_TYPE_NORMAL

however, the second one is. Let's look through this entire list and see if we understand any of the types natively. If it doesn't exist, we still return the raw first atom, to preserve previous behavior.

Unclear if this fixes #5065, but it is certainly a bug that is easily fixed, so let's fix it :)