### PR TITLE
Nix flake: Migrate to dbus-fast + Correct formatting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,106 +5,134 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs = { self, nixpkgs }: let
-    supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+  outputs =
+    { self, nixpkgs }:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-    forAllSystems = function:
-      nixpkgs.lib.genAttrs supportedSystems
-      (system: let
-        nixpkgs-settings = {
-          inherit system;
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          let
+            nixpkgs-settings = {
+              inherit system;
 
-          overlays = [
-            (import ./nix/overlays.nix self)
-          ];
-        };
-      in function (import nixpkgs nixpkgs-settings));
+              overlays = [
+                (import ./nix/overlays.nix self)
+              ];
+            };
+          in
+          function (import nixpkgs nixpkgs-settings)
+        );
 
-  in {
-    checks = forAllSystems (pkgs: pkgs.python3Packages.qtile.passthru.tests);
+    in
+    {
+      checks = forAllSystems (pkgs: pkgs.python3Packages.qtile.passthru.tests);
 
-    overlays.default = import ./nix/overlays.nix self;
+      overlays.default = import ./nix/overlays.nix self;
 
-    packages = forAllSystems (pkgs: let
-      qtile' = pkgs.python3Packages.qtile;
-    in {
-      default = self.packages.${pkgs.system}.qtile;
+      packages = forAllSystems (
+        pkgs:
+        let
+          qtile' = pkgs.python3Packages.qtile;
+        in
+        {
+          default = self.packages.${pkgs.system}.qtile;
 
-      qtile = qtile'.overrideAttrs (prev: {
-        name = "${qtile'.pname}-${qtile'.version}";
-        passthru.unwrapped = qtile';
-      });
-    });
+          qtile = qtile'.overrideAttrs (prev: {
+            name = "${qtile'.pname}-${qtile'.version}";
+            passthru.unwrapped = qtile';
+          });
+        }
+      );
 
