### PR TITLE
asyncio.iscoroutinefunction -> inspect

### DIFF
--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -338,7 +338,7 @@ class CommandObject(metaclass=abc.ABCMeta):
     def function(self, function, *args, **kwargs) -> asyncio.Task | None:
         """Call a function with current object as argument"""
         try:
-            if asyncio.iscoroutinefunction(function):
+            if inspect.iscoroutinefunction(function):
                 return create_task(function(self, *args, **kwargs))
             else:
                 return function(self, *args, **kwargs)

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 from typing import TYPE_CHECKING
 
 from libqtile import backend, utils
@@ -203,7 +204,7 @@ class Registry:
 
         for i in subscriptions[self.name].get(event, []):
             try:
-                if asyncio.iscoroutinefunction(i):
+                if inspect.iscoroutinefunction(i):
                     _fire_async_event(i(*args, **kwargs), unsubscribe_func(event, i))
                 elif asyncio.iscoroutine(i):
                     _fire_async_event(i, unsubscribe_func(event, i))

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import inspect
 import math
 import subprocess
 from typing import TYPE_CHECKING
@@ -432,7 +433,7 @@ class _Widget(CommandObject, configurable.Configurable):
     def _wrapper(self, method, *method_args):
         self._remove_dead_timers()
         try:
-            if asyncio.iscoroutinefunction(method):
+            if inspect.iscoroutinefunction(method):
                 create_task(method(*method_args))
             elif asyncio.iscoroutine(method):
                 create_task(method)


### PR DESCRIPTION
Looks like this is deprecated as of 3.14:

    2025-08-26T20:23:04.5973602Z DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead