### PR TITLE
[wayc] Fix listeners being added too early

### DIFF
--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -371,11 +371,21 @@ static void qw_xdg_view_handle_map(struct wl_listener *listener, void *data) {
     struct wlr_xdg_toplevel *xdg_toplevel = xdg_view->xdg_toplevel;
 
     // Set foreign top level attributes
-    if (xdg_view->base.ftl_handle != NULL && xdg_toplevel->parent != NULL) {
-        struct qw_xdg_view *parent_view = xdg_toplevel->parent->base->data;
-        if (parent_view->base.ftl_handle != NULL) {
-            wlr_foreign_toplevel_handle_v1_set_parent(xdg_view->base.ftl_handle,
-                                                      parent_view->base.ftl_handle);
+    if (xdg_view->base.ftl_handle != NULL) {
+        if (xdg_view->base.title != NULL) {
+            wlr_foreign_toplevel_handle_v1_set_title(xdg_view->base.ftl_handle,
+                                                     xdg_view->base.title);
+        }
+        if (xdg_view->base.app_id != NULL) {
+            wlr_foreign_toplevel_handle_v1_set_app_id(xdg_view->base.ftl_handle,
+                                                      xdg_view->base.app_id);
+        }
+        if (xdg_toplevel->parent != NULL) {
+            struct qw_xdg_view *parent_view = xdg_toplevel->parent->base->data;
+            if (parent_view != NULL && parent_view->base.ftl_handle != NULL) {
+                wlr_foreign_toplevel_handle_v1_set_parent(xdg_view->base.ftl_handle,
+                                                          parent_view->base.ftl_handle);
+            }
         }
     }
 

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -304,6 +304,7 @@ static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data
     wl_signal_add(&xwayland_surface->surface->events.commit, &xwayland_view->commit);
     xwayland_view->commit.notify = qw_xwayland_view_handle_commit;
 
+    // Add listeners with Python callbacks after the view has been managed
     wl_signal_add(&xwayland_surface->events.request_fullscreen, &xwayland_view->request_fullscreen);
     xwayland_view->request_fullscreen.notify = qw_xwayland_view_handle_request_fullscreen;
 

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -287,11 +287,21 @@ static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data
     xwayland_view->base.height = xwayland_surface->height;
 
     // Set properties for foreign toplevel manager
-    if (xwayland_view->base.ftl_handle != NULL && xwayland_surface->parent != NULL) {
-        struct qw_xwayland_view *parent_view = xwayland_surface->parent->data;
-        if (parent_view->base.ftl_handle != NULL) {
-            wlr_foreign_toplevel_handle_v1_set_parent(xwayland_view->base.ftl_handle,
-                                                      parent_view->base.ftl_handle);
+    if (xwayland_view->base.ftl_handle != NULL) {
+        if (xwayland_view->base.title != NULL) {
+            wlr_foreign_toplevel_handle_v1_set_title(xwayland_view->base.ftl_handle,
+                                                     xwayland_view->base.title);
+        }
+        if (xwayland_view->base.app_id != NULL) {
+            wlr_foreign_toplevel_handle_v1_set_app_id(xwayland_view->base.ftl_handle,
+                                                      xwayland_view->base.app_id);
+        }
+        if (xwayland_surface->parent != NULL) {
+            struct qw_xwayland_view *parent_view = xwayland_surface->parent->data;
+            if (parent_view != NULL && parent_view->base.ftl_handle != NULL) {
+                wlr_foreign_toplevel_handle_v1_set_parent(xwayland_view->base.ftl_handle,
+                                                          parent_view->base.ftl_handle);
+            }
         }
     }
 


### PR DESCRIPTION
Listeners that have a python callback need to be called after the view is managed (otherwise the callback doesn't exist)

Also make sure listerners are destroyed by the correct method