### PR TITLE
Update command_graph.rst

### DIFF
--- a/docs/manual/commands/command_graph.rst
+++ b/docs/manual/commands/command_graph.rst
@@ -13,8 +13,8 @@ follows the available paths in the graph. This is what the graph looks like:
     :api_page_root: api/
 
 Each arrow can be read as "holds a reference to". So, we can see that a
-``widget`` object *holds a reference to* objects of type ``bar``, ``screen``
-and ``group``. Let's start with some simple examples of how the addressing
+``widget`` object *holds a reference to* objects of type ``bar`` and ``screen``. 
+Let's start with some simple examples of how the addressing
 works. Which particular objects we hold reference to depends on the context -
 for instance, widgets hold a reference to the screen that they appear on, and
 the bar they are attached to.


### PR DESCRIPTION
Fixed the references description to match the graph above it. See: https://docs.qtile.org/en/stable/manual/commands/command_graph.html and https://docs.qtile.org/en/stable/manual/commands/api/widgets.html. ``widget`` only references ``bar`` and ``screen``.