### PR TITLE
tests: bump dgroups spawn= test timeout

### DIFF
--- a/test/test_dgroups.py
+++ b/test/test_dgroups.py
@@ -93,7 +93,7 @@ def test_dgroup_nonpersist(manager):
 
 @dgroups_spawn_config
 def test_dgroup_spawn_in_group(manager):
-    @Retry(ignore_exceptions=(AssertionError,))
+    @Retry(ignore_exceptions=(AssertionError,), tmax=10)
     def wait_for_window():
         assert len(manager.c.windows()) > 0
 


### PR DESCRIPTION
I have seen a bunch of failures like this recently:

    =================================== FAILURES ===================================
    ___________ test_dgroup_spawn_in_group[1-wayland-DGroupsSpawnConfig] ___________

    manager = <test.helpers.TestManager object at 0x7ff33a324a10>

        @dgroups_spawn_config
        def test_dgroup_spawn_in_group(manager):
            @Retry(ignore_exceptions=(AssertionError,))
            def wait_for_window():
                assert len(manager.c.windows()) > 0

    >       wait_for_window()

    test/test_dgroups.py:100:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    test/helpers.py:74: in wrapper
        raise self.last_failure
    test/helpers.py:64: in wrapper
        return fn(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

        @Retry(ignore_exceptions=(AssertionError,))
        def wait_for_window():
    >       assert len(manager.c.windows()) > 0
    E       assert 0 > 0
    E        +  where 0 = len([])
    E        +    where [] = <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d81d0>()
    E        +      where <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d81d0> = <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d6360>.windows
    E        +        where <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d6360> = <test.helpers.TestManager object at 0x7ff33a324a10>.c

    test/test_dgroups.py:98: AssertionError
    ----------------------------- Captured stderr call -----------------------------
    Failed to initialize glamor, falling back to sw
    The XKEYBOARD keymap compiler (xkbcomp) reports:
    > Warning:          Could not resolve keysym XF86CameraAccessEnable
    > Warning:          Could not resolve keysym XF86CameraAccessDisable
    > Warning:          Could not resolve keysym XF86CameraAccessToggle
    > Warning:          Could not resolve keysym XF86NextElement
    > Warning:          Could not resolve keysym XF86PreviousElement
    > Warning:          Could not resolve keysym XF86AutopilotEngageToggle
    > Warning:          Could not resolve keysym XF86MarkWaypoint
    > Warning:          Could not resolve keysym XF86Sos
    > Warning:          Could not resolve keysym XF86NavChart
    > Warning:          Could not resolve keysym XF86FishingChart
    > Warning:          Could not resolve keysym XF86SingleRangeRadar
    > Warning:          Could not resolve keysym XF86DualRangeRadar
    > Warning:          Could not resolve keysym XF86RadarOverlay
    > Warning:          Could not resolve keysym XF86TraditionalSonar
    > Warning:          Could not resolve keysym XF86ClearvuSonar
    > Warning:          Could not resolve keysym XF86SidevuSonar
    > Warning:          Could not resolve keysym XF86NavInfo
    Errors from xkbcomp are not fatal to the X server
    xterm: cannot load font "-misc-fixed-medium-r-semicondensed--13-120-75-75-c-60-iso10646-1"
    --------------------------- Captured stdout teardown ---------------------------
    2025-08-25 08:43:25,079 libqtile wlrq.py:finalize_listener():L238  Failed to remove listener for event: <pywayland.server.listener.Signal object at 0x7ff33a35e1e0>
    2025-08-25 08:43:25,080 libqtile wlrq.py:finalize_listener():L238  Failed to remove listener for event: <pywayland.server.listener.Signal object at 0x7ff33a35e150>
    --------------------------- Captured stderr teardown ---------------------------
    (EE) failed to write to Xwayland fd: Broken pipe
    =========================== short test summary info ============================
    FAILED test/test_dgroups.py::test_dgroup_spawn_in_group[1-wayland-DGroupsSpawnConfig] - assert 0 > 0
     +  where 0 = len([])
     +    where [] = <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d81d0>()
     +      where <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d81d0> = <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d6360>.windows
     +        where <libqtile.command.client.InteractiveCommandClient object at 0x7ff3408d6360> = <test.helpers.TestManager object at 0x7ff33a324a10>.c
    ====== 1 failed, 1260 passed, 59 skipped, 2 xpassed in 894.51s (0:14:54) =======

from e.g. https://github.com/qtile/qtile/actions/runs/17180156566/job/48799190681

I think the problem here is that it might take Qtile more than the default 5 seconds to spawn a window when running in a fully loaded CI environment.

Let's bump this timeout. Ideally we would have the window be able to write a file or something to signal that it's been launched, but for now, perhaps this will stop our spurious failures...