### PR TITLE
Handle uppercase letters and special characters for internal windows

### DIFF
--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -282,15 +282,19 @@ class Keyboard(_Device):
             )
             keysyms = [xkb_keysym[0][i] for i in range(nsyms)]
             mods = reduce(or_, [k.keyboard.modifier for k in self.core.keyboards])
-            handled = False
             should_repeat = False
+
             if event.state == KEY_PRESSED:
                 for keysym in keysyms:
                     if (keysym, mods) in self.grabbed_keys:
                         should_repeat = True
-                        if self.qtile.process_key_event(keysym, mods)[1]:
-                            handled = True
-                            break
+                        handled, _ = self.qtile.process_key_event(keysym, mods)
+                        if handled:
+                            return
+
+                if self.core.focused_internal:
+                    keysym = lib.xkb_state_key_get_one_sym(self.keyboard._ptr.xkb_state, keycode)
+                    self.core.focused_internal.process_key_press(keysym)
 
             repeat_delay = self.keyboard._ptr.repeat_info.delay
             if should_repeat and repeat_delay > 0:
@@ -305,12 +309,6 @@ class Keyboard(_Device):
                 if self.repeat_rate_future is not None:
                     self.repeat_rate_future.cancel()
                     self.repeat_rate_future = None
-
-            if handled:
-                return
-            if self.core.focused_internal:
-                self.core.focused_internal.process_key_press(keysym)
-                return
 
         self.seat.keyboard_notify_key(event)
 


### PR DESCRIPTION
### Summary
This PR fixes an issue with the key input handling on the wayland backend where uppercase letters and special characters could not be typed into internal windows, like the prompt widget on the bar. On X11, this is not an issue.

### Solution
- Moved the `handled` check earlier in the `_on_key` function.
- Adjusted keysyms based on modifiers and passed the adjusted keysym to `process_key_press` for internal windows, because just passing modifiers alongside default keysyms like with `process_key_event` was not an option.

### Testing
- Verified that uppercase letters and special characters can now be typed in internal windows.