### PR TITLE
fix(images): do not fail on input zero

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -199,6 +199,8 @@ class Img:
     height = _PixelSize("height")
 
     def resize(self, width=None, height=None):
+        if width == 0 or height == 0:
+            return
         width0, height0 = self.default_size
         width_factor, height_factor = None, None
         if width is not None:
@@ -213,6 +215,8 @@ class Img:
         raise ValueError("You must supply either width or height!")
 
     def scale(self, width_factor=None, height_factor=None, lock_aspect_ratio=False):
+        if width_factor == 0 or height_factor == 0:
+            return
         if not (width_factor or height_factor):
             raise ValueError("You must supply width_factor or height_factor")
         if lock_aspect_ratio:

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -182,6 +182,24 @@ class TestImgScale:
         with pytest.raises(ValueError):
             png_img.scale()
 
+    def test_scale_zero(self, png_img):
+        size = png_img.default_size
+        png_img.scale(width_factor=0, height_factor=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
+
+    def test_scale_width_zero(self, png_img):
+        size = png_img.default_size
+        png_img.scale(width_factor=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
+
+    def test_scale_height_zero(self, png_img):
+        size = png_img.default_size
+        png_img.scale(height_factor=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
+
 
 class TestImgResize:
     def test_resize(self, png_img):
@@ -202,6 +220,28 @@ class TestImgResize:
         png_img.resize(height=10)
         assert png_img.height == 10
         assert (png_img.width / png_img.height) == pytest.approx(ratio)
+
+    def test_resize_fail(self, png_img):
+        with pytest.raises(ValueError):
+            png_img.resize()
+
+    def test_resize_zero(self, png_img):
+        size = png_img.default_size
+        png_img.resize(width=0, height=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
+
+    def test_resize_width_zero(self, png_img):
+        size = png_img.default_size
+        png_img.resize(width=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
+
+    def test_resize_height_zero(self, png_img):
+        size = png_img.default_size
+        png_img.resize(height=0)
+        assert png_img.width == size.width
+        assert png_img.height == size.height
 
 
 class TestLoader:


### PR DESCRIPTION
In image resize and scale, instead of raising an error, do nothing when the width or height is zero.