### PR TITLE
Enable warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,6 @@ python_files = "test_*.py"
 testpaths = ["test"]
 filterwarnings = [
     "error:::libqtile",
+    "error:::test",
+    "ignore:::dbus_next",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-cov
 tox
 pre-commit
 PyGObject
+isort

--- a/test/core/test_exitcode.py
+++ b/test/core/test_exitcode.py
@@ -18,10 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import multiprocessing
 import os
 import subprocess
 import tempfile
-import threading
 import time
 
 import test
@@ -74,20 +74,20 @@ def deferred_stop(code=0):
 # and a second instance started by run_qtile,
 # which is used to test the actual exit code behavior
 def test_exitcode_default(backend):
-    thread = threading.Thread(target=deferred_stop)
-    thread.daemon = False
-    thread.start()
+    proc = multiprocessing.Process(target=deferred_stop)
+    proc.start()
 
     exitcode = run_qtile(backend)
+    proc.join()
     assert exitcode == 0
 
 
 def test_exitcode_explicit(backend):
     code = 23
 
-    thread = threading.Thread(target=deferred_stop, args=(code,))
-    thread.daemon = False
-    thread.start()
+    proc = multiprocessing.Process(target=deferred_stop, args=(code,))
+    proc.start()
 
     exitcode = run_qtile(backend)
+    proc.join()
     assert exitcode == code

--- a/test/core/test_exitcode.py
+++ b/test/core/test_exitcode.py
@@ -73,29 +73,21 @@ def deferred_stop(code=0):
 # which is used to evaluate code coverage
 # and a second instance started by run_qtile,
 # which is used to test the actual exit code behavior
-def test_exitcode_default(manager):
+def test_exitcode_default(backend):
     thread = threading.Thread(target=deferred_stop)
     thread.daemon = False
     thread.start()
 
-    exitcode = run_qtile(manager.backend)
-
-    # shutdown qtile instance started by testmanager
-    manager.c.shutdown()
-
+    exitcode = run_qtile(backend)
     assert exitcode == 0
 
 
-def test_exitcode_explicit(manager):
+def test_exitcode_explicit(backend):
     code = 23
 
     thread = threading.Thread(target=deferred_stop, args=(code,))
     thread.daemon = False
     thread.start()
 
-    exitcode = run_qtile(manager.backend)
-
-    # shutdown qtile instance started by testmanager
-    manager.c.shutdown()
-
+    exitcode = run_qtile(backend)
     assert exitcode == code

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ testdeps =
     PyGObject   
     isort
 commands =
+    # pywayland has to be installed before pywlroots
     !x11: pip install pywlroots==0.17.0
     pip install --break-system-packages .
     !x11: {toxinidir}/scripts/ffibuild
@@ -47,7 +48,6 @@ allowlist_externals =
 deps =
     {[base]deps}
     {[base]testdeps}
-# pywayland has to be installed before pywlroots
 commands =
     {[base]commands}
 
@@ -78,7 +78,6 @@ allowlist_externals =
 deps =
     {[base]deps}
     {[base]testdeps}
-# pywayland has to be installed before pywlroots
 commands =
     {[base]commands}
     python -m pytest {posargs}
@@ -96,7 +95,6 @@ allowlist_externals =
 deps =
     {[base]deps}
     {[base]testdeps}
-# pywayland has to be installed before pywlroots
 commands =
     {[base]commands}
     x11: python -m pytest --backend=x11 {posargs}


### PR DESCRIPTION
With the first few patches we now have a clean run of the tests without warnings, so let's enable warnings from the test code to keep it that way.

I started working on this because I think I am seeing the race that os.fork() is complaining about sometimes as part of debugging #5020, so hopefully with this series landed I can get back to debugging that :)