### PR TITLE
[wayc] Update move up/down

### DIFF
--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -87,3 +87,20 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
         }
     #endif
 }
+
+bool qw_surfaces_on_same_output(struct wlr_surface *surface_a, struct wlr_surface *surface_b) {
+    if (surface_a == NULL || surface_b == NULL) {
+        return false;
+    }
+
+    struct wlr_surface_output *output_a;
+    wl_list_for_each(output_a, &surface_a->current_outputs, link) {
+        struct wlr_surface_output *output_b;
+        wl_list_for_each(output_b, &surface_b->current_outputs, link) {
+            if (output_a->output == output_b->output) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/libqtile/backend/wayland/qw/util.h
+++ b/libqtile/backend/wayland/qw/util.h
@@ -29,4 +29,6 @@ xkb_keysym_t qwu_keysym_from_name(const char *name);
 
 void qw_util_deactivate_surface(struct wlr_surface *surface);
 
+bool qw_surfaces_on_same_output(struct wlr_surface *surface_a, struct wlr_surface *surface_b);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
Moving windows up and down now moves relative to windows that aren't hidden and are on the same output.

@jwijenbergh here's an attempt at the stacking logic that we discussed on discord. 