### PR TITLE
core: do not (double) fork in spawn()

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -30,6 +30,7 @@ import shlex
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 from collections import defaultdict
 from logging.handlers import RotatingFileHandler
@@ -1323,82 +1324,34 @@ class Qtile(CommandObject):
             logger.error("couldn't find `%s`", to_lookup)
             return -1
 
-        r, w = os.pipe()
-        pid = os.fork()
-        if pid < 0:
-            os.close(r)
-            os.close(w)
-            return pid
+        if len(env) == 0:
+            env = os.environ.copy()
+            # if qtile was installed in a virutal env, we don't
+            # necessarily want to propagate that to children
+            # applications, since it may change e.g. the behavior
+            # of shells that spawn python applications
+            env.pop("VIRTUAL_ENV", None)
 
-        if pid == 0:
-            os.close(r)
+        # std{in,out,err} should be /dev/null
+        null = os.open("/dev/null", os.O_RDONLY)
+        file_actions: list[tuple] = [
+            (os.POSIX_SPAWN_DUP2, 0, null),
+            (os.POSIX_SPAWN_DUP2, 1, null),
+            (os.POSIX_SPAWN_DUP2, 2, null),
+        ]
 
-            # close qtile's stdin, stdout, stderr so the called process doesn't
-            # pollute our xsession-errors.
-            os.close(0)
-            os.close(1)
-            os.close(2)
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 13:
+            # we should close all fds so that child processes don't
+            # accidentally write to our x11 event loop or whatever; we never
+            # used to do this, so it seems fine to only do it on python 3.13 or
+            # above, where this nice API to do it exists.
+            file_actions.append((os.POSIX_SPAWN_CLOSEFROM, 3))  # type: ignore
 
-            pid2 = os.fork()
-            if pid2 == 0:
-                os.close(w)
-                try:
-                    # if qtile was installed in a virutal env, we don't
-                    # necessarily want to propagate that to children
-                    # applications, since it may change e.g. the behavior
-                    # of shells that spawn python applications
-                    del os.environ["VIRTUAL_ENV"]
-                except KeyError:
-                    pass
-
-                for k, v in env.items():
-                    os.environ[k] = v
-
-                # Open /dev/null as stdin, stdout, stderr
-                try:
-                    fd = os.open(os.devnull, os.O_RDWR)
-                except OSError:
-                    # This shouldn't happen, catch it just in case
-                    pass
-                else:
-                    # For Python >=3.4, need to set file descriptor to inheritable
-                    try:
-                        os.set_inheritable(fd, True)
-                    except AttributeError:
-                        pass
-
-                    # Again, this shouldn't happen, but we should just check
-                    if fd > 0:
-                        os.dup2(fd, 0)
-
-                    os.dup2(fd, 1)
-                    os.dup2(fd, 2)
-
-                try:
-                    os.execvp(args[0], args)
-                except OSError:
-                    # can't log here since we forked :(
-                    pass
-
-                os._exit(1)
-            else:
-                # Here it doesn't matter if fork failed or not, we just write
-                # its return code and exit.
-                os.write(w, str(pid2).encode())
-                os.close(w)
-
-                # sys.exit raises SystemExit, which will then be caught by our
-                # top level catchall and we'll end up with two qtiles; os._exit
-                # actually calls exit.
-                os._exit(0)
-        else:
-            os.close(w)
-            os.waitpid(pid, 0)
-
-            # 1024 bytes should be enough for any pid. :)
-            pid = int(os.read(r, 1024))
-            os.close(r)
-            return pid
+        try:
+            return os.posix_spawnp(args[0], args, env, file_actions=file_actions)
+        except OSError as e:
+            logger.warning("failed to execute: %s: %s", str(args), str(e))
+            return -1
 
     @expose_command()
     def status(self) -> Literal["OK"]:


### PR DESCRIPTION
We are getting a bunch of warnings when running the tests under 3.12:

      /opt/hostedtoolcache/Python/3.12.7/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=6043) is multi-threaded, use of fork() may lead to deadlocks in the child.
        self.pid = os.fork()

    -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
    ==== 1277 passed, 25 skipped, 2 xpassed, 299 warnings in 1252.65s (0:20:52) ====

This is because as of 3.12, qtile warns about using os.fork() in multithreaded processes. While Qtile itself does not explicitly use any threads, asyncio will create them implicitly for running threads that do blocking IO.

Note that I don't think this is a *real* bug: python is being overly paranoid here, in case a child-forked process started interfering with locks or other internal python state in a way that python was not generally expecting. However, our code doesn't do that: it immediately forks again and then exec()s, in order to daemonize anything that it spawns.

When I originally wrote this double-fork-daemonize implementation, asyncio did not exist and we had our own custom written event loop, so it was also safe to fork. Additionally, I thought it was pretty important to double fork, so qtile was not the parent of everything, mostly for aesthetic reasons. In practice it doesn't matter if qtile is the parent of these tasks, in case the X server crashes, tasks that are using $DISPLAY etc. will also die, because their X server crashed. Tasks that are not will naturally get reparented to init, and so no work that would have otherwise been lost is saved by the double-fork-daemonize approach.

