### PR TITLE
manager: always respect window.can_steal_focus = False

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     !!! breaking changes !!!
         - Spiral layout: `shuffle_up` and `shuffle_down` commands now shuffle the focused window instead of rotating all windows.
+        - `window.can_steal_focus = False` should be set in a `group_window_add` instead of the previously recommended `client_new` hook.
     * features
         - Add TunedManager Widget to show the currently active power profile and cycle through a list of configurable power profiles
     * bugfixes

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -735,7 +735,7 @@ class Qtile(CommandObject):
         if self.current_screen and isinstance(win, base.Window):
             # Window may have been bound to a group in the hook.
             if not win.group and self.current_screen.group:
-                self.current_screen.group.add(win, focus=win.can_steal_focus)
+                self.current_screen.group.add(win)
 
         hook.fire("client_managed", win)
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -251,7 +251,7 @@ class _Group(CommandObject):
             screen=self.screen.index if self.screen else None,
         )
 
-    def add(self, win, focus=True, force=False):
+    def add(self, win, force=False):
         hook.fire("group_window_add", self, win)
         if win not in self.windows:
             self.windows.append(win)
@@ -266,7 +266,7 @@ class _Group(CommandObject):
             self.tiled_windows.add(win)
             for i in self.layouts:
                 i.add_client(win)
-        if focus:
+        if win.can_steal_focus:
             self.focus(win, warp=True, force=force)
         else:
             self.layout_all(focus=False)

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -408,11 +408,11 @@ class Prompt(base._TextBox):
             if self.active and not win == self.bar.window:
                 self._unfocus()
 
-        def prevent_focus_steal(win):
+        def prevent_focus_steal(group, win):
             if self.active:
                 win.can_steal_focus = False
 
-        hook.subscribe.client_new(prevent_focus_steal)
+        hook.subscribe.group_window_add(prevent_focus_steal)
         hook.subscribe.client_focus(f)
 
         # Define key handlers (action to do when a specific key is hit)

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -335,7 +335,7 @@ def test_focus_switch(manager):
     assert manager.c.widget["windowname"].info()["text"] == "One"
 
 
-def set_steal_focus(win):
+def set_steal_focus(group, win):
     if win.name != "three":
         win.can_steal_focus = False
 
@@ -354,7 +354,7 @@ def test_can_steal_focus(manager_nospawn):
     """
 
     class AntiFocusStealConfig(BareConfig):
-        hook.subscribe.client_new(set_steal_focus)
+        hook.subscribe.group_window_add(set_steal_focus)
 
     manager_nospawn.start(AntiFocusStealConfig)
     manager_nospawn.test_window("one")


### PR DESCRIPTION
Previously some windows could bypass window.can_steal_focus = False as group.add() is called in various places.

This is fixed by checking window.can_steal_focus inside group.add().

Users should switch to hook.subscribe.group_window_add instead of the previously recommended hook.subscribe.client_new to set window.can_steal_focus = False.

Fixes #5199