### PR TITLE
image: finish surfaces/patterns as necessary

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -159,12 +159,12 @@ class Img:
         self.path = path
 
     def _reset(self):
-        attrs = ("surface", "pattern")
-        for attr in attrs:
-            try:
-                delattr(self, attr)
-            except AttributeError:
-                pass
+        if hasattr(self, "surface"):
+            self.surface.finish()
+            del self.surface
+        if hasattr(self, "pattern"):
+            # patterns do not need to be finish()ed, only surfaces do
+            del self.pattern
 
     @classmethod
     def from_path(cls, image_path):


### PR DESCRIPTION
I was poking through this code when looking at cairo scaling, and noticed that we do not finalize a surface we allocate here. As in 1c6634d8141c1dc60b8b6bf65c443677ce474542, we need to finish() any Cairo surfaces we allocate.

It looks like I had previously noticed this in
https://github.com/qtile/qtile/issues/4821#issuecomment-2170373089 but failed to send a patch, d'oh. Hopefully this will fix some more leaks for more people.