### PR TITLE
[WAYC] fix: adjust includes and variable scoping in Wayland backend

### DIFF
--- a/libqtile/backend/wayland/qw/input-device.c
+++ b/libqtile/backend/wayland/qw/input-device.c
@@ -1,3 +1,4 @@
+#include <server.h>
 #include <wlr/util/log.h>
 
 #include "input-device.h"

--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -242,6 +242,9 @@ void qw_output_paint_wallpaper(struct qw_output *output, cairo_surface_t *source
     cairo_rectangle(cr, 0, 0, o_width, o_height);
     cairo_clip(cr);
 
+    int t_x;
+    int t_y;
+
     switch (mode) {
 
     // We don't touch the image and draw it at 0, 0
@@ -267,8 +270,8 @@ void qw_output_paint_wallpaper(struct qw_output *output, cairo_surface_t *source
 
     // Center image on screen but don't scale image
     case WALLPAPER_MODE_CENTER:
-        int t_x = (o_width - img_width) / 2;
-        int t_y = (o_height - img_height) / 2;
+        t_x = (o_width - img_width) / 2;
+        t_y = (o_height - img_height) / 2;
         cairo_translate(cr, t_x, t_y);
         break;
 

--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -1,6 +1,7 @@
 #include "util.h"
 #include <string.h>
 #include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_xdg_shell.h>
 
 int qw_util_get_button_code(uint32_t button) {
     // Array of Linux input event button codes (from linux/input-event-codes.h)
@@ -79,10 +80,10 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
     }
 
     #if WLR_HAS_XWAYLAND
-    struct wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
-    if (xwayland_surface) {
-        wlr_xwayland_surface_activate(xwayland_surface, false);
-        return;
-    }
+        struct wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
+        if (xwayland_surface) {
+            wlr_xwayland_surface_activate(xwayland_surface, false);
+            return;
+        }
     #endif
 }

--- a/libqtile/backend/wayland/qw/util.h
+++ b/libqtile/backend/wayland/qw/util.h
@@ -2,6 +2,7 @@
 #define UTIL_H
 
 #include <stdint.h>
+#include <wlr/types/wlr_compositor.h>
 #include <xkbcommon/xkbcommon.h>
 
 // Enum defining button codes for scroll events.

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -1,12 +1,12 @@
 #include "xwayland-view.h"
-#include "qw/util.h"
 #include "server.h"
+#include "util.h"
 #include "view.h"
 #include "wayland-server-core.h"
 #include "wayland-util.h"
-#include "wlr/types/wlr_xdg_decoration_v1.h"
 #include "wlr/util/log.h"
 #include "xdg-view.h"
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <wlr/xwayland.h>


### PR DESCRIPTION
- Added missing headers: server.h, wlr_xdg_shell.h, wlr_compositor.h to ensure proper struct and function visibility.
- Fixed local variable scoping in qw_output_paint_wallpaper to avoid redeclaration inside case statement.
- Adjusted include order in xwayland-view.c for consistency and proper dependency resolution.

Just minor fixes, and diagnostic warning resolutions.