### PR TITLE
New widget CurrentLayoutIconOrText

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
+      - Add new widget CurrentLayoutIconOrText
     * bugfixes
 
 Qtile 0.32.0, released 2025-06-09:

--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -42,6 +42,7 @@ widgets = {
     "CryptoTicker": "crypto_ticker",
     "CurrentLayout": "currentlayout",
     "CurrentLayoutIcon": "currentlayout",
+    "CurrentLayoutIconOrText": "currentlayout",
     "CurrentScreen": "currentscreen",
     "DF": "df",
     "DoNotDisturb": "do_not_disturb",

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -222,3 +222,48 @@ class CurrentLayoutIcon(CurrentLayout):
             self.surfaces[layout_name] = img
 
         self.icons_loaded = True
+
+
+class CurrentLayoutIconOrText(CurrentLayoutIcon):
+    """
+    Either display the icon of the current layout or its name, imagine switching
+    between CurrentLayout and CurrentLayoutIcon with a click.
+    """
+
+    defaults = [
+        ("draw_icon_first", True, "Should draw icon or text when bar is initialized."),
+    ]
+
+    def __init__(self, **config):
+        super().__init__(**config)
+        self.add_defaults(CurrentLayoutIconOrText.defaults)
+
+    def _configure(self, qtile, bar):
+        super()._configure(qtile, bar)
+        self.image_length = self.length
+
+        self.add_callbacks(
+            {
+                "Button3": self.change_draw_method,
+            }
+        )
+
+    def change_draw_method(self):
+        self.draw_icon_first = not self.draw_icon_first
+        self.draw()
+        self.bar.draw()
+
+    def hook_response(self, layout, group):
+        if group.screen is not None and group.screen == self.bar.screen:
+            self.current_layout = layout.name
+            self.draw()
+            self.bar.draw()
+
+    def draw(self):
+        if self.draw_icon_first:
+            self.length = self.image_length
+            super().draw()
+        else:
+            self.text = self.current_layout
+            self.length = super().calculate_length()
+            base._TextBox.draw(self)

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -61,9 +61,15 @@ class CurrentLayout(base._TextBox):
             self.bar.draw()
 
     def setup_hooks(self):
+        """
+        Listens for layout change and performs a redraw when it occurs.
+        """
         hook.subscribe.layout_change(self.hook_response)
 
     def remove_hooks(self):
+        """
+        Listens for layout change and performs a redraw when it occurs.
+        """
         hook.unsubscribe.layout_change(self.hook_response)
 
     def finalize(self):
@@ -71,7 +77,7 @@ class CurrentLayout(base._TextBox):
         base._TextBox.finalize(self)
 
 
-class CurrentLayoutIcon(base._TextBox):
+class CurrentLayoutIcon(CurrentLayout):
     """
     Display the icon representing the current layout of the
     current group of the screen on which the bar containing the widget is.
@@ -115,40 +121,18 @@ class CurrentLayoutIcon(base._TextBox):
         self.length = 0
 
     def _configure(self, qtile, bar):
-        base._TextBox._configure(self, qtile, bar)
-        layout_id = self.bar.screen.group.current_layout
-        self.text = self.bar.screen.group.layouts[layout_id].name
+        super()._configure(qtile, bar)
         self.current_layout = self.text
         self.icons_loaded = False
         self.icon_paths = []
         self.surfaces = {}
         self._update_icon_paths()
         self._setup_images()
-        self._setup_hooks()
-
-        self.add_callbacks(
-            {
-                "Button1": qtile.next_layout,
-                "Button2": qtile.prev_layout,
-            }
-        )
 
     def hook_response(self, layout, group):
         if group.screen is not None and group.screen == self.bar.screen:
             self.current_layout = layout.name
             self.bar.draw()
-
-    def _setup_hooks(self):
-        """
-        Listens for layout change and performs a redraw when it occurs.
-        """
-        hook.subscribe.layout_change(self.hook_response)
-
-    def _remove_hooks(self):
-        """
-        Listens for layout change and performs a redraw when it occurs.
-        """
-        hook.unsubscribe.layout_change(self.hook_response)
 
     def draw(self):
         if self.icons_loaded:
@@ -238,7 +222,3 @@ class CurrentLayoutIcon(base._TextBox):
             self.surfaces[layout_name] = img
 
         self.icons_loaded = True
-
-    def finalize(self):
-        self._remove_hooks()
-        base._TextBox.finalize(self)

--- a/test/widgets/test_currentlayout.py
+++ b/test/widgets/test_currentlayout.py
@@ -1,0 +1,115 @@
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Widget specific tests
+
+import libqtile.bar
+import libqtile.config
+import libqtile.confreader
+import libqtile.layout
+from libqtile import widget
+
+
+def get_widget_config(_widget, config):
+    config.screens = [
+        libqtile.config.Screen(top=libqtile.bar.Bar([_widget], 10)),
+    ]
+    config.layouts = [
+        libqtile.layout.Columns(),
+        libqtile.layout.Max(),
+        libqtile.layout.Stack(),
+    ]
+    return config
+
+
+def test_current_layout(manager_nospawn, minimal_conf_noscreen):
+    config = get_widget_config(widget.CurrentLayout(), minimal_conf_noscreen)
+    manager_nospawn.start(config)
+    topbar = manager_nospawn.c.bar["top"]
+
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "columns"
+
+    manager_nospawn.c.next_layout()
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "max"
+
+    manager_nospawn.c.prev_layout()
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "columns"
+
+    topbar.fake_button_press(0, 0, button=1)
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "max"
+
+    topbar.fake_button_press(0, 0, button=2)
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "columns"
+
+    manager_nospawn.c.screen.next_group()
+    manager_nospawn.c.to_layout_index(-1)
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "stack"
+
+    manager_nospawn.c.screen.prev_group()
+    layout = topbar.info()["widgets"][0]["text"]
+    assert layout == "columns"
+
+
+def test_current_layout_icon(manager_nospawn, minimal_conf_noscreen):
+    config = get_widget_config(widget.CurrentLayoutIcon(), minimal_conf_noscreen)
+    manager_nospawn.start(config)
+    topbar = manager_nospawn.c.bar["top"]
+
+    icons = int(topbar.eval("len(self.widgets[0].surfaces)")[1])
+    assert icons == 3
+
+    length = int(topbar.eval("self.widgets[0].length")[1])
+    assert length != 0
+
+
+def test_current_layout_draw_icon_first(manager_nospawn, minimal_conf_noscreen):
+    config = get_widget_config(
+        widget.CurrentLayoutIconOrText(draw_icon_first=True), minimal_conf_noscreen
+    )
+    manager_nospawn.start(config)
+    topbar = manager_nospawn.c.bar["top"]
+    image_length = int(topbar.eval("self.widgets[0].image_length")[1])
+
+    length = int(topbar.eval("self.widgets[0].length")[1])
+    assert length == image_length
+
+    topbar.fake_button_press(0, 0, button=3)
+    length = int(topbar.eval("self.widgets[0].length")[1])
+    assert length != image_length
+
+    topbar.fake_button_press(0, 0, button=3)
+    length = int(topbar.eval("self.widgets[0].length")[1])
+    assert length == image_length
+
+
+def test_current_layout_draw_text_first(manager_nospawn, minimal_conf_noscreen):
+    config = get_widget_config(
+        widget.CurrentLayoutIconOrText(draw_icon_first=False), minimal_conf_noscreen
+    )
+    manager_nospawn.start(config)
+    topbar = manager_nospawn.c.bar["top"]
+    image_length = int(topbar.eval("self.widgets[0].image_length")[1])
+
+    length = int(topbar.eval("self.widgets[0].length")[1])
+    assert length != image_length


### PR DESCRIPTION
Either display the icon of the current layout or its name, imagine switching between `CurrentLayout` and `CurrentLayoutIcon` with a click.

I like to have the icon displayed with the `CurrentLayoutIcon` widget in my bar but sometimes I forget what the icon meant, and I end up adding the `CurrentLayout`. This would save space in the bar since I can have only display the icon and when I'd like to know more then simply right-click and I will get the current layout name.