### PR TITLE
[wayc] Build wayc with makefile

### DIFF
--- a/libqtile/backend/wayland/cffi/Makefile
+++ b/libqtile/backend/wayland/cffi/Makefile
@@ -1,0 +1,29 @@
+# Paths
+QW_PATH      := ../qw
+QW_PROTO_OUT := ../qw/proto
+
+# Compiler/linker
+CC := gcc
+CFLAGS := -O2 -fPIC \
+          -DWLR_USE_UNSTABLE \
+          -I$(QW_PATH) \
+          -I$(QW_PROTO_OUT) \
+          $(shell pkg-config --cflags wlroots-0.19 wayland-server cairo pixman-1 libdrm)
+
+LDFLAGS := -shared $(shell pkg-config --libs wlroots-0.19 wayland-server cairo pixman-1 libdrm)
+
+TARGET := ../libwayc.so
+
+.PHONY: all
+all: $(TARGET)
+
+$(TARGET): $(wildcard $(QW_PATH)/*.c)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+.PHONY: rebuild
+rebuild: clean all
+

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -143,25 +143,21 @@ for file in cdef_files:
             CDEF += line
 
 SOURCE = ""
+for header in cdef_files:
+    SOURCE += f'#include "{header}"\n'
 
-for root, dirs, files in os.walk(QW_PATH):
-    for file in files:
-        if file.endswith(".c"):
-            with open(QW_PATH / file) as f:
-                SOURCE += f.read()
-
-
+#TODO: Is this used/needed?
 def get_include_path(lib: str) -> str:
     return subprocess.run(
         ["pkg-config", "--variable=includedir", lib], text=True, stdout=subprocess.PIPE
     ).stdout.strip()
 
+LIBWAYC = QW_PATH / ".." / "libmyffi.so"
 
 ffi = FFI()
 ffi.set_source(
     "libqtile.backend.wayland._ffi",
     SOURCE,
-    libraries=["wlroots-0.19", "wayland-server", "input", "cairo"],
     define_macros=[("WLR_USE_UNSTABLE", None)],
     include_dirs=[
         os.getenv("QTILE_CAIRO_PATH", "/usr/include/cairo"),
@@ -171,8 +167,11 @@ ffi.set_source(
         QW_PATH,
         QW_PROTO_OUT_PATH,
     ],
+    extra_link_args=[LIBWAYC],
 )
 
+def build_library():
+    subprocess.run(["make", "-C", ".", "rebuild"], check=True)
 
 def ffi_compile(verbose: bool = False) -> None:
     # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
@@ -191,4 +190,6 @@ def ffi_compile(verbose: bool = False) -> None:
 
 ffi.cdef(CDEF)
 if __name__ == "__main__":
+
+    build_library()
     ffi_compile()


### PR DESCRIPTION
Build wayc as library with a makefile. Then build an interface to the library via cffi

This avoids creating a single _ffi.c source file making reading errors and debugging more natural

Maybe improves stability of build process?