### PR TITLE
Make cmd_obj print proper JSON

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Qtile x.xx.x, released xxxx-xx-xx:
+    !!! breaking changes !!!
+      - Output of `qtile cmd-obj` is now in JSON.
     * features
     * bugfixes
 

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import argparse
 import itertools
-import pprint
+import json
 import sys
 import textwrap
 
@@ -38,6 +38,12 @@ from libqtile.command.client import CommandClient
 from libqtile.command.graph import CommandGraphRoot
 from libqtile.command.interface import IPCCommandInterface
 from libqtile.ipc import Client, find_sockfile
+
+
+def set_to_list(obj):
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError
 
 
 def get_formated_info(obj: CommandClient, cmd: str, args=True, short=True) -> str:
@@ -177,7 +183,7 @@ def cmd_obj(args) -> None:
         else:
             ret = run_function(obj, args.function, args.args)
             if ret is not None:
-                pprint.pprint(ret)
+                print(json.dumps(ret, indent=2, default=set_to_list))
     else:
         print_base_objects()
         sys.exit(1)

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import json
 import os
 import re
 import subprocess
@@ -89,16 +90,18 @@ class ServerConfig(Config):
 server_config = pytest.mark.parametrize("manager", [ServerConfig], indirect=True)
 
 
-def run_qtile_cmd(args, no_eval=False):
+def run_qtile_cmd(args, no_json_loads=False):
     cmd = os.path.join(os.path.dirname(__file__), "..", "bin", "qtile")
     argv = [cmd, "cmd-obj"]
     argv.extend(args.split())
     pipe = subprocess.Popen(argv, stdout=subprocess.PIPE)
     output, _ = pipe.communicate()
     output = output.decode()
-    if no_eval:
+    if not output:
+        return False
+    if no_json_loads:
         return output
-    return eval(output)  # as returned by pprint.pprint
+    return json.loads(output)
 
 
 @server_config
@@ -166,4 +169,6 @@ def test_cmd_obj_root_node(manager):
     cmd_no_root = base
     cmd_with_root = f"{base} -o root"
 
-    assert run_qtile_cmd(cmd_no_root, no_eval=True) == run_qtile_cmd(cmd_with_root, no_eval=True)
+    assert run_qtile_cmd(cmd_no_root, no_json_loads=True) == run_qtile_cmd(
+        cmd_with_root, no_json_loads=True
+    )


### PR DESCRIPTION
The output look like json but it's not valid JSON and make JSON tools like jq and gron fail.

This will possible break script people already have created.
But I think it would be worth it so we can use JSON tools to parse the output.