### PR TITLE
[wayc] Disable flaky spawn_in_group test

### DIFF
--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -428,7 +428,10 @@ def test_spawn_list(manager):
 
 
 @manager_config
-def test_spawn_in_group(manager):
+def test_spawn_in_group(manager, backend_name):
+    if backend_name == "wayland":
+        pytest.skip("TODO: X11 only for now.")
+
     @Retry(ignore_exceptions=(AssertionError,))
     def wait_for_window(empty=False):
         assert (len(manager.c.windows()) > 0) is not empty


### PR DESCRIPTION
We're getting regular failures on one test with wayland. This commit has already been merged in `master` but, rather than rebasing the entire `wayc` branch and force-pushing (which may cause issues for some people tracking the branch), I've just created a separate PR to pull it straight into `wayc`.