### PR TITLE
core: delete finalized gaps

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -493,6 +493,16 @@ class Screen(CommandObject):
     def gaps(self) -> Iterable[BarType]:
         return (i for i in [self.top, self.bottom, self.left, self.right] if i)
 
+    def finalize_gaps(self) -> None:
+        def remove(attr: str) -> None:
+            gap = getattr(self, attr, None)
+            if gap is not None:
+                setattr(self, attr, None)
+                gap.finalize()
+
+        for attr in ["top", "bottom", "left", "right"]:
+            remove(attr)
+
     @property
     def dx(self) -> int:
         if self.left and getattr(self.left, "reserve", True):

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -330,8 +330,7 @@ class Qtile(CommandObject):
                     layout.finalize()
 
             for screen in self.screens:
-                for gap in screen.gaps:
-                    gap.finalize()
+                screen.finalize_gaps()
         except:  # noqa: E722
             logger.exception("exception during finalize")
         hook.clear()


### PR DESCRIPTION
If we finalize these gaps, we delete their drawers, but do not actually delete the gap. Later, windows (maybe e.g. other gap bars that received WM_DELETE_WINDOW and are also shutting down via unmap + destroy) can force a redraw of these bar objects, which will crash:

    2024-12-08 20:31:06,779 ERROR libqtile core.py:_xpoll():L359 Got an exception in poll loop
    Traceback (most recent call last):
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/backend/x11/core.py", line 334, in _xpoll
        self.handle_event(event)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/backend/x11/core.py", line 301, in handle_event
        ret = target(event)
              ^^^^^^^^^^^^^
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/backend/x11/core.py", line 771, in handle_DestroyNotify
        self.qtile.unmanage(event.window)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/core/manager.py", line 744, in unmanage
        self.free_reserved_space(c.reserved_space, c.screen)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/core/manager.py", line 714, in free_reserved_space
        self.reserve_space(reserved_space, screen)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/core/manager.py", line 702, in reserve_space
        screen.resize()
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/config.py", line 647, in resize
        self._configure(self.qtile, self.index, x, y, w, h, self.group)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/config.py", line 479, in _configure
        i._configure(qtile, self, reconfigure=reconfigure_gaps)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/bar.py", line 331, in _configure
        self.drawer.clear(self.background)
      File "/home/nizar/.local/lib/python3.12/site-packages/libqtile/backend/base/drawer.py", line 315, in clear
        self.ctx.save()
        ^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'save'

let's also set these bar gaps to None, so that these redraws will be no-ops and we don't crash.

We should probably *ignore* these unmaps if we know we are shutting down, but we have to be careful to distinguish between shutdowns and config reloads, which has been a source of bugs in the past. I'm happy with just this for now...