### PR TITLE
x11: prepend primary output when computing screens

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -405,6 +405,7 @@ class RandR:
 
     def query_crtcs(self, root):
         infos = []
+        primary = self.ext.GetOutputPrimary(root).reply().output
         for output in self.ext.GetScreenResources(root).reply().outputs:
             info = self.ext.GetOutputInfo(output, xcffib.CurrentTime).reply()
 
@@ -414,7 +415,14 @@ class RandR:
 
             crtc_info = self.ext.GetCrtcInfo(info.crtc, xcffib.CurrentTime).reply()
 
-            infos.append(ScreenRect(crtc_info.x, crtc_info.y, crtc_info.width, crtc_info.height))
+            rect = ScreenRect(crtc_info.x, crtc_info.y, crtc_info.width, crtc_info.height)
+
+            # prepend the primary output, append all others in screen
+            # resources order
+            if primary == output:
+                infos.insert(0, rect)
+            else:
+                infos.append(rect)
         return infos
 
     def enable_screen_change_notifications(self, conn):


### PR DESCRIPTION
It is still not clear to me that this is quite the correct thing to do; xrandr -q does not sort the outputs as near as I can tell. Here is where it renders things:

https://gitlab.freedesktop.org/xorg/app/xrandr/-/blob/6f714830da6c8d74f024be6b0bb32c1ea39c1217/xrandr.c#L3629-3643

which it does in the order of `all_outputs`; `all_outputs` is populated here:

https://gitlab.freedesktop.org/xorg/app/xrandr/-/blob/6f714830da6c8d74f024be6b0bb32c1ea39c1217/xrandr.c#L1773-1810

Which seems to do it in the order of the outputs from ScreenResources, the same as we were doing before. And yet, it seems to fix the ordering issue for at least one person. Short of any better ideas as to how to sort things, let's land this for now as a band-aid for #5305. Perhaps it is the "complete fix", but it would be nice to understand why the ordering is different5305. Perhaps it is the "complete fix", but it would be nice to understand why the ordering is different for our queries vs. the ones that xrandr does...