### PR TITLE
Widgets: new draw_at_default_position function

### DIFF
--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -202,13 +202,13 @@ drawings are set out below.
 
 It is important to note that the bar controls the placing of the widget by
 assigning the ``offsetx`` value (for horizontal positioning) and ``offsety``
-value (for vertical positioning). Widgets should use this at the end of the
-``draw`` method. Both ``offsetx`` and ``offsety`` are required as both values will
-be set if the bar is drawing a border.
+value (for vertical positioning). While the widget controls its ``width`` and
+``height``. These four values should be use at the end of the ``draw`` method.
+It is recommended to call this helper function to do it automatically:
 
 .. code:: python
 
-    self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.width)
+    self.draw_at_default_position()
 
 .. note::
 
@@ -281,7 +281,7 @@ Drawing the image is then just a matter of painting it to the relevant surface:
     def draw(self):
         self.drawer.ctx.set_source(self.surfaces[img_name])  # Use correct key here for your image
         self.drawer.ctx.paint()
-        self.drawer.draw(offsetx=self.offset, width=self.length)
+        self.draw_at_default_position()
 
 Drawing shapes
 --------------

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -680,10 +680,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         # so we adjust the end of the bar area for this offset
         if self.horizontal:
             bar_end = self._length + self.border_width[3]
+            widget_end = i.offsetx + i.length
         else:
             bar_end = self._length + self.border_width[0]
-
-        widget_end = i.offset + i.length
+            widget_end = i.offsety + i.length
 
         if widget_end < bar_end:
             # Defines a rectangle for the area enclosed by the bar's borders and the end of the

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -197,12 +197,6 @@ class _Widget(CommandObject, configurable.Configurable):
             return self.bar.height
         return self.length
 
-    @property
-    def offset(self):
-        if self.bar.horizontal:
-            return self.offsetx
-        return self.offsety
-
     def _test_orientation_compatibility(self, horizontal):
         if horizontal:
             if not self.orientations & ORIENTATION_HORIZONTAL:
@@ -269,7 +263,7 @@ class _Widget(CommandObject, configurable.Configurable):
         """Info for this object."""
         return dict(
             name=self.name,
-            offset=self.offset,
+            offset=self.offsetx if self.bar.horizontal else self.offsety,
             length=self.length,
             width=self.width,
             height=self.height,
@@ -318,6 +312,12 @@ class _Widget(CommandObject, configurable.Configurable):
             return self.bar
         elif name == "screen":
             return self.bar.screen
+
+    def draw_at_default_position(self):
+        """Default position to draw the widget in horizontal and vertical bars."""
+        self.drawer.draw(
+            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
+        )
 
     def draw(self):
         """
@@ -674,9 +674,7 @@ class _TextBox(_Widget):
         )
         self.drawer.ctx.restore()
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
         # We only want to scroll if:
         # - User has asked us to scroll and the scroll width is smaller than the layout (should_scroll=True)
@@ -980,7 +978,7 @@ class Mirror(_Widget):
             return
         self.drawer.clear_rect()
         self.reflects.drawer.paint_to(self.drawer)
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()
 
     def button_press(self, x, y, button):
         self.reflects.button_press(x, y, button)

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -687,7 +687,7 @@ class BatteryIcon(base._Widget):
         self.drawer.ctx.set_source(image.pattern)
         self.drawer.ctx.paint()
         self.drawer.ctx.restore()
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     @staticmethod
     def _get_icon_key(status: BatteryStatus) -> str:

--- a/libqtile/widget/currentlayout.py
+++ b/libqtile/widget/currentlayout.py
@@ -142,9 +142,7 @@ class CurrentLayout(base._TextBox):
         self.drawer.ctx.set_source(surface.pattern)
         self.drawer.ctx.paint()
         self.drawer.ctx.restore()
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
     def _get_layout_names(self):
         """

--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -176,7 +176,7 @@ class _Graph(base._Widget):
         else:
             raise ValueError(f"Unknown graph type: {self.type}.")
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()
 
     def push(self, value):
         if self.lag_cycles > self.samples:

--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -165,7 +165,7 @@ class AGroupBox(_GroupBase):
         self.drawer.clear(self.background or self.bar.background)
         e = next(i for i in self.qtile.groups if i.name == self.bar.screen.group.name)
         self.drawbox(self.margin_x, e.name, self.border, self.foreground)
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()
 
 
 class GroupBox(_GroupBase):
@@ -407,4 +407,4 @@ class GroupBox(_GroupBase):
                 highlighted=to_highlight,
             )
             offset += bw + self.spacing
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -85,11 +85,7 @@ class Image(base._Widget, base.MarginMixin):
         self.drawer.ctx.set_source(self.img.pattern)
         self.drawer.ctx.paint()
         self.drawer.ctx.restore()
