### PR TITLE
qtile shell: more improvements

### DIFF
--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -45,6 +45,31 @@ if TYPE_CHECKING:
     from typing import Any
 
 
+# From: https://stackoverflow.com/a/64333329/3087339
+# Matches commas that are not enclosed in quote marks
+COMMA_MATCHER = re.compile(r",(?=(?:[^\"']*[\"'][^\"']*[\"'])*[^\"']*$)")
+
+# Matches string in the form of "key=value" and stores results in
+# groups named "key" and "value"
+KWARG_MATCHER = re.compile(r"(?P<key>\w+)\s?=\s*(?P<value>.*)")
+
+
+def split_args(args):
+    pos_args = []
+    kwargs = {}
+    for arg in args:
+        if kwarg := KWARG_MATCHER.match(arg.strip()):
+            kwargs[kwarg.group("key")] = tidy_str(kwarg.group("value"))
+        else:
+            pos_args.append(tidy_str(arg))
+
+    return pos_args, kwargs
+
+
+def tidy_str(text):
+    return text.strip(""" "'\t\r\n""")
+
+
 def terminal_width():
     width = None
     try:
@@ -324,13 +349,16 @@ class QSh:
             cmd = command_match.group("cmd")
             args = command_match.group("args")
             cmd_args: tuple
+            kwargs: dict[str, str] = {}
             if args:
                 if cmd == "eval":
                     # For eval, the whole argument should be a single string of code
                     # so we shouldn't split it.
                     cmd_args = (args,)
                 else:
-                    cmd_args = tuple(map(str.strip, args.split(",")))
+                    # For everything else, we split by commas except where they
+                    # are enclosed in quotation marks (i.e. part of a string)
+                    cmd_args, kwargs = split_args(COMMA_MATCHER.split(args))
             else:
                 cmd_args = ()
 
@@ -338,7 +366,7 @@ class QSh:
                 return f"Command does not exist: {cmd}"
 
             try:
-                return self._command_client.call(cmd, *cmd_args)
+                return self._command_client.call(cmd, *cmd_args, **kwargs)
             except CommandException as e:
                 return f"Caught command exception (is the command invoked incorrectly?): {e}\n"
 

--- a/test/test_sh.py
+++ b/test/test_sh.py
@@ -23,13 +23,21 @@
 import pytest
 
 from libqtile import config, ipc, resources
+from libqtile.bar import Bar
+from libqtile.command.base import expose_command
 from libqtile.command.interface import IPCCommandInterface
 from libqtile.confreader import Config
 from libqtile.layout import Max
-from libqtile.sh import QSh
+from libqtile.sh import COMMA_MATCHER, QSh, split_args
+from libqtile.widget import TextBox
 
 
 class ShConfig(Config):
+    class ShellWidget(TextBox):
+        @expose_command
+        def return_args(self, *args: str, **kwargs: dict[str, str]):
+            return {"length": len(args), "args": list(args), "kwargs": kwargs}
+
     keys = []
     mouse = []
     groups = [
@@ -40,7 +48,7 @@ class ShConfig(Config):
         Max(),
     ]
     floating_layout = resources.default_config.floating_layout
-    screens = [config.Screen()]
+    screens = [config.Screen(top=Bar([ShellWidget("")], 20))]
 
 
 sh_config = pytest.mark.parametrize("manager", [ShConfig], indirect=True)
@@ -144,3 +152,44 @@ def test_eval(manager):
     sh.process_line("eval(self._test_val=(1,2))")
     _, result = sh.process_line("eval(self._test_val)")
     assert result == "(1, 2)"
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        ("1, 2, 3", ["1", " 2", " 3"]),
+        ("1, 2, 3, '4, 5, 6'", ["1", " 2", " 3", " '4, 5, 6'"]),
+        ('1, "2, 3, 4", 5, 6', ["1", ' "2, 3, 4"', " 5", " 6"]),
+    ],
+)
+def test_comma_split_regex(input, output):
+    assert COMMA_MATCHER.split(input) == output
+
+
+@pytest.mark.parametrize(
+    "input,args,kwargs",
+    [
+        ("1, 2, 3", ["1", "2", "3"], {}),
+        ("1, 2, 3, '4, 5, 6'", ["1", "2", "3", "4, 5, 6"], {}),
+        ("1, 2, 3, 4=5", ["1", "2", "3"], {"4": "5"}),
+        ("1, 2, 3, 4='5, 6'", ["1", "2", "3"], {"4": "5, 6"}),
+        ("1, 2, 3, 4 = '5, 6'", ["1", "2", "3"], {"4": "5, 6"}),
+        ("1, 2, 3, 4='5=6'", ["1", "2", "3"], {"4": "5=6"}),
+    ],
+)
+def test_args_splitting(input, args, kwargs):
+    assert split_args(COMMA_MATCHER.split(input)) == (args, kwargs)
+
+
+@sh_config
+def test_comma_splitting(manager):
+    client = ipc.Client(manager.sockfile)
+    command = IPCCommandInterface(client)
+    sh = QSh(command)
+
+    assert sh.do_cd("widget/shellwidget") == "widget[shellwidget]"
+
+    result = sh.process_line("return_args(1, 2, '3, 4, 5', test_kwarg='test')")
+    assert result["length"] == 3
+    assert result["args"][2] == "3, 4, 5"
+    assert result["kwargs"] == {"test_kwarg": "test"}


### PR DESCRIPTION
This PR fixes two issues with qtile shell:

1) qtile shell splits command arguments by every comma but this is undesirable if the comma is part of a string. We now only split on commas that are not inside quotation marks.

2) allow users to pass keyword arguments as key=value pairs.