### PR TITLE
Dont fork tests

### DIFF
--- a/libqtile/scripts/udev.py
+++ b/libqtile/scripts/udev.py
@@ -1,4 +1,3 @@
-import argparse
 import glob
 import os
 import shutil
@@ -36,7 +35,7 @@ def udev(options):
 
 
 def add_subcommand(subparsers, parents):
-    parser = subparsers.add_parser("udev", parents=parents, help=argparse.SUPPRESS)
+    parser = subparsers.add_parser("udev", parents=parents)
     parser.add_argument("kind", choices=["backlight", "battery"])
     parser.add_argument("--device")
     parser.add_argument("--group", default="sudo")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,6 +5,7 @@ Defining them here rather than in conftest.py avoids issues with circular import
 between test/conftest.py and test/backend/<backend>/conftest.py files.
 """
 
+import faulthandler
 import functools
 import logging
 import multiprocessing
@@ -153,6 +154,8 @@ class TestManager:
 
     def __enter__(self):
         """Set up resources"""
+        faulthandler.enable(all_threads=True)
+        faulthandler.register(signal.SIGUSR2, all_threads=True)
         self._sockfile = tempfile.NamedTemporaryFile()
         self.sockfile = self._sockfile.name
         return self

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -1305,17 +1305,16 @@ def test_widget_duplicate_names(manager):
 
 
 @duplicate_widgets_config
-def test_widget_duplicate_warnings(logger, manager):
-    # Logging messages were created during setup so we need to access them
-    records = logger.get_records("setup")
+def test_widget_duplicate_warnings(manager):
+    records = manager.get_log_buffer().splitlines()
 
     # We need to filter out other potential log messages here
-    records = [r for r in records if r.msg.startswith("The following widgets")]
+    records = [r for r in records if "The following widgets" in r]
 
     assert len(records) == 1
 
     for w in ["prompt_1", "prompt_2", "groupbox_1", "groupbox_2", "foo_1"]:
-        assert w in records[0].msg
+        assert w in records[0]
 
     # Check this message level was info
-    assert all([r.levelno == logging.INFO for r in records])
+    assert all([r.startswith("INFO") for r in records])

--- a/test/widgets/test_base.py
+++ b/test/widgets/test_base.py
@@ -207,15 +207,13 @@ scrolling_text_config = pytest.mark.parametrize("manager", [ScrollingTextConfig]
 
 
 @scrolling_text_config
-def test_text_scroll_no_width(logger, manager):
+def test_text_scroll_no_width(manager):
     """
     Scrolling text needs a fixed width. If this is not set a warning is provided and
     scrolling is disabled.
     """
-    records = [r for r in logger.get_records("setup") if r.msg.startswith("no_width")]
-    assert records
-    assert records[0].levelname == "WARNING"
-    assert records[0].msg == "no_width: You must specify a width when enabling scrolling."
+    logs = manager.get_log_buffer()
+    assert "WARNING - no_width: You must specify a width when enabling scrolling." in logs
     _, output = manager.c.widget["no_width"].eval("self.scroll")
     assert output == "False"
 

--- a/test/widgets/test_image.py
+++ b/test/widgets/test_image.py
@@ -100,7 +100,7 @@ def test_no_scale(manager_nospawn, minimal_conf_noscreen):
     assert info["widgets"][0]["width"] == 24
 
 
-def test_no_image(manager_nospawn, minimal_conf_noscreen, logger):
+def test_no_image(manager_nospawn, minimal_conf_noscreen):
     img = widget.Image()
 
     config = minimal_conf_noscreen
@@ -108,10 +108,10 @@ def test_no_image(manager_nospawn, minimal_conf_noscreen, logger):
 
     manager_nospawn.start(config)
 
-    assert "Image filename not set!" in logger.text
+    assert "Image filename not set!" in manager_nospawn.get_log_buffer()
 
 
-def test_invalid_path(manager_nospawn, minimal_conf_noscreen, logger):
+def test_invalid_path(manager_nospawn, minimal_conf_noscreen):
     filename = "/made/up/file.png"
     img = widget.Image(filename=filename)
 
@@ -120,4 +120,4 @@ def test_invalid_path(manager_nospawn, minimal_conf_noscreen, logger):
 
     manager_nospawn.start(config)
 
-    assert f"Image does not exist: {filename}" in logger.text
+    assert f"Image does not exist: {filename}" in manager_nospawn.get_log_buffer()

--- a/test/widgets/test_tasklist.py
+++ b/test/widgets/test_tasklist.py
@@ -243,16 +243,16 @@ def test_tasklist_click_task(tasklist_manager):
 @xdg
 @configure_tasklist(theme_mode="non-existent-mode")
 @pytest.mark.xfail
-def test_tasklist_bad_theme_mode(tasklist_manager, logger):
-    msgs = [rec.msg for rec in logger.get_records("setup")]
+def test_tasklist_bad_theme_mode(tasklist_manager):
+    msgs = tasklist_manager.get_log_buffer()
     assert "Unexpected theme_mode (non-existent-mode). Theme icons will be disabled." in msgs
 
 
 @no_xdg
 @configure_tasklist(theme_mode="non-existent-mode")
 @pytest.mark.xfail
-def test_tasklist_no_xdg(tasklist_manager, logger):
-    msgs = [rec.msg for rec in logger.get_records("setup")]
+def test_tasklist_no_xdg(tasklist_manager):
+    msgs = tasklist_manager.get_log_buffer()
     assert "You must install pyxdg to use theme icons." in msgs
 
 


### PR DESCRIPTION
Here is the first patches in what I hope will not be a super long slog to get rid of our fork warnings in the tests. Then we should enable `-W error` so we can catch these sooner :)