### PR TITLE
[wayc] Scene tree: store a reference to internal views

### DIFF
--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -131,6 +131,7 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
         .unhide = qw_internal_view_unhide,
     };
     view->base = base;
+    view->base.content_tree->node.data = view;
 
     // Create the initial buffer and disable the scene node by default
     qw_internal_view_buffer_new(view, true);


### PR DESCRIPTION
Currently required for query_tree() to count wids correctly.

Internal views have default wid = -1. Unclear whether we need to set the wid, title or other attributes of these views via callback