### PR TITLE
Use float state setters in group.add()

### DIFF
--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -246,7 +246,7 @@ class Window(_Window, metaclass=ABCMeta):
 
     qtile: Qtile
 
-    # If float_x or float_y are None, the window has never floated
+    # If float_x or float_y are None, the window has never been placed
     float_x: int | None
     float_y: int | None
 
@@ -319,6 +319,15 @@ class Window(_Window, metaclass=ABCMeta):
     def has_user_set_position(self) -> bool:
         """Whether this window has user-defined geometry"""
         return False
+
+    def is_placed(self) -> bool:
+        """Whether this window has been placed, i.e. both float offsets are not None."""
+        return (
+            self.group is not None
+            and self.group.screen is not None
+            and self.float_x is not None
+            and self.float_y is not None
+        )
 
     def is_transient_for(self) -> WindowType | None:
         """What window is this window a transient window for?"""

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -409,8 +409,8 @@ class Window(typing.Generic[S], _Base, base.Window, HasListeners):
     @floating.setter
     def floating(self, do_float: bool) -> None:
         if do_float and self._float_state == FloatStates.NOT_FLOATING:
-            if self.group and self.group.screen:
-                screen = self.group.screen
+            if self.is_placed():
+                screen = self.group.screen  # type: ignore[union-attr] # see is_placed()
                 if not self._float_width:  # These might start as 0
                     self._float_width = self._width
                     self._float_height = self._height

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1728,7 +1728,7 @@ class Window(_Window, base.Window):
         tiled = [win.window.wid for win in (self.group.tiled_windows if self.group else [])]
         tiled_stack = [wid for wid in stack if wid in tiled and wid != self.window.wid]
         if do_float and self._float_state == FloatStates.NOT_FLOATING:
-            if self.group and self.group.screen:
+            if self.is_placed():
                 screen = self.group.screen
                 self._enablefloating(
                     screen.x + self.float_x,

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from libqtile import hook, utils
-from libqtile.backend.base import FloatStates
 from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 
@@ -258,14 +257,12 @@ class _Group(CommandObject):
             self.windows.append(win)
         win.group = self
         if self.qtile.config.auto_fullscreen and win.wants_to_fullscreen:
-            win._float_state = FloatStates.FULLSCREEN
+            win.fullscreen = True
         elif self.floating_layout.match(win) and not win.fullscreen:
-            win._float_state = FloatStates.FLOATING
-            if self.qtile.config.floats_kept_above:
-                win.keep_above(enable=True)
+            win.floating = True
         if win.floating and not win.fullscreen:
             self.floating_layout.add_client(win)
-        if not win.floating or win.fullscreen:
+        else:
             self.tiled_windows.add(win)
             for i in self.layouts:
                 i.add_client(win)


### PR DESCRIPTION
This replaces direct assignments to `win._float_state` with usage of the appropriate property setters in `group.add()`.

This required a change in the window.floating setter to avoid trying to
make windows floating which have not yet been placed.

I could not resist adding a small refactoring by replacing `if not win.floating or win.fullscreen:` with `else:`, but I can (re)move that (to a separate commit/PR) if you prefer.

Fixes #5130.
