### PR TITLE
drop mailing list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,6 @@ Qtile is supported by a dedicated group of users. If you need any help, please
 don't hesitate to fire off an email to our mailing list or join us on IRC. You
 can also ask questions on the discussions board.
 
-:Mailing List: https://groups.google.com/group/qtile-dev
 :Q&A: https://github.com/qtile/qtile/discussions/categories/q-a
 :IRC: irc://irc.oftc.net:6667/qtile
 :Discord: https://discord.gg/ehh233wCrC (Bridged with IRC)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,10 +17,9 @@ to have it running exactly the way you want.
 You'll find a lot of what you need within these docs but, if you still have some
 questions, you can find support in the following places:
 
+:Q&A: https://github.com/qtile/qtile/discussions/categories/q-a
 :IRC: irc://irc.oftc.net:6667/qtile
 :Discord: https://discord.gg/ehh233wCrC (Bridged with IRC)
-:Q&A: https://github.com/qtile/qtile/discussions/categories/q-a
-:Mailing List: https://groups.google.com/group/qtile-dev
 
 .. toctree::
     :maxdepth: 1

--- a/docs/manual/howto/layout.rst
+++ b/docs/manual/howto/layout.rst
@@ -714,12 +714,3 @@ The full code for the example layout is as follows:
 This should result in a layout looking like this: |layout_image|.
 
 .. |layout_image| image:: ../../_static/layouts/twobytwo.png
-
-Getting help
-============
-
-If you still need help with developing your widget then please submit a question in the
-`qtile-dev group <https://groups.google.com/forum/#!forum/qtile-dev>`_ or submit an issue
-on the github page if you believe there's an error in the codebase.
-
-

--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -678,10 +678,3 @@ of the bar then you need a few extra steps:
         # Take a screenshot. Will take screenshot of whole bar unless
         # a `width` parameter is set.
         bar.take_screenshot(target, width=width)
-
-Getting help
-============
-
-If you still need help with developing your widget then please submit a question in the
-`qtile-dev group <https://groups.google.com/forum/#!forum/qtile-dev>`_ or submit an issue
-on the github page if you believe there's an error in the codebase.


### PR DESCRIPTION
...and clean up other bits by deleting some redundant docs and re-ordering things there to be the same as in the README.

The mailing list has been essentially unused (one or two "real" messages in the last year), and it is completely full of spam (sad that even Google can't figure out we don't want to buy DMT :). Given it's light usage and the maintenance burden it has caused (for a while, I was banned from qtile-dev!), I think it's best we put it out to pasture, in favor of IRC/discord and github discussions. If we land this, I will do some work to figure out how to properly "archive" the google group.