### PR TITLE
pyproject: drop wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "cairocffi[xcb]>=1.6.0",
     "setuptools>=61",
     "setuptools-scm>=7.0",
-    "wheel",
 ]
 backend-path=["."]
 build-backend = "builder"


### PR DESCRIPTION
looks like my copypasta from 44766de9cf6e7af6a57ea1f85442bab694f39e9b nee https://stackoverflow.com/questions/72270892/git-versioning-with-setuptools-in-pyproject-toml was overzealous, and `wheel` is not needed.

Reported-by: Sviatoslav Sydorenko <webknjaz@redhat.com>