### PR TITLE
x11: don't focus twice in focus_by_click()

### DIFF
--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -901,8 +901,7 @@ class Core(base.Core):
             try:
                 if window.group.screen is not qtile.current_screen:
                     qtile.focus_screen(window.group.screen.index, warp=False)
-                qtile.current_group.focus(window, False)
-                window.focus(False)
+                qtile.current_group.focus(window, warp=False)
             except AttributeError:
                 # probably clicked an internal window
                 screen = qtile.find_screen(e.root_x, e.root_y)


### PR DESCRIPTION
In focus_by_click(), we call:

group.focus() -> layout_all() -> current_window.focus()

but then we do an explicit window.focus() again in focus_by_click(), resulting in two focus events, two hooks called, etc.

Let's drop that second explicit focus_by_click(), so we only generate on event.