### PR TITLE
Fix PusleVolume widget breaking after reload config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * features
         - Add TunedManager Widget to show the currently active power profile and cycle through a list of configurable power profiles
     * bugfixes
+        - PulseVolume widget: fix breakage with xrandr/wlr-randr + reload config #5111
 
 Qtile 0.30.0, released 2025-01-06:
     !!! breaking changes !!!

--- a/libqtile/widget/pulse_volume.py
+++ b/libqtile/widget/pulse_volume.py
@@ -44,7 +44,7 @@ class PulseConnection:
         self.default_sink_name = None
         self.pulse = None
         self.configured = False
-        self.callbacks = []
+        self.callbacks = set()
         self.qtile = qtile
         self.timer = None
 
@@ -147,7 +147,7 @@ class PulseConnection:
         pulse server.
         """
         need_configure = not bool(self.callbacks)
-        self.callbacks.append(callback)
+        self.callbacks.add(callback)
 
         if need_configure:
             create_task(self._configure())
@@ -159,10 +159,7 @@ class PulseConnection:
         Removing the last client closes the connection with the
         pulse server and cancels future calls to connect.
         """
-        try:
-            self.callbacks.remove(callback)
-        except ValueError:
-            pass
+        self.callbacks.discard(callback)
 
         if not self.callbacks:
             self.pulse.close()


### PR DESCRIPTION
Fixes #5111. Using xrandr/wlr-randr causes the widget to reconfigure resulting in duplicate subscriptions, which aren't correctly unsubscribed from when reloading config

To prevent duplicate subscriptions, callbacks list is replaced by a set