### PR TITLE
[wayc] Fix geometry for outputs during tests

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -158,6 +158,9 @@ class Core(base.Core):
         self.qw.cursor_motion_cb = lib.cursor_motion_cb
         self.qw.cursor_button_cb = lib.cursor_button_cb
         self.qw.on_screen_change_cb = lib.on_screen_change_cb
+        # During tests, we want to fix the geometry of the 1 or 2 outputs
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            lib.qw_server_enable_test_env(self.qw)
         lib.qw_server_start(self.qw)
 
     def new_wid(self) -> int:

--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -52,9 +52,18 @@ void qw_server_output_new(struct qw_server *server, struct wlr_output *wlr_outpu
     wlr_output_state_init(&state);
     wlr_output_state_set_enabled(&state, true);
 
-    struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
-    if (mode) {
-        wlr_output_state_set_mode(&state, mode);
+    if (server->test_env) {
+        if (server->output_count == 0) {
+            wlr_output_state_set_custom_mode(&state, 800, 600, 0);
+        }
+        else {
+            wlr_output_state_set_custom_mode(&state, 640, 480, 0);
+        }
+    } else {
+        struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
+        if (mode) {
+            wlr_output_state_set_mode(&state, mode);
+        }
     }
 
     wlr_output_commit_state(wlr_output, &state);
@@ -74,7 +83,11 @@ void qw_server_output_new(struct qw_server *server, struct wlr_output *wlr_outpu
     output->destroy.notify = qw_output_handle_destroy;
     wl_signal_add(&wlr_output->events.destroy, &output->destroy);
 
-    wl_list_insert(&server->outputs, &output->link);
+    // Insert output at end of list
+    wl_list_insert(server->outputs.prev, &output->link);
+    if (server->test_env) {
+        server->output_count++;
+    }
 
     // Add the output to the output layout automatically and to the scene layout
     struct wlr_output_layout_output *l_output =

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -244,6 +244,10 @@ struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly
     return tree->node.data;
 }
 
+void qw_server_enable_test_env(struct qw_server *server) {
+    server->test_env = true;
+}
+
 // Create and initialize the server object with all components and listeners.
 struct qw_server *qw_server_create() {
     wlr_log_init(WLR_INFO, NULL);

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -70,6 +70,8 @@ struct qw_server {
     cursor_button_cb_t cursor_button_cb;
     on_screen_change_cb_t on_screen_change_cb;
     void *cb_data;
+    bool test_env;
+    int output_count;
 
     // Private data
     struct wl_event_loop *event_loop;
@@ -126,5 +128,8 @@ struct qw_server *qw_server_create();
 // sx and sy are surface-local coordinates of the point
 struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly,
                                   struct wlr_surface **surface, double *sx, double *sy);
+
+// Fix the geometry of outputs 1 and 2 during tests
+void qw_server_enable_test_env(struct qw_server *server);
 
 #endif /* SERVER_H */


### PR DESCRIPTION
Call a qw_server function to set test_env flag

Count as outputs are added and set custom modes:
- Output 1: 800 x 600
- Output 2: 640 x 480

Related test: test/test_manager.py > test_screen_dim (but requires working Window.info())

Also changed insertion order of wl_list server->outputs, so they are iterated in order added