### PR TITLE
Remove setter proxies to self.layout attributes

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -404,8 +404,8 @@ class TextLayout:
             try:
                 attrlist, value, accel_char = pangocffi.parse_markup(value)
                 self.layout.set_attributes(attrlist)
-            except pangocffi.BadMarkup:
-                logger.warning("parse_markup() failed for {value}")
+            except pangocffi.BadMarkup as e:
+                logger.warning(e)
         self.layout.set_text(utils.scrub_to_utf8(value))
 
     @property

--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -376,8 +376,7 @@ class TextLayout:
         layout.set_alignment(pangocffi.ALIGN_CENTER)
         if not wrap:  # pango wraps by default
             layout.set_ellipsize(pangocffi.ELLIPSIZE_END)
-        desc = pangocffi.FontDescription.from_string(font_family)
-        desc.set_absolute_size(pangocffi.units_from_double(float(font_size)))
+        desc = pangocffi.FontDescription.from_string(f"{font_family} {font_size}px")
         layout.set_font_description(desc)
         self.font_shadow = font_shadow
         self.layout = layout
@@ -446,12 +445,11 @@ class TextLayout:
     @property
     def font_size(self):
         d = self.fontdescription()
-        return d.get_size()
+        return pangocffi.units_to_double(int(d.get_size()))
 
     @font_size.setter
     def font_size(self, size):
         d = self.fontdescription()
-        d.set_size(size)
         d.set_absolute_size(pangocffi.units_from_double(size))
         self.layout.set_font_description(d)
 

--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -419,8 +419,7 @@ class TextLayout:
         self._width = value
         self.layout.set_width(pangocffi.units_from_double(value))
 
-    @width.deleter
-    def width(self):
+    def reset_width(self):
         self._width = None
         self.layout.set_width(-1)
 

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -231,7 +231,7 @@ class Section(TreeNode):
         self.title = title
 
     def draw(self, layout, top, level=0):
-        del layout._layout.width  # no centering
+        layout._layout.reset_width()  # no centering
         # draw a horizontal line above the section
         layout._drawer.draw_hbar(layout.section_fg, 0, layout.panel_width, top, linewidth=1)
         # draw the section title

