### PR TITLE
[wayc] Implement input device configuration (incomplete)

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -80,7 +80,7 @@ extern "Python" void set_title_cb(char* title, void *userdata);
 extern "Python" void set_app_id_cb(char* app_id, void *userdata);
 """
 
-cdef_files = ["log.h", "server.h", "view.h", "util.h", "output.h", "internal-view.h", "cursor.h"]
+cdef_files = ["log.h", "server.h", "view.h", "util.h", "output.h", "internal-view.h", "cursor.h", "input-device.h"]
 
 for file in cdef_files:
     with open(QW_PATH / file) as f:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -73,6 +73,7 @@ from typing import TYPE_CHECKING
 
 from libqtile import hook, log_utils
 from libqtile.backend import base
+from libqtile.backend.wayland import inputs
 from libqtile.backend.wayland.window import Internal, Window, WindowType
 from libqtile.command.base import expose_command
 from libqtile.config import ScreenRect
@@ -266,8 +267,9 @@ class Core(base.Core):
 
         # Apply input device configuration
         if self.qtile.config.wl_input_rules:
-            # TODO: configure devices (keyboards, pointers)
-            pass
+            inputs.configure_input_devices(self.qw, self.qtile.config.wl_input_rules)
+
+        #TODO: Also configure devices when a new device is added
 
     def handle_screen_change(self):
         hook.fire("screen_change", None)

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -1,0 +1,149 @@
+import enum
+from libqtile import configurable
+from typing import Any
+from libqtile.log_utils import logger
+
+try:
+    from libqtile.backend.wayland._ffi import ffi, lib
+
+except ModuleNotFoundError:
+    print("Warning: Wayland backend not built. Backend will not run.")
+
+    from libqtile.backend.wayland.ffi_stub import ffi, lib
+
+
+class InputConfig(configurable.Configurable):
+    """
+    This is used to configure input devices. An instance of this class represents one
+    set of settings that can be applied to an input device.
+
+    To use this, define a dictionary called ``wl_input_rules`` in your config. The keys
+    are used to match input devices, and the values are instances of this class with the
+    desired settings. For example:
+
+    .. code-block:: python
+
+        from libqtile.backend.wayland import InputConfig
+
+        wl_input_rules = {
+            "1267:12377:ELAN1300:00 04F3:3059 Touchpad": InputConfig(left_handed=True),
+            "*": InputConfig(left_handed=True, pointer_accel=True),
+            "type:keyboard": InputConfig(kb_options="ctrl:nocaps,compose:ralt"),
+        }
+
+    When a input device is being configured, the most specific matching key in the
+    dictionary is found and the corresponding settings are used to configure the device.
+    Unique identifiers are chosen first, then ``"type:X"``, then ``"*"``.
+
+    The command ``qtile cmd-obj -o core -f get_inputs`` can be used to get information
+    about connected devices, including their identifiers.
+
+    Options default to ``None``, leave a device's default settings intact. For
+    information on what each option does, see the documenation for libinput:
+    https://wayland.freedesktop.org/libinput/doc/latest/configuration.html. Note that
+    devices often only support a subset of settings.
+
+    This tries to mirror how Sway configures libinput devices. For more information
+    check out sway-input(5): https://man.archlinux.org/man/sway-input.5#LIBINPUT_CONFIGURATION
+
+    Keyboards, managed by `xkbcommon <https://github.com/xkbcommon/libxkbcommon>`_, are
+    configured with the options prefixed by ``kb_``. X11's helpful `XKB guide
+    <https://www.x.org/releases/X11R7.5/doc/input/XKB-Config.html>`_ may be useful for
+    figuring out the syntax for some of these settings.
+    """
+
+    defaults = [
+        ("accel_profile", None, "``'adaptive'`` or ``'flat'``"),
+        ("click_method", None, "``'none'``, ``'button_areas'`` or ``'clickfinger'``"),
+        ("drag", None, "``True`` or ``False``"),
+        ("drag_lock", None, "``True`` or ``False``"),
+        ("dwt", None, "True or False"),
+        ("left_handed", None, "``True`` or ``False``"),
+        ("middle_emulation", None, "``True`` or ``False``"),
+        ("natural_scroll", None, "``True`` or ``False``"),
+        ("pointer_accel", None, "A ``float`` between -1 and 1."),
+        ("scroll_button", None, "``'disable'``, 'Button[1-3,8,9]' or a keycode"),
+        (
+            "scroll_method",
+            None,
+            "``'none'``, ``'two_finger'``, ``'edge'``, or ``'on_button_down'``",
+        ),
+        ("tap", None, "``True`` or ``False``"),
+        ("tap_button_map", None, "``'lrm'`` or ``'lmr'``"),
+        ("kb_layout", None, "Keyboard layout i.e. ``XKB_DEFAULT_LAYOUT``"),
+        ("kb_options", None, "Keyboard options i.e. ``XKB_DEFAULT_OPTIONS``"),
+        ("kb_variant", None, "Keyboard variant i.e. ``XKB_DEFAULT_VARIANT``"),
+        ("kb_repeat_rate", 25, "Keyboard key repeats made per second"),
+        ("kb_repeat_delay", 600, "Keyboard delay in milliseconds before repeating"),
+    ]
+
+    def __init__(self, **config: Any) -> None:
+        configurable.Configurable.__init__(self, **config)
+        self.add_defaults(InputConfig.defaults)
+
+@enum.unique
+class InputDeviceType(enum.IntEnum):
+    KEYBOARD = lib.WLR_INPUT_DEVICE_KEYBOARD
+    POINTER = lib.WLR_INPUT_DEVICE_POINTER
+    TOUCH = lib.WLR_INPUT_DEVICE_TOUCH
+    TABLET = lib.WLR_INPUT_DEVICE_TABLET
+    TABLET_PAD = lib.WLR_INPUT_DEVICE_TABLET_PAD
+    SWITCH = lib.WLR_INPUT_DEVICE_SWITCH
+
+@enum.unique
+class InputDeviceAccelProfile(enum.IntEnum):
+    adaptive = lib.LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE
+    flat = lib.LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT
+
+def configure_input_devices(server, configs):
+    @ffi.callback("void(struct qw_input_device *input_device, char *name, int type, int vendor, int product)")
+    def input_device_cb(input_device, name, type, vendor, product):
+        # Get the device type and identifier for this input device. These can be used be
+        # used to assign ``InputConfig`` options to devices or types of devices.
+        name = ffi.string(name).decode()
+        if name == " " or not name.isprintable():
+            name = "_"
+        type_key = "type:" + InputDeviceType(type).name.lower()
+        identifier = f"{vendor:d}:{product:d}:{name!s}"
+
+        #TODO: The original backend has a check for whether the pointer is a touchpad,
+        # but shouldn't touchpads be identified as touchpads? Is this needed because some
+        # touchpads are incorrectly identified as pointers?
+
+        if identifier in configs:
+            conf = configs[identifier]
+        elif type_key in configs:
+            conf = configs[type_key]
+        elif "*" in configs:
+            conf = configs["*"]
+        else:
+            conf = None
+
+        if conf is not None:
+            if type == InputDeviceType.POINTER:
+                device = lib.qw_input_device_get_libinput_handle(input_device)
+                if device == ffi.NULL:
+                    return
+
+                if conf.accel_profile is not None:
+                    lib.qw_input_device_config_accel_set_profile(device, InputDeviceAccelProfile[conf.accel_profile].value)
+
+                if conf.drag is not None:
+                    lib.qw_input_device_config_tap_set_drag_enabled(device, conf.drag)
+
+                if conf.drag_lock is not None:
+                    lib.qw_input_device_config_tap_set_drag_lock_enabled(device, conf.drag_lock)
+
+                if conf.natural_scroll is not None:
+                    lib.qw_input_device_config_scroll_set_natural_scroll_enabled(device, conf.natural_scroll)
+
+            elif type == InputDeviceType.KEYBOARD:
+                keyboard = lib.qw_input_device_get_keyboard(input_device)
+                if keyboard == ffi.NULL:
+                    return
+
+                lib.qw_input_device_config_kbd_set_repeat_info(keyboard, conf.kb_repeat_rate, conf.kb_repeat_delay) 
+                #TODO:Update keymap here
+
+    lib.qw_server_loop_input_devices(server, input_device_cb)
+

--- a/libqtile/backend/wayland/qw/input-device.c
+++ b/libqtile/backend/wayland/qw/input-device.c
@@ -1,0 +1,53 @@
+#include <libinput.h>
+#include <wlr/backend/libinput.h>
+#include "input-device.h"
+
+void qw_server_input_device_new(struct qw_server *server, struct wlr_input_device *device) {
+    struct qw_input_device *input_device = calloc(1, sizeof(*input_device));
+    if (input_device == NULL) {
+        wlr_log(WLR_ERROR, "failed to create qw_input_device struct");
+        return;
+    }
+
+    input_device->server = server;
+    input_device->device = device;
+    wl_list_insert(&server->input_devices, &input_device->link); 
+
+    // TODO: Remove devices from list when they are removed
+}
+
+struct libinput_device *qw_input_device_get_libinput_handle(struct qw_input_device *input_device) {
+    if (wlr_input_device_is_libinput(input_device->device) == false) {
+        return NULL;
+    }
+    return wlr_libinput_get_device_handle(input_device->device);
+}
+
+struct wlr_keyboard *qw_input_device_get_keyboard(struct qw_input_device *input_device) {
+    struct wlr_keyboard *keyboard = wlr_keyboard_from_input_device(input_device->device);
+    return keyboard;
+}
+
+void qw_input_device_config_kbd_set_repeat_info(struct wlr_keyboard *keyboard, int kb_repeat_rate, int kb_repeat_delay) {
+    wlr_keyboard_set_repeat_info(keyboard, kb_repeat_rate, kb_repeat_delay);
+}
+
+void qw_input_device_config_accel_set_profile(struct libinput_device *device, int accel_profile) {
+    if (libinput_device_config_accel_is_available(device) != 0) {
+        libinput_device_config_accel_set_profile(device, accel_profile);
+    }
+}
+
+void qw_input_device_config_tap_set_drag_enabled(struct libinput_device *device, int drag) {
+    libinput_device_config_tap_set_drag_enabled(device, drag);
+}
+
+void qw_input_device_config_tap_set_drag_lock_enabled(struct libinput_device *device, int drag_lock) {
+    libinput_device_config_tap_set_drag_lock_enabled(device, drag_lock);
+}
+
+void qw_input_device_config_scroll_set_natural_scroll_enabled(struct libinput_device *device, int natural_scroll) {
+    if (libinput_device_config_scroll_has_natural_scroll(device) != 0) {
+        libinput_device_config_scroll_set_natural_scroll_enabled(device, natural_scroll);
+    }
+}

--- a/libqtile/backend/wayland/qw/input-device.h
+++ b/libqtile/backend/wayland/qw/input-device.h
@@ -1,0 +1,43 @@
+#ifndef INPUT_DEVICE_H
+#define INPUT_DEVICE_H
+
+enum wlr_input_device_type {
+    WLR_INPUT_DEVICE_KEYBOARD,
+    WLR_INPUT_DEVICE_POINTER,
+    WLR_INPUT_DEVICE_TOUCH,
+    WLR_INPUT_DEVICE_TABLET,
+    WLR_INPUT_DEVICE_TABLET_PAD,
+    WLR_INPUT_DEVICE_SWITCH,
+};
+
+enum libinput_config_accel_profile {
+    LIBINPUT_CONFIG_ACCEL_PROFILE_NONE = 0,
+    LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT = (1 << 0),
+    LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE = (1 << 1),
+    LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM = (1 << 2),
+};
+
+struct qw_input_device {
+    // Private data
+    struct qw_server *server;
+    struct wl_list link;
+    struct wlr_input_device *device;
+};
+
+void qw_server_input_device_new(struct qw_server *server, struct wlr_input_device *device);
+
+struct libinput_device *qw_input_device_get_libinput_handle(struct qw_input_device *input_device);
+
+struct wlr_keyboard *qw_input_device_get_keyboard(struct qw_input_device *input_device);
+
+void qw_input_device_config_kbd_set_repeat_info(struct wlr_keyboard *keyboard, int kb_repeat_rate, int kb_repeat_delay);
+
+void qw_input_device_config_accel_set_profile(struct libinput_device *device, int accel_profile);
+
+void qw_input_device_config_tap_set_drag_enabled(struct libinput_device *device, int drag);
+
+void qw_input_device_config_tap_set_drag_lock_enabled(struct libinput_device *input_device, int drag_lock);
+
+void qw_input_device_config_scroll_set_natural_scroll_enabled(struct libinput_device *device, int natural_scroll);
+
+#endif

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -77,6 +77,12 @@ struct qw_output;
 // Callback for when the screen reserves space
 typedef void (*on_screen_reserve_space_cb_t)(struct qw_output *output, void *userdata);
 
+// Forward declaration of input device struct
+struct qw_input_device;
+
+// Iterate input devices callback
+typedef void (*input_device_cb_t)(struct qw_input_device *input_device, const char* name, int type, int vendor, int product);
+
 enum {
     LAYER_BACKGROUND,   // background, layer shell
     LAYER_BOTTOM,       // bottom, layer shell
@@ -142,6 +148,7 @@ struct qw_server {
     struct wl_listener new_input;
     struct wl_listener renderer_lost;
     struct wl_list keyboards;
+    struct wl_list input_devices;
     struct wlr_seat *seat;
     struct qw_cursor *cursor;
     struct wlr_xdg_shell *xdg_shell;
@@ -205,5 +212,7 @@ void qw_server_paint_wallpaper(struct qw_server *server, int x, int y, cairo_sur
                                enum qw_wallpaper_mode mode);
 
 void qw_server_paint_background_color(struct qw_server *server, int x, int y, float color[4]);
+
+void qw_server_loop_input_devices(struct qw_server *server, input_device_cb_t cb);
 
 #endif /* SERVER_H */


### PR DESCRIPTION
Apply config from wl_input_rules

Need to reload config to take effect

This is a functional but incomplete implementation. Most pointer configuration options haven't been added and there are various todos marked in the code