### PR TITLE
Less threads

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -396,7 +396,7 @@ class _LinuxBattery(_Battery, configurable.Configurable):
         )
 
 
-class Battery(base.BackgroundPoll):
+class Battery(base.InLoopPollText):
     """
     A text-based battery monitoring widget supporting both Linux and FreeBSD.
 
@@ -485,7 +485,7 @@ class Battery(base.BackgroundPoll):
     ]
 
     def __init__(self, **config) -> None:
-        base.BackgroundPoll.__init__(self, "", **config)
+        base.InLoopPollText.__init__(self, "", **config)
         self.add_defaults(self.defaults)
 
         self._battery = self._load_battery(**config)
@@ -497,7 +497,7 @@ class Battery(base.BackgroundPoll):
             self.low_background = self.background
         self.normal_background = self.background
 
-        base.BackgroundPoll._configure(self, qtile, bar)
+        base.InLoopPollText._configure(self, qtile, bar)
 
     @expose_command()
     def charge_to_full(self):

--- a/libqtile/widget/cpu.py
+++ b/libqtile/widget/cpu.py
@@ -23,7 +23,7 @@ import psutil
 from libqtile.widget import base
 
 
-class CPU(base.BackgroundPoll):
+class CPU(base.InLoopPollText):
     """
     A simple widget to display CPU load and frequency.
 

--- a/libqtile/widget/df.py
+++ b/libqtile/widget/df.py
@@ -22,7 +22,7 @@ import os
 from libqtile.widget import base
 
 
-class DF(base.BackgroundPoll):
+class DF(base.InLoopPollText):
     """Disk Free Widget
 
     By default the widget only displays if the space is less than warn_space.
@@ -46,7 +46,7 @@ class DF(base.BackgroundPoll):
     measures = {"G": 1024 * 1024 * 1024, "M": 1024 * 1024, "B": 1024}
 
     def __init__(self, **config):
-        base.BackgroundPoll.__init__(self, "", **config)
+        base.InLoopPollText.__init__(self, "", **config)
         self.add_defaults(DF.defaults)
         self.user_free = 0
         self.calc = self.measures[self.measure]
@@ -57,7 +57,7 @@ class DF(base.BackgroundPoll):
         else:
             self.layout.colour = self.foreground
 
-        base.BackgroundPoll.draw(self)
+        base.InLoopPollText.draw(self)
 
     def poll(self):
         statvfs = os.statvfs(self.partition)

--- a/libqtile/widget/hdd.py
+++ b/libqtile/widget/hdd.py
@@ -21,7 +21,7 @@
 from libqtile.widget import base
 
 
-class HDD(base.BackgroundPoll):
+class HDD(base.InLoopPollText):
     """
     Displays HDD usage in percent based on the number of milliseconds the device has been performing I/O operations.
     """

--- a/libqtile/widget/load.py
+++ b/libqtile/widget/load.py
@@ -23,7 +23,7 @@ from libqtile.command.base import expose_command
 from libqtile.widget import base
 
 
-class Load(base.BackgroundPoll):
+class Load(base.InLoopPollText):
     """
     A small widget to show the load averages of the system.
     Depends on psutil.

--- a/libqtile/widget/memory.py
+++ b/libqtile/widget/memory.py
@@ -24,7 +24,7 @@ from libqtile.widget import base
 __all__ = ["Memory"]
 
 
-class Memory(base.BackgroundPoll):
+class Memory(base.InLoopPollText):
     """Display memory/swap usage.
 
     The following fields are available in the `format` string:

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -28,7 +28,7 @@ from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
-class Net(base.BackgroundPoll):
+class Net(base.InLoopPollText):
     """
     Displays interface down and up speed
 
@@ -76,7 +76,7 @@ class Net(base.BackgroundPoll):
     ]
 
     def __init__(self, **config):
-        base.BackgroundPoll.__init__(self, "", **config)
+        base.InLoopPollText.__init__(self, "", **config)
         self.add_defaults(Net.defaults)
 
         self.factor = 1000.0

--- a/libqtile/widget/pomodoro.py
+++ b/libqtile/widget/pomodoro.py
@@ -26,7 +26,7 @@ from libqtile.utils import send_notification
 from libqtile.widget import base
 
 
-class Pomodoro(base.BackgroundPoll):
+class Pomodoro(base.InLoopPollText):
     """Pomodoro technique widget"""
 
     defaults = [
@@ -65,7 +65,7 @@ class Pomodoro(base.BackgroundPoll):
     pomodoros = 1
 
     def __init__(self, **config):
-        base.BackgroundPoll.__init__(self, "", **config)
+        base.InLoopPollText.__init__(self, "", **config)
         self.add_defaults(Pomodoro.defaults)
         self.prefix = {
             "inactive": self.prefix_inactive,

--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -28,7 +28,7 @@ import psutil
 from libqtile.widget import base
 
 
-class ThermalSensor(base.BackgroundPoll):
+class ThermalSensor(base.InLoopPollText):
     """Widget to display temperature sensor information
 
     For using the thermal sensor widget you need to have lm-sensors installed.
@@ -62,7 +62,7 @@ class ThermalSensor(base.BackgroundPoll):
     ]
 
     def __init__(self, **config):
-        base.BackgroundPoll.__init__(self, **config)
+        base.InLoopPollText.__init__(self, **config)
         self.add_defaults(ThermalSensor.defaults)
         temp_values = self.get_temp_sensors()
 
@@ -77,7 +77,7 @@ class ThermalSensor(base.BackgroundPoll):
 
     def _configure(self, qtile, bar):
         self.unit = "°C" if self.metric else "°F"
-        base.BackgroundPoll._configure(self, qtile, bar)
+        base.InLoopPollText._configure(self, qtile, bar)
         self.foreground_normal = self.foreground
 
     def get_temp_sensors(self):

--- a/libqtile/widget/thermal_zone.py
+++ b/libqtile/widget/thermal_zone.py
@@ -2,7 +2,7 @@ from libqtile.log_utils import logger
 from libqtile.widget import base
 
 
-class ThermalZone(base.BackgroundPoll):
+class ThermalZone(base.InLoopPollText):
     """Thermal zone widget.
 
     This widget was made to read thermal zone files and transform values to


### PR DESCRIPTION
With the asyncio switch I am sort of on a rampage to use less threads in qtile, since they add complexity (viz. things like event loop policies, etc.), memory footprint, complexities due to fork(), etc.

A bunch of the widgets were just using threads where they didn't need to, so here's those simple conversions.

I am working on more porting to GenPollCommand for some other widgets, but that will come in a later branch.