--- a/libqtile/pango_ffi.py
+++ b/libqtile/pango_ffi.py
@@ -48,6 +48,8 @@ pango_ffi.cdef(
 
     int
     pango_units_from_double (double d);
+    double
+    pango_units_to_double (int i);
 
     typedef void* gpointer;
     typedef int gboolean;

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -71,6 +71,7 @@ def patch_cairo_context(cairo_t):
 ALIGN_CENTER = pango.PANGO_ALIGN_CENTER
 ELLIPSIZE_END = pango.PANGO_ELLIPSIZE_END
 units_from_double = pango.pango_units_from_double
+units_to_double = pango.pango_units_to_double
 
 
 ALIGNMENTS = {

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -178,12 +178,14 @@ def parse_markup(value, accel_marker=0):
     attr_list = ffi.new("PangoAttrList**")
     text = ffi.new("char**")
     error = ffi.new("GError**")
-    value = value.encode()
+    markup_text = value.encode()
 
-    ret = pango.pango_parse_markup(value, -1, accel_marker, attr_list, text, ffi.NULL, error)
+    ret = pango.pango_parse_markup(
+        markup_text, -1, accel_marker, attr_list, text, ffi.NULL, error
+    )
 
     if ret == 0:
-        raise BadMarkup(f"parse_markup() failed for {value}")
+        raise BadMarkup(f"parse_markup() failed for: {value}")
 
     return attr_list[0], ffi.string(text[0]), chr(accel_marker)
 

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -46,7 +46,7 @@ class Popup(configurable.Configurable):
         ("border", "#111111", "Border colour."),
         ("border_width", 0, "Line width of drawn borders."),
         ("font", "sans", "Font used in notifications."),
-        ("font_size", 14, "Size of font."),
+        ("fontsize", 14, "Size of font."),
         ("fontshadow", None, "Colour for text shadows, or None for no shadows."),
         ("horizontal_padding", 0, "Padding at sides of text."),
         ("vertical_padding", 0, "Padding at top and bottom of text."),
@@ -80,7 +80,7 @@ class Popup(configurable.Configurable):
             text="",
             colour=self.foreground,
             font_family=self.font,
-            font_size=self.font_size,
+            font_size=self.fontsize,
             font_shadow=self.fontshadow,
             wrap=self.wrap,
             markup=True,
@@ -114,24 +114,6 @@ class Popup(configurable.Configurable):
     def height(self, value: int) -> None:
         self.win.height = value
         self.drawer.height = value
-
-    @property
-    def text(self) -> str:
-        return self.layout.text
-
-    @text.setter
-    def text(self, value: str) -> None:
-        self.layout.text = value
-
-    @property
-    def foreground(self) -> ColorType:
-        return self._foreground
-
-    @foreground.setter
-    def foreground(self, value: ColorType) -> None:
-        self._foreground = value
-        if hasattr(self, "layout"):
-            self.layout.colour = value
 
     def set_border(self, color: ColorType) -> None:
         self.win.paint_borders(color, self.border_width)

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -545,36 +545,6 @@ class _TextBox(_Widget):
         return self.fmt.format(self._text)
 
     @property
-    def foreground(self):
-        return self._foreground
-
-    @foreground.setter
-    def foreground(self, fg):
-        self._foreground = fg
-        if self.layout:
-            self.layout.colour = fg
-
-    @property
-    def font(self):
-        return self._font
-
-    @font.setter
-    def font(self, value):
-        self._font = value
-        if self.layout:
-            self.layout.font = value
-
-    @property
-    def fontshadow(self):
-        return self._fontshadow
-
-    @fontshadow.setter
-    def fontshadow(self, value):
-        self._fontshadow = value
-        if self.layout:
-            self.layout.font_shadow = value
-
-    @property
     def actual_padding(self):
         if self.padding is None:
             return self.fontsize // 2
@@ -777,12 +747,15 @@ class _TextBox(_Widget):
             self.fontsize = fontsize
         if fontshadow != "":
             self.fontshadow = fontshadow
+        if self.layout:
+            self.layout.font_family = self.font
+            self.layout.font_size = self.fontsize
+            self.layout.font_shadow = self.fontshadow
         self.bar.draw()
 
     @expose_command()
     def info(self):
         d = _Widget.info(self)
-        d["foreground"] = self.foreground
         d["text"] = self.formatted_text
         return d
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -589,7 +589,7 @@ class _TextBox(_Widget):
         """
         # Reset the layout width to let the layout calculate
         # the width based on the length of the text.
-        del self.layout.width
+        self.layout.reset_width()
         if self.layout.width > self._scroll_width:
             if self.bar.horizontal or self.rotate:
                 self.length_type = bar.STATIC

--- a/libqtile/widget/chord.py
+++ b/libqtile/widget/chord.py
@@ -63,7 +63,7 @@ class Chord(base._TextBox):
 
             self.text = self.name_transform(chord_name)
             if chord_name in self.chords_colors:
-                (self.background, self.foreground) = self.chords_colors.get(chord_name)
+                self.background, self.layout.colour = self.chords_colors.get(chord_name)
             else:
                 self.reset_colours()
 
@@ -74,7 +74,7 @@ class Chord(base._TextBox):
 
     def reset_colours(self):
         self.background = self.default_background
-        self.foreground = self.default_foreground
+        self.layout.colour = self.default_foreground
 
     def clear(self, *args):
         self.reset_colours()

--- a/libqtile/widget/currentscreen.py
+++ b/libqtile/widget/currentscreen.py
@@ -43,8 +43,8 @@ class CurrentScreen(base._TextBox):
 
     def update_text(self):
         if self.qtile.current_screen == self.bar.screen:
-            self.foreground = self.active_color
+            self.layout.colour = self.active_color
             self.update(self.active_text)
         else:
-            self.foreground = self.inactive_color
+            self.layout.colour = self.inactive_color
             self.update(self.inactive_text)

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -104,8 +104,6 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
         highlighted=False,
     ):
         self.layout.text = self.fmt.format(text)
-        self.layout.font_family = self.font
-        self.layout.font_size = self.fontsize
         self.layout.colour = textcolor
         if width is not None:
             self.layout.width = width

--- a/libqtile/widget/khal_calendar.py
+++ b/libqtile/widget/khal_calendar.py
@@ -110,8 +110,8 @@ class KhalCalendar(base.ThreadPoolText):
         data = "".join(filter(lambda x: x in string.printable, data))
         # colorize the event if it is within reminder time
         if (starttime - remtime <= now) and (endtime > now):
-            self.foreground = self.reminder_color
+            self.layout.colour = self.reminder_color
         else:
-            self.foreground = self.default_foreground
+            self.layout.colour = self.default_foreground
 
         return data

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -134,7 +134,7 @@ class LaunchBar(base._Widget):
     @property
     def actual_padding(self):
         if self.padding is None:
-            return self.fontsize / 2
+            return self.fontsize // 2
         else:
             return self.padding
 

--- a/libqtile/widget/nvidia_sensors.py
+++ b/libqtile/widget/nvidia_sensors.py
@@ -65,9 +65,9 @@ class NvidiaSensors(base.ThreadPoolText):
             for gpu in sensors_data:
                 if gpu.get("temp"):
                     if int(gpu["temp"]) > self.threshold:
-                        self.foreground = self.foreground_alert
+                        self.layout.colour = self.foreground_alert
                     else:
-                        self.foreground = self.foreground_normal
+                        self.layout.colour = self.foreground_normal
             return " - ".join([self.format.format(**gpu) for gpu in sensors_data])
         except Exception:
             return None

--- a/libqtile/widget/vertical_clock.py
+++ b/libqtile/widget/vertical_clock.py
@@ -72,7 +72,7 @@ class VerticalClock(Clock):
 
         if isinstance(self.foreground, str):
             self.foreground = self._to_list(self.foreground)
-        elif not isinstance(self.fontsize, list):
+        elif not isinstance(self.foreground, list):
             raise ConfigError("foreground should be a string or a list of strings.")
 
         if len(self.fontsize) != len(self.format):

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -105,7 +105,7 @@ class Volume(base._TextBox):
     ]
 
     def __init__(self, **config):
-        base._TextBox.__init__(self, "0", **config)
+        base._TextBox.__init__(self, "", **config)
         self.add_defaults(Volume.defaults)
         self.surfaces = {}
         self.volume = None
@@ -161,7 +161,7 @@ class Volume(base._TextBox):
 
     def _update_drawer(self):
         if self.mute_foreground is not None:
-            self.foreground = self.mute_foreground if self.is_mute else self.unmute_foreground
+            self.layout.colour = self.mute_foreground if self.is_mute else self.unmute_foreground
 
         if self.theme_path:
             self.drawer.clear(self.background or self.bar.background)

--- a/test/widgets/test_chord.py
+++ b/test/widgets/test_chord.py
@@ -84,32 +84,32 @@ def test_chord_widget(fake_window, fake_qtile):
 
     # Chord is in chords_colors so check colours
     assert chord.background == RED
-    assert chord.foreground == BLUE
+    assert chord.layout.colour == BLUE
     assert chord.text == "testcolor"
 
     # New chord, not in dictionary so should be default colours
     hook.fire("enter_chord", "test")
     assert chord.text == "test"
     assert chord.background == BASE_BACKGROUND
-    assert chord.foreground == BASE_FOREGROUND
+    assert chord.layout.colour == BASE_FOREGROUND
 
     # Unnamed chord so no text
     hook.fire("enter_chord", "")
     assert chord.text == ""
     assert chord.background == BASE_BACKGROUND
-    assert chord.foreground == BASE_FOREGROUND
+    assert chord.layout.colour == BASE_FOREGROUND
 
     # Back into testcolor and custom colours
     hook.fire("enter_chord", "testcolor")
     assert chord.background == RED
-    assert chord.foreground == BLUE
+    assert chord.layout.colour == BLUE
     assert chord.text == "testcolor"
 
     # Colours shoud reset when leaving chord
     hook.fire("leave_chord")
     assert chord.text == ""
     assert chord.background == BASE_BACKGROUND
-    assert chord.foreground == BASE_FOREGROUND
+    assert chord.layout.colour == BASE_FOREGROUND
 
     # Finalize the widget to prevent segfault (the drawer needs to be finalised)
     # We clear the _futures attribute as there are no real timers in it and calls

--- a/test/widgets/test_currentscreen.py
+++ b/test/widgets/test_currentscreen.py
@@ -24,7 +24,7 @@ import libqtile.bar
 import libqtile.config
 import libqtile.confreader
 import libqtile.layout
-from libqtile import widget
+from libqtile.widget import CurrentScreen
 from test.conftest import dualmonitor
 
 ACTIVE = "#FF0000"
@@ -33,23 +33,21 @@ INACTIVE = "#00FF00"
 
 @dualmonitor
 def test_change_screen(manager_nospawn, minimal_conf_noscreen):
-    cswidget = widget.CurrentScreen(active_color=ACTIVE, inactive_color=INACTIVE)
+    cswidget = CurrentScreen(active_color=ACTIVE, inactive_color=INACTIVE)
 
     config = minimal_conf_noscreen
     config.screens = [
         libqtile.config.Screen(top=libqtile.bar.Bar([cswidget], 10)),
         libqtile.config.Screen(),
     ]
-
     manager_nospawn.start(config)
 
-    w = manager_nospawn.c.screen[0].bar["top"].info()["widgets"][0]
+    widget = manager_nospawn.c.widget["currentscreen"]
 
-    assert w["text"] == "A"
-    assert w["foreground"] == ACTIVE
+    assert widget.eval("self.text")[1] == "A"
+    assert widget.eval("self.layout.colour")[1] == ACTIVE
 
     manager_nospawn.c.to_screen(1)
 
-    w = manager_nospawn.c.screen[0].bar["top"].info()["widgets"][0]
-    assert w["text"] == "I"
-    assert w["foreground"] == INACTIVE
+    assert widget.eval("self.text")[1] == "I"
+    assert widget.eval("self.layout.colour")[1] == INACTIVE

--- a/test/widgets/test_misc.py
+++ b/test/widgets/test_misc.py
@@ -51,8 +51,10 @@ widget_conf = pytest.mark.parametrize("manager", [WidgetTestConf], indirect=True
 
 @widget_conf
 def test_textbox_color_change(manager):
-    manager.c.widget["colorchanger"].update("f")
-    assert manager.c.widget["colorchanger"].info()["foreground"] == "0000ff"
+    widget = manager.c.widget["colorchanger"]
 
-    manager.c.widget["colorchanger"].update("f")
-    assert manager.c.widget["colorchanger"].info()["foreground"] == "ff0000"
+    widget.update("f")
+    assert widget.eval("self.foreground")[1] == "0000ff"
+
+    widget.update("f")
+    assert widget.eval("self.foreground")[1] == "ff0000"

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -91,13 +91,13 @@ def test_foregrounds(fake_qtile, fake_window):
 
     vol.volume = 50
     vol._update_drawer()
-    assert vol.foreground == foreground
+    assert vol.layout.colour == foreground
 
     vol.mute_foreground = mute_foreground = "#888888"
     vol.is_mute = False
     vol._update_drawer()
-    assert vol.foreground == foreground
+    assert vol.layout.colour == foreground
 
     vol.is_mute = True
     vol._update_drawer()
-    assert vol.foreground == mute_foreground
+    assert vol.layout.colour == mute_foreground


### PR DESCRIPTION
Write this as an alternative to #5309. I see this as an improvement and cleaner approach.

It removes the temporary placeholder class: https://github.com/qtile/qtile/pull/5309#pullrequestreview-2979617118 and removes the setters to the `self.layout` attributes.

Instead when an attribute needs to be set, it is placed directly to `self.layout`.

PS. I also added some `fix: ...` commits that I found along the way.