### PR TITLE
CI: add libxcb-cursor0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
                   imagemagick git xserver-xephyr xterm xvfb dbus-x11 libnotify-bin \
                   libxcb-composite0-dev libxcb-icccm4-dev libxcb-res0-dev libxcb-render0-dev libxcb-res0-dev \
                   libxcb-xfixes0-dev vlc volumeicon-alsa libxkbcommon-dev python-gi-dev libcairo2-dev \
-                  gir1.2-gdkpixbuf-2.0 librsvg2-dev
+                  gir1.2-gdkpixbuf-2.0 librsvg2-dev libxcb-cursor0
             - name: Cache Wayland dependencies
               uses: actions/cache@v4
               with:


### PR DESCRIPTION
we have apparently never installed this library in CI, and thus never actually tested the xcursors code there. Let's add this library so we can test it :)