### PR TITLE
[Wayc] save wlr_session and add change_vt support

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -402,7 +402,10 @@ class Core(base.Core):
     @expose_command()
     def change_vt(self, vt: int) -> bool:
         """Change virtual terminal to that specified"""
-        raise Exception("TODO: implement")
+        success = lib.qw_server_change_vt(self.qw, vt)
+        if not success:
+            logger.warning("Could not change VT to: %s", vt)
+        return success
 
     @expose_command()
     def hide_cursor(self) -> None:

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <wlr/backend/session.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
@@ -295,7 +296,8 @@ struct qw_server *qw_server_create() {
     }
 
     server->display = wl_display_create();
-    server->backend = wlr_backend_autocreate(wl_display_get_event_loop(server->display), NULL);
+    server->backend =
+        wlr_backend_autocreate(wl_display_get_event_loop(server->display), &server->session);
     if (!server->backend) {
         wlr_log(WLR_ERROR, "failed to create wlr_backend");
         free(server);

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -392,3 +392,10 @@ struct qw_server *qw_server_create() {
 
     return server;
 }
+
+bool qw_server_change_vt(struct qw_server *server, int vt) {
+    if (!server || !server->session) {
+        return false;
+    }
+    return wlr_session_change_vt(server->session, vt);
+}

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -161,4 +161,7 @@ struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly
                                   struct wlr_surface **surface, double *sx, double *sy);
 void qw_server_keyboard_clear_focus(struct qw_server *server);
 
+// Change virtual terminal
+bool qw_server_change_vt(struct qw_server *server, int vt);
+
 #endif /* SERVER_H */

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
+#include <wlr/backend/session.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_alpha_modifier_v1.h>
@@ -100,6 +101,7 @@ struct qw_server {
     struct wlr_compositor *compositor;
     struct wl_display *display;
     struct wlr_backend *backend;
+    struct wlr_session *session;
     struct wlr_renderer *renderer;
     struct wlr_allocator *allocator;
     struct wlr_scene *scene;


### PR DESCRIPTION
Adds support for `change_vt` which requires retrieving the `wlr_session` object from the backend.

I'm not a C coder so you can be as rude as you like about this!