### PR TITLE
fix the CI badge in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Please also consider submitting useful scripts etc. to the qtile-examples repo
 .. |pypi| image:: https://img.shields.io/pypi/v/qtile.svg
     :alt: PyPI
     :target: https://pypi.org/project/qtile/
-.. |ci| image:: https://github.com/qtile/qtile/workflows/ci/badge.svg?branch=master
+.. |ci| image:: https://github.com/qtile/qtile/actions/workflows/ci.yml/badge.svg?branch=master
     :alt: CI status
     :target: https://github.com/qtile/qtile/actions
 .. |rtd| image:: https://readthedocs.org/projects/qtile/badge/?version=latest


### PR DESCRIPTION
this has read `No Status` for a long time, because apparently github changed their URL structure:

https://github.com/orgs/community/discussions/14980#discussioncomment-12384428