### PR TITLE
[WayC]: Move and resize handling for XDG surface

### DIFF
--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -4,6 +4,12 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
+enum qw_cursor_mode {
+    QW_CURSOR_PASSTHROUGH,
+    QW_CURSOR_MOVE,
+    QW_CURSOR_RESIZE,
+};
+
 struct qw_server; // Forward declaration to avoid circular dependency
 
 // Cursor structure that holds cursor state and event listeners
@@ -24,6 +30,11 @@ struct qw_cursor {
     uint32_t saved_hotspot_x;
     uint32_t saved_hotspot_y;
     bool hidden;
+    enum qw_cursor_mode cursor_mode;
+    struct qw_xdg_view *xdg_view;
+    double grab_x, grab_y;
+    struct wlr_box grab_geobox;
+    uint32_t resize_edges;
 };
 
 // Destroy the cursor and free its resources

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <getopt.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <unistd.h>
 
 #include <cairo.h>

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -1,10 +1,12 @@
 #include "xdg-view.h"
+#include "cursor.h"
 #include "server.h"
 #include "util.h"
 #include "view.h"
 #include "wayland-server-core.h"
 #include "wayland-util.h"
 #include "wlr/types/wlr_xdg_decoration_v1.h"
+#include "wlr/util/edges.h"
 #include "xdg-shell-protocol.h"
 #include <stdlib.h>
 
@@ -261,6 +263,60 @@ static void qw_xdg_view_handle_set_app_id(struct wl_listener *listener, void *da
     }
 }
 
+/* This function sets up an interactive move or resize operation, where the
+ * compositor stops propegating pointer events to clients and instead
+ * consumes them itself, to move or resize windows */
+static void qw_xdg_begin_interactive(struct qw_xdg_view *xdg_view, enum qw_cursor_mode mode,
+                                     uint32_t edges) {
+    struct qw_server *server = xdg_view->server;
+    server->cursor->xdg_view = xdg_view;
+    server->cursor->cursor_mode = mode;
+
+    if (mode == QW_CURSOR_MOVE) {
+        server->cursor->grab_x = server->cursor->cursor->x - xdg_view->scene_tree->node.x;
+        server->cursor->grab_y = server->cursor->cursor->y - xdg_view->scene_tree->node.y;
+    } else {
+        struct wlr_box *geo_box = &xdg_view->xdg_toplevel->base->geometry;
+
+        double border_x = (xdg_view->scene_tree->node.x + geo_box->x) +
+                          ((edges & WLR_EDGE_RIGHT) ? geo_box->width : 0);
+        double border_y = (xdg_view->scene_tree->node.y + geo_box->y) +
+                          ((edges & WLR_EDGE_BOTTOM) ? geo_box->height : 0);
+
+        server->cursor->grab_x = server->cursor->cursor->x - border_x;
+        server->cursor->grab_y = server->cursor->cursor->y - border_y;
+
+        server->cursor->grab_geobox = *geo_box;
+        server->cursor->grab_geobox.x += xdg_view->scene_tree->node.x;
+        server->cursor->grab_geobox.y += xdg_view->scene_tree->node.y;
+
+        server->cursor->resize_edges = edges;
+    }
+}
+
+static void qw_xdg_view_handle_request_move(struct wl_listener *listener, void *data) {
+    /* This event is raised when a client would like to begin an interactive
+     * move, typically because the user clicked on their client-side
+     * decorations.
+     * TODO: compositor should check the provided serial against a list of
+     * button press serials sent to this client, to prevent the client from
+     * requesting this whenever they want. */
+    struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, request_move);
+    qw_xdg_begin_interactive(xdg_view, QW_CURSOR_MOVE, 0);
+}
+
+static void qw_xdg_view_handle_request_resize(struct wl_listener *listener, void *data) {
+    /* This event is raised when a client would like to begin an interactive
+     * resize, typically because the user clicked on their client-side
+     * decorations.
+     * TODO: compositor should check the provided serial against a list of
+     * button press serials sent to this client, to prevent the client from
+     * requesting this whenever they want. */
+    struct wlr_xdg_toplevel_resize_event *event = data;
+    struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, request_resize);
+    qw_xdg_begin_interactive(xdg_view, QW_CURSOR_RESIZE, event->edges);
+}
+
 // Handle client decoration mode requests, enforce server-side decorations
 static void qw_xdg_view_handle_decoration_request_mode(struct wl_listener *listener, void *data) {
     struct qw_xdg_view *xdg_view = wl_container_of(listener, xdg_view, decoration_request_mode);
@@ -409,4 +465,8 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
 
     xdg_view->set_app_id.notify = qw_xdg_view_handle_set_app_id;
     wl_signal_add(&xdg_toplevel->events.set_app_id, &xdg_view->set_app_id);
+    xdg_view->request_move.notify = qw_xdg_view_handle_request_move;
+    wl_signal_add(&xdg_toplevel->events.request_move, &xdg_view->request_move);
+    xdg_view->request_resize.notify = qw_xdg_view_handle_request_resize;
+    wl_signal_add(&xdg_toplevel->events.request_resize, &xdg_view->request_resize);
 }

--- a/libqtile/backend/wayland/qw/xdg-view.h
+++ b/libqtile/backend/wayland/qw/xdg-view.h
@@ -35,7 +35,8 @@ struct qw_xdg_view {
     struct wl_listener request_fullscreen;
     struct wl_listener set_title;
     struct wl_listener set_app_id;
-    // TODO: add listeners for move and resize requests
+    struct wl_listener request_move;
+    struct wl_listener request_resize;
 
     // Listeners for client decoration protocol events
     struct wl_listener decoration_request_mode;


### PR DESCRIPTION
* **Move & Resize Handling**

  * Handles `request_move` and `request_resize` events for XDG surfaces
  * Enables interactive move/resize via `qw_xdg_begin_interactive` when requested by clients