### PR TITLE
Fix bluetooth test failure

### DIFF
--- a/test/widgets/test_bluetooth.py
+++ b/test/widgets/test_bluetooth.py
@@ -138,13 +138,18 @@ class Battery(ServiceInterface):
         return 75
 
 
+class QtileRoot(ServiceInterface):
+    def __init__(self):
+        super().__init__("org.qtile.root")
+
+
 class Bluez:
     """Class that runs fake UPower interface."""
 
     async def start_server(self):
         """Connects to the bus and publishes 3 interfaces."""
         bus = await MessageBus().connect()
-        root = ServiceInterface("org.qtile.root")
+        root = QtileRoot()
         bus.export("/", root)
 
         unpaired_device = Device(


### PR DESCRIPTION
dbus-fast does not allow `ServiceInterface` objects to be instantiated directly. Instead, a new class must be created which inherits this class.