### PR TITLE
Wayc updates by Gurjaka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_static/screenshots/
 
 # ViM tags
 /tags
+
+# ccls
+.ccls-cache/

--- a/libqtile/backend/wayland/qw/cairo-buffer.h
+++ b/libqtile/backend/wayland/qw/cairo-buffer.h
@@ -3,6 +3,12 @@
 
 #include <stdlib.h>
 
+/* Creates a wlroots buffer backed by Cairo pixel data.
+ * Parameters:
+ * - width, height: dimensions of the buffer
+ * - stride: number of bytes per row in data
+ * - data: pointer to the pixel data (must remain valid while buffer exists)
+ * Returns a pointer to the base wlr_buffer interface. */
 struct wlr_buffer *cairo_buffer_create(int width, int height, size_t stride, void *data);
 
 #endif // CAIRO_BUFFER_H

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -4,8 +4,9 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
-struct qw_server;
+struct qw_server; // Forward declaration to avoid circular dependency
 
+// Cursor structure that holds cursor state and event listeners
 struct qw_cursor {
     struct qw_server *server;
     struct wlr_cursor *cursor;
@@ -18,7 +19,10 @@ struct qw_cursor {
     struct wlr_xcursor_manager *mgr;
 };
 
+// Destroy the cursor and free its resources
 void qw_cursor_destroy(struct qw_cursor *cursor);
+
+// Create and initialize a new cursor associated with the server
 struct qw_cursor *qw_server_cursor_create(struct qw_server *cursor);
 
 #endif /* CURSOR_H */

--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -1,21 +1,28 @@
-#include "cairo-buffer.h"
 #include "internal-view.h"
+#include "cairo-buffer.h"
 #include "pixman.h"
 #include "server.h"
 #include "view.h"
 #include <stdlib.h>
 #include <wlr/util/log.h>
 
+// Create or recreate the internal view's buffer and associated Cairo surface
+// If init is false, drop the old buffer before creating a new one
 static void qw_internal_view_buffer_new(struct qw_internal_view *view, bool init) {
     if (!init) {
         wlr_buffer_drop(view->buffer);
     }
 
+    // Create a new Cairo image surface with ARGB32 format
     view->image_surface =
         cairo_image_surface_create(CAIRO_FORMAT_ARGB32, view->base.width, view->base.height);
+
     unsigned char *data = cairo_image_surface_get_data(view->image_surface);
     size_t stride = cairo_image_surface_get_stride(view->image_surface);
+
+    // Create a wlr_buffer backed by the Cairo surface's pixel data
     view->buffer = cairo_buffer_create(view->base.width, view->base.height, stride, data);
+
     if (!view->buffer) {
         wlr_log(WLR_ERROR, "failed allocating wlr_buffer for internal view");
     } else if (!init) {
@@ -23,17 +30,24 @@ static void qw_internal_view_buffer_new(struct qw_internal_view *view, bool init
     }
 }
 
+// Update the scene buffer with damage in the specified rectangle region
 void qw_internal_view_set_buffer_with_damage(struct qw_internal_view *view, int x, int y, int width,
                                              int height) {
     if (!view->scene_buffer || !view->buffer) {
         return;
     }
+
+    // Initialize a pixman region covering the damage rectangle
     pixman_region32_t region;
     pixman_region32_init_rect(&region, x, y, width, height);
+
     wlr_scene_buffer_set_buffer_with_damage(view->scene_buffer, view->buffer, &region);
+
+    // Clean up pixman region
     pixman_region32_fini(&region);
 }
 
+// Return the underlying scene node for this internal view
 static struct wlr_scene_node *qw_internal_view_get_tree_node(void *self) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     if (!view->scene_buffer) {
@@ -42,11 +56,14 @@ static struct wlr_scene_node *qw_internal_view_get_tree_node(void *self) {
     return &view->scene_buffer->node;
 }
 
+// Raise this internal view's node to the top of the scene tree (bring to front)
 static void qw_internal_view_bring_to_front(void *self) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     wlr_scene_node_raise_to_top(&view->base.content_tree->node);
 }
 
+// Place the internal view at a new position and resize if needed
+// If 'above' is nonzero, bring the view to the front
 static void qw_internal_view_place(void *self, int x, int y, int width, int height, int bw,
                                    float (*bc)[4], int bn, int above) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
@@ -57,6 +74,7 @@ static void qw_internal_view_place(void *self, int x, int y, int width, int heig
     view->base.y = y;
     wlr_scene_node_set_position(&view->base.content_tree->node, x, y);
 
+    // Resize and recreate buffer if size changed
     if (width != view->base.width || height != view->base.height) {
         view->base.width = width;
         view->base.height = height;
@@ -64,15 +82,18 @@ static void qw_internal_view_place(void *self, int x, int y, int width, int heig
     }
 }
 
+// TODO: Focus logic for internal views (empty for now)
 void qw_internal_view_focus(void *self, int above) {
     // TODO
 }
 
+// Hide this internal view by disabling its scene node
 static void qw_internal_view_hide(void *self) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     wlr_scene_node_set_enabled(&view->base.content_tree->node, false);
 }
 
+// Unhide this internal view by enabling its scene node
 static void qw_internal_view_unhide(void *self) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     wlr_scene_node_set_enabled(&view->base.content_tree->node, true);
@@ -80,11 +101,13 @@ static void qw_internal_view_unhide(void *self) {
 
 static void qw_internal_view_kill(void *self) { qw_internal_view_hide(self); }
 
-// internal views have no PID
+// Internal views don't have a PID, so return 0
 static int qw_internal_view_get_pid(void *self) { return 0; }
 
+// Get pointer to the base view struct inside the internal view
 struct qw_view *qw_internal_view_get_base(struct qw_internal_view *view) { return &view->base; }
 
+// Allocate and initialize a new internal view with the specified geometry
 struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, int x, int y,
                                                      int width, int height) {
     struct qw_internal_view *view = calloc(1, sizeof(*view));
@@ -92,6 +115,8 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
         wlr_log(WLR_ERROR, "failed to create qw_internal_view struct");
         return NULL;
     }
+
+    // Initialize the base qw_view with provided geometry and callbacks
     struct qw_view base = {
         .x = x,
         .y = y,
@@ -99,8 +124,7 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
         .height = height,
         .bn = 0,
         .state = NOT_FLOATING,
-        // will be filled in by qtile
-        .wid = -1,
+        .wid = -1, // Window ID, to be set by compositor
         .content_tree = wlr_scene_tree_create(&server->scene->tree),
         .get_tree_node = qw_internal_view_get_tree_node,
         .place = qw_internal_view_place,
@@ -113,9 +137,13 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
     };
     view->base = base;
     view->server = server;
+
+    // Create the initial buffer and disable the scene node by default
     qw_internal_view_buffer_new(view, true);
     wlr_scene_node_set_enabled(&view->base.content_tree->node, false);
     wlr_scene_node_set_position(&view->base.content_tree->node, x, y);
+
+    // Create the scene buffer node for rendering the buffer
     view->scene_buffer = wlr_scene_buffer_create(view->base.content_tree, view->buffer);
     return view;
 }

--- a/libqtile/backend/wayland/qw/internal-view.h
+++ b/libqtile/backend/wayland/qw/internal-view.h
@@ -15,10 +15,14 @@ struct qw_internal_view {
     cairo_surface_t *image_surface;
 };
 
+// Update the buffer's damaged region (x, y, width, height)
 void qw_internal_view_set_buffer_with_damage(struct qw_internal_view *view, int x, int y, int width,
                                              int height);
+
+// Get pointer to the base qw_view inside the internal view struct
 struct qw_view *qw_internal_view_get_base(struct qw_internal_view *view);
 
+// Create a new internal view with given geometry attached to server
 struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, int x, int y,
                                                      int width, int height);
 

