### PR TITLE
x11: clear _NET_ACTIVE_WINDOW when not focused

### DIFF
--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -117,3 +117,6 @@ class Core(CommandObject, metaclass=ABCMeta):
     def info(self) -> dict[str, Any]:
         """Get basic information about the running backend."""
         return {"backend": self.name, "display_name": self.display_name}
+
+    def clear_focus(self):
+        """Do any WM spec things if e.g. an empty group is focused"""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -307,6 +307,10 @@ class Core(base.Core):
         self._root.set_input_focus()
         self._root.set_property("_NET_ACTIVE_WINDOW", self._root.wid)
 
+    def clear_focus(self):
+        """Clear _NET_ACTIVE_WINDOW so that there is no focused window"""
+        self._root.set_property("_NET_ACTIVE_WINDOW", 0)
+
     def convert_selection(self, selection_atom, _type="UTF8_STRING") -> None:
         type_atom = self.conn.atoms[_type]
         self.conn.conn.core.ConvertSelection(

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -170,6 +170,9 @@ class _Group(CommandObject):
                         # Screen has lost focus so we reset record of focused window so
                         # focus will warp when screen is focused again
                         self.last_focused = None
+        elif self.screen and not self.windows and self.screen == self.qtile.current_screen:
+            # Clear active window when switching to an empty group on the current screen
+            self.qtile.core.clear_focus()
 
     def set_screen(self, screen, warp=True):
         """Set this group's screen to screen"""

--- a/test/backend/x11/test_xcore.py
+++ b/test/backend/x11/test_xcore.py
@@ -52,3 +52,17 @@ def test_net_client_list(xmanager, conn):
     assert_clients(1)
     xmanager.kill_window(two)
     assert_clients(0)
+
+
+@pytest.mark.parametrize("xmanager", [ManagerConfig], indirect=True)
+def test_clear_focus_empty_group(xmanager, conn):
+    """Test that _NET_ACTIVE_WINDOW is 0 when focusing an empty group"""
+    xmanager.test_window("one")
+
+    active = conn.default_screen.root.get_property("_NET_ACTIVE_WINDOW", unpack=int)
+    assert active[0] != 0
+
+    xmanager.c.screen.next_group()
+
+    active = conn.default_screen.root.get_property("_NET_ACTIVE_WINDOW", unpack=int)
+    assert active[0] == 0


### PR DESCRIPTION
EWMH says this should be None (0) if no window is focuse:

https://specifications.freedesktop.org/wm-spec/1.3/ar01s03.html#id-1.4.10