### PR TITLE
Fix render issue with transparent bar

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -52,10 +52,6 @@ class Drawer:
     finally drawing all operations to a backend-specific target.
     """
 
-    # We need to track extent of drawing to know when to redraw.
-    previous_rect: tuple[int, int, int | None, int | None]
-    current_rect: tuple[int, int, int | None, int | None]
-
     def __init__(self, qtile: Qtile, win: Internal, width: int, height: int):
         self.qtile = qtile
         self._win = win
@@ -67,12 +63,8 @@ class Drawer:
         self.ctx: cairocffi.Context
         self._reset_surface()
 
-        self.old_ink_extents: tuple[float, float, float, float] | None = None
-
         self._has_mirrors = False
 
-        self.current_rect = (0, 0, 0, 0)
-        self.previous_rect = (-1, -1, -1, -1)
         self._enabled = True
 
     def finalize(self):
@@ -128,25 +120,6 @@ class Drawer:
         if hasattr(self, "last_surface"):
             self.last_surface.finish()
         self.last_surface = cairocffi.RecordingSurface(cairocffi.CONTENT_COLOR_ALPHA, None)
-
-    @property
-    def needs_update(self) -> bool:
-        # We can't test for the surface's ink_extents here on its own as a completely
-        # transparent background would not show any extents but we may still need to
-        # redraw (e.g. if a Spacer widget has changed position and/or size)
-        # Check if the size of the area being drawn has changed
-        rect_changed = self.current_rect != self.previous_rect
-
-        # Check if draw has content (would be False for completely transparent drawer)
-        ink_extents = self.surface.ink_extents()
-        if self.old_ink_extents is None:
-            ink_changed = True
-        else:
-            ink_changed = any(ink_extents[i] != self.old_ink_extents[i] for i in range(4))
-
-        self.old_ink_extents = ink_extents
-
-        return ink_changed or rect_changed
 
     def paint_to(self, drawer: Drawer) -> None:
         drawer.ctx.set_source_surface(self.last_surface)

--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -67,6 +67,8 @@ class Drawer:
         self.ctx: cairocffi.Context
         self._reset_surface()
 
+        self.old_ink_extents: tuple[float, float, float, float] | None = None
+
         self._has_mirrors = False
 
         self.current_rect = (0, 0, 0, 0)
@@ -136,7 +138,13 @@ class Drawer:
         rect_changed = self.current_rect != self.previous_rect
 
         # Check if draw has content (would be False for completely transparent drawer)
-        ink_changed = any(not math.isclose(0.0, i) for i in self.surface.ink_extents())
+        ink_extents = self.surface.ink_extents()
+        if self.old_ink_extents is None:
+            ink_changed = True
+        else:
+            ink_changed = any(ink_extents[i] != self.old_ink_extents[i] for i in range(4))
+
+        self.old_ink_extents = ink_extents
 
         return ink_changed or rect_changed
 

--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -55,16 +55,6 @@ class Drawer(drawer.Drawer):
         if offsetx > self._win.width:
             return
 
-        # We need to set the current draw area so we can compare to the previous one
-        self.current_rect = (offsetx, offsety, width, height)
-        # rect_changed = current_rect != self.previous_rect
-
-        if not self.needs_update:
-            return
-
-        # Keep track of latest rect covered by this drawwer
-        self.previous_rect = self.current_rect
-
         # Make sure geometry doesn't extend beyond texture
         if width is None:
             width = self.width

--- a/libqtile/backend/x11/drawer.py
+++ b/libqtile/backend/x11/drawer.py
@@ -160,14 +160,10 @@ class Drawer(drawer.Drawer):
             self._xcb_surface = self._create_xcb_surface()
 
     def _paint(self):
-        # Only attempt to run RecordingSurface's operations if ie actually need to
-        if self.needs_update:
-            # Paint RecordingSurface operations to the XCBSurface
-            ctx = cairocffi.Context(self._xcb_surface)
-            ctx.set_source_surface(self.surface, 0, 0)
-            ctx.paint()
-
-            self.previous_rect = self.current_rect
+        # Paint RecordingSurface operations to the XCBSurface
+        ctx = cairocffi.Context(self._xcb_surface)
+        ctx.set_source_surface(self.surface, 0, 0)
+        ctx.paint()
 
     def _draw(
         self,
@@ -178,8 +174,6 @@ class Drawer(drawer.Drawer):
         src_x: int = 0,
         src_y: int = 0,
     ):
-        self.current_rect = (offsetx, offsety, width, height)
-
         # If this is our first draw, create the gc
         if self._gc is None:
             self._gc = self._create_gc()


### PR DESCRIPTION
Some widgets do not refresh correctly on fully transparent bar. This is an issue with STRETCH widgets that have no content. In this scenario, the `Drawer.needs_update` method will return `False` because there's no content but there is still a widget to render.

This PR fixes the issue by checking if the content of the widget has changed (e.g. clearing all text will trigger `needs_update` to return `True`).

Fixes #5173