### PR TITLE
StatusNotifier - check for dbus icon

### DIFF
--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -259,7 +259,11 @@ class StatusNotifierItem:  # noqa: E303
             if not self.icon:
                 self.icon = self._get_xdg_icon(icon_name)
 
-        if not self.icon and fallback:
+        if fallback:
+            for icon in ["Icon", "Attention", "Overlay"]:
+                await self._get_icon(icon)
+
+        if not self.has_icons and fallback:
             # Use fallback icon libqtile/resources/status_notifier/fallback_icon.png
             logger.warning("Could not find icon for '%s'. Using fallback icon.", icon_name)
             path = Path(__file__).parent / "fallback_icon.png"


### PR DESCRIPTION
Some apps use a combination of icons from users' systems and also provided over the dbus interface. The widget has a bug where, if the first icon is a local icon, it will not check for icons provided over dbus. This results in the "fallback" icon being displayed instead of the correct icon.

Fixes #5122