### PR TITLE
x11: don't ignore powered off monitors

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -408,9 +408,7 @@ class RandR:
         for output in self.ext.GetScreenResources(root).reply().outputs:
             info = self.ext.GetOutputInfo(output, xcffib.CurrentTime).reply()
 
-            # ignore disconnected monitors
-            if info.connection != xcffib.randr.Connection.Connected:
-                continue
+            # ignore outputs with no monitor plugged in
             if not info.crtc:
                 continue
 


### PR DESCRIPTION
we recently switched to defaulting to xrandr backends, which now correctly identifies when some attached monitors are powered off, vs xinerama which did not. However, some of our bar drawing logic does not correctly reason about when to re-draw the bar when this happens, resulting in visual bugs (and missing bars).

Let's revert to the same behavior as xinerama for the time being, until we find and fix the visual bar bugs.

Fixes #5303