### PR TITLE
[wayc] Deactivate previous surfaces on focus

### DIFF
--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -70,3 +70,19 @@ int qw_util_get_modifier_code(const char *codestr) {
 xkb_keysym_t qwu_keysym_from_name(const char *name) {
 	return xkb_keysym_from_name(name, XKB_KEYSYM_CASE_INSENSITIVE);
 }
+
+void qw_util_deactivate_surface(struct wlr_surface *surface) {
+    struct wlr_xdg_toplevel *xdg_toplevel = wlr_xdg_toplevel_try_from_wlr_surface(surface);
+    if (xdg_toplevel) {
+        wlr_xdg_toplevel_set_activated(xdg_toplevel, false);
+        return;
+    }
+
+    #if WLR_HAS_XWAYLAND
+    struct wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
+    if (xwayland_surface) {
+        wlr_xwayland_surface_activate(xwayland_surface, false);
+        return;
+    }
+    #endif
+}

--- a/libqtile/backend/wayland/qw/util.h
+++ b/libqtile/backend/wayland/qw/util.h
@@ -26,4 +26,6 @@ int qw_util_get_modifier_code(const char *codestr);
 // the search is case insensitive
 xkb_keysym_t qwu_keysym_from_name(const char *name);
 
+void qw_util_deactivate_surface(struct wlr_surface *surface);
+
 #endif /* UTIL_H */

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -1,5 +1,6 @@
 #include "xdg-view.h"
 #include "server.h"
+#include "util.h"
 #include "view.h"
 #include "wayland-server-core.h"
 #include "wayland-util.h"
@@ -21,13 +22,9 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
         return;
     }
 
-    // Deactivate previous toplevel if any
+    // Deactivate previous surface if any
     if (prev_surface) {
-        struct wlr_xdg_toplevel *prev_toplevel =
-            wlr_xdg_toplevel_try_from_wlr_surface(prev_surface);
-        if (prev_toplevel) {
-            wlr_xdg_toplevel_set_activated(prev_toplevel, false);
-        }
+        qw_util_deactivate_surface(prev_surface);
     }
 
     wlr_xdg_toplevel_set_activated(xdg_view->xdg_toplevel, true);

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -1,4 +1,5 @@
 #include "xwayland-view.h"
+#include "qw/util.h"
 #include "server.h"
 #include "view.h"
 #include "wayland-server-core.h"
@@ -25,6 +26,13 @@ static void qw_xwayland_view_do_focus(struct qw_xwayland_view *xwayland_view,
     }
 
     wlr_scene_node_raise_to_top(&xwayland_view->base.content_tree->node);
+
+    // Deactivate previous surface if any
+    if (prev_surface != NULL) {
+        qw_util_deactivate_surface(prev_surface);
+    }
+
+    wlr_xwayland_surface_activate(xwayland_view->xwayland_surface, true);
 
     // Notify keyboard about entering this surface (for keyboard input)
     struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);


### PR DESCRIPTION
xwayland_view requires activation of a newly focused surface and deactivation of the previously focused service. The absence of which was causing issues with xwayland views reliably receiving keyboard input

Since the previous surface could be either an xdg_toplevel or xwayland_surface (or potentially other in future), deactivate_surface needs to work for all these different surfaces

xdg_view requires the same surface deactivation of the previously focused surface