### PR TITLE
improve license specification in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ build-backend = "builder"
 name = "qtile"
 description = "A pure-Python tiling window manager."
 dynamic = ["version", "readme", "dependencies", "optional-dependencies"]
-license = {text = "MIT"}
+license = "MIT"
+license-files = [ "LICENSE" ]
 classifiers = [
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: BSD :: FreeBSD",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Our license is the MIT license. Let's use the "new" PEP0639 formatting for it.

Fixes #5233