### PR TITLE
docs: move to recommending `uv`

### DIFF
--- a/docs/manual/howto/git.rst
+++ b/docs/manual/howto/git.rst
@@ -50,7 +50,7 @@ The numeric pull request id can be found in the url or next to the title
 
 .. note:: Having the feature branch checked out doesn't mean that it is
    installed and will be loaded when you restart qtile. You might still need to
-   install it with ``pip``.
+   install it with ``uv``.
 
 I committed changes and the tests failed
 ========================================

--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -99,15 +99,15 @@ With the dependencies in place, you can now install the stable version of qtile 
 
 .. code-block:: bash
 
-   pip install qtile
+   uv tool install qtile
 
 Or with sets of dependencies:
 
 .. code-block:: bash
 
-   pip install qtile[wayland]  # for Wayland dependencies
-   pip install qtile[widgets]  # for all widget dependencies
-   pip install qtile[all]      # for all dependencies
+   uv tool install qtile[wayland]  # for Wayland dependencies
+   uv tool install qtile[widgets]  # for all widget dependencies
+   uv tool install qtile[all]      # for all dependencies
 
 Or install qtile-git with:
 
@@ -115,8 +115,8 @@ Or install qtile-git with:
 
     git clone https://github.com/qtile/qtile.git
     cd qtile
-    pip install .
-    pip install --config-setting backend=wayland .  # adds wayland dependencies
+    uv tool install .
+    uv tool install --reinstall .[wayland]  # reinstall with wayland deps
 
 .. _starting-qtile:
 

--- a/docs/manual/install/ubuntu.rst
+++ b/docs/manual/install/ubuntu.rst
@@ -21,7 +21,9 @@ required:
 
    sudo apt install xserver-xorg xinit
    sudo apt install libpangocairo-1.0-0
-   sudo apt install python3-pip python3-xcffib python3-cairocffi
+   sudo apt install uv  # if your distro doesn't have uv, try:
+   # curl -LsSf https://astral.sh/uv/install.sh | sh
+
 
 
 Either Qtile can then be downloaded from the package index or the Github 
@@ -29,4 +31,4 @@ repository can be used, see :ref:`installing-from-source`:
 
 .. code-block:: bash
 
-   pip install qtile
+   uv tool install qtile


### PR DESCRIPTION
I have been using uv for a while, and it's great. It is much cleaner than managing venvs, passing --break-system-packages, or whatever other hacks people have been doing. We should recommend people use it.

Fixes #5294