### PR TITLE
fix: libdrm repository name change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     container: quay.io/pypa/manylinux_2_28_x86_64
     env:
       libdrm-version: "2.4.121"
-      libdrm-hash: "70c4f836ccffa972978bc58c9cc0434f85984be8"
       seatd-version: "0.6.4"
       pixman-version: "0.42.0"
       xkbcommon-version: "1.7.0"
@@ -76,7 +75,7 @@ jobs:
           tar -xzf xorgproto-xorgproto-${{ env.inputproto-version }}.tar.gz
           tar -xzf libxcvt-libxcvt-${{ env.xcvt-version }}.tar.gz
           tar -xzf xserver-xwayland-${{ env.xwayland-version }}.tar.gz
-          tar -xzf drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          tar -xzf libdrm-libdrm-${{ env.libdrm-version }}.tar.gz
           tar -xjf pixman-pixman-${{ env.pixman-version }}.tar.bz2
           tar -xzf seatd.tar.gz
           tar -xzf wlroots.tar.gz
@@ -87,7 +86,7 @@ jobs:
           XWAYLAND_URL: https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-${{ env.xwayland-version }}/xserver-xwayland-${{ env.xwayland-version }}.tar.gz
           XCVT_URL: https://gitlab.freedesktop.org/xorg/lib/libxcvt/-/archive/libxcvt-${{ env.xcvt-version }}/libxcvt-libxcvt-${{ env.xcvt-version }}.tar.gz
           INPUTPROTO_URL: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/archive/xorgproto-${{ env.inputproto-version}}/xorgproto-xorgproto-${{ env.inputproto-version}}.tar.gz
-          LIBDRM_URL: https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${{ env.libdrm-version }}/drm-libdrm-${{ env.libdrm-version }}.tar.gz
+          LIBDRM_URL: https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-${{ env.libdrm-version }}/libdrm-libdrm-${{ env.libdrm-version }}.tar.gz
           SEATD_URL: https://github.com/kennylevinsen/seatd/archive/refs/tags/${{ env.seatd-version }}.tar.gz
           PIXMAN_URL: https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-${{ env.pixman-version }}/pixman-pixman-${{ env.pixman-version }}.tar.bz2
           WLROOTS_URL: https://gitlab.freedesktop.org/wlroots/wlroots/-/archive/${{ env.wlroots-version }}/wlroots-${{ env.wlroots-version }}.tar.gz
@@ -116,7 +115,7 @@ jobs:
           DESTDIR=~/wayland ninja -C build install
           ninja -C build install
       - name: Build libdrm
-        working-directory: libdrm-libdrm-${{ env.libdrm-version }}-${{ env.libdrm-hash }}
+        working-directory: libdrm-libdrm-${{ env.libdrm-version }}
         run: |
           meson build --prefix=/usr
           ninja -C build

--- a/scripts/ubuntu_wayland_setup
+++ b/scripts/ubuntu_wayland_setup
@@ -13,7 +13,6 @@ WAYLAND_PROTOCOLS=1.32
 WLROOTS=0.17.3
 SEATD=0.6.4
 LIBDRM=2.4.121
-LIBDRM_HASH=70c4f836ccffa972978bc58c9cc0434f85984be8
 PIXMAN=0.42.0
 XWAYLAND=22.1.9
 HWDATA=0.364
@@ -66,9 +65,9 @@ sudo ninja -C build install
 cd ../
 
 # Build libdrm
-wget https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-$LIBDRM/drm-libdrm-$LIBDRM.tar.gz
-tar -xzf drm-libdrm-$LIBDRM.tar.gz
-cd libdrm-libdrm-$LIBDRM-$LIBDRM_HASH
+wget https://gitlab.freedesktop.org/mesa/libdrm/-/archive/libdrm-$LIBDRM/libdrm-libdrm-$LIBDRM.tar.gz
+tar -xzf libdrm-libdrm-$LIBDRM.tar.gz
+cd libdrm-libdrm-$LIBDRM
 meson build --prefix=/usr
 ninja -C build
 sudo ninja -C build install


### PR DESCRIPTION
Using a hash is not really needed if you use the current repository name. This should be more maintainable than using the hash.