### PR TITLE
tests: fix failing tests on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           # tests
           coverage
           pytest
+          isort
         ];
 
       tests = {
@@ -76,6 +77,7 @@
         wlroots_0_17
         # test/backend/wayland/test_window.py
         gtk-layer-shell
+        imagemagick
       ] ++ (builtins.attrValues tests);
     in {
       default = pkgs.mkShell {

--- a/test/backend/x11/test_window.py
+++ b/test/backend/x11/test_window.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import tempfile
 from multiprocessing import Value
@@ -775,7 +776,17 @@ def test_multiple_borders(xmanager):
     wid = xmanager.c.window.info()["id"]
 
     name = os.path.join(tempfile.gettempdir(), "test_multiple_borders.txt")
-    cmd = ["import", "-border", "-window", str(wid), "-crop", "5x1+0+4", "-depth", "8", name]
+    cmd = [
+        shutil.which("import"),
+        "-border",
+        "-window",
+        str(wid),
+        "-crop",
+        "5x1+0+4",
+        "-depth",
+        "8",
+        name,
+    ]
     subprocess.run(cmd, env={"DISPLAY": xmanager.display})
 
     with open(name) as f:


### PR DESCRIPTION
Fixes issues with missing isort package in
test/migrate/test_migrations.py::test_all_migrations[MatchListRegex-0] and a FileNotFoundError for "import" in
test/backend/x11/test_window.py::test_multiple_borders.

when env= is set in subprocess.run(), it gets passed along to os.get_exec_path, and the current $PATH is not automatically inserted, in which case it uses a fallback of PATH=/usr/bin:/bin. So either $PATH would need to be added to env=, or a filepath would need to be passed as the executable.

TLDR: to make that test work on NixOS, we would either need shutil.which, or add $PATH to subprocess.run(env=...)

Related: #4658