### PR TITLE
wl: do not handle SIGCHLD when initializing xwayland

### DIFF
--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -627,3 +627,18 @@ def remove_dbus_rules() -> None:
         # We need to manually close the socket until https://github.com/altdesktop/python-dbus-next/pull/148
         # gets merged. There's no error on multiple calls to 'close()'.
         bus._sock.close()
+
+
+def reap_zombies() -> None:
+    """
+    A SIGCHLD handler that reaps all zombies until there are no more.
+    """
+    try:
+        # One signal might mean mulitple children have exited. Reap everything
+        # that has exited, until there's nothing left.
+        while True:
+            wait_result = os.waitid(os.P_ALL, 0, os.WEXITED | os.WNOHANG)
+            if wait_result is None:
+                return
+    except ChildProcessError:
+        pass


### PR DESCRIPTION
the wayland backend via wlroots wants to double fork an X server for XWayland, and expects to waitpid() on the middle fork to make sure things were successful. our SIGCHLD handler races with this process and interferes, causing things like:

    waitpid for Xwayland fork failed: No child processes

let's delay installing our SIGCHLD handler until after XWayland is initialized to hopefully dodge this error.

Fixes #5101