### PR TITLE
Fix X11 backend test (and docs)

### DIFF
--- a/test/backend/x11/conftest.py
+++ b/test/backend/x11/conftest.py
@@ -72,7 +72,7 @@ def stop_x11(proc, display, display_file):
 
     # clean up the lock file for the display we allocated
     try:
-        display_file.close()
+        os.close(display_file)
         os.remove(xcffib.testing.lock_path(int(display[1:])))
     except OSError:
         pass


### PR DESCRIPTION
xcffib>1.11.0 has a breaking change. `xcffib.testing.find_display()` now returns a tuple of the display number and a file decriptor. Previously, the method returned a file object which we closed with `.close()`.