### PR TITLE
rework logging path handling

### DIFF
--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -85,9 +85,6 @@ def get_default_log() -> Path:
         data_directory = os.path.expanduser("~/.local/share")
 
     qtile_directory = Path(data_directory) / "qtile"
-    if not qtile_directory.exists():
-        qtile_directory.mkdir(parents=True)
-
     return qtile_directory / "qtile.log"
 
 
@@ -111,6 +108,13 @@ def init_log(
 
     else:
         # Otherwise during normal usage, log to file.
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except PermissionError as e:
+            # ok, only one place to write: stderr
+            print(f"couldn't mkdir {log_path.parent}: {e}", file=sys.stderr)
+            os._exit(1)
+
         handler = RotatingFileHandler(
             log_path,
             maxBytes=log_size,

--- a/libqtile/scripts/main.py
+++ b/libqtile/scripts/main.py
@@ -26,14 +26,6 @@ except PackageNotFoundError:
     VERSION = "dev"
 
 
-def check_folder(value):
-    path = Path(value)
-    if not path.parent.is_dir():
-        raise argparse.ArgumentTypeError("Log path destination folder does not exist.")
-    # init_log expects a Path object so return `path` not `value`
-    return path
-
-
 def main():
     parent_parser = argparse.ArgumentParser(add_help=False)
     parent_parser.add_argument(
@@ -50,7 +42,7 @@ def main():
         "--log-path",
         default=get_default_log(),
         dest="log_path",
-        type=check_folder,
+        type=Path,
         help="Set alternative qtile log path",
     )
     main_parser = argparse.ArgumentParser(


### PR DESCRIPTION
1. do not unconditionally mkdir the default log path, even if people have specified a different one
2. do allow people to specify a path that doesn't exist, we can just create the directories for them

Fixes #5286