### PR TITLE
[wayc] Fix client cursor interaction (regression)

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -390,6 +390,14 @@ struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly
     }
 
     if (node->type == WLR_SCENE_NODE_BUFFER || node->type == WLR_SCENE_NODE_RECT) {
+        if (node->type == WLR_SCENE_NODE_BUFFER) {
+            struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_from_node(node);
+            struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(scene_buffer);
+            if(scene_surface) {
+                *surface = scene_surface->surface;
+            }
+        }
+
         // Walk up the tree to find the associated view
         struct wlr_scene_tree *tree = node->parent;
         while (tree && !tree->node.data) {

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -393,7 +393,7 @@ struct qw_view *qw_server_view_at(struct qw_server *server, double lx, double ly
         if (node->type == WLR_SCENE_NODE_BUFFER) {
             struct wlr_scene_buffer *scene_buffer = wlr_scene_buffer_from_node(node);
             struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(scene_buffer);
-            if(scene_surface) {
+            if(scene_surface != NULL) {
                 *surface = scene_surface->surface;
             }
         }


### PR DESCRIPTION
Commit 15e8e53 inadvertantly removed the code from qw_server_view_at() that is responsible for returning the surface under the cursor