### PR TITLE
allow for vertical text direction to be overriden

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -497,10 +497,12 @@ class _TextBox(_Widget):
         ),
         ("rotate", True, "Rotate text in vertical bar."),
         (
-            "vertical_text_direction",
-            "default",
-            "Override direction the text would read in, in a vertical bar"
-            "'default', 'top_to_bottom', 'bottom_to_top'",
+            "direction", 
+            "default", 
+            "Override the text direction in vertical bar, has no effect on text in horizontal bar."
+            "default: text displayed based on vertical bar position (left/right)"
+            "ttb: text read from top to bottom, btt: text read from bottom to top."
+            "'default', 'ttb', 'btt'",
         ),
     ]  # type: list[tuple[str, Any, str]]
 
@@ -583,6 +585,11 @@ class _TextBox(_Widget):
         _Widget._configure(self, qtile, bar)
         if self.fontsize is None:
             self.fontsize = self.bar.height - self.bar.height / 5
+        if self.direction != "default" and self.direction != "ttb" and self.direction != "btt":
+            logger.warning("""Invalid value set for direction: %s
+                               Valid values are: default, ttb, btt
+                               direction set to default""", self.direction)
+            self.direction = "default"
         self.layout = self.drawer.textlayout(
             self.formatted_text,
             self.foreground,
@@ -656,20 +663,20 @@ class _TextBox(_Widget):
             # Left bar reads bottom to top
             # Can be overriden to read bottom to top all the time with vertical_text_direction
             if (
-                self.bar.screen.left is self.bar
-                and self.vertical_text_direction == "default"
-                or self.vertical_text_direction == "bottom_to_top"
-            ):
+                (self.bar.screen.left is self.bar
+                and self.direction == "default")
+                or self.direction == "btt"
+                ):
                 self.drawer.ctx.rotate(-90 * math.pi / 180.0)
                 self.drawer.ctx.translate(-self.length, 0)
 
             # Right bar is top to bottom
             # Can be overriden to read top to bottom all the time with vertical_text_direction
             elif (
-                self.bar.screen.right is self.bar
-                and self.vertical_text_direction == "default"
-                or self.vertical_text_direction == "top_to_bottom"
-            ):
+                (self.bar.screen.right is self.bar
+                and self.direction == "default")
+                or self.direction == "ttb"
+                ):
                 self.drawer.ctx.translate(self.bar.width, 0)
                 self.drawer.ctx.rotate(90 * math.pi / 180.0)
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -497,8 +497,8 @@ class _TextBox(_Widget):
         ),
         ("rotate", True, "Rotate text in vertical bar."),
         (
-            "direction", 
-            "default", 
+            "direction",
+            "default",
             "Override the text direction in vertical bar, has no effect on text in horizontal bar."
             "default: text displayed based on vertical bar position (left/right)"
             "ttb: text read from top to bottom, btt: text read from bottom to top."
@@ -586,9 +586,12 @@ class _TextBox(_Widget):
         if self.fontsize is None:
             self.fontsize = self.bar.height - self.bar.height / 5
         if self.direction != "default" and self.direction != "ttb" and self.direction != "btt":
-            logger.warning("""Invalid value set for direction: %s
+            logger.warning(
+                """Invalid value set for direction: %s
                                Valid values are: default, ttb, btt
-                               direction set to default""", self.direction)
+                               direction set to default""",
+                self.direction,
+            )
             self.direction = "default"
         self.layout = self.drawer.textlayout(
             self.formatted_text,
@@ -663,20 +666,16 @@ class _TextBox(_Widget):
             # Left bar reads bottom to top
             # Can be overriden to read bottom to top all the time with vertical_text_direction
             if (
-                (self.bar.screen.left is self.bar
-                and self.direction == "default")
-                or self.direction == "btt"
-                ):
+                self.bar.screen.left is self.bar and self.direction == "default"
+            ) or self.direction == "btt":
                 self.drawer.ctx.rotate(-90 * math.pi / 180.0)
                 self.drawer.ctx.translate(-self.length, 0)
 
             # Right bar is top to bottom
             # Can be overriden to read top to bottom all the time with vertical_text_direction
             elif (
-                (self.bar.screen.right is self.bar
-                and self.direction == "default")
-                or self.direction == "ttb"
-                ):
+                self.bar.screen.right is self.bar and self.direction == "default"
+            ) or self.direction == "ttb":
                 self.drawer.ctx.translate(self.bar.width, 0)
                 self.drawer.ctx.rotate(90 * math.pi / 180.0)
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -585,11 +585,10 @@ class _TextBox(_Widget):
         _Widget._configure(self, qtile, bar)
         if self.fontsize is None:
             self.fontsize = self.bar.height - self.bar.height / 5
