### PR TITLE
[wayc]: Refactor XWayland view creation and improve safety

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -53,10 +53,10 @@ void qw_server_finalize(struct qw_server *server) {
     wl_list_remove(&server->renderer_lost.link);
     wl_list_remove(&server->request_activate.link);
     wl_list_remove(&server->new_token.link);
-    #if WLR_HAS_XWAYLAND
+#if WLR_HAS_XWAYLAND
     wl_list_remove(&server->new_xwayland_surface.link);
     wlr_xwayland_destroy(server->xwayland);
-    #endif
+#endif
 
     wl_display_destroy_clients(server->display);
     wlr_scene_node_destroy(&server->scene->tree.node);
@@ -370,7 +370,7 @@ static void qw_server_handle_new_layer_surface(struct wl_listener *listener, voi
 static void qw_server_handle_new_xwayland_surface(struct wl_listener *listener, void *data) {
     struct qw_server *server = wl_container_of(listener, server, new_xwayland_surface);
     struct wlr_xwayland_surface *xwayland_surface = data;
-    qw_server_xwayland_view_new(server, xwayland_surface);
+    qw_create_xwayland_view(server, xwayland_surface);
 }
 
 const char *qw_server_xwayland_display_name(struct qw_server *server) {

--- a/libqtile/backend/wayland/qw/xwayland-view.h
+++ b/libqtile/backend/wayland/qw/xwayland-view.h
@@ -72,7 +72,7 @@ struct qw_xwayland_unmanaged {
 // void qw_xwayland_view_unmanaged_destroy(struct wl_listener *listener, void *data);
 // void qw_xwayland_view_unmanaged_override_redirect(struct wl_listener *listener, void *data);
 // void qw_xwayland_view_unmanaged_request_activate(struct wl_listener *listener, void *data);
-struct qw_xwayland_view *create_xwayland_view(struct wlr_xwayland_surface *qw_xsurface);
-void qw_server_xwayland_view_new(struct qw_server *server, struct wlr_xwayland_surface *xwayland_surface);
+struct qw_xwayland_view *qw_create_xwayland_view(struct qw_server *server,
+                                                 struct wlr_xwayland_surface *qw_xsurface);
 
 #endif /* QW_XWAYLAND_VIEW */


### PR DESCRIPTION
- Rename `create_xwayland_view` to `qw_create_xwayland_view` for consistency.
- Remove `qw_server_xwayland_view_new` for deduplication.
- Remove unused or redundant functions and code comments.
- Add null checks for content_tree and scene_tree to prevent potential crashes.
- Ensure proper listener removal and cleanup in `handle_destroy`.
- Improve readability and maintain a consistent coding style across xwayland-view.c/h.