### PR TITLE
fix(images): do not fail on input zero

### DIFF
--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -199,21 +199,20 @@ class Img:
     height = _PixelSize("height")
 
     def resize(self, width=None, height=None):
-        width0, height0 = self.default_size
-        width_factor, height_factor = None, None
-        if width is not None:
-            width_factor = width / width0
-        if height is not None:
-            height_factor = height / height0
+        if width is None and height is None:
+            raise ValueError("You must supply width or height")
 
-        if width and height:
+        width0, height0 = self.default_size
+        width_factor = width / width0 if width is not None else None
+        height_factor = height / height0 if height is not None else None
+
+        if width_factor is not None and height_factor is not None:
             return self.scale(width_factor, height_factor, lock_aspect_ratio=False)
-        if width or height:
+        else:
             return self.scale(width_factor, height_factor, lock_aspect_ratio=True)
-        raise ValueError("You must supply either width or height!")
 
     def scale(self, width_factor=None, height_factor=None, lock_aspect_ratio=False):
-        if not (width_factor or height_factor):
+        if width_factor is None and height_factor is None:
             raise ValueError("You must supply width_factor or height_factor")
         if lock_aspect_ratio:
             res = self._scale_lock(width_factor, height_factor, self.default_size)
@@ -223,17 +222,13 @@ class Img:
 
     @staticmethod
     def _scale_lock(width_factor, height_factor, initial_size):
-        if width_factor and height_factor:
-            raise ValueError(
-                "Can't rescale with locked aspect ratio "
-                "and give width_factor and height_factor."
-                f" {width_factor}, {height_factor}"
-            )
+        if width_factor is not None and height_factor is not None:
+            raise ValueError("No lock_aspect_ratio scale with width_factor and height_factor")
         width0, height0 = initial_size
-        if width_factor:
+        if width_factor is not None:
             width = width0 * width_factor
             height = height0 / width0 * width
-        else:
+        if height_factor is not None:
             height = height0 * height_factor
             width = width0 / height0 * height
         return _ImgSize(width, height)

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -182,6 +182,22 @@ class TestImgScale:
         with pytest.raises(ValueError):
             png_img.scale()
 
+    @pytest.mark.parametrize("width_factor,height_factor", [(0, 0), (-1, -1)])
+    def test_scale_less_than_one(self, png_img, width_factor, height_factor):
+        png_img.scale(width_factor, height_factor)
+        assert png_img.width == 1
+        assert png_img.height == 1
+
+    @pytest.mark.parametrize("width_factor", [0, -1])
+    def test_scale_less_than_one_width(self, png_img, width_factor):
+        png_img.scale(width_factor=width_factor)
+        assert png_img.width == 1
+
+    @pytest.mark.parametrize("height_factor", [0, -1])
+    def test_scale_less_than_one_height(self, png_img, height_factor):
+        png_img.scale(height_factor=height_factor)
+        assert png_img.height == 1
+
 
 class TestImgResize:
     def test_resize(self, png_img):
@@ -202,6 +218,26 @@ class TestImgResize:
         png_img.resize(height=10)
         assert png_img.height == 10
         assert (png_img.width / png_img.height) == pytest.approx(ratio)
+
+    def test_resize_fail(self, png_img):
+        with pytest.raises(ValueError):
+            png_img.resize()
+
+    @pytest.mark.parametrize("width,height", [(0, 0), (-1, -1)])
+    def test_resize_less_than_one(self, png_img, width, height):
+        png_img.resize(width, height)
+        assert png_img.width == 1
+        assert png_img.height == 1
+
+    @pytest.mark.parametrize("width", [0, -1])
+    def test_resize_less_than_one_width(self, png_img, width):
+        png_img.resize(width=width)
+        assert png_img.width == 1
+
+    @pytest.mark.parametrize("height", [0, -1])
+    def test_resize_less_than_one_height(self, png_img, height):
+        png_img.resize(height=height)
+        assert png_img.height == 1
 
 
 class TestLoader:


### PR DESCRIPTION
This is a rewrite of #5344. Now instead of returning early on zero, attempt the resize/scale and let the width/height be set to one pixel.

Right now when the input is a negative number, it sets the width/height to one pixel, I don't know if that was intended, but using the same mechanism lets apply it to zero input as well instead of raising an error.