### PR TITLE
core: drop sys import

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -30,7 +30,6 @@ import shlex
 import shutil
 import signal
 import subprocess
-import sys
 import tempfile
 from collections import defaultdict
 from logging.handlers import RotatingFileHandler


### PR DESCRIPTION
Not sure how this skipped past our PR checks, maybe a new version of ruff or something? Anyway, we can drop this import.