### PR TITLE
Don't raise exception when unsubscribing hooks

### DIFF
--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -149,8 +149,8 @@ class Unsubscribe(HookHandlerCollection):
         try:
             lst.remove(func)
         except ValueError:
-            raise utils.QtileError(
-                "Tried to unsubscribe a hook that was not currently subscribed"
+            logger.warning(
+                f"Tried to unsubscribe a hook ({event}) that was not currently subscribed."
             )
 
 


### PR DESCRIPTION
Occasionally, we can get multiple calls to unsubscribe the same hook. Raising an exception is overkill here and we can just log an error instead.

We should look to fix any code that triggers this but, given the unsubscribe method could be used by users in their own code, a warning message is probably a better approach.