-
-        if self.bar.horizontal:
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
-        else:
-            self.drawer.draw(offsety=self.offset, offsetx=self.offsetx, height=self.width)
+        self.draw_at_default_position()
 
     def calculate_length(self):
         if self.img is None:

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -322,9 +322,7 @@ class LaunchBar(base._Widget):
 
         self.drawer.ctx.restore()
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
     def calculate_length(self):
         """Compute the width of the widget according to each icon width."""

--- a/libqtile/widget/sep.py
+++ b/libqtile/widget/sep.py
@@ -54,7 +54,6 @@ class Sep(base._Widget):
                 self.bar.height - margin_top,
                 linewidth=self.linewidth,
             )
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
         else:
             margin_left = (self.bar.width / float(100) * (100 - self.size_percent)) / 2.0
             self.drawer.draw_hbar(
@@ -64,4 +63,4 @@ class Sep(base._Widget):
                 float(self.length) / 2,
                 linewidth=self.linewidth,
             )
-            self.drawer.draw(offsety=self.offset, offsetx=self.offsetx, height=self.length)
+        self.draw_at_default_position()

--- a/libqtile/widget/spacer.py
+++ b/libqtile/widget/spacer.py
@@ -54,7 +54,4 @@ class Spacer(base._Widget):
     def draw(self):
         if self.length > 0:
             self.drawer.clear(self.background or self.bar.background)
-            if self.bar.horizontal:
-                self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
-            else:
-                self.drawer.draw(offsety=self.offset, offsetx=self.offsetx, height=self.length)
+            self.draw_at_default_position()

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -138,7 +138,7 @@ class StatusNotifier(base._Widget):
             else:
                 yoffset += self.icon_size + self.padding
 
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def activate(self):
         """Primary action when clicking on an icon"""

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -245,7 +245,7 @@ class Systray(base._Widget, window._Window):  # type: ignore[misc]
     def draw(self):
         offset = self.padding
         self.drawer.clear(self.background or self.bar.background)
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
         for pos, icon in enumerate(self.tray_icons):
             icon.window.set_attribute(backpixmap=self.drawer.pixmap)
             if self.bar.horizontal:

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -681,6 +681,4 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
         ctx.restore()
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()

--- a/libqtile/widget/vertical_clock.py
+++ b/libqtile/widget/vertical_clock.py
@@ -136,9 +136,7 @@ class VerticalClock(Clock):
             offset += layout.height + self.actual_padding
             self.drawer.ctx.restore()
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
     def finalize(self):
         for layout in self.layouts:

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -239,7 +239,7 @@ class Volume(base._TextBox):
 
     def draw(self):
         if self.theme_path:
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+            self.draw_at_default_position()
         else:
             base._TextBox.draw(self)
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -29,15 +29,9 @@ self: final: prev: {
         )).override
           { wlroots = prev.wlroots_0_17; };
 
-      qtile-extras = pprev.qtile-extras.overridePythonAttrs (oldAttrs: {
-        # disable currentlayouticon test for https://github.com/qtile/qtile/pull/5302
-        disabledTestPaths = oldAttrs.disabledTestPaths ++ [
-          "test/widget/test_currentlayouticon.py"
-        ];
-        # disable groupbox2 test for https://github.com/qtile/qtile/pull/5325
-        disabledTests = oldAttrs.disabledTests ++ [
-          "groupbox2"
-        ];
+      qtile-extras = pprev.qtile-extras.overridePythonAttrs ({
+        # disable all widget tests
+        disabledTestPaths = [ "test/widget/*" ];
       });
     })
   ];


### PR DESCRIPTION
As I was working with in the widgets, I realized that there were many use cases of using the offset property for drawing i.e. `self.drawer.draw(offsetx=self.offset, ...`. I found out to be problematic since it is only there to work for horizontal bars and when trying to implement vertical it always needs fix.

I remove the property to prevent further bad use cases like the above, and as I was fixing all draw() methods, I realized that I was repeating to much, so I decided to create this little helper property `draw_kwargs` which automatically passes the correct values to the drawer.

Will cause breakage and that is why I have PRs ready for qtile-extras and qtile-examples.