### PR TITLE
Fire window_remove hook earlier

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -269,8 +269,8 @@ class _Group(CommandObject):
             self.focus(win, warp=True, force=force)
 
     def remove(self, win, force=False):
-        self.windows.remove(win)
         hook.fire("group_window_remove", self, win)
+        self.windows.remove(win)
         hadfocus = self._remove_from_focus_history(win)
         win.group = None
 


### PR DESCRIPTION
Moving group_window_remove hook to first statement, so hooks can know what index the removed window was at.

Not sure if a migration is needed for this. Seems like the hook is new enough and the use-case for this is rare enough to get by without one.