### PR TITLE
Add transient hooks

### DIFF
--- a/docs/manual/config/hooks.rst
+++ b/docs/manual/config/hooks.rst
@@ -87,3 +87,9 @@ will run them asynchronously in the event loop:
     @hook.subscribe.focus_change
     async def _():
         ...
+
+Transient hooks
+---------------
+
+Transient hooks can be created by having the hooked function return ``True``. This
+will automtically unsubscribe the hook after is has been run.


### PR DESCRIPTION
Hooks that return ``True`` will be automatically unsubscribed.

The idea behind this was needing some code to restack windows that had been temporarily elevated to a higher layer without constantly needing to fire hooks.

Draft for now just to get feedback on the idea.

If people like it, I'll add some tests.