### PR TITLE
Better handling of `eval` in `qtile shell`

### DIFF
--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -323,8 +323,14 @@ class QSh:
         if command_match:
             cmd = command_match.group("cmd")
             args = command_match.group("args")
+            cmd_args: tuple
             if args:
-                cmd_args = tuple(map(str.strip, args.split(",")))
+                if cmd == "eval":
+                    # For eval, the whole argument should be a single string of code
+                    # so we shouldn't split it.
+                    cmd_args = (args,)
+                else:
+                    cmd_args = tuple(map(str.strip, args.split(",")))
             else:
                 cmd_args = ()
 

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -134,3 +134,13 @@ def test_help(manager):
     sh = QSh(command)
     assert sh.do_help("nonexistent").startswith("No such command")
     assert sh.do_help("help")
+
+
+@sh_config
+def test_eval(manager):
+    client = ipc.Client(manager.sockfile)
+    command = IPCCommandInterface(client)
+    sh = QSh(command)
+    sh.process_line("eval(self._test_val=(1,2))")
+    _, result = sh.process_line("eval(self._test_val)")
+    assert result == "(1, 2)"


### PR DESCRIPTION
This fixes a small but annoying bug. Using `eval` in `qtile shell` will fail when the code string contains a comma. This is because `qtile shell` creates a tuple of arguments by splitting the string on a comma. However `eval` expects a single string of code.

This PR fixes this issue by preserving the args as a single string when a user calls `eval`.


Ideally, we shouldn't split on commas where they're in the middle of a string but I've gone with this approach instead!