### PR TITLE
Fix `qtile run-cmd` bug

### DIFF
--- a/libqtile/scripts/run_cmd.py
+++ b/libqtile/scripts/run_cmd.py
@@ -52,11 +52,13 @@ def run_cmd(opts) -> None:
     }
 
     graph_cmd = root.call("add_rule")
-    _, rule_id = client.send((root.selectors, graph_cmd.name, (match_args, rule_args), {}))
+    # client.send(selectors, name, args, kwargs, lifted)
+    _, rule_id = client.send((root.selectors, graph_cmd.name, (match_args, rule_args), {}, False))
 
     def remove_rule() -> None:
         cmd = root.call("remove_rule")
-        client.send((root.selectors, cmd.name, (rule_id,), {}))
+        # client.send(selectors, name, args, kwargs, lifted)
+        client.send((root.selectors, cmd.name, (rule_id,), {}, False))
 
     atexit.register(remove_rule)
 


### PR DESCRIPTION
When we added type lifting to `qtile cmd-obj`, we introduced a new argument in the IPC calls. This wasn't updated in `qtile run-cmd` resulting in the wrong number of arguments being supplied.

Fixes #5179