-    devShells = forAllSystems (pkgs: let
-      common-python-deps = ps: with ps;
-        [ python-dateutil ]
-        ++ [
-          # docs building
-          numpydoc
-          sphinx
-          sphinx_rtd_theme
-          # tests
-          coverage
-          pytest
-          isort
-        ];
+      devShells = forAllSystems (
+        pkgs:
+        let
+          common-python-deps =
+            ps:
+            with ps;
+            [ python-dateutil ]
+            ++ [
+              # docs building
+              numpydoc
+              sphinx
+              sphinx_rtd_theme
+              # tests
+              coverage
+              pytest
+              isort
+            ];
 
-      tests = {
-        wayland = pkgs.writeScriptBin "qtile-run-tests-wayland" ''
-          ./scripts/ffibuild -v
-          pytest -x --backend=wayland
-        '';
+          tests = {
+            wayland = pkgs.writeScriptBin "qtile-run-tests-wayland" ''
+              ./scripts/ffibuild -v
+              pytest -x --backend=wayland
+            '';
 
-        x11 = pkgs.writeScriptBin "qtile-run-tests-x11" ''
-          ./scripts/ffibuild -v
-          pytest -x --backend=x11
-        '';
-      };
+            x11 = pkgs.writeScriptBin "qtile-run-tests-x11" ''
+              ./scripts/ffibuild -v
+              pytest -x --backend=x11
+            '';
+          };
 
-      common-system-deps = with pkgs; [
-        # Gdk namespaces
-        wrapGAppsHook
-        gobject-introspection
+          common-system-deps =
+            with pkgs;
+            [
+              # Gdk namespaces
+              wrapGAppsHook
+              gobject-introspection
 
-        # docs graphs
-        graphviz
+              # docs graphs
+              graphviz
 
-        # x11 deps
-        xorg.xorgserver
-        xorg.libX11
+              # x11 deps
+              xorg.xorgserver
+              xorg.libX11
 
-        wlroots_0_17
-        # test/backend/wayland/test_window.py
-        gtk-layer-shell
-        imagemagick
-      ] ++ (builtins.attrValues tests);
-    in {
-      default = pkgs.mkShell {
-        env = {
-          QTILE_PIXMAN_PATH = "${pkgs.pixman}/include/pixman-1";
-          QTILE_LIBDRM_PATH = "${pkgs.libdrm.dev}/include/libdrm";
+              wlroots_0_17
+              # test/backend/wayland/test_window.py
+              gtk-layer-shell
+              imagemagick
+            ]
+            ++ (builtins.attrValues tests);
+        in
+        {
+          default = pkgs.mkShell {
+            env = {
+              QTILE_PIXMAN_PATH = "${pkgs.pixman}/include/pixman-1";
+              QTILE_LIBDRM_PATH = "${pkgs.libdrm.dev}/include/libdrm";
 
-          LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
-            glib
-            pango
-            xcb-util-cursor
-            pixman
-            libdrm.dev
-          ];
-        };
+              LD_LIBRARY_PATH =
+                with pkgs;
+                lib.makeLibraryPath [
+                  glib
+                  pango
+                  xcb-util-cursor
+                  pixman
+                  libdrm.dev
+                ];
+            };
 
-        shellHook = ''
-          export PYTHONPATH=$(readlink -f .):$PYTHONPATH
-        '';
+            shellHook = ''
+              export PYTHONPATH=$(readlink -f .):$PYTHONPATH
+            '';
 
-        inputsFrom = [ self.packages.${pkgs.system}.qtile ];
+            inputsFrom = [ self.packages.${pkgs.system}.qtile ];
 
-        packages = with pkgs; [
-          (python3.withPackages common-python-deps)
-          pre-commit
-        ] ++ common-system-deps;
-      };
-    });
-  };
+            packages =
+              with pkgs;
+              [
+                (python3.withPackages common-python-deps)
+                pre-commit
+              ]
+              ++ common-system-deps;
+          };
+        }
+      );
+    };
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,44 +1,50 @@
 self: final: prev: {
-  pythonPackagesOverlays =
-    (prev.pythonPackagesOverlays or [])
-    ++ [
-      (_: pprev: {
-        qtile = (pprev.qtile.overrideAttrs (old: let
-          flakever = self.shortRev or "dev";
+  pythonPackagesOverlays = (prev.pythonPackagesOverlays or [ ]) ++ [
+    (_: pprev: {
+      qtile =
+        (pprev.qtile.overrideAttrs (
+          old:
+          let
+            flakever = self.shortRev or "dev";
 
-          releases = (builtins.filter
-            (x: !builtins.isList x && prev.lib.strings.hasPrefix "Qtile" x)
-            (builtins.split "\n" (builtins.readFile ../CHANGELOG)));
+            releases = (
+              builtins.filter (x: !builtins.isList x && prev.lib.strings.hasPrefix "Qtile" x) (
+                builtins.split "\n" (builtins.readFile ../CHANGELOG)
+              )
+            );
 
-          # the 0th element is the template
-          current-release-title = builtins.elemAt releases 1;
+            # the 0th element is the template
+            current-release-title = builtins.elemAt releases 1;
 
-          symver = builtins.head
-            (builtins.match
-              "Qtile ([0-9.]+), released ([0-9-]+):"
-              current-release-title);
+            symver = builtins.head (
+              builtins.match "Qtile ([0-9.]+), released ([0-9-]+):" current-release-title
+            );
 
-        in {
-          version = "${symver}+${flakever}.flake";
-          # use the source of the git repo
-          src = ./..;
-          # for qtile migrate, not in nixpkgs yet
-          propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ 
-            pprev.libcst 
-            pprev.dbus-fast
-          ];
-          dependencies = prev.lib.filter (x: x != pprev.dbus-next) (old.propagatedBuildInputs or [ ]);
-        })).override {
-          wlroots = prev.wlroots_0_17;
-        };
-      })
-    ];
-  python3 = let
-    self = prev.python3.override {
-      inherit self;
-      packageOverrides = prev.lib.composeManyExtensions final.pythonPackagesOverlays;
-    };
-  in
+          in
+          {
+            version = "${symver}+${flakever}.flake";
+            # use the source of the git repo
+            src = ./..;
+            # for qtile migrate, not in nixpkgs yet
+            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+              pprev.libcst
+              pprev.dbus-fast
+            ];
+            dependencies = prev.lib.filter (x: x != pprev.dbus-next) (old.propagatedBuildInputs or [ ]);
+          }
+        )).override
+          {
+            wlroots = prev.wlroots_0_17;
+          };
+    })
+  ];
+  python3 =
+    let
+      self = prev.python3.override {
+        inherit self;
+        packageOverrides = prev.lib.composeManyExtensions final.pythonPackagesOverlays;
+      };
+    in
     self;
   python3Packages = final.python3.pkgs;
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -23,7 +23,11 @@ self: final: prev: {
           # use the source of the git repo
           src = ./..;
           # for qtile migrate, not in nixpkgs yet
-          propagatedBuildInputs = old.propagatedBuildInputs ++ [ pprev.libcst ];
+          propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ 
+            pprev.libcst 
+            pprev.dbus-fast
+          ];
+          dependencies = prev.lib.filter (x: x != pprev.dbus-next) (old.propagatedBuildInputs or [ ]);
         })).override {
           wlroots = prev.wlroots_0_17;
         };


### PR DESCRIPTION
With this commit I removed dbus-next from Nix's Qtile package build dependency, and added dbus-fast as a runtime dependency. Also formatted Flake and Overlays file using [Nixfmt](https://github.com/NixOS/nixfmt) (the official Nix formatter ). So far Qtile builds as expected, and haven't faced any issues!
```
qtile --version
0.29.0+c987163.flake
```