### PR TITLE
add prompt_toolkit to optional core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional_core = [
     "dbus-fast",
     "libcst >= 1.0.0",
     "setproctitle",
+    "prompt_toolkit",
 ]
 widgets = [
     "imaplib2",


### PR DESCRIPTION
we use this for the repl, which I was just using to debug some stuff. let's add it so it gets installed.