### PR TITLE
inhibitor: don't fail if dbus is not present

### DIFF
--- a/libqtile/resources/sleep.py
+++ b/libqtile/resources/sleep.py
@@ -97,7 +97,14 @@ class Inhibitor:
         Attaches handler to the "PrepareForSleep" signal.
         """
         # Connect to bus and Manager interface
-        self.bus = await MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True).connect()
+        try:
+            self.bus = await MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True).connect()
+        except FileNotFoundError:
+            self.bus = None
+            logger.warning(
+                "Could not find logind service. Suspend and resume hooks will be unavailable."
+            )
+            return
 
         try:
             introspection = await self.bus.introspect(LOGIND_SERVICE, LOGIND_PATH)


### PR DESCRIPTION
We already don't fail if we can't introspect the connection correctly, let's also not fail if we can't even connect.