### PR TITLE
Nix flake dependencies fix

### DIFF
--- a/docs/manual/install/nixos.rst
+++ b/docs/manual/install/nixos.rst
@@ -124,7 +124,3 @@ In the development shell, there are a few useful things:
 
 - `qtile-run-tests-wayland`: Run all Wayland tests
 - `qtile-run-tests-x11`: Run all X11 tests
-
-Furthermore nix build can also be used to run NixOS VM tests:
-
-- `nix build .\#checks.x86_64-linux.qtile` create a full nixos vm using Qemu, and take a screenshot of a opened terminal using a driver script

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -26,16 +26,10 @@ self: final: prev: {
             # use the source of the git repo
             src = ./..;
             # for qtile migrate, not in nixpkgs yet
-            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
-              pprev.libcst
-              pprev.dbus-fast
-            ];
-            dependencies = prev.lib.filter (x: x != pprev.dbus-next) (old.propagatedBuildInputs or [ ]);
+            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pprev.libcst ];
           }
         )).override
-          {
-            wlroots = prev.wlroots_0_17;
-          };
+          { wlroots = prev.wlroots_0_17; };
     })
   ];
   python3 =


### PR DESCRIPTION
Last commit about flake tried to migrate Qtile flake from dbus-next to dbus-fast, however I didn't take correct approach which resulted in having both dbus packages and unexpected behaviors. This commit tries to fix all that, before opening this pr I checked if everything worked as expected, even checked Qtile dependencies after built and seems like everything should be fixed, however I still demand careful review by @jwijenbergh and @Sigmanificient !!!

![image](https://github.com/user-attachments/assets/cc77818b-3cf6-415b-a2b8-68ae554be2f8)
