### PR TITLE
nix: remove qtile-extras overlay

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -28,13 +28,6 @@ self: final: prev: {
           }
         )).override
           { wlroots = prev.wlroots_0_17; };
-
-      qtile-extras = pprev.qtile-extras.overridePythonAttrs (oldAttrs: {
-        # disable currentlayouticon test for https://github.com/qtile/qtile/pull/5302
-        disabledTestPaths = oldAttrs.disabledTestPaths ++ [
-          "test/widget/test_currentlayouticon.py"
-        ];
-      });
     })
   ];
   python3 =


### PR DESCRIPTION
This PR removes the `qtile-extras` overlay that was previously used to disable the `test_currentlayouticon` test for [qtile/qtile#5302](https://github.com/qtile/qtile/pull/5302).

**Reason:**
The overlay is no longer necessary once [Nixpkgs#421427](https://nixpk.gs/pr-tracker.html?pr=421427) is merged and reaches `nixos-unstable`.
> Note: After that point, we should avoid modifying `qtile-extras` in this repository altogether.

**Do not merge this PR until** [Nixpkgs#421427](https://nixpk.gs/pr-tracker.html?pr=421427) has landed in `nixos-unstable`.