### PR TITLE
[wayc] Fix xdg_view destroy

### DIFF
--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -65,6 +65,8 @@ static void qw_xdg_view_handle_destroy(struct wl_listener *listener, void *data)
     wl_list_remove(&xdg_view->set_app_id.link);
     // TODO: Remove request_move and request_resize listeners if added
 
+    wlr_scene_node_destroy(&xdg_view->base.content_tree->node);
+
     free(xdg_view);
 }
 


### PR DESCRIPTION
Remove view's top node (xdg_view->base.content_tree) from the scene graph when they are destroyed

Relates to issue #5459