### PR TITLE
[wayc] Add support for scene_buffer borders

### DIFF
--- a/libqtile/backend/wayland/qw/cairo-buffer.h
+++ b/libqtile/backend/wayland/qw/cairo-buffer.h
@@ -1,6 +1,7 @@
 #ifndef CAIRO_BUFFER_H
 #define CAIRO_BUFFER_H
 
+#include "view.h"
 #include <stdlib.h>
 
 /* Creates a wlroots buffer backed by Cairo pixel data.
@@ -10,5 +11,18 @@
  * - data: pointer to the pixel data (must remain valid while buffer exists)
  * Returns a pointer to the base wlr_buffer interface. */
 struct wlr_buffer *cairo_buffer_create(int width, int height, size_t stride, void *data);
+
+struct wlr_buffer *cairo_buffer_from_surface_region(cairo_surface_t *surface, int x, int y,
+                                                    int width, int height);
+
+// Creates a wlr_buffer from a subregion of a cairo image surface
+struct wlr_buffer *cairo_buffer_from_surface_region(cairo_surface_t *surface, int x, int y,
+                                                    int width, int height);
+
+// Given a surface, slice it into 4 fixed regions and create scene buffers
+struct wlr_scene_buffer **create_scene_buffers_from_surface(struct wlr_scene_tree *scene,
+                                                            cairo_surface_t *surface,
+                                                            struct wlr_box *regions,
+                                                            int num_regions);
 
 #endif // CAIRO_BUFFER_H

--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -58,8 +58,8 @@ static struct wlr_scene_node *qw_internal_view_get_tree_node(void *self) {
 
 // Place the internal view at a new position and resize if needed
 // If 'above' is nonzero, bring the view to the front
-static void qw_internal_view_place(void *self, int x, int y, int width, int height, int bw,
-                                   float (*bc)[4], int bn, int above) {
+static void qw_internal_view_place(void *self, int x, int y, int width, int height,
+                                   const struct qw_border *borders, int bn, int above) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     if (above != 0) {
         qw_view_reparent(&view->base, LAYER_BRINGTOFRONT);

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -77,7 +77,7 @@ static void qw_xdg_view_handle_map(struct wl_listener *listener, void *data) {
     xdg_view->base.height = geom.height;
 
     xdg_view->base.server->manage_view_cb((struct qw_view *)&xdg_view->base,
-                                     xdg_view->base.server->cb_data);
+                                          xdg_view->base.server->cb_data);
 
     // Focus the view upon mapping
     qw_xdg_view_do_focus(xdg_view, xdg_view->xdg_toplevel->base->surface);
@@ -132,8 +132,8 @@ static void qw_xdg_view_clip(struct qw_xdg_view *xdg_view) {
 }
 
 // Place the xdg_view at given position and size with border and stacking info
-static void qw_xdg_view_place(void *self, int x, int y, int width, int height, int bw,
-                              float (*bc)[4], int bn, int above) {
+static void qw_xdg_view_place(void *self, int x, int y, int width, int height,
+                              const struct qw_border *borders, int border_count, int above) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     struct wlr_xdg_surface *surface = xdg_view->xdg_toplevel->base;
     struct wlr_xdg_toplevel_state state = xdg_view->xdg_toplevel->current;
@@ -166,7 +166,7 @@ static void qw_xdg_view_place(void *self, int x, int y, int width, int height, i
     }
 
     // Paint borders around the view with given border colors and width
-    qw_view_paint_borders((struct qw_view *)xdg_view, bc, bw, bn);
+    qw_view_paint_borders((struct qw_view *)xdg_view, borders, border_count);
 
     // Raise view to front if requested
     if (above != 0) {


### PR DESCRIPTION
This PR adds support in the wayc backend for borders to be rendered via wlr_scene_buffer objects. The immediate beneficiary of this is the qtile-extras library which provides different border styles instead of solid colours.

I needed a lot of help from ChatGPT on this one (and also had to correct its mistakes...).

I can't guarantee there aren't any memory leaks here.