### PR TITLE
Spiral layout: shuffle methods call client list's respective shuffle methods instead of rotate methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Qtile x.xx.x, released xxxx-xx-xx:
+    !!! breaking changes !!!
+        - Spiral layout: `shuffle_up` and `shuffle_down` commands now shuffle the focused window instead of rotating all windows.
     * features
     * bugfixes
 

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -372,13 +372,13 @@ class Spiral(_SimpleLayoutBase):
     @expose_command()
     def shuffle_down(self):
         if self.clients:
-            self.clients.rotate_down()
+            self.clients.shuffle_down()
             self.group.layout_all()
 
     @expose_command()
     def shuffle_up(self):
         if self.clients:
-            self.clients.rotate_up()
+            self.clients.shuffle_up()
             self.group.layout_all()
 
     @expose_command()

--- a/test/layouts/test_spiral.py
+++ b/test/layouts/test_spiral.py
@@ -202,6 +202,56 @@ def test_spiral_bottom_anticlockwise(manager):
     assert_dimensions(manager, 200, 150, 198, 148)
 
 
+@spiral_config
+def test_spiral_shuffle_up(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.test_window("four")
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three", "four"]
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()["clients"] == ["one", "two", "four", "three"]
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()["clients"] == ["one", "four", "two", "three"]
+
+
+@spiral_config
+def test_spiral_shuffle_down(manager):
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.test_window("four")
+    # wrap focus back to first window
+    manager.c.layout.down()
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three", "four"]
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()["clients"] == ["two", "one", "three", "four"]
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()["clients"] == ["two", "three", "one", "four"]
+
+
+@spiral_config
+def test_spiral_shuffle_no_wrap_down(manager):
+    # test that shuffling down doesn't wrap around
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    manager.c.layout.shuffle_down()
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+
+
+@spiral_config
+def test_spiral_shuffle_no_wrap_up(manager):
+    # test that shuffling up doesn't wrap around
+    manager.test_window("one")
+    manager.test_window("two")
+    manager.test_window("three")
+    # wrap focus back to first window
+    manager.c.layout.down()
+    manager.c.layout.shuffle_up()
+    assert manager.c.layout.info()["clients"] == ["one", "two", "three"]
+
+
 @singleborder_disabled_config
 def test_singleborder_disable(manager):
     manager.test_window("one")


### PR DESCRIPTION
Fixes #5152 