### PR TITLE
Add default formatter (nixfmt-rfc-style) + git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     rev: v2.10
     hooks:
       - id: vulture
+  - repo: https://github.com/NixOS/nixfmt
+    rev: 8d4bd69
+    hooks:
+      - id: nixfmt

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1736798957,
+        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+    }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -29,6 +32,8 @@
 
     in
     {
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+
       checks = forAllSystems (pkgs: pkgs.python3Packages.qtile.passthru.tests);
 
       overlays.default = import ./nix/overlays.nix self;
@@ -139,6 +144,8 @@
               [
                 (python3.withPackages common-python-deps)
                 pre-commit
+                cabal-install
+                ghc
               ]
               ++ common-system-deps;
           };


### PR DESCRIPTION
This pull request adds the default Nix file formatter (`nixfmt-rfc-style`) and added nixfmt to pre commit hooks to make sure nix files are formatted with nixfmt