### PR TITLE
Nix flake: remove propagated-build-inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1746663147,
+        "narHash": "sha256-Ua0drDHawlzNqJnclTJGf87dBmaO/tn7iZ+TCkTRpRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "dda3dcd3fe03e991015e9a74b22d35950f264a54",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Qtile's flake, full-featured, hackable tiling window manager written and configured in Python";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
   outputs =
@@ -41,22 +41,10 @@
         {
           default = self.packages.${pkgs.system}.qtile;
 
-          qtile = qtile'.overrideAttrs (
-            prev:
-            let
-              remove-dbus-next = dep: dep.pname != pkgs.python3Packages.dbus-next.pname;
-
-              # seems like dependencies is a fancy wrapper on that one!
-              propagatedBuildInputs =
-                with pkgs.python3Packages;
-                [ dbus-fast ] ++ (pkgs.lib.filter remove-dbus-next prev.propagatedBuildInputs);
-            in
-            {
-              name = "${qtile'.pname}-${qtile'.version}";
-              inherit propagatedBuildInputs;
-              passthru.unwrapped = qtile';
-            }
-          );
+          qtile = qtile'.overrideAttrs (prev: {
+            name = "${qtile'.pname}-${qtile'.version}";
+            passthru.unwrapped = qtile';
+          });
         }
       );
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -25,8 +25,6 @@ self: final: prev: {
             version = "${symver}+${flakever}.flake";
             # use the source of the git repo
             src = ./..;
-            # for qtile migrate, not in nixpkgs yet
-            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pprev.libcst ];
           }
         )).override
           { wlroots = prev.wlroots_0_17; };


### PR DESCRIPTION
**Remove unnecessary `propagated-build-inputs` from flake**

This commit should not be merged until the following PR is resolved:  
[Nixpkgs PR #371737](https://github.com/NixOS/nixpkgs/pull/371737)

```bash
❯ qtile --version
0.30.0+5d5efe8.flake
```