### PR TITLE
drawer: don't stack trace with bad markup

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -38,6 +38,7 @@ import typing
 import cairocffi
 
 from libqtile import pangocffi, utils
+from libqtile.log_utils import logger
 
 if typing.TYPE_CHECKING:
     from libqtile.backend.base import Internal
@@ -400,8 +401,11 @@ class TextLayout:
             # pangocffi doesn't like None here, so we use "".
             if value is None:
                 value = ""
-            attrlist, value, accel_char = pangocffi.parse_markup(value)
-            self.layout.set_attributes(attrlist)
+            try:
+                attrlist, value, accel_char = pangocffi.parse_markup(value)
+                self.layout.set_attributes(attrlist)
+            except pangocffi.BadMarkup:
+                logger.warning("parse_markup() failed for {value}")
         self.layout.set_text(utils.scrub_to_utf8(value))
 
     @property

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -170,6 +170,10 @@ class FontDescription:
         return pango.pango_font_description_get_size(self._pointer)
 
 
+class BadMarkup(Exception):
+    pass
+
+
 def parse_markup(value, accel_marker=0):
     attr_list = ffi.new("PangoAttrList**")
     text = ffi.new("char**")
@@ -179,7 +183,7 @@ def parse_markup(value, accel_marker=0):
     ret = pango.pango_parse_markup(value, -1, accel_marker, attr_list, text, ffi.NULL, error)
 
     if ret == 0:
-        raise Exception(f"parse_markup() failed for {value}")
+        raise BadMarkup(f"parse_markup() failed for {value}")
 
     return attr_list[0], ffi.string(text[0]), chr(accel_marker)
 

--- a/libqtile/widget/crashme.py
+++ b/libqtile/widget/crashme.py
@@ -53,5 +53,3 @@ class _CrashMe(base._TextBox):
     def button_press(self, x, y, button):
         if button == 1:
             1 / 0
-        elif button == 3:
-            self.text = "<span>\xc3GError"

--- a/test/widgets/test_crashme.py
+++ b/test/widgets/test_crashme.py
@@ -53,9 +53,3 @@ def test_crashme_init(manager_nospawn, minimal_conf_noscreen):
         topbar.fake_button_press(0, 0, button=1)
 
     assert e_info.match("ZeroDivisionError")
-
-    # Simulate right click to trigger parse_markup error
-    with pytest.raises(CommandException) as e_info:
-        topbar.fake_button_press(0, 0, button=3)
-
-    assert e_info.match("parse_markup[(][)] failed")


### PR DESCRIPTION
In #5176 it seems that if/when we truncate at the wrong spot, we can break markup and cause a stack trace in users' logs. There isn't really a good fix for this, short of implementing our own markup parser, which would defeat the point of using this function in the first place :)

Instead, let's just swallow these errors and log them as warnings. This way people know their markup was truncated, but hopefully we will see less bug reports, since mostly these are not actual bugs.

I removed the markup failure handling from the crashme widget, since it shouldn't be generated any more. If we want to keep it, that's fine, but we'll have to move the exception to some other file, since when I tried that it generated a circular import.

Fixes #5176