### PR TITLE
feat(wlan): add `{ipaddr}` to display local IP address

### DIFF
--- a/libqtile/scripts/migrations/change_wlan_args.py
+++ b/libqtile/scripts/migrations/change_wlan_args.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025, trimclain. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import libcst as cst
+import libcst.matchers as m
+
+from libqtile.scripts.migrations._base import (
+    Check,
+    MigrationTransformer,
+    _QtileMigrator,
+    add_migration,
+)
+
+
+class WlanArgsTransformer(MigrationTransformer):
+    @m.call_if_inside(m.Call(func=m.Name("Wlan")) | m.Call(func=m.Attribute(attr=m.Name("Wlan"))))
+    @m.leave(m.Arg(keyword=m.Name("ethernet_message")))
+    def update_wlan_args(self, original_node, updated_node) -> cst.Arg:
+        """Changes 'ethernet_message' to 'ethernet_message_format'."""
+        self.lint(
+            original_node,
+            "The 'ethernet_message' argument is deprecated and should be replaced with 'ethernet_message_format'.",
+        )
+        return updated_node.with_changes(keyword=cst.Name("ethernet_message_format"))
+
+
+class WlanArgs(_QtileMigrator):
+    ID = "UpdateWlanArgs"
+
+    SUMMARY = "Updates ``Wlan`` argument signature."
+
+    HELP = """
+    The ``Wlan`` widget previously accepted a ``ethernet_message`` keyword argument. This has
+    been deprecated and should be replaced with a keyword argument named ``ethernet_message_format``.
+
+    For example:
+
+    .. code:: python
+
+        widget.Wlan(ethernet_message="eth")
+
+    should be changed to:
+
+    .. code::
+
+        widget.Wlan(ethernet_message_format="eth")
+
+    """
+
+    AFTER_VERSION = "0.31.0"
+
+    TESTS = [
+        Check(
+            """
+            from libqtile import bar, widget
+            from libqtile.widget import Wlan
+
+            bar.Bar(
+                [
+                    Wlan(ethernet_message="eth"),
+                    widget.Wlan(ethernet_message="eth"),
+                ],
+                20,
+            )
+            """,
+            """
+            from libqtile import bar, widget
+            from libqtile.widget import Wlan
+
+            bar.Bar(
+                [
+                    Wlan(ethernet_message_format="eth"),
+                    widget.Wlan(ethernet_message_format="eth"),
+                ],
+                20,
+            )
+            """,
+        ),
+    ]
+
+    visitor = WlanArgsTransformer
+
+
+add_migration(WlanArgs)

--- a/libqtile/widget/wlan.py
+++ b/libqtile/widget/wlan.py
@@ -25,6 +25,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import subprocess
+
 import iwlib
 
 from libqtile.log_utils import logger
@@ -39,6 +41,28 @@ def get_status(interface_name):
     quality = interface["stats"]["quality"]
     essid = bytes(interface["ESSID"]).decode()
     return essid, quality
+
+
+def get_private_ip(interface_name):
+    try:
+        result = subprocess.run(
+            ["ip", "-brief", "addr", "show", "dev", interface_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        logger.exception(f"Couldn't get the IP for {interface_name}:")
+        return "N/A"
+
+    output = result.stdout.strip()
+    parts = output.split()
+    if len(parts) > 2 and parts[1] == "UP":
+        ip_address = parts[2].split("/")[0]
+        if ":" not in ip_address:
+            return ip_address
+
+    return "N/A"
 
 
 class Wlan(base.InLoopPollText):
@@ -60,7 +84,11 @@ class Wlan(base.InLoopPollText):
         ),
         ("update_interval", 1, "The update interval."),
         ("disconnected_message", "Disconnected", "String to show when the wlan is diconnected."),
-        ("ethernet_message", "eth", "String to show when ethernet is being used"),
+        (
+            "ethernet_message_format",
+            "eth",
+            "String to show when ethernet is being used. For IP of ethernet interface use {ipaddr}.",
+        ),
         (
             "use_ethernet",
             False,
@@ -69,11 +97,16 @@ class Wlan(base.InLoopPollText):
         (
             "format",
             "{essid} {quality}/70",
-            'Display format. For percents you can use "{essid} {percent:2.0%}"',
+            'Display format. For percents you can use "{essid} {percent:2.0%}". For IP of wlan interface use {ipaddr}.',
         ),
     ]
 
     def __init__(self, **config):
+        if "ethernet_message" in config:
+            logger.warning(
+                "`ethernet_message` parameter is deprecated. Please rename to `ethernet_message_format`"
+            )
+            config["ethernet_message_format"] = config.pop("ethernet_message")
         base.InLoopPollText.__init__(self, **config)
         self.add_defaults(Wlan.defaults)
         self.ethernetInterfaceNotFound = False
@@ -82,14 +115,18 @@ class Wlan(base.InLoopPollText):
         try:
             essid, quality = get_status(self.interface)
             disconnected = essid is None
-            if disconnected:
+            ipaddr = "N/A"
+            if not disconnected:
+                ipaddr = get_private_ip(self.interface)
+            else:
                 if self.use_ethernet:
+                    ipaddr = get_private_ip(self.ethernet_interface)
                     try:
                         with open(
                             f"/sys/class/net/{self.ethernet_interface}/operstate"
                         ) as statfile:
                             if statfile.read().strip() == "up":
-                                return self.ethernet_message
+                                return self.ethernet_message_format.format(ipaddr=ipaddr)
                             else:
                                 return self.disconnected_message
                     except FileNotFoundError:
@@ -100,7 +137,10 @@ class Wlan(base.InLoopPollText):
                 else:
                     return self.disconnected_message
             return self.format.format(
-                essid=markup_escape_text(essid), quality=quality, percent=(quality / 70)
+                essid=markup_escape_text(essid),
+                quality=quality,
+                percent=(quality / 70),
+                ipaddr=ipaddr,
             )
         except OSError:
             logger.error(

--- a/test/widgets/test_wlan.py
+++ b/test/widgets/test_wlan.py
@@ -118,7 +118,7 @@ def test_wlan_display_escape_essid(
         ({"interface": "wlan1", "use_ethernet": True}, "up", "eth"),
         ({"interface": "wlan1", "use_ethernet": True}, "down", "Disconnected"),
         (
-            {"interface": "wlan1", "use_ethernet": True, "ethernet_message": "Wired"},
+            {"interface": "wlan1", "use_ethernet": True, "ethernet_message_format": "Wired"},
             "up",
             "Wired",
         ),


### PR DESCRIPTION
Hey there,

first of all, thank you for your amazing work on `qtile`!

With this PR I wanted to add the ability to display the local IP in the qtile bar, so that I can have
```
ethernet_message="🖧 {ipaddr}"
```
in my config, similar to how [i3status](https://i3wm.org/docs/i3status.html#_ethernet) and [waybar](https://github.com/Alexays/Waybar/wiki/Module:-Network#format-replacements) allow to do it.

What do you think?