### PR TITLE
pyproject: fix xdg component

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ widgets = [
     "pulsectl_asyncio",
     "python-mpd2",
     "pytz",
-    "xdg",
+    "pyxdg",
     "xmltodict",
     "aiohttp",
 ]


### PR DESCRIPTION
As the pypi for xdg notes https://pypi.org/project/xdg/:

    xdg has been renamed to xdg-base-dirs due to an import collision with PyXDG. Therefore the xdg package is deprecated. Install xdg-base-dirs instead.

indeed, we really want pyxdg in the tasklist widget. So let's specify that.