### PR TITLE
[WayC]: Add pywlroots copyright and license header to log.c

### DIFF
--- a/libqtile/backend/wayland/qw/log.c
+++ b/libqtile/backend/wayland/qw/log.c
@@ -1,7 +1,43 @@
+/*
+ * Copyright (c) 2018 Sean Vig
+ *
+ * This file contains code copied or adapted from pywlroots,
+ * which is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimers.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimers in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the names of the developers nor the names of its contributors may be
+ *   used to endorse or promote products derived from this Software without
+ *   specific prior written permission.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Modifications Copyright (c) 2025 The Qtile Project
+ *
+ * Licensed under the MIT License.
+ * See the LICENSE file in the root of this repository for details.
+ */
+
 #include "log.h"
 #include <stdio.h>
-
-// TODO: add pywlroots copyright
 
 // Function pointer for Python callback to receive formatted log messages
 static wrapped_log_func_t py_callback = NULL;


### PR DESCRIPTION
This file contains code copied or adapted from pywlroots, which is licensed under the MIT License (Copyright © 2018 Sean Vig).

Added the full MIT license text for compliance, and included Qtile Project copyright for modifications.

This ensures proper attribution and license compliance for copied code within the Qtile Wayland backend.