### PR TITLE
Enhancements to Minimize, Unminimize and Unhide Functionality

### DIFF
--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1694,7 +1694,7 @@ class Window(_Window, base.Window):
         self._wm_class: list[str] | None = None
         self.update_wm_class()
         self.update_name()
-        self.set_group()
+        self.togroup()
 
         # add window to the save-set, so it gets mapped when qtile dies
         qtile.core.conn.conn.core.ChangeSaveSet(SetMode.Insert, self.window.wid)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -2080,15 +2080,14 @@ class Window(_Window, base.Window):
         else:
             width, height, x, y = self.width, self.height, self.x, self.y
 
-        if self.group and self.group.screen:
-            self.place(
-                x,
-                y,
-                width,
-                height,
-                self.borderwidth,
-                self.bordercolor,
-            )
+        self.place(
+            x,
+            y,
+            width,
+            height,
+            self.borderwidth,
+            self.bordercolor,
+        )
         self.update_state()
         return False
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -2089,6 +2089,7 @@ class Window(_Window, base.Window):
             self.bordercolor,
         )
         self.update_state()
+        self.unhide()
         return False
 
     def update_wm_net_icon(self):

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1861,6 +1861,10 @@ class Window(_Window, base.Window):
         if do_minimize:
             if self._float_state != FloatStates.MINIMIZED:
                 self._enablefloating(new_float_state=FloatStates.MINIMIZED)
+                for win in reversed(self.group.focus_history[:-1]):
+                    if not win.minimized:
+                        self.group.focus(win)
+                        break
         else:
             if self._float_state == FloatStates.MINIMIZED:
                 self.floating = False

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -232,6 +232,7 @@ class _Group(CommandObject):
                 self.floating_layout.blur()
                 for layout in self.layouts:
                     layout.focus(win)
+            win.minimized = False
             hook.fire("focus_change")
             self.layout_all(warp)
 


### PR DESCRIPTION
This pull request addresses several issues related to the minimizing, unminimizing, and unhiding of applications when invoked from system tray icons or via web browsers:

### Handling Configure Requests:
When an application (e.g., Telegram) is launched from a browser, a configure request is generated. Previously, this was only applied to windows in the current group, potentially leaving applications in other groups unhandled. This PR ensures that such requests are processed regardless of the group, and in stack mode, ensures hidden windows are unhidden.

### Systray Application Group Handling:
When opening an application from a systray icon, the application should open in the current group rather than switching to the group where the application was last active. The `set_group()` method has been replaced with `togroup()` to ensure new windows open in the current group.

### Focus Management Post-Minimization:
Minimizing an application should automatically shift focus to the last unminimized window to prevent unexpected behavior, especially in stack mode. This PR corrects the focus not changing from the minimized window.

### State Change on Reinvocation:
If an application is minimized and then called again from another program (e.g., `rofi`, `wmctrl`, `alttab`), it should both become visible and have its minimized state reverted. This PR ensures that the application's state is updated to unminimized when it receives focus.

**Note:** Some of these changes might cause existing tests to fail. I believe this indicates that the current test behavior needs adjustment to reflect these improvements.