-        if self.direction != "default" and self.direction != "ttb" and self.direction != "btt":
+        if self.direction not in ("default", "ttb", "btt"):
             logger.warning(
-                """Invalid value set for direction: %s
-                               Valid values are: default, ttb, btt
-                               direction set to default""",
+                "Invalid value set for direction: %s. Valid values are: 'default', 'ttb', 'btt'. "
+                "direction has been set to 'default'",
                 self.direction,
             )
             self.direction = "default"

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -497,8 +497,8 @@ class _TextBox(_Widget):
         ),
         ("rotate", True, "Rotate text in vertical bar."),
         (
-            "vertical_text_direction", 
-            "default", 
+            "vertical_text_direction",
+            "default",
             "Override direction the text would read in, in a vertical bar"
             "'default', 'top_to_bottom', 'bottom_to_top'",
         ),

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -496,6 +496,12 @@ class _TextBox(_Widget):
             "Setting ``scroll_fixed_width=True`` will force the widget to have a fixed width, regardless of the size of the text.",
         ),
         ("rotate", True, "Rotate text in vertical bar."),
+        (
+            "vertical_text_direction", 
+            "default", 
+            "Override direction the text would read in, in a vertical bar"
+            "'default', 'top_to_bottom', 'bottom_to_top'"
+        ),
     ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, text=" ", width=bar.CALCULATED, **config):
@@ -648,12 +654,18 @@ class _TextBox(_Widget):
 
         if not self.bar.horizontal and self.rotate:
             # Left bar reads bottom to top
-            if self.bar.screen.left is self.bar:
+            # Can be overriden to read bottom to top all the time with vertical_text_direction
+            if self.bar.screen.left is self.bar and \
+                    self.vertical_text_direction == "default" or \
+                    self.vertical_text_direction == "bottom_to_top":
                 self.drawer.ctx.rotate(-90 * math.pi / 180.0)
                 self.drawer.ctx.translate(-self.length, 0)
 
             # Right bar is top to bottom
-            else:
+            # Can be overriden to read top to bottom all the time with vertical_text_direction
+            elif self.bar.screen.right is self.bar and \
+                    self.vertical_text_direction == "default" or \
+                    self.vertical_text_direction == "top_to_bottom":
                 self.drawer.ctx.translate(self.bar.width, 0)
                 self.drawer.ctx.rotate(90 * math.pi / 180.0)
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -500,7 +500,7 @@ class _TextBox(_Widget):
             "vertical_text_direction", 
             "default", 
             "Override direction the text would read in, in a vertical bar"
-            "'default', 'top_to_bottom', 'bottom_to_top'"
+            "'default', 'top_to_bottom', 'bottom_to_top'",
         ),
     ]  # type: list[tuple[str, Any, str]]
 
@@ -655,17 +655,21 @@ class _TextBox(_Widget):
         if not self.bar.horizontal and self.rotate:
             # Left bar reads bottom to top
             # Can be overriden to read bottom to top all the time with vertical_text_direction
-            if self.bar.screen.left is self.bar and \
-                    self.vertical_text_direction == "default" or \
-                    self.vertical_text_direction == "bottom_to_top":
+            if (
+                self.bar.screen.left is self.bar
+                and self.vertical_text_direction == "default"
+                or self.vertical_text_direction == "bottom_to_top"
+            ):
                 self.drawer.ctx.rotate(-90 * math.pi / 180.0)
                 self.drawer.ctx.translate(-self.length, 0)
 
             # Right bar is top to bottom
             # Can be overriden to read top to bottom all the time with vertical_text_direction
-            elif self.bar.screen.right is self.bar and \
-                    self.vertical_text_direction == "default" or \
-                    self.vertical_text_direction == "top_to_bottom":
+            elif (
+                self.bar.screen.right is self.bar
+                and self.vertical_text_direction == "default"
+                or self.vertical_text_direction == "top_to_bottom"
+            ):
                 self.drawer.ctx.translate(self.bar.width, 0)
                 self.drawer.ctx.rotate(90 * math.pi / 180.0)
 


### PR DESCRIPTION
Change keeps default behavior unless specified, won't affect other users negatively.
Allows for user to override vertical text direction if wanted.
Especially important for some writing systems like Mongolian Script, which must be rotated 90 degrees and read top to bottom.
As currently the text appears upside down in left bar.

Previously mentioned:
#5127 