### PR TITLE
deps: move pycairo to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "cairocffi >= 1.7.0",
     "cffi >= 1.1.0",
     "xcffib >= 1.4.0",
-    "pycairo >= 1.25.1",
 ]
 license = "MIT"
 license-files = [ "LICENSE" ]
@@ -50,6 +49,7 @@ dev = [
     "pytest-cov",
     "pre-commit",
     "PyGObject",
+    "pycairo >= 1.25.1",
     "isort",
     "pytest >= 6.2.1",
     "mypy",


### PR DESCRIPTION
I added the explicit dependency in 2347e18663ff ("move to pycairo 1.25.1") to work around a seg fault we were getting in CI, but we do not actually use it anywhere in our codebase (`git grep "import cairo"` returns nothing), so it doesn't need to be a runtime dependency. Indeed, when I added the explicit dependency I was also confused about what was happening:

https://github.com/qtile/qtile/issues/4502#issuecomment-1753121787

However, looking further,

`uv pip tree` gives us:

    pygobject v3.52.3
    └── pycairo v1.28.0

Meaning that our PyGobject dependency is bring in + importing cairo, which was ultimately the thing causing the seg fault.

Without some hackery it does not seem possible to install pygobject without the pycairo dependency: https://gitlab.gnome.org/GNOME/pygobject/-/issues/395

We only use gobject (and thus pycairo) in some of our tests (git grep "import gi") to drive some test windows, so we can remove this as a runtime dependency but keep it as a test dependency (with the version with the bugfix hardcoded), hopefully making packaging a bit more obvious :)