### PR TITLE
Add window swapping to Bsp and Columns Layouts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
       - the GenPollUrl widget now uses the asyncio infrastrcutre of
         BackgroundPoll above, and depends on aiohttp as a result. in-tree
         widgets that use GenPollUrl also depend on aihottp now.
+      - Add `swap` method to Bsp layout
     * bugfixes
 
 Qtile 0.33.0, released 2025-07-24:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
         BackgroundPoll above, and depends on aiohttp as a result. in-tree
         widgets that use GenPollUrl also depend on aihottp now.
       - Add `swap` method to Bsp layout
+      - Add `swap` method to Columns layout
     * bugfixes
 
 Qtile 0.33.0, released 2025-07-24:

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -191,6 +191,15 @@ class Bsp(Layout):
         if self.margin_on_single is None:
             self.margin_on_single = self.margin
 
+    def swap(self, c1: Window, c2: Window) -> None:
+        node_c1 = self.get_node(c1)
+        node_c2 = self.get_node(c2)
+
+        node_c1.client = c2
+        node_c2.client = c1
+
+        self.group.layout_all()
+
     def clone(self, group: _Group) -> Self:
         c = Layout.clone(self, group)
         c.root = _BspNode()

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -193,6 +193,26 @@ class Columns(Layout):
             )
             self.align = Columns._right
 
+    def swap(self, c1: Window, c2: Window) -> None:
+        col_c1: tuple[_Column, int]
+        col_c2: tuple[_Column, int]
+
+        for c in self.columns:
+            for i, w in enumerate(c.clients):
+                if w is c1:
+                    col_c1 = (c, i)
+                elif w is c2:
+                    col_c2 = (c, i)
+
+        col_c1[0].clients[col_c1[1]], col_c2[0].clients[col_c2[1]] = c2, c1
+
+        height_c1 = col_c1[0].heights.pop(c1)
+        height_c2 = col_c2[0].heights.pop(c2)
+
+        col_c1[0].heights[c2], col_c2[0].heights[c1] = height_c1, height_c2
+
+        self.group.layout_all()
+
     def clone(self, group: _Group) -> Self:
         c = Layout.clone(self, group)
         c.columns = [_Column(self.split, self.insert_position)]

--- a/test/layouts/test_bsp.py
+++ b/test/layouts/test_bsp.py
@@ -112,3 +112,24 @@ def test_bsp_wrap_clients(manager):
     # and here
     manager.c.layout.previous()
     assert_focused(manager, "two")
+
+
+def test_bsp_swap():
+    bsp = layout.Bsp()
+    bsp._group = libqtile.group._Group("A")
+
+    bsp.add_client("one")
+    bsp.add_client("two")
+    bsp.add_client("three")
+    bsp.add_client("four")
+
+    assert bsp.get_windows() == ["one", "three", "two", "four"]
+
+    bsp.swap("one", "two")
+
+    assert bsp.get_windows() == ["two", "three", "one", "four"]
+
+    bsp.add_client("five")
+    bsp.swap("one", "five")
+
+    assert bsp.get_windows() == ["two", "one", "three", "five", "four"]

--- a/test/layouts/test_columns.py
+++ b/test/layouts/test_columns.py
@@ -296,3 +296,36 @@ def test_columns_initial_ratio_left(manager):
     manager.c.layout.normalize()
     info = manager.c.window.info()
     assert info["width"] == WIDTH / 2
+
+
+def test_columns_swap():
+    columns = layout.Columns()
+    columns._group = libqtile.group._Group("A")
+
+    columns.add_client("one")
+    columns.add_client("two")
+    columns.add_client("three")
+    columns.focus("one")
+    columns.add_client("four")
+
+    assert columns.get_windows() == ["four", "one", "three", "two"]  # test vertical swap
+
+    columns.swap("four", "one")
+
+    assert columns.get_windows() == ["one", "four", "three", "two"]
+
+    columns.swap("one", "two")
+
+    assert columns.get_windows() == ["two", "four", "three", "one"]  # test horizontal swap
+
+    columns.add_client("five")
+    columns.shuffle_left()
+    columns.swap("five", "three")
+
+    assert columns.get_windows() == [
+        "three",
+        "two",
+        "four",
+        "five",
+        "one",
+    ]  # test swap with three columns


### PR DESCRIPTION
Implements the  `swap` method for the `Bsp` and the `Columns` Layouts.
This is used by `lazy.window.set_position()`