### PR TITLE
ci: use github mirror for seatd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           XCVT_URL: https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-${{ env.xcvt-version }}/libxcvt-libxcvt-${{ env.xcvt-version }}.tar.gz
           INPUTPROTO_URL: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/archive/xorgproto-${{ env.inputproto-version}}/xorgproto-xorgproto-${{ env.inputproto-version}}.tar.gz
           LIBDRM_URL: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{ env.libdrm-version }}/drm-libdrm-${{ env.libdrm-version }}.tar.gz
-          SEATD_URL: https://git.sr.ht/~kennylevinsen/seatd/archive/${{ env.seatd-version }}.tar.gz
+          SEATD_URL: https://github.com/kennylevinsen/seatd/archive/refs/tags/${{ env.seatd-version }}.tar.gz
           PIXMAN_URL: https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-${{ env.pixman-version }}/pixman-pixman-${{ env.pixman-version }}.tar.bz2
           WLROOTS_URL: https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${{ env.wlroots-version }}/wlroots-${{ env.wlroots-version }}.tar.gz
       - name: Install meson

--- a/scripts/ubuntu_wayland_setup
+++ b/scripts/ubuntu_wayland_setup
@@ -74,7 +74,7 @@ sudo ninja -C build install
 cd ../
 
 # Build seatd
-wget https://git.sr.ht/~kennylevinsen/seatd/archive/$SEATD.tar.gz
+wget https://github.com/kennylevinsen/seatd/archive/refs/tags/$SEATD.tar.gz
 tar -xzf $SEATD.tar.gz
 cd seatd-$SEATD
 meson build --prefix=/usr


### PR DESCRIPTION
we are seeing 403s for sr.ht's seatd tarball:

     + wget https://git.sr.ht/~kennylevinsen/seatd/archive/0.6.4.tar.gz
    --2025-01-27 18:21:24--  https://git.sr.ht/~kennylevinsen/seatd/archive/0.6.4.tar.gz
    Resolving git.sr.ht (git.sr.ht)... 46.23.81.155, 2a03:6000:1813:1337::155
    Connecting to git.sr.ht (git.sr.ht)|46.23.81.155|:443... connected.
    HTTP request sent, awaiting response... 403 Forbidden
    2025-01-27 18:21:25 ERROR 403: Forbidden.

this is likely because of some blocking from sr.ht itself, e.g.: https://lists.sr.ht/~sircmpwn/sr.ht-discuss/%3C760231CF-7FB5-4341-ACA7-71DAEE629074@jonmsterling.com%3E

...or similar. There is a github mirror with the relevant tags, so let's use that instead.