--- a/libqtile/backend/wayland/qw/keyboard.h
+++ b/libqtile/backend/wayland/qw/keyboard.h
@@ -1,9 +1,9 @@
 #ifndef KEYBOARD_H
 #define KEYBOARD_H
 
-#include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_input_device.h> // For wlr_input_device type
 
-struct qw_server;
+struct qw_server; // Forward declaration since qw_server is used but not defined here
 
 struct qw_keyboard {
     struct wl_list link;
@@ -15,6 +15,7 @@ struct qw_keyboard {
     struct wl_listener destroy;
 };
 
+// Creates and sets up a new keyboard on the server from the input device
 void qw_server_keyboard_new(struct qw_server *server, struct wlr_input_device *device);
 
 #endif /* KEYBOARD_H */

--- a/libqtile/backend/wayland/qw/log.c
+++ b/libqtile/backend/wayland/qw/log.c
@@ -2,14 +2,20 @@
 #include <stdio.h>
 
 // TODO: add pywlroots copyright
+
+// Function pointer for Python callback to receive formatted log messages
 static wrapped_log_func_t py_callback = NULL;
+
+// Callback function passed to wlroots logging system
+// Formats the log message and forwards it to the Python callback
 static void qw_log_callback(enum wlr_log_importance importance, const char *fmt, va_list args) {
     char formatted_str[4096];
-    vsnprintf(formatted_str, 4096, fmt, args);
-    py_callback(importance, formatted_str);
+    vsnprintf(formatted_str, 4096, fmt, args); // Format the message safely into buffer
+    py_callback(importance, formatted_str);    // Call the Python callback with formatted string
 }
 
+// Initializes wlroots logging with the specified verbosity and Python callback
 void qw_log_init(enum wlr_log_importance verbosity, wrapped_log_func_t callback) {
-    py_callback = callback;
-    wlr_log_init(verbosity, qw_log_callback);
+    py_callback = callback;                   // Store Python callback for use in log handler
+    wlr_log_init(verbosity, qw_log_callback); // Register our log callback with wlroots
 }

--- a/libqtile/backend/wayland/qw/log.h
+++ b/libqtile/backend/wayland/qw/log.h
@@ -3,8 +3,10 @@
 
 #include <wlr/util/log.h>
 
+// Callback type for forwarding wlroots log messages to external handlers
 typedef void (*wrapped_log_func_t)(enum wlr_log_importance importance, const char *log_str);
 
+// Initialize logging with specified verbosity and a custom callback to handle log messages
 void qw_log_init(enum wlr_log_importance verbosity, wrapped_log_func_t callback);
 
 #endif // LOG_H_

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -34,17 +34,34 @@
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
+// Callback typedefs for input and view events
+
+// Keyboard key event callback: keysym, modifier mask, and user data
 typedef int (*keyboard_key_cb_t)(xkb_keysym_t keysym, uint32_t mask, void *userdata);
+
+// Forward declaration of view struct
 struct qw_view;
+
+// Callbacks for managing views
 typedef void (*unmanage_view_cb_t)(struct qw_view *view, void *userdata);
 typedef void (*manage_view_cb_t)(struct qw_view *view, void *userdata);
+
+// Cursor motion event callback: relative x, y and user data
 typedef void (*cursor_motion_cb_t)(int x, int y, void *userdata);
+
+// Cursor button event callback: button, modifiers, pressed state, position, user data
 typedef int (*cursor_button_cb_t)(int button, uint32_t mask, bool pressed, int x, int y,
                                   void *userdata);
+
+// Output dimensions callback: x, y, width, height of output
 typedef void (*output_dims_cb_t)(int x, int y, int width, int height);
+
+// Callback for when screen configuration changes
 typedef void (*on_screen_change_cb_t)(void *userdata);
 
+// Main server struct containing Wayland and wlroots state and user callbacks
 struct qw_server {
+    // Public API
     const char *socket;
     keyboard_key_cb_t keyboard_key_cb;
     manage_view_cb_t manage_view_cb;
@@ -81,13 +98,32 @@ struct qw_server {
     struct wl_listener request_cursor;
 };
 
+// Utility functions exposed by the server API
+
+// Get symbolic key name string from a key code
 const char *qw_server_get_sym_from_code(struct qw_server *server, int code);
+
+// Poll for server events (non-blocking)
 void qw_server_poll(struct qw_server *server);
+
+// Clean up and free server resources
 void qw_server_finalize(struct qw_server *server);
+
+// Start the server event loop (blocking)
 void qw_server_start(struct qw_server *server);
+
+// Get file descriptor of the event loop (for integration with other event loops)
 int qw_server_get_event_loop_fd(struct qw_server *server);
+
+// Iterate over outputs and call the provided callback with their geometry
 void qw_server_loop_output_dims(struct qw_server *server, output_dims_cb_t cb);
+
+// Create and initialize a new server instance (allocates memory)
 struct qw_server *qw_server_create();
+
+// Find the view at a given layout coordinate (lx, ly)
+// If a surface pointer is provided, it will be set to the surface under the point
+// sx and sy are surface-local coordinates of the point
 struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly,
                                   struct wlr_surface **surface, double *sx, double *sy);
 

--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -3,30 +3,35 @@
 #include <wlr/types/wlr_keyboard.h>
 
 int qw_util_get_button_code(uint32_t button) {
-    // from linux/input-event-codes.h
+    // Array of Linux input event button codes (from linux/input-event-codes.h)
+    // These codes represent mouse buttons and scroll events
     uint32_t mappings[] = {
-        // BTN_LEFT
+        // BTN_LEFT (left mouse button)
         0x110,
-        // BTN_MIDDLE
+        // BTN_MIDDLE (middle mouse button)
         0x112,
-        // BTN_RIGHT
+        // BTN_RIGHT (right mouse button)
         0x111,
         BUTTON_SCROLL_UP,
         BUTTON_SCROLL_DOWN,
         BUTTON_SCROLL_LEFT,
         BUTTON_SCROLL_RIGHT,
-        // BTN_SIDE
+        // BTN_SIDE (side mouse button)
         0x113,
-        // BTN_EXTRA
+        // BTN_EXTRA (extra mouse button)
         0x114,
     };
-    // we don't use size_t as we're returning an int too
+
+    // Calculate the number of elements in the mappings array
     int n = sizeof(mappings) / sizeof(mappings[0]);
+
     for (int i = 0; i < n; ++i) {
         if (button == mappings[i]) {
+            // Return the 1-based index of the button mapping
             return i + 1;
         }
     }
+
     return 0;
 }
 
@@ -36,6 +41,7 @@ int qw_util_get_modifier_code(const char *codestr) {
         enum wlr_keyboard_modifier mod;
     };
 
+    // Mapping from modifier key names to Wayland keyboard modifier enums
     // clang-format off
     struct code_mapping mappings[] = {
         {"shift", WLR_MODIFIER_SHIFT},
@@ -47,9 +53,11 @@ int qw_util_get_modifier_code(const char *codestr) {
         {"mod4", WLR_MODIFIER_LOGO},
         {"mod5", WLR_MODIFIER_MOD5}
     };
-    // clang-format on
+    //clang-format on
 
     size_t n = sizeof(mappings) / sizeof(mappings[0]);
+
+    // Search for the modifier name matching the input string
     for (size_t i = 0; i < n; ++i) {
         if (strcmp(codestr, mappings[i].name) == 0) {
             return mappings[i].mod;

--- a/libqtile/backend/wayland/qw/util.h
+++ b/libqtile/backend/wayland/qw/util.h
@@ -3,7 +3,9 @@
 
 #include <stdint.h>
 
-// The base is 0x299 defined at linux/input-event-codes.h
+// Enum defining button codes for scroll events.
+// These values start from 0x300 and correspond to Linux input-event-codes.h.
+// They represent scroll wheel directions for mouse input.
 enum BUTTON_SCROLL {
     BUTTON_SCROLL_UP = 0x300,
     BUTTON_SCROLL_DOWN = 0x301,
@@ -11,7 +13,12 @@ enum BUTTON_SCROLL {
     BUTTON_SCROLL_RIGHT = 0x303,
 };
 
+// Function to convert a raw button code into a simplified button ID.
+// Returns an int representing the button index (1-based), or 0 if unknown.
 int qw_util_get_button_code(uint32_t button);
+
+// Function to convert a modifier key string name into the corresponding
+// wlr_keyboard_modifier enum value. Returns -1 if the modifier name is unknown.
 int qw_util_get_modifier_code(const char *codestr);
 
 #endif /* UTIL_H */

--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <wlr/util/log.h>
 
+// Frees all border rectangles and their associated scene nodes of the view.
+// Checks if borders exist, then destroys each of the 4 border scene nodes per border set.
+// Finally frees the allocated borders array.
 void qw_view_cleanup_borders(struct qw_view *view) {
     if (!view->borders) {
         return;
@@ -14,24 +17,32 @@ void qw_view_cleanup_borders(struct qw_view *view) {
     free(view->borders);
 }
 
+// Creates and paints multiple border layers around the view content.
+// colors: array of RGBA colors for each border layer (each is 4 floats).
+// width: total border width in pixels.
+// n: number of border layers to draw.
 void qw_view_paint_borders(struct qw_view *view, float (*colors)[4], int width, int n) {
     struct wlr_scene_node *tree_node = view->get_tree_node(view);
     if (!tree_node || !view->content_tree) {
         return;
     }
     qw_view_cleanup_borders(view);
+
     view->bn = n;
     view->borders = malloc(n * sizeof(struct wlr_scene_rect[4]));
     if (!view->borders) {
         wlr_log(WLR_ERROR, "failed to allocate memory for borders");
         return;
     }
+
+    // Offset the view's tree node by the border width so content appears centered inside borders
     wlr_scene_node_set_position(tree_node, width, width);
 
     int outer_w = view->width + width * 2;
     int outer_h = view->height + width * 2;
-    int coord = 0;
+    int coord = 0; // Keeps track of cumulative offset for layering borders
 
+    // Helper struct to define rectangle parameters for each border side
     struct border_pairs {
         int x;
         int y;
@@ -40,26 +51,30 @@ void qw_view_paint_borders(struct qw_view *view, float (*colors)[4], int width, 
     };
 
     for (int i = 0; i < n; i++) {
-        // set the current border width to equal parts of the total width
-        // and distribute the remainder
+        // Divide the total border width into equal parts for each border layer
+        // Add leftover pixels to the first few layers to sum to total width
         int bw = (int)(width / n) + (int)(i < (width % n));
-        // let's keep it readable
-        // clang format makes a giant mess here
+
         // clang-format off
         struct border_pairs pairs[4] = {
-            { .x = coord, .y = coord, .w = outer_w - coord * 2, .h = bw },
-            { .x = outer_w - bw - coord, .y = bw + coord, .w = bw, .h = outer_h - bw * 2 - coord * 2 },
-            { .x = coord, .y = outer_h - bw - coord, .w = outer_w - coord * 2, .h = bw },
-            { .x = coord, .y = bw + coord, .w = bw, .h = outer_h - bw * 2 - coord * 2 },
+            { .x = coord, .y = coord, .w = outer_w - coord * 2, .h = bw },                          // top border
+            { .x = outer_w - bw - coord, .y = bw + coord, .w = bw, .h = outer_h - bw * 2 - coord * 2 },  // right border
+            { .x = coord, .y = outer_h - bw - coord, .w = outer_w - coord * 2, .h = bw },          // bottom border
+            { .x = coord, .y = bw + coord, .w = bw, .h = outer_h - bw * 2 - coord * 2 },          // left border
         };
         // clang-format on
+
+        // Create rectangles and position them according to pairs
         for (int j = 0; j < 4; j++) {
             view->borders[i][j] =
                 wlr_scene_rect_create(view->content_tree, pairs[j].w, pairs[j].h, colors[i]);
             wlr_scene_node_set_position(&view->borders[i][j]->node, pairs[j].x, pairs[j].y);
         }
+
+        // Increase the offset for the next inner border layer
         coord += bw;
     }
 
+    // Ensure the tree node is painted above other nodes
     wlr_scene_node_raise_to_top(tree_node);
 }

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -4,8 +4,8 @@
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_scene.h>
 
-// pretty much a copy of backend/base/window.py
 // TODO: avoid this duplication
+// View states representing window states, similar to backend/base/window.py
 enum qw_view_state {
     NOT_FLOATING = 1,
     FLOATING = 2,
@@ -15,7 +15,10 @@ enum qw_view_state {
     MINIMIZED = 6,
 };
 
+// Callback type for fullscreen request (true = enter fullscreen, false = exit)
 typedef int (*request_fullscreen_cb_t)(bool fullscreen, void *userdata);
+
+// Callback type for maximize request (true = maximize, false = unmaximize)
 typedef int (*request_maximize_cb_t)(bool maximize, void *userdata);
 
 struct qw_view {
@@ -23,14 +26,16 @@ struct qw_view {
     int y;
     int width;
     int height;
-    int bn;
+    int bn; // Number of border layers
     enum qw_view_state state;
-    int wid;
-    struct wlr_scene_tree *content_tree;
+    int wid;                             // Window identifier (e.g. X11 window id or similar)
+    struct wlr_scene_tree *content_tree; // Scene tree holding the view's content
+
     request_maximize_cb_t request_maximize_cb;
     request_fullscreen_cb_t request_fullscreen_cb;
-    void *cb_data;
+    void *cb_data; // User data passed to callbacks
 
+    // Methods, implemented as function pointers
     struct wlr_scene_node *(*get_tree_node)(void *self);
     void (*update_fullscreen)(void *self, bool fullscreen);
     void (*update_maximized)(void *self, bool maximize);
@@ -43,12 +48,14 @@ struct qw_view {
     void (*unhide)(void *self);
     int (*get_pid)(void *self);
 
-    // private data
+    // Private data: pointer to an array of 4 pointers to wlr_scene_rect for borders
     struct wlr_scene_rect *(*borders)[4];
 };
 
+// Free all border rectangles and clear border data
 void qw_view_cleanup_borders(struct qw_view *xdg_view);
 
+// Create and paint borders with specified colors, border width, and number of layers
 void qw_view_paint_borders(struct qw_view *xdg_view, float (*colors)[4], int width, int n);
 
 #endif /* VIEW_H */

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -1,20 +1,25 @@
+#include "xdg-view.h"
 #include "server.h"
 #include "view.h"
 #include "wlr/types/wlr_xdg_decoration_v1.h"
 #include "xdg-shell-protocol.h"
-#include "xdg-view.h"
 #include <stdlib.h>
 
+// Focus the given xdg_view's surface, managing activation and keyboard focus
 static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surface *surface) {
     if (!xdg_view) {
         return;
     }
+
     struct qw_server *server = xdg_view->server;
     struct wlr_seat *seat = server->seat;
     struct wlr_surface *prev_surface = seat->keyboard_state.focused_surface;
+
     if (prev_surface == surface) {
         return;
     }
+
+    // Deactivate previous toplevel if any
     if (prev_surface) {
         struct wlr_xdg_toplevel *prev_toplevel =
             wlr_xdg_toplevel_try_from_wlr_surface(prev_surface);
@@ -22,9 +27,13 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
             wlr_xdg_toplevel_set_activated(prev_toplevel, false);
         }
     }
-    struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
+
     wlr_scene_node_raise_to_top(&xdg_view->base.content_tree->node);
+
     wlr_xdg_toplevel_set_activated(xdg_view->xdg_toplevel, true);
+
+    // Notify keyboard about entering this surface (for keyboard input)
+    struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
     if (keyboard) {
         wlr_seat_keyboard_notify_enter(seat, xdg_view->xdg_toplevel->base->surface,
                                        keyboard->keycodes, keyboard->num_keycodes,
@@ -32,6 +41,7 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
     }
 }
 
+// Handle the unmap event for the xdg_view (when it's hidden/unmapped)
 static void qw_xdg_view_handle_unmap(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, unmap);
     qw_view_cleanup_borders((struct qw_view *)xdg_view);
@@ -39,6 +49,7 @@ static void qw_xdg_view_handle_unmap(struct wl_listener *listener, void *data) {
                                        xdg_view->server->cb_data);
 }
 
+// Handle the destroy event of the xdg_view (cleanup and free memory)
 static void qw_xdg_view_handle_destroy(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, destroy);
 
@@ -48,28 +59,35 @@ static void qw_xdg_view_handle_destroy(struct wl_listener *listener, void *data)
     wl_list_remove(&xdg_view->destroy.link);
     wl_list_remove(&xdg_view->request_maximize.link);
     wl_list_remove(&xdg_view->request_fullscreen.link);
-    // TODO wl_list_remove request_{move,resize}
+    // TODO: Remove request_move and request_resize listeners if added
+
     free(xdg_view);
 }
 
+// Handle map event: when the xdg_view becomes visible/mapped
 static void qw_xdg_view_handle_map(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, map);
     xdg_view->mapped = true;
 
+    // Focus the view upon mapping
     qw_xdg_view_do_focus(xdg_view, xdg_view->xdg_toplevel->base->surface);
 
+    // If the protocol version supports tiled state, set tiled on all edges
     if (wl_resource_get_version(xdg_view->xdg_toplevel->resource) >=
         XDG_TOPLEVEL_STATE_TILED_RIGHT_SINCE_VERSION) {
         wlr_xdg_toplevel_set_tiled(xdg_view->xdg_toplevel,
                                    WLR_EDGE_TOP | WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT);
     } else {
+        // Otherwise maximize as fallback for older clients
         wlr_xdg_toplevel_set_maximized(xdg_view->xdg_toplevel, true);
     }
 }
 
+// Handle commit event: called when surface commits state changes
 static void qw_xdg_view_handle_commit(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, commit);
 
+    // On initial commit, set size and notify server to manage this view
     if (xdg_view->xdg_toplevel->base->initial_commit) {
         wlr_xdg_toplevel_set_size(xdg_view->xdg_toplevel, 0, 0);
         xdg_view->server->manage_view_cb((struct qw_view *)&xdg_view->base,
@@ -77,12 +95,15 @@ static void qw_xdg_view_handle_commit(struct wl_listener *listener, void *data) 
     }
 }
 
+// Bring the xdg_view's content scene node to the front
 static void qw_xdg_view_bring_to_front(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_scene_node_raise_to_top(&xdg_view->base.content_tree->node);
 }
 
+// Clip the xdg_view's scene tree if needed
 static void qw_xdg_view_clip(struct qw_xdg_view *xdg_view) {
+    // Only clip if scene_tree exists, node is disabled, and node is linked
     if (!xdg_view->scene_tree) {
         return;
     }
@@ -92,56 +113,82 @@ static void qw_xdg_view_clip(struct qw_xdg_view *xdg_view) {
     if (!xdg_view->scene_tree->node.link.next) {
         return;
     }
-    struct wlr_box clip = {.x = xdg_view->geom.x,
-                           .y = xdg_view->geom.y,
-                           .width = xdg_view->base.width,
-                           .height = xdg_view->base.height};
+
+    // clang-format off
+    struct wlr_box clip = {
+        .x = xdg_view->geom.x,
+        .y = xdg_view->geom.y,
+        .width = xdg_view->base.width,
+        .height = xdg_view->base.height
+    };
+    // clang-format on
+
+    // Apply clipping to subsurface tree
     wlr_scene_subsurface_tree_set_clip(&xdg_view->scene_tree->node, &clip);
 }
 
+// Place the xdg_view at given position and size with border and stacking info
 static void qw_xdg_view_place(void *self, int x, int y, int width, int height, int bw,
                               float (*bc)[4], int bn, int above) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     struct wlr_xdg_surface *surface = xdg_view->xdg_toplevel->base;
     struct wlr_xdg_toplevel_state state = xdg_view->xdg_toplevel->current;
+
+    // Check if placement or geometry changed
     bool place_changed = xdg_view->base.x != x || xdg_view->base.y != y ||
                          xdg_view->base.width != width || xdg_view->base.height != height ||
                          state.width != width || state.height != height;
+
     struct wlr_box geom = surface->geometry;
     bool geom_changed = xdg_view->geom.x != geom.x || xdg_view->geom.y != geom.y ||
                         xdg_view->geom.width != geom.width || xdg_view->geom.height != geom.height;
+
     bool needs_repos = place_changed || geom_changed;
+
+    // Update stored geometry and base view rectangle
     xdg_view->geom = geom;
     xdg_view->base.x = x;
     xdg_view->base.y = y;
     xdg_view->base.width = width;
     xdg_view->base.height = height;
 
+    // Set position of the content scene node
     wlr_scene_node_set_position(&xdg_view->base.content_tree->node, x, y);
+
     if (needs_repos) {
+        // Resize the toplevel surface and apply clipping if needed
         wlr_xdg_toplevel_set_size(xdg_view->xdg_toplevel, width, height);
         qw_xdg_view_clip(xdg_view);
     }
+
+    // Paint borders around the view with given border colors and width
     qw_view_paint_borders((struct qw_view *)xdg_view, bc, bw, bn);
+
+    // Raise view to front if requested
     if (above != 0) {
         qw_xdg_view_bring_to_front(self);
     }
 }
 
+// Send close event to the xdg_toplevel surface (kill the view)
 static void qw_xdg_view_kill(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_xdg_toplevel_send_close(xdg_view->xdg_toplevel);
 }
 
+// Hide the xdg_view (disable scene node and clear keyboard focus if needed)
 static void qw_xdg_view_hide(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_scene_node_set_enabled(&xdg_view->base.content_tree->node, false);
+
+    // Clear keyboard focus if this view was focused
     if (xdg_view->xdg_toplevel->base->surface ==
         xdg_view->server->seat->keyboard_state.focused_surface) {
         wlr_seat_keyboard_clear_focus(xdg_view->server->seat);
     }
 }
 
+// Unhide the xdg_view by enabling its content_tree scene node if currently disabled
 static void qw_xdg_view_unhide(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     if (!xdg_view->base.content_tree->node.enabled) {
@@ -149,14 +196,16 @@ static void qw_xdg_view_unhide(void *self) {
     }
 }
 
+// Focus the xdg_view if it is mapped (visible), calling internal focus helper
 void qw_xdg_view_focus(void *self, int above) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     if (!xdg_view->mapped) {
-        return;
+        return; // Can't focus if not mapped
     }
     qw_xdg_view_do_focus(xdg_view, xdg_view->xdg_toplevel->base->surface);
 }
 
+// Retrieve the PID of the client owning this xdg_view
 static int qw_xdg_view_get_pid(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     int pid;
@@ -164,24 +213,29 @@ static int qw_xdg_view_get_pid(void *self) {
     return pid;
 }
 
+// Handle a request from the client to maximize the window
 static void qw_xdg_view_handle_request_maximize(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, request_maximize);
     int handled = xdg_view->base.request_maximize_cb(xdg_view->xdg_toplevel->requested.maximized,
                                                      xdg_view->base.cb_data);
     if (!handled) {
+        // If not handled, fallback to scheduling configure to apply maximize
         wlr_xdg_surface_schedule_configure(xdg_view->xdg_toplevel->base);
     }
 }
 
+// Handle a request from the client to fullscreen the window
 static void qw_xdg_view_handle_request_fullscreen(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, request_fullscreen);
     int handled = xdg_view->base.request_fullscreen_cb(xdg_view->xdg_toplevel->requested.fullscreen,
                                                        xdg_view->base.cb_data);
     if (!handled) {
+        // Fallback configure if request not handled
         wlr_xdg_surface_schedule_configure(xdg_view->xdg_toplevel->base);
     }
 }
 
+// Handle client decoration mode requests, enforce server-side decorations
 static void qw_xdg_view_handle_decoration_request_mode(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, decoration_request_mode);
     if (xdg_view->xdg_toplevel->base->initialized)
@@ -189,6 +243,7 @@ static void qw_xdg_view_handle_decoration_request_mode(struct wl_listener *liste
                                                 WLR_XDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
 }
 
+// Cleanup listeners when decoration is destroyed to avoid dangling pointers
 static void qw_xdg_view_handle_decoration_destroy(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, decoration_destroy);
 
@@ -196,6 +251,7 @@ static void qw_xdg_view_handle_decoration_destroy(struct wl_listener *listener, 
     wl_list_remove(&xdg_view->decoration_request_mode.link);
 }
 
+// Initialize decoration handling for a new decoration object
 void qw_xdg_view_decoration_new(struct qw_xdg_view *xdg_view,
                                 struct wlr_xdg_toplevel_decoration_v1 *decoration) {
     xdg_view->decoration = decoration;
@@ -204,9 +260,11 @@ void qw_xdg_view_decoration_new(struct qw_xdg_view *xdg_view,
     xdg_view->decoration_destroy.notify = qw_xdg_view_handle_decoration_destroy;
     wl_signal_add(&decoration->events.destroy, &xdg_view->decoration_destroy);
 
+    // Immediately set decoration mode upon creation
     qw_xdg_view_handle_decoration_request_mode(&xdg_view->decoration_request_mode, decoration);
 }
 
+// Return the scene node for this view's scene tree, or NULL if none exists
 static struct wlr_scene_node *qw_xdg_view_get_tree_node(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     if (!xdg_view->scene_tree) {
@@ -215,39 +273,56 @@ static struct wlr_scene_node *qw_xdg_view_get_tree_node(void *self) {
     return &xdg_view->scene_tree->node;
 }
 
+// Update fullscreen state of the toplevel surface
 static void qw_xdg_view_update_fullscreen(void *self, bool fullscreen) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_xdg_toplevel_set_fullscreen(xdg_view->xdg_toplevel, fullscreen);
 }
 
+// Update maximized state of the toplevel surface
 static void qw_xdg_view_update_maximized(void *self, bool maximized) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_xdg_toplevel_set_maximized(xdg_view->xdg_toplevel, maximized);
 }
 
+// Create a new qw_xdg_view for a given wlr_xdg_toplevel, setting up scene tree, listeners, and
+// callbacks
 void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *xdg_toplevel) {
     struct qw_xdg_view *xdg_view = calloc(1, sizeof(*xdg_view));
     if (!xdg_view) {
         wlr_log(WLR_ERROR, "failed to create qw_xdg_view struct");
         return;
     }
+
     struct wlr_box geom = {.x = 0, .y = 0, .width = 0, .height = 0};
     xdg_view->geom = geom;
     xdg_view->server = server;
     xdg_view->xdg_toplevel = xdg_toplevel;
+
+    // Create a scene tree node for this view inside the server's main scene tree
     xdg_view->base.content_tree = wlr_scene_tree_create(&server->scene->tree);
+
+    // If the protocol version supports WM capabilities, set maximize/fullscreen/minimize
     if (wl_resource_get_version(xdg_view->xdg_toplevel->resource) >=
         XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION) {
-        wlr_xdg_toplevel_set_wm_capabilities(xdg_toplevel,
-                                             XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE |
-                                                 XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN |
-                                                 XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE);
+
+        // clang-format off
+        wlr_xdg_toplevel_set_wm_capabilities(
+            xdg_toplevel,
+            XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE |
+            XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN |
+            XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE
+        );
+        // clang-format on
     }
+
+    // Create scene node for the toplevel surface under the content tree
     xdg_view->scene_tree =
         wlr_scene_xdg_surface_create(xdg_view->base.content_tree, xdg_toplevel->base);
     xdg_view->scene_tree->node.data = xdg_view;
     xdg_toplevel->base->data = xdg_view;
 
+    // Assign function pointers for base view operations
     xdg_view->base.get_tree_node = qw_xdg_view_get_tree_node;
     xdg_view->base.update_fullscreen = qw_xdg_view_update_fullscreen;
     xdg_view->base.update_maximized = qw_xdg_view_update_maximized;
@@ -259,6 +334,7 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
     xdg_view->base.hide = qw_xdg_view_hide;
     xdg_view->base.unhide = qw_xdg_view_unhide;
 
+    // Add listeners for surface lifecycle events (map, unmap, commit)
     xdg_view->map.notify = qw_xdg_view_handle_map;
     wl_signal_add(&xdg_toplevel->base->surface->events.map, &xdg_view->map);
     xdg_view->unmap.notify = qw_xdg_view_handle_unmap;
@@ -266,8 +342,11 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
     xdg_view->commit.notify = qw_xdg_view_handle_commit;
     wl_signal_add(&xdg_toplevel->base->surface->events.commit, &xdg_view->commit);
 
+    // Add listener for toplevel destroy event
     xdg_view->destroy.notify = qw_xdg_view_handle_destroy;
     wl_signal_add(&xdg_toplevel->events.destroy, &xdg_view->destroy);
+
+    // Add listeners for maximize and fullscreen requests
     xdg_view->request_maximize.notify = qw_xdg_view_handle_request_maximize;
     wl_signal_add(&xdg_toplevel->events.request_maximize, &xdg_view->request_maximize);
     xdg_view->request_fullscreen.notify = qw_xdg_view_handle_request_fullscreen;

--- a/libqtile/backend/wayland/qw/xdg-view.h
+++ b/libqtile/backend/wayland/qw/xdg-view.h
@@ -1,36 +1,46 @@
 #ifndef XDG_VIEW_H
 #define XDG_VIEW_H
 
+// Include the generic view base struct and Wayland/WLRoots core and types
 #include "view.h"
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xdg_shell.h>
 
+// Forward declarations for server and decoration struct types
 struct qw_server;
 struct wlr_xdg_toplevel_decoration_v1;
 
+// Struct representing an XDG toplevel view in the compositor
 struct qw_xdg_view {
     struct qw_view base;
     struct qw_server *server;
     struct wlr_xdg_toplevel *xdg_toplevel;
     struct wlr_scene_tree *scene_tree;
     struct wlr_box geom;
+
+    // Listeners for Wayland events on the toplevel surface lifecycle and requests
     struct wl_listener map;
     struct wl_listener unmap;
     struct wl_listener commit;
     struct wl_listener destroy;
     struct wl_listener request_maximize;
     struct wl_listener request_fullscreen;
-    // TODO: request_{move,resize}
+    // TODO: add listeners for move and resize requests
+
+    // Listeners for client decoration protocol events
     struct wl_listener decoration_request_mode;
     struct wl_listener decoration_destroy;
     struct wlr_xdg_toplevel_decoration_v1 *decoration;
-    bool mapped;
+
+    bool mapped; // Is the view currently mapped (visible)?
 };
 
+// Initialize decoration handling for a new decoration object associated with this view
 void qw_xdg_view_decoration_new(struct qw_xdg_view *xdg_view,
                                 struct wlr_xdg_toplevel_decoration_v1 *deco);
 
+// Create and initialize a new qw_xdg_view wrapping the given wlr_xdg_toplevel
 void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *xdg_toplevel);
 
 #endif /* XDG_VIEW_H */


### PR DESCRIPTION
This PR includes several important improvements and cleanups to the `wayc` branch:

* **Fix Cairo surface pointer issue:**
  Resolved a bug where an invalid or improperly handled Cairo surface pointer could lead to graphical or memory-related issues during rendering.

* **Improve code clarity:**
  Added concise and meaningful comments throughout the codebase to aid future contributors and improve maintainability.

* **Development hygiene:**
  `.gitignore` updated to exclude `.ccls-cache/`, keeping the repo clean from local development artifacts.

* **Flake sync:**
  Revert removed cairo and wlroots path in `flake.nix`
