### PR TITLE
Fix wayland builder

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, elParaguayo. All rights reserved.
+# Copyright (c) 2025 elParaguayo
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@ from setuptools import build_meta as _orig
 from setuptools.build_meta import *  # noqa: F401,F403
 
 WAYLAND_DEPENDENCIES = ["pywlroots>=0.17.0,<0.18.0"]
+WAYLAND_FFI_BUILD = "./libqtile/backend/wayland/cffi/build.py"
 
 
 def wants_wayland(config_settings):
@@ -44,15 +45,20 @@ def get_requires_for_build_wheel(config_settings=None):
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    """Stop building if wayland requested but pywlroots is not installed."""
+    """If wayland backend is requested, build it!"""
     if config_settings is None:
         config_settings = {}
 
-    if wants_wayland(config_settings):
-        try:
-            import wlroots  # noqa: F401
-        except ImportError:
-            sys.exit("Wayland backend requested but pywlroots is not installed.")
+    wayland_requested = wants_wayland(config_settings)
+    try:
+        from libqtile.backend.wayland.cffi.build import ffi_compile
+
+        ffi_compile(verbose=wayland_requested)
+    except Exception as e:
+        if wayland_requested:
+            sys.exit(f"Wayland backend requested but backend could not be built: {e}")
+        else:
+            print("Wayland backend was not built.")
 
     # Write library paths to file, if they are specified at build time via
     # --config-settings=PANGO_PATH=...

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import wlroots.ffi_build as wlr
 from cffi import FFI
@@ -30,5 +31,21 @@ ffi.include(wlr.ffi_builder)
 ffi.cdef(libinput.CDEF)
 ffi.cdef(cairo_buffer.CDEF)
 
+
+def ffi_compile(verbose: bool = False) -> None:
+    # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
+    # at libqtile/backend/wayland/_ffi.so.
+    # This is built at the path specified in tmpdir which is "." by default. So, if we're in a
+    # virtual environment, libqtile might be at .venv/lib/python3.13/site-packages/ but if we run
+    # the builder script, we'll get a new libqtile folder in th current directory that only has that
+    # tree shown above and the libtile library won't find the `_ffi` library.
+    # We therefore set the tmpdir to be the path to the folder containing libqtile so the library
+    # is always created in the correct folder.
+    # The compile command is nested in a function to ensure that the tmpdir value is not overwritten.
+    ffi.compile(
+        tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(), verbose=verbose
+    )
+
+
 if __name__ == "__main__":
-    ffi.compile()
+    ffi_compile()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,14 @@ docs = [
     "sphinx_rtd_theme",
 ]
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 include = ["libqtile*"]
+
+[tool.setuptools.package-data]
+"libqtile.backend.wayland" = ["*.so"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
We removed `setup.py` but our build script (`builder.py`) did not actually trigger the wayland backend build, instead it just ensured the correct dependencies were injected into the build requirement.

This PR updates `builder.py` to trigger the build. qtile will still build even if the wayland backend build fails unless the user passes `--config-settings backend=wayland` in which case an exception will be raised if the backend cannot be built.


Can some people test these please as I'm getting an odd message when trying locally:
`WARNING: Built wheel for qtile is invalid: Wheel has unexpected file name: expected '0.33.1.dev41+g79ea647a', got '0.33.1.dev41+g79ea647a.d20250815'`

The backend is building but install is not completing.