### PR TITLE
Fix statusnotifier when icons rapidly change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
         - Spiral layout: `shuffle_up` and `shuffle_down` commands now shuffle the focused window instead of rotating all windows.
     * features
     * bugfixes
+        - Fix StatusNotifier displaying wrong icon when icon changes too quickly (e.g. nm-applet)
 
 Qtile 0.30.0, released 2025-01-06:
     !!! breaking changes !!!

--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -277,6 +277,7 @@ class StatusNotifierItem:  # noqa: E303
     def _update_local_icon(self):
         if self._get_local_icon_task is not None and not self._get_local_icon_task.done():
             self._get_local_icon_task.cancel()
+            self._get_local_icon_task.remove_done_callback(self._redraw)
             self._get_local_icon_task.add_done_callback(lambda task: self._update_local_icon())
         else:
             self.icon = None
@@ -365,10 +366,7 @@ class StatusNotifierItem:  # noqa: E303
 
         return arr
 
-    def _redraw(self, task):
-        if task.cancelled():
-            return
-
+    def _redraw(self, result):
         """Method to invalidate icon cache and redraw icons."""
         self._invalidate_icons()
         if self.on_icon_changed is not None:

--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -17,6 +17,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from asyncio import current_task
 from collections.abc import Callable
 from contextlib import suppress
 from functools import partial
@@ -132,6 +133,7 @@ class StatusNotifierItem:  # noqa: E303
         self.icon_theme = icon_theme
         self.icon = None
         self.path = path if path else STATUSNOTIFIER_PATH
+        self.last_icon_name = None
 
     def __eq__(self, other):
         # Convenience method to find Item in list by service path
@@ -248,6 +250,13 @@ class StatusNotifierItem:  # noqa: E303
         # the app. We also don't want to do the recursive lookup with an empty
         # icon name as, otherwise, the glob will match things that are not images.
         if icon_name:
+            if icon_name == self.last_icon_name:
+                current_task().remove_done_callback(self._redraw)
+                return
+
+            self.last_icon_name = icon_name
+            self.icon = None
+
             try:
                 icon_path = await self.item.get_icon_theme_path()
             except (AttributeError, DBusError):
@@ -261,6 +270,8 @@ class StatusNotifierItem:  # noqa: E303
                 self.icon = icon
             else:
                 self.icon = self._get_xdg_icon(icon_name)
+        else:
+            self.icon = None
 
         if fallback:
             for icon in ["Icon", "Attention", "Overlay"]:
@@ -277,7 +288,6 @@ class StatusNotifierItem:  # noqa: E303
         task.add_done_callback(self._redraw)
 
     def _update_local_icon(self):
-        self.icon = None
         self._create_task_and_draw(self._get_local_icon())
 
     def _new_icon(self):


### PR DESCRIPTION
Certain apps (e.g. nm-applet) can rapidly change their status icon (e.g. when connecting to a WiFi) causing statusnotifier to display the wrong icon - #5161

To remedy: if _update_local_icon is called before a previous task to update the icon has completed, then cancel this running task and create a new one to process the latest update