### PR TITLE
nix: force software rendering to bypass gpu issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,7 @@
 
             shellHook = ''
               export PYTHONPATH=$(readlink -f .):$PYTHONPATH
+              export WLR_RENDERER=pixman
             '';
 
             inputsFrom = [ self.packages.${pkgs.system}.qtile ];


### PR DESCRIPTION
sometimes wayc just hangs at this:
```bash
gurami on desktop qtile on  wayc-xwayland [2+1?] via 🐍 python v3.12.10 via  impure (nix-shell-env) 
➜ ./result/bin/qtile start -b wayland
InputConfig couldn't be imported from libqtile.backend.wayland
If this happened during setup.py installation, ignore this message.
Otherwise, make sure to run ./scripts/ffibuild.```

The fix I found is exporting `WLR_RENDERER=pixman` so I added that to flake