### PR TITLE
feat: support single pixel buffer protocol (wayland)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
+        - Add support for `single-pixel-buffer` protocol for wayland 
     * bugfixes
 
 Qtile 0.31.0, released 2025-03-07:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ MOCK_MODULES = [
     "wlroots.wlr_types.output_power_management_v1",
     "wlroots.wlr_types.scene",
     "wlroots.wlr_types.server_decoration",
+    "wlroots.wlr_types.single_pixel_buffer_v1",
     "wlroots.wlr_types.virtual_keyboard_v1",
     "wlroots.wlr_types.virtual_pointer_v1",
     "wlroots.wlr_types.xdg_shell",

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -92,6 +92,7 @@ from wlroots.wlr_types.server_decoration import (
     ServerDecorationManager,
     ServerDecorationManagerMode,
 )
+from wlroots.wlr_types.single_pixel_buffer_v1 import SinglePixelBufferManagerV1
 from wlroots.wlr_types.xdg_shell import XdgShell, XdgSurface, XdgSurfaceRole
 from xkbcommon import xkb
 
@@ -329,6 +330,7 @@ class Core(base.Core, wlrq.HasListeners):
         GammaControlManagerV1(self.display)
         Viewporter(self.display)
         FractionalScaleManagerV1(self.display)
+        SinglePixelBufferManagerV1(self.display)
         self.scene.set_presentation(Presentation.create(self.display, self.backend))
         output_power_manager = OutputPowerManagerV1(self.display)
         self.add_listener(


### PR DESCRIPTION
Hi, this adds support for `SinglePixelBuffer` protocol. It is not a very widely known or used protocol, however, it is used by a lovely tool called `chayang` (https://git.sr.ht/~emersion/chayang).

Since the support for the protocol is already in `pywlroots`, the change is very simple.

I tested this locally and `chayang` now works (which it didn't before). I don't know if there's any other way how to properly test a support for a particular protocol.

Also, I'm sorry I didn't check before opening the PR whether it would be welcome, but I figured, that this is such a trivial change, that it should be non-contentious.