### PR TITLE
core: only cancel tasks once

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -58,7 +58,6 @@ from libqtile.resources.sleep import inhibitor
 from libqtile.scratchpad import ScratchPad
 from libqtile.scripts.main import VERSION
 from libqtile.utils import (
-    cancel_tasks,
     create_task,
     get_cache_dir,
     lget,
@@ -350,7 +349,6 @@ class Qtile(CommandObject):
         self._finalize_configurables()
         remove_dbus_rules()
         inhibitor.stop()
-        cancel_tasks()
         self.core.finalize()
 
     def add_autogen_group(self, screen_idx: int) -> _Group:

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -57,7 +57,7 @@ dbus_bus_connections = set()
 
 # Create a list to collect references to tasks so they're not garbage collected
 # before they've run
-TASKS: list[asyncio.Task[None]] = []
+TASKS: set[asyncio.Task[None]] = set()
 
 
 def create_task(coro: Coroutine) -> asyncio.Task | None:
@@ -72,20 +72,11 @@ def create_task(coro: Coroutine) -> asyncio.Task | None:
     if not loop:
         return None
 
-    def tidy(task: asyncio.Task) -> None:
-        TASKS.remove(task)
-
     task = asyncio.create_task(coro)
-    TASKS.append(task)
-    task.add_done_callback(tidy)
+    TASKS.add(task)
+    task.add_done_callback(TASKS.discard)
 
     return task
-
-
-def cancel_tasks() -> None:
-    """Cancel scheduled tasks."""
-    for task in TASKS:
-        task.cancel()
 
 
 class QtileError(Exception):


### PR DESCRIPTION
While debugging something else in our exit path, I noticed we try to cancel asyncio tasks twice, once in libqtile/core/loop.py::_cancel_all_tasks(), and once in the finalizer.

The version in _cancel_all_tasks() is probably preferable, since it iterates over all asyncio tasks, so we will cancel stuff that's started by libraries or whatever. So, let's drop our own version.

Also, while I was here, I switched our task list to a set like the docs show, and removed some of the unnecessary callbacks by calling set.discard() directly.