### PR TITLE
[Wayland] Improve blurry bar on HiDPI displays

### DIFF
--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -95,7 +95,15 @@ class Core(CommandObject, metaclass=ABCMeta):
         """A context manager to suppress window events while operating on many windows."""
         yield
 
-    def create_internal(self, x: int, y: int, width: int, height: int) -> Internal:
+    def create_internal(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        *,
+        scale: float | None = None,
+    ) -> Internal:
         """Create an internal window controlled by Qtile."""
         raise NotImplementedError  # Only error when called, not when instantiating class
 

--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -123,6 +123,7 @@ class _Window(CommandObject, metaclass=ABCMeta):
         above=False,
         margin=None,
         respect_hints=False,
+        scale=None,
     ):
         """Place the window in the given position."""
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -1557,9 +1557,17 @@ class Core(base.Core, wlrq.HasListeners):
     def flush(self) -> None:
         self._poll()
 
-    def create_internal(self, x: int, y: int, width: int, height: int) -> base.Internal:
+    def create_internal(
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        scale: float | None = 1.0,
+    ) -> base.Internal:
         assert self.qtile is not None
-        internal = window.Internal(self, self.qtile, x, y, width, height)
+        scale = scale if scale is not None else 1.0
+        internal = window.Internal(self, self.qtile, x, y, width, height, scale)
         self.qtile.manage(internal)
         return internal
 

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -75,9 +75,16 @@ class Drawer(drawer.Drawer):
         if height > self._win.height - offsety:
             height = self._win.height - offsety
 
+        # Despite checks for None above, mypy requires these aserts
+        assert width is not None
+        assert height is not None
+
+        scale = self._win.scale
+
         # Paint recorded operations to our window's underlying ImageSurface
         with cairocffi.Context(self._win.surface) as context:
             context.set_operator(cairocffi.OPERATOR_SOURCE)
+            context.scale(scale, scale)
             # Adjust the source surface position by src_x and src_y e.g. if we want
             # to render part of the surface in a different position
             context.set_source_surface(self.surface, offsetx - src_x, offsety - src_y)
@@ -85,7 +92,9 @@ class Drawer(drawer.Drawer):
             context.fill()
 
         damage = PixmanRegion32()
-        damage.init_rect(offsetx, offsety, width, height)
+        damage.init_rect(
+            int(offsetx * scale), int(offsety * scale), int(width * scale), int(height * scale)
+        )
         # TODO: do we really need to `set_buffer` here? would be good to just set damage
         self._win._scene_buffer.set_buffer_with_damage(self._win.wlr_buffer, damage)
         damage.fini()

--- a/libqtile/backend/wayland/output.py
+++ b/libqtile/backend/wayland/output.py
@@ -135,7 +135,8 @@ class Output(HasListeners):
 
     def get_screen_info(self) -> ScreenRect:
         width, height = self.wlr_output.effective_resolution()
-        return ScreenRect(int(self.x), int(self.y), width, height)
+        scale = self.wlr_output.scale
+        return ScreenRect(int(self.x), int(self.y), width, height, scale)
 
     def organise_layers(self) -> None:
         """Organise the positioning of layer shell surfaces."""

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -927,7 +927,16 @@ class Internal(_Base, base.Internal):
     Internal windows are simply textures controlled by the compositor.
     """
 
-    def __init__(self, core: Core, qtile: Qtile, x: int, y: int, width: int, height: int):
+    def __init__(
+        self,
+        core: Core,
+        qtile: Qtile,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        scale: float,
+    ):
         self.core = core
         self.qtile = qtile
         self._wid: int = self.core.new_wid()
@@ -935,6 +944,7 @@ class Internal(_Base, base.Internal):
         self.y: int = y
         self._width: int = width
         self._height: int = height
+        self._scale: float = scale
         self._opacity: float = 1.0
 
         # Store this object on the scene node for finding the window under the pointer.
@@ -985,6 +995,10 @@ class Internal(_Base, base.Internal):
     def unhide(self) -> None:
         self.tree.node.set_enabled(enabled=True)
 
+    @property
+    def scale(self) -> float:
+        return self._scale
+
     @expose_command()
     def focus(self, warp: bool = True) -> None:
         self.core.focus_window(self)
@@ -1009,6 +1023,7 @@ class Internal(_Base, base.Internal):
         above: bool = False,
         margin: int | list[int] | None = None,
         respect_hints: bool = False,
+        scale: float = 1.0,
     ) -> None:
         if above:
             self.bring_to_front()
@@ -1017,10 +1032,11 @@ class Internal(_Base, base.Internal):
         self.y = y
         self.tree.node.set_position(x, y)
 
-        if width != self._width or height != self._height:
-            # Changed size, we need to regenerate the buffer
+        if width != self._width or height != self._height or scale != self._scale:
+            # Changed size or scale, we need to regenerate the buffer
             self._width = width
             self._height = height
+            self._scale = scale
             self.wlr_buffer, self.surface = self._new_buffer()
 
     def paint_borders(self, colors: ColorsType | None, width: int) -> None:

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -28,6 +28,7 @@ import cairocffi
 import wlroots.wlr_types.foreign_toplevel_management_v1 as ftm
 from pywayland.server import Client, Listener
 from wlroots import PtrHasData
+from wlroots import lib as wlr_lib
 from wlroots.util.box import Box
 from wlroots.wlr_types import Buffer
 from wlroots.wlr_types.idle_inhibit_v1 import IdleInhibitorV1
@@ -958,6 +959,7 @@ class Internal(_Base, base.Internal):
         if scene_buffer is None:
             raise RuntimeError("Couldn't create scene buffer")
         self._scene_buffer = scene_buffer
+        wlr_lib.wlr_scene_buffer_set_dest_size(scene_buffer._ptr, width, height)
         # The borders are wlr_scene_rects.
         # Inner list: N, E, S, W edges
         # Outer list: outside-in borders i.e. multiple for multiple borders
@@ -971,10 +973,12 @@ class Internal(_Base, base.Internal):
         if not init:
             self.wlr_buffer.drop()
 
-        surface = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, self._width, self._height)
+        width = int(self._width * self._scale)
+        height = int(self._height * self._scale)
+        surface = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, width, height)
         stride = surface.get_stride()
         data = cairocffi.cairo.cairo_image_surface_get_data(surface._pointer)
-        wlr_buffer = lib.cairo_buffer_create(self._width, self._height, stride, data)
+        wlr_buffer = lib.cairo_buffer_create(width, height, stride, data)
         if wlr_buffer == ffi.NULL:
             raise RuntimeError("Couldn't allocate cairo buffer.")
 
@@ -982,6 +986,9 @@ class Internal(_Base, base.Internal):
 
         if not init:
             self._scene_buffer.set_buffer_with_damage(buffer)
+            wlr_lib.wlr_scene_buffer_set_dest_size(
+                self._scene_buffer._ptr, self._width, self._height
+            )
 
         return buffer, surface
 

--- a/libqtile/backend/wayland/xdgwindow.py
+++ b/libqtile/backend/wayland/xdgwindow.py
@@ -245,6 +245,7 @@ class XdgWindow(Window[XdgSurface]):
         above: bool = False,
         margin: int | list[int] | None = None,
         respect_hints: bool = False,
+        scale: float | None = None,
     ) -> None:
         # Adjust the placement to account for layout margins, if there are any.
         if margin is not None:

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -596,7 +596,13 @@ class Core(base.Core):
             i._reset_mask()
 
     def create_internal(
-        self, x: int, y: int, width: int, height: int, desired_depth: int | None = 32
+        self,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        desired_depth: int | None = 32,
+        scale: float | None = None,
     ) -> base.Internal:
         assert self.qtile is not None
 

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -832,6 +832,7 @@ class _Window:
         above=False,
         margin=None,
         respect_hints=False,
+        scale=None,
     ):
         """
         Places the window at the specified location with the given size.

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -306,7 +306,7 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                 )
 
                 self.window = qtile.core.create_internal(  # type: ignore [call-arg]
-                    self.x, self.y, width, height, depth
+                    self.x, self.y, width, height, desired_depth=depth
                 )
 
             else:

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -289,7 +289,7 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         if self.window:
             # We get _configure()-ed with an existing window when screens are getting
             # reconfigured but this screen is present both before and after
-            self.window.place(self.x, self.y, width, height, 0, None)
+            self.window.place(self.x, self.y, width, height, 0, None, scale=screen.scale)
 
         else:
             # Whereas we won't have a window if we're startup up for the first time or
@@ -310,7 +310,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                 )
 
             else:
-                self.window = qtile.core.create_internal(self.x, self.y, width, height)
+                self.window = qtile.core.create_internal(
+                    self.x, self.y, width, height, scale=screen.scale
+                )
 
             self.window.opacity = self.opacity
             self.window.unhide()

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -383,19 +383,24 @@ class ScreenRect:
     y: int
     width: int
     height: int
+    scale: float | None = None
 
     def hsplit(self, columnwidth: int) -> tuple[ScreenRect, ScreenRect]:
         assert 0 < columnwidth < self.width
         return (
-            self.__class__(self.x, self.y, columnwidth, self.height),
-            self.__class__(self.x + columnwidth, self.y, self.width - columnwidth, self.height),
+            self.__class__(self.x, self.y, columnwidth, self.height, self.scale),
+            self.__class__(
+                self.x + columnwidth, self.y, self.width - columnwidth, self.height, self.scale
+            ),
         )
 
     def vsplit(self, rowheight: int) -> tuple[ScreenRect, ScreenRect]:
         assert 0 < rowheight < self.height
         return (
-            self.__class__(self.x, self.y, self.width, rowheight),
-            self.__class__(self.x, self.y + rowheight, self.width, self.height - rowheight),
+            self.__class__(self.x, self.y, self.width, rowheight, self.scale),
+            self.__class__(
+                self.x, self.y + rowheight, self.width, self.height - rowheight, self.scale
+            ),
         )
 
 
@@ -439,6 +444,7 @@ class Screen(CommandObject):
         y: int | None = None,
         width: int | None = None,
         height: int | None = None,
+        scale: float | None = None,
     ) -> None:
         self.top = top
         self.bottom = bottom
@@ -455,6 +461,7 @@ class Screen(CommandObject):
         self.y = y if y is not None else 0
         self.width = width if width is not None else 0
         self.height = height if height is not None else 0
+        self.scale = scale
         self.previous_group: _Group | None = None
 
     def _configure(
@@ -467,6 +474,7 @@ class Screen(CommandObject):
         height: int,
         group: _Group,
         reconfigure_gaps: bool = False,
+        scale: float | None = None,
     ) -> None:
         self.qtile = qtile
         self.index = index
@@ -474,6 +482,7 @@ class Screen(CommandObject):
         self.y = y
         self.width = width
         self.height = height
+        self.scale = scale
 
         for i in self.gaps:
             i._configure(qtile, self, reconfigure=reconfigure_gaps)
@@ -534,7 +543,7 @@ class Screen(CommandObject):
         return val
 
     def get_rect(self) -> ScreenRect:
