### PR TITLE
nix: pin nixpkgs to nixos-unstable branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754511038,
-        "narHash": "sha256-fie5dSsWbHKtR1443lYwhUxeVk2dEQrq3L+FKOKPpGk=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a66fdcbf442afb2e4c3b8795c73a3c3ded92392a",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "a66fdcbf442afb2e4c3b8795c73a3c3ded92392a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,7 @@
 {
   description = "Qtile's flake, full-featured, hackable tiling window manager written and configured in Python";
   inputs = {
-    # note: we are using a commit hash to a fix,
-    # this should be removed one the pr has landed into unstable, see:
-    # https://nixpk.gs/pr-tracker.html?pr=431532
-    nixpkgs.url = "github:nixos/nixpkgs/a66fdcbf442afb2e4c3b8795c73a3c3ded92392a";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
   outputs =
     {


### PR DESCRIPTION
The tracker (https://nixpk.gs/pr-tracker.html?pr=431532) has reached nixos-unstable, there is no longer need to keep nixpkgs input pinned to a specific commit.