However, I think it makes sense to heed python's warning: the switch to asyncio and implied thread creation went unnoticed (even though it is obvious in hindsight :) to me for a long time. Given that we're not explicitly managing things any more and letting asyncio do the heavy lifting for us, it makes sense to heed python's warning about os.fork(), since who knows what housekeeping asyncio may add in the future, even if things still seem to work today.

After some conversation with friends, it seems that a few people would find it mildly useful to have qtile be a parent of their session tasks so that they can easily find them. That means that instead of having to figure out how to fork safely, we can use os.posix_spawnp() to use "safe" API to do this, and dodge both python 3.12's DeprecationWarning and some ugly hacks multiprocessing and friends have that we'd have to leverage for daemonizing.

There is an additional bugfix here: if people forked tasks from their xsession that died, qtile will now wait() on them, instead of leaving those around forever.

The end result is that you get a process tree that looks like this:

    root        1950  0.0  0.0 306792  8956 ?        SLsl Nov13   0:00 /usr/sbin/lightdm
    root      395385  4.0  1.8 1429680 600712 tty7   Ssl+ 12:29   0:06  \_ /usr/lib/xorg/Xorg -core :0 -seat seat0 -auth /var/run/lightdm/root/:0 -nolisten tcp vt7 -novtswitch
    root      395479  0.0  0.0 162904 10696 ?        Sl   12:29   0:00  \_ lightdm --session-child 12 19
    tycho     395703  2.1  0.2 535980 71848 ?        Ssl  12:31   0:01      \_ qtile
    tycho     395878  0.0  0.0   7980  1072 ?        Ss   12:31   0:00          \_ /usr/bin/ssh-agent /home/tycho/.xsession
    tycho     395901  0.2  0.2 1320028 88752 ?       Sl   12:31   0:00          \_ alacritty
    tycho     395921  0.1  0.0  32184 26400 pts/0    Ss   12:31   0:00          |   \_ /bin/bash
    tycho     397301  0.0  0.0  16080  6612 pts/0    S+   12:32   0:00          |       \_ /usr/bin/git commit -a --amend
    tycho     397360  1.0  0.0  67180 25896 pts/0    S+   12:32   0:00          |           \_ /usr/bin/vim /home/tycho/packages/qtile/.git/COMMIT_EDITMSG
    tycho     395902  0.0  0.0 236556  5280 ?        Sl   12:31   0:00          \_ xss-lock -- i3lock -f -c ff0000
    tycho     395982  0.2  0.2 1317552 89300 ?       Sl   12:31   0:00          \_ alacritty -e sh -c ssh irc.tycho.pizza
    tycho     396176  0.0  0.0   2892   956 pts/2    Ss+  12:31   0:00          |   \_ sh -c ssh irc.tycho.pizza
    tycho     396178  0.0  0.0  16996  7776 pts/2    S+   12:31   0:00          |       \_ ssh irc.tycho.pizza
    tycho     395988  7.0  0.9 1220432528 298888 ?   SLl  12:31   0:04          \_ /opt/Signal/signal-desktop
    tycho     396021  0.0  0.1 34070368 52388 ?      S    12:31   0:00          |   \_ /opt/Signal/signal-desktop --type=zygote --no-zygote-sandbox
    tycho     396401  1.2  0.5 34593328 194636 ?     Sl   12:31   0:00          |   |   \_ /opt/Signal/signal-desktop --type=gpu-process --enable-crash-reporter=de966526-368b-485c-a34b-7bc8d56c5f47,no_channel --user-d
    tycho     396022  0.0  0.1 34070360 52448 ?      S    12:31   0:00          |   \_ /opt/Signal/signal-desktop --type=zygote
    tycho     396067  0.0  0.0 34070360 10980 ?      S    12:31   0:00          |   |   \_ /opt/Signal/signal-desktop --type=zygote
    tycho     396418  0.0  0.2 33874244 66988 ?      Sl   12:31   0:00          |   \_ /opt/Signal/signal-desktop --type=utility --utility-sub-type=network.mojom.NetworkService --lang=en-US --service-sandbox-type=none
    tycho     396493  6.7  1.0 1212644844 330984 ?   Sl   12:31   0:04          |   \_ /opt/Signal/signal-desktop --type=renderer --enable-crash-reporter=de966526-368b-485c-a34b-7bc8d56c5f47,no_channel --user-data-dir
    tycho     397361  3.0  0.2 1319656 96044 ?       Sl   12:32   0:00          \_ alacritty
    tycho     397376  1.6  0.0  32176 26108 pts/3    Ss   12:32   0:00              \_ /bin/bash
    tycho     397396  0.0  0.0  13096  3992 pts/3    R+   12:32   0:00                  \_ ps auxf