-        return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight)
+        return ScreenRect(self.dx, self.dy, self.dwidth, self.dheight, self.scale)
 
     def set_group(
         self, new_group: _Group | None, save_prev: bool = True, warp: bool = True
@@ -654,7 +663,7 @@ class Screen(CommandObject):
             w = self.width
         if h is None:
             h = self.height
-        self._configure(self.qtile, self.index, x, y, w, h, self.group)
+        self._configure(self.qtile, self.index, x, y, w, h, self.group, scale=self.scale)
         for bar in [self.top, self.bottom, self.left, self.right]:
             if bar:
                 bar.draw()

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -372,13 +372,15 @@ class Qtile(CommandObject):
             config = self.config.fake_screens
         else:
             # Alias screens with the same x and y coordinates, taking largest
-            xywh = {}  # type: dict[tuple[int, int], tuple[int, int]]
+            xywhs = {}  # type: dict[tuple[int, int], tuple[int, int, float | None]]
             for info in self.core.get_screen_info():
                 pos = (info.x, info.y)
-                width, height = xywh.get(pos, (0, 0))
-                xywh[pos] = (max(width, info.width), max(height, info.height))
+                width, height, scale = xywhs.get(pos, (0, 0, 1.0))
+                # Could screens with same x and y coordinates also have different wlr_scale?
+                # How to handle?
+                xywhs[pos] = (max(width, info.width), max(height, info.height), info.scale)
 
-            screen_info = [ScreenRect(x, y, w, h) for (x, y), (w, h) in xywh.items()]
+            screen_info = [ScreenRect(x, y, w, h, s) for (x, y), (w, h, s) in xywhs.items()]
             config = self.config.screens
 
         for i, info in enumerate(screen_info):
@@ -425,6 +427,7 @@ class Qtile(CommandObject):
                 info.height,
                 grp,
                 reconfigure_gaps=reconfigure_gaps,
+                scale=info.scale,
             )
             screens.append(scr)
 

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -460,7 +460,7 @@ class TreeTab(Layout):
 
     def _create_panel(self, screen_rect):
         self._panel = self.group.qtile.core.create_internal(
-            screen_rect.x, screen_rect.y, self.panel_width, 100
+            screen_rect.x, screen_rect.y, self.panel_width, 100, scale=screen_rect.scale
         )
         self._create_drawer(screen_rect)
         self._panel.process_window_expose = self.draw_panel
@@ -483,7 +483,13 @@ class TreeTab(Layout):
     def configure(self, client: base.Window, screen_rect: ScreenRect) -> None:
         if self._nodes and client is self._focused:
             client.place(
-                screen_rect.x, screen_rect.y, screen_rect.width, screen_rect.height, 0, None
+                screen_rect.x,
+                screen_rect.y,
+                screen_rect.width,
+                screen_rect.height,
+                0,
+                None,
+                scale=screen_rect.scale,
             )
             client.unhide()
         else:
@@ -762,7 +768,13 @@ class TreeTab(Layout):
     def _resize_panel(self, screen_rect):
         if self._panel:
             self._panel.place(
-                screen_rect.x, screen_rect.y, screen_rect.width, screen_rect.height, 0, None
+                screen_rect.x,
+                screen_rect.y,
+                screen_rect.width,
+                screen_rect.height,
+                0,
+                None,
+                scale=screen_rect.scale,
             )
             self._create_drawer(screen_rect)
             self.draw_panel()

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -67,8 +67,9 @@ class Popup(configurable.Configurable):
         self.add_defaults(Popup.defaults)
         self.qtile = qtile
 
+        self.scale = qtile.current_screen.scale
         self.win: Any = qtile.core.create_internal(
-            x, y, width, height
+            x, y, width, height, scale=self.scale
         )  # TODO: better annotate Internal
         self.win.opacity = self.opacity
         self.win.process_button_click = self.process_button_click
@@ -150,7 +151,14 @@ class Popup(configurable.Configurable):
 
     def place(self) -> None:
         self.win.place(
-            self.x, self.y, self.width, self.height, self.border_width, self.border, above=True
+            self.x,
+            self.y,
+            self.width,
+            self.height,
+            self.border_width,
+            self.border,
+            above=True,
+            scale=self.scale,
         )
 
     def unhide(self) -> None:


### PR DESCRIPTION
Relevant issue: #3646

Same solution as proposed in #4625, except instead of relying on a single config scale value, attempts to obtain Wayland scale factor for each screen. Also allows fractional scaling

This fix works by using Cairo to scale up the bar (and other internal windows) instead of Wayland. This works for text and Cairo (vector) drawing

The difference without and with this fix:

![comparison_small](https://github.com/user-attachments/assets/21533dae-e604-4551-a0a2-594111da8ec6)

Limitations: Doesn't fix scaling of images such as icons