### PR TITLE
[WayC]: Handle gpu reset

### DIFF
--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -119,6 +119,7 @@ struct qw_server {
     struct wl_listener new_output;
     struct wl_listener output_layout_change;
     struct wl_listener new_input;
+    struct wl_listener renderer_lost;
     struct wl_list keyboards;
     struct wlr_seat *seat;
     struct qw_cursor *cursor;


### PR DESCRIPTION
Add qw_server_handle_renderer_lost() to gracefully recover from GPU resets by recreating the renderer and allocator when the renderer is lost. This ensures the compositor continues functioning after graphics driver crashes or GPU hardware resets.

Inspiration from: https://github.com/labwc/labwc/pull/1997

From issue: https://github.com/qtile/qtile/issues/5361