### PR TITLE
Update python 3.14 version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
                 # python version in .readthedocs.yaml
                 # TODO: Add back pypy here and in release.yml once:
                 # https://github.com/pypy/pypy/issues/4956 is resolved
-                python-version: ['3.12', '3.13', '3.14-dev']
+                python-version: ['3.12', '3.13', '3.14']
                 backend: ['x11', 'wayland']
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.14 has been released so let's use release version in CI.

@tych0 If we add branch protections for this now we'll need to rebase every open PR. How do you feel about that?