### PR TITLE
Screen: add a __hash__ function

### DIFF
--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -490,6 +490,9 @@ class Screen(CommandObject):
             and other.height == self.height
         )
 
+    def __hash__(self) -> int:
+        return hash((self.x, self.y, self.width, self.height))
+
     def _configure(
         self,
         qtile: Qtile,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -104,3 +104,13 @@ def test_ezclick_ezdrag():
     btn = config.EzDrag("A-2", cmd)
     assert btn.button == "Button2"
     assert btn.modifiers == [config.EzClick.modifier_keys["A"]]
+
+
+def test_screen_underbar_methods():
+    one = config.Screen(x=10, y=10, width=10, height=10)
+    two = config.Screen(x=20, y=20, width=20, height=20)
+
+    assert hash(one) != hash(two)
+    assert hash(one) == hash(one)
+    assert one != two
+    assert one == one


### PR DESCRIPTION
we have reports of the following stack trace:

    2025-04-25 16:25:23,640 ERROR libqtile start.py:start():L111 Qtile crashed
    Traceback (most recent call last):
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/scripts/start.py", line 109, in start
        q.loop()
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/core/manager.py", line 204, in loop
        asyncio.run(self.async_loop())
      File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/asyncio/runners.py", line 195, in run
        return runner.run(main)
               ^^^^^^^^^^^^^^^^
      File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/asyncio/runners.py", line 118, in run
        return self._loop.run_until_complete(task)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
        return future.result()
               ^^^^^^^^^^^^^^^
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/core/manager.py", line 216, in async_loop
        self.load_config(initial=True)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/core/manager.py", line 141, in load_config
        self._process_screens(reloading=not initial)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/core/manager.py", line 419, in _process_screens
        scr._configure(
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/config.py", line 517, in _configure
        self.paint(self.wallpaper, self.wallpaper_mode)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/config.py", line 523, in paint
        self.qtile.paint_screen(self, path, mode)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/core/manager.py", line 460, in paint_screen
        self.core.painter.paint(screen, image_path, mode)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/backend/wayland/wlrq.py", line 170, in paint
        self._clear_previous_background(screen)
      File "/nix/store/v3v63bbhrb3n2bilxfnp070nxx5g34w3-python3.12-qtile-0.31.0+72ad60f.flake/lib/python3.12/site-packages/libqtile/backend/wayland/wlrq.py", line 125, in _clear_previous_background
        if screen in self.core.wallpapers:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: unhashable type: 'Screen'

this happens because in 72ad60fa0697 ("add screen __eq__"), we defined a __eq__ function. When python sees a __eq__ function for an object, it does not override __hash__ automatically, since if two objects are __eq__() they should __hash__() to the same value.

This means that Screen() objects were unhashable, even though we relied on them being hashable, viz. the above stack trace.

Let's add a __hash__ using the same somewhat-broken comparison as __eq__ does (i.e. the caveats in __eq__ apply).

Fixes #5328