### PR TITLE
Improve Nix Flake Configuration and CI for Qtile

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,36 @@
+name: Nix Flake Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+
+      - name: Run nix flake check
+        run: nix flake check --print-build-logs
+
+      - name: Check Nix formatting
+        run: |
+          nix fmt .
+          if git diff --exit-code -- '*.nix'; then
+            echo "All Nix files are formatted correctly"
+          else
+            echo "Nix files need formatting. Run 'nix fmt' locally."
+            exit 1
+          fi
+
+      - name: Build Qtile package
+        run: nix build .#qtile --no-link --print-build-logs
+
+      - name: Verify Qtile version
+        run: nix shell .#qtile -c qtile --version

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+    }:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -26,9 +29,10 @@
           in
           function (import nixpkgs nixpkgs-settings)
         );
-
     in
     {
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+
       checks = forAllSystems (pkgs: pkgs.python3Packages.qtile.passthru.tests);
 
       overlays.default = import ./nix/overlays.nix self;

--- a/flake.nix
+++ b/flake.nix
@@ -45,22 +45,10 @@
         {
           default = self.packages.${pkgs.system}.qtile;
 
-          qtile = qtile'.overrideAttrs (
-            prev:
-            let
-              remove-dbus-next = dep: dep.pname != pkgs.python3Packages.dbus-next.pname;
-
-              # seems like dependencies is a fancy wrapper on that one!
-              propagatedBuildInputs =
-                with pkgs.python3Packages;
-                [ dbus-fast ] ++ (pkgs.lib.filter remove-dbus-next prev.propagatedBuildInputs);
-            in
-            {
-              name = "${qtile'.pname}-${qtile'.version}";
-              inherit propagatedBuildInputs;
-              passthru.unwrapped = qtile';
-            }
-          );
+          qtile = qtile'.overrideAttrs (prev: {
+            name = "${qtile'.pname}-${qtile'.version}";
+            passthru.unwrapped = qtile';
+          });
         }
       );
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -27,6 +27,14 @@ self: final: prev: {
           }
         )).override
           { wlroots = prev.wlroots_0_17; };
+      qtile-extras = pprev.qtile-extras.overridePythonAttrs (oldAttrs: {
+        # disable broken tests
+        disabledTestPaths = oldAttrs.disabledTestPaths ++ [
+          "test/widget/test_animated_image.py"
+          "test/widget/test_groupbox2.py"
+          "test/widget/test_image.py"
+        ];
+      });
     })
   ];
   python3 =

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -19,14 +19,11 @@ self: final: prev: {
             symver = builtins.head (
               builtins.match "Qtile ([0-9.]+), released ([0-9-]+):" current-release-title
             );
-
           in
           {
             version = "${symver}+${flakever}.flake";
             # use the source of the git repo
             src = ./..;
-            # for qtile migrate, not in nixpkgs yet
-            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pprev.libcst ];
           }
         )).override
           { wlroots = prev.wlroots_0_17; };


### PR DESCRIPTION
This PR brings several improvements to the Nix flake setup:

* **Formatter integration:** Adds `nixfmt-rfc-style` as the default formatter to ensure consistent formatting across the codebase.
* **Dependency cleanup:** Removes redundant `propagatedBuildInputs` for a slimmer, more efficient flake.

  > ⚠️ *Note:* This change depends on [PR #371737](https://nixpk.gs/pr-tracker.html?pr=371737) being merged into `nixos-unstable`. Until then, this might cause issues.
* **Flake lockfile updated:** Refreshes `flake.lock` to pull in the latest upstream dependencies.
* **CI improvement:** Introduces a GitHub workflow to run `nix flake check`, helping catch issues early in development.
* **Test workaround:** Temporarily disables broken `Qtile-Extras` tests to prevent errors during `nix flake check`.
  > ℹ️ *Note*: This should be reverted after the next release.

These updates improve consistency, streamline the flake setup, and establish a foundation for automated quality checks.