### PR TITLE
widget: drop InLoopPollText's _configure() override

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -794,14 +794,6 @@ class InLoopPollText(_TextBox):
             self.timeout_add(update_interval, self.timer_setup)
         # If update_interval is False, we won't re-call
 
-    def _configure(self, qtile, bar):
-        should_tick = self.configured
-        _TextBox._configure(self, qtile, bar)
-
-        # Update when we are being re-configured.
-        if should_tick:
-            self.tick()
-
     def button_press(self, x, y, button):
         self.tick()
         _TextBox.button_press(self, x, y, button)


### PR DESCRIPTION
This method does two things: it explicitly calls tick(), and it only does that when the widget is actually configured.

But the timer_setup() method itself calls tick(), and the parent _TextBox -> _Widget's _configure() has logic to only call timer_setup() once, when the widget is first configured, so it will *always* be okay to call.

That means we can drop this function entirely.