### PR TITLE
fix for CheckUpdates widget on fedora #5201

### DIFF
--- a/libqtile/widget/check_updates.py
+++ b/libqtile/widget/check_updates.py
@@ -36,7 +36,7 @@ CMD_DICT = {
     "Gentoo_eix": ("EIX_LIMIT=0 eix -u# --world", 0),
     "Guix": ("guix upgrade --dry-run", 0),
     "Ubuntu": ("aptitude search ~U", 0),
-    "Fedora": ("dnf list updates -q", 1),
+    "Fedora": ("dnf list --upgrades -q", 1),
     "FreeBSD": ("pkg upgrade -n | awk '/\t/ { print $0 }'", 0),
     "Mandriva": ("urpmq --auto-select", 0),
     "Void": ("xbps-install -nuMS", 0),


### PR DESCRIPTION
This PR fix updates not showing on Fedora 41. Maintains compatibility between dnf4 and dnf5.