### PR TITLE
fix tarball paths in wayland setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     container: quay.io/pypa/manylinux_2_28_x86_64
     env:
       libdrm-version: "2.4.121"
+      libdrm-hash: "70c4f836ccffa972978bc58c9cc0434f85984be8"
       seatd-version: "0.6.4"
       pixman-version: "0.42.0"
       xkbcommon-version: "1.7.0"
@@ -115,7 +116,7 @@ jobs:
           DESTDIR=~/wayland ninja -C build install
           ninja -C build install
       - name: Build libdrm
-        working-directory: drm-libdrm-${{ env.libdrm-version }}
+        working-directory: libdrm-libdrm-${{ env.libdrm-version }}-${{ env.libdrm-hash }}
         run: |
           meson build --prefix=/usr
           ninja -C build

--- a/scripts/ubuntu_wayland_setup
+++ b/scripts/ubuntu_wayland_setup
@@ -13,6 +13,7 @@ WAYLAND_PROTOCOLS=1.32
 WLROOTS=0.17.3
 SEATD=0.6.4
 LIBDRM=2.4.121
+LIBDRM_HASH=70c4f836ccffa972978bc58c9cc0434f85984be8
 PIXMAN=0.42.0
 XWAYLAND=22.1.9
 HWDATA=0.364
@@ -67,7 +68,7 @@ cd ../
 # Build libdrm
 wget https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-$LIBDRM/drm-libdrm-$LIBDRM.tar.gz
 tar -xzf drm-libdrm-$LIBDRM.tar.gz
-cd drm-libdrm-$LIBDRM
+cd libdrm-libdrm-$LIBDRM-$LIBDRM_HASH
 meson build --prefix=/usr
 ninja -C build
 sudo ninja -C build install


### PR DESCRIPTION
gitlab seems to have changed the structure of their tarballs:

    /tmp wget https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-2.4.121/drm-libdrm-2.4.121.tar.gz
    --2025-05-22 08:18:56--  https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-2.4.121/drm-libdrm-2.4.121.tar.gz
    Resolving gitlab.freedesktop.org (gitlab.freedesktop.org)... 151.101.67.52, 151.101.131.52, 151.101.3.52, ...
    Connecting to gitlab.freedesktop.org (gitlab.freedesktop.org)|151.101.67.52|:443... connected.
    HTTP request sent, awaiting response... 200
    Length: unspecified [application/octet-stream]
    Saving to: ‘drm-libdrm-2.4.121.tar.gz’

    drm-libdrm-2.4.121.tar.gz      [   <=>                                 ] 656.03K   975KB/s    in 0.7s

    2025-05-22 08:18:57 (975 KB/s) - ‘drm-libdrm-2.4.121.tar.gz’ saved [671779]

    /tmp tar -xzf drm-libdrm-2.4.121.tar.gz
    /tmp file libdrm-libdrm-2.4.121-70c4f836ccffa972978bc58c9cc0434f85984be8/
    libdrm-libdrm-2.4.121-70c4f836ccffa972978bc58c9cc0434f85984be8/: directory

and is now appending the tag hash. Let's add that.