### PR TITLE
nix: remove qtile-extras overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749794982,
-        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
         "type": "github"
       },
       "original": {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -28,14 +28,6 @@ self: final: prev: {
           }
         )).override
           { wlroots = prev.wlroots_0_17; };
-      qtile-extras = pprev.qtile-extras.overridePythonAttrs (oldAttrs: {
-        # disable broken tests
-        disabledTestPaths = oldAttrs.disabledTestPaths ++ [
-          "test/widget/test_animated_image.py"
-          "test/widget/test_groupbox2.py"
-          "test/widget/test_image.py"
-        ];
-      });
     })
   ];
   python3 =


### PR DESCRIPTION
This PR removes the `qtile-extras tests` overlay from the flake.

The overlay becomes unnecessary once [PR #415827](https://github.com/NixOS/nixpkgs/pull/415827) is merged and reaches `nixos-unstable`, as `qtile-extras 0.32.0` includes fixes for previously broken tests.

**Note:**
Do **not** merge this until the tracker confirms that [PR #415827](https://github.com/NixOS/nixpkgs/pull/415827) is available in `nixos-unstable`:
👉 [Check status here](https://nixpk.gs/pr-tracker.html?pr=415827)