### PR TITLE
Prevent interactive help in `qtile repl`

### DIFF
--- a/libqtile/interactive/repl.py
+++ b/libqtile/interactive/repl.py
@@ -34,6 +34,13 @@ COMPLETION_REQUEST = "___COMPLETE___::"
 REPL_PORT = 41414
 
 
+def mark_unavailable(func):
+    def _wrapper(*args, **kwargs):
+        print(f"'{func.__name__}' is disabled in this REPL.")
+
+    return _wrapper
+
+
 def make_safer_env():
     """
     Returns a dict to be passed to the REPL's global environment.
@@ -53,6 +60,9 @@ def make_safer_env():
 
     # Store original help so we can still call it safely
     builtins.help = safe_help
+
+    # Mask other builtins
+    builtins.input = mark_unavailable(builtins.input)
 
     return {"__builtins__": builtins}
 


### PR DESCRIPTION
`help()` starts an interactive help session in a standard python repl session but it will block qtile's event loop.

This PR patches help to tell users that interactive help is unavailable.


Any other commands we should repeat this approach? Anything blocking is going to be bad so maybe a generic warning?