### PR TITLE
upgrade mypy

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@
 
 # blackify code
 c8fdbedd248173d3f415b411792a2980d7a448d2
+
+# upgrade mypy
+2d3efb6c758ef89df9404df18a03f0f9021863b2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.1
     hooks:
       - id: mypy
         additional_dependencies: ["types-python-dateutil", "types-pytz"]

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -215,12 +215,12 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         # Hacky solution that shows limitations of typing Configurable. We want the
         # option to accept `int | list[int]` but the attribute to be `list[int]`.
         self.margin: list[int]
-        if isinstance(self.margin, int):  # type: ignore [unreachable]
-            self.margin = [self.margin] * 4  # type: ignore [unreachable]
+        if isinstance(self.margin, int):
+            self.margin = [self.margin] * 4
 
         self.border_width: list[int]
-        if isinstance(self.border_width, int):  # type: ignore [unreachable]
-            self.border_width = [self.border_width] * 4  # type: ignore [unreachable]
+        if isinstance(self.border_width, int):
+            self.border_width = [self.border_width] * 4
 
         self.border_color: ColorsType
 

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -470,7 +470,7 @@ class _Widget(CommandObject, configurable.Configurable):
     def add_mirror(self, widget: _Widget):
         if not self._mirrors:
             self._old_draw = self.draw
-            self.draw = self._draw_with_mirrors  # type: ignore
+            self.draw = self._draw_with_mirrors
 
         self._mirrors.add(widget)
         if not self.drawer.has_mirrors:

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -96,9 +96,7 @@ class Icon(window._Window):
     handle_UnmapNotify = handle_DestroyNotify  # noqa: N815
 
 
-# Mypy doesn't like the inheritance of height and width as _Widget's
-# properties are read only but _Window's have a getter and setter.
-class Systray(base._Widget, window._Window):  # type: ignore[misc]
+class Systray(base._Widget, window._Window):
     """
     A widget that manages system tray.
 


### PR DESCRIPTION
This allows us to drop some unused type ignores that newer mypys can "see" through.