### PR TITLE
manager: always respect window.can_steal_focus = False

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
       - Output of `qtile cmd-obj` is now in JSON.
     * features
     * bugfixes
+      - `window.can_steal_focus = False` should be set in a `group_window_add` instead of the previously recommended `client_new` hook.
 
 Qtile 0.31.0, released 2025-03-07:
     !!! breaking changes !!!

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -735,7 +735,7 @@ class Qtile(CommandObject):
         if self.current_screen and isinstance(win, base.Window):
             # Window may have been bound to a group in the hook.
             if not win.group and self.current_screen.group:
-                self.current_screen.group.add(win, focus=win.can_steal_focus)
+                self.current_screen.group.add(win)
 
         hook.fire("client_managed", win)
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -251,7 +251,7 @@ class _Group(CommandObject):
             screen=self.screen.index if self.screen else None,
         )
 
-    def add(self, win, focus=True, force=False):
+    def add(self, win, force=False):
         hook.fire("group_window_add", self, win)
         if win not in self.windows:
             self.windows.append(win)
@@ -266,7 +266,7 @@ class _Group(CommandObject):
             self.tiled_windows.add(win)
             for i in self.layouts:
                 i.add_client(win)
-        if focus:
+        if win.can_steal_focus:
             self.focus(win, warp=True, force=force)
         else:
             self.layout_all(focus=False)

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -497,6 +497,8 @@ hooks: list[Hook] = [
         "group_window_add",
         """Called when a new window is added to a group
 
+        This hook can for example be used for focus decisions.
+
         **Arguments**
 
             * ``Group`` receiving the new window
@@ -507,13 +509,15 @@ hooks: list[Hook] = [
         .. code:: python
 
           from libqtile import hook
-          from libqtile.utils import send_notification
+          from libqtile import qtile
 
 
           @hook.subscribe.group_window_add
           def group_window_add(group, window):
-              send_notification("qtile", f"Window {window.name} added to {group.name}")
-
+              #disallow focus steals except if there's no focus
+              if not qtile.current_window:
+                  return
+              window.can_steal_focus = False
         """,
     ),
     Hook(
@@ -546,6 +550,7 @@ hooks: list[Hook] = [
 
         Use this hook to declare windows static, or add them to a group on
         startup. This hook is not called for internal windows.
+        Use ``group_window_add`` for focus decisions.
 
         **Arguments**
 

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -408,11 +408,11 @@ class Prompt(base._TextBox):
             if self.active and not win == self.bar.window:
                 self._unfocus()
 
-        def prevent_focus_steal(win):
+        def prevent_focus_steal(group, win):
             if self.active:
                 win.can_steal_focus = False
 
-        hook.subscribe.client_new(prevent_focus_steal)
+        hook.subscribe.group_window_add(prevent_focus_steal)
         hook.subscribe.client_focus(f)
 
         # Define key handlers (action to do when a specific key is hit)

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -335,7 +335,7 @@ def test_focus_switch(manager):
     assert manager.c.widget["windowname"].info()["text"] == "One"
 
 
-def set_steal_focus(win):
+def set_steal_focus(group, win):
     if win.name != "three":
         win.can_steal_focus = False
 
@@ -354,7 +354,7 @@ def test_can_steal_focus(manager_nospawn):
     """
 
     class AntiFocusStealConfig(BareConfig):
-        hook.subscribe.client_new(set_steal_focus)
+        hook.subscribe.group_window_add(set_steal_focus)
 
     manager_nospawn.start(AntiFocusStealConfig)
     manager_nospawn.test_window("one")


### PR DESCRIPTION
Previously some windows could bypass window.can_steal_focus = False as group.add() is called in various places.

This is fixed by checking window.can_steal_focus inside group.add().

Users should switch to hook.subscribe.group_window_add instead of the previously recommended hook.subscribe.client_new to set window.can_steal_focus = False.

Fixes #5199