### PR TITLE
drop DefaultEventLoopPolicy

### DIFF
--- a/libqtile/__init__.py
+++ b/libqtile/__init__.py
@@ -18,6 +18,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import asyncio
 
 
 class _UndefinedCore:
@@ -29,6 +30,7 @@ class _UndefinedQtile:
 
 
 qtile = _UndefinedQtile()
+event_loop: asyncio.AbstractEventLoop
 
 
 def init(q):

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -10,8 +10,6 @@ from libqtile.log_utils import logger
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from libqtile.core.manager import Qtile
-
 
 class LoopContext(contextlib.AbstractAsyncContextManager):
     def __init__(
@@ -62,20 +60,3 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
                 logger.exception("Exception in event loop:", exc_info=exc)  # noqa: G202
         else:
             logger.error("unhandled error in event loop: %s", context["msg"])
-
-
-class QtileEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-    """
-    Asyncio policy to ensure the main event loop is accessible
-    even if `get_event_loop()` is called from a different thread.
-    """
-
-    def __init__(self, qtile: Qtile) -> None:
-        asyncio.DefaultEventLoopPolicy.__init__(self)
-        self.qtile = qtile
-
-    def get_event_loop(self) -> asyncio.AbstractEventLoop:
-        if isinstance(self.qtile._eventloop, asyncio.AbstractEventLoop):
-            return self.qtile._eventloop
-
-        raise RuntimeError

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -42,6 +42,7 @@ try:
 except ImportError:
     has_dbus = False
 
+import libqtile
 from libqtile.log_utils import logger
 
 ColorType = str | tuple[int, int, int] | tuple[int, int, int, float]
@@ -301,12 +302,8 @@ def send_notification(
     id_ = randint(10, 1000) if id_ is None else id_
     urgency = 2 if urgent else 1
 
-    try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
-        logger.warning("Eventloop has not started. Cannot send notification.")
-    else:
-        loop.create_task(_notify(title, message, urgency, timeout, id_))
+    loop = libqtile.event_loop
+    loop.create_task(_notify(title, message, urgency, timeout, id_))
 
     return id_
 


### PR DESCRIPTION
python3.14 depreciates event loop policies entirely, in favor of just manually specifying the event loop as an argument to asyncio.run().

we were really using the event loop policy as a hack for not having a global variable, so let's switch to a global variable instead, and use it in the one place we need it.

we have to drop two verisons of python because they do not have the loop_factory= argument to asyncio:

    raise AssertionError(f"Error launching qtile, traceback:\n{error}")
    AssertionError: Error launching qtile, traceback:
    Traceback (most recent call last):
      File "/home/runner/work/qtile/qtile/test/helpers.py", line 207, in run_qtile
        ).loop()
      File "/home/runner/work/qtile/qtile/libqtile/core/manager.py", line 216, in loop
        asyncio.run(self.async_loop(), loop_factory=lambda: libqtile.event_loop)
    TypeError: run() got an unexpected keyword argument 'loop_factory'

but maybe that's ok: 3.10 is outside of our last-three-versions policy, and 3.11 will be outside it in a few months when 3.14 is released.

There is another option here: since the motivation for this was really #2620, we could "just" switch the battery to running in-loop, which would mean that it is not run via run_in_executor() i.e. in a separate thread. That means that get_running_loop() would return the right loop, and we wouldn't need this hack at all.

(It also means that the battery could potentially block the UI while reading from e.g. procfs/sysfs files, but that seems unlikely. Perhaps it also suggests another widget type: something with an `async def poll()`, which could run in the main loop and avoid both of these problems.)

The only other widget which uses send_notification() is pomodoro, which doesn't read any files at all and just uses gettimeofday(), which is a VDSO i.e. memory access, that should also not block, so if we convert the battery widget, we should do this one as well.

Finally, we suggest use of send_notification() in the hooks documentation, but all hooks are fired from the main thread, so the get_running_loop() call should work fine there.

That does mean we'd have to be careful to always send_notification() from the main thread going forward, but it doesn't seem like that hard of a challenge.

Fixes #5346