### PR TITLE
widget: move update_interval to the base widget

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -495,6 +495,11 @@ class _TextBox(_Widget):
             "When ``scroll=True`` the ``width`` parameter is a maximum width and, when text is shorter than this, the widget will resize. "
             "Setting ``scroll_fixed_width=True`` will force the widget to have a fixed width, regardless of the size of the text.",
         ),
+        (
+            "update_interval",
+            600,
+            "Update interval in seconds, if none, the widget updates only once.",
+        ),
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -771,18 +776,6 @@ class InLoopPollText(_TextBox):
     ('fast' here means that this runs /in/ the event loop, so don't block! If
     you want to run something nontrivial, use ThreadPoolText.)"""
 
-    defaults = [
-        (
-            "update_interval",
-            600,
-            "Update interval in seconds, if none, the widget updates only once.",
-        ),
-    ]  # type: list[tuple[str, Any, str]]
-
-    def __init__(self, default_text="N/A", **config):
-        _TextBox.__init__(self, default_text, **config)
-        self.add_defaults(InLoopPollText.defaults)
-
     def timer_setup(self):
         update_interval = self.tick()
         # If self.update_interval is defined and .tick() returns None, re-call
@@ -825,18 +818,6 @@ class ThreadPoolText(_TextBox):
 
     param: text - Initial text to display.
     """
-
-    defaults = [
-        (
-            "update_interval",
-            600,
-            "Update interval in seconds, if none, the widget updates only once.",
-        ),
-    ]  # type: list[tuple[str, Any, str]]
-
-    def __init__(self, text, **config):
-        super().__init__(text, **config)
-        self.add_defaults(ThreadPoolText.defaults)
 
     def timer_setup(self):
         def on_done(future):


### PR DESCRIPTION
This one is a little uglier, and not a strongly held opinion, but maybe it's worth merging.

"Almost" all widgets (see below)  poll things instead of listen for events in the event loop. So they all have some kind of update_interval, which lets us get rid of these custom __init__ methods. Since _Widget has the logic to call setup_timer, the concept of widget timers is already implied by _Widget, so I think this probably makes sense.

We could commonize these to a mixin, but that's almost more code than just leaving them copypasta'd.

Widgets like pulse_volume do not actually need a timer (which it notes in its docs) because it installs an fd listener directly in the event loop. However, it installs one anyway by virtue of inheriting from Volume :)

In principle the mpris2widget also does not need a timer doing the same eventloop trick, but it does have additional custom code to install a timer based on a configuration setting called poll_interval instead, so it does *both*. Perhaps we should s/poll_interval/update_interval and delete some of that at the very least.