### PR TITLE
[wayc] Stop screen_change hook on VT change

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -202,7 +202,13 @@ static void qw_server_handle_output_layout_change(struct wl_listener *listener, 
     }
 
     wlr_output_manager_v1_set_configuration(server->output_mgr, config);
-    server->on_screen_change_cb(server->cb_data);
+
+    // Only trigger screen change callback if the session is active
+    // or if session is NULL (i.e. in a nested or headless session)
+    // This prevents the hook firing on VT changes
+    if (server->session == NULL || server->session->active) {
+        server->on_screen_change_cb(server->cb_data);
+    }
 }
 
 // Reconfigure output(s) according to the provided configuration.


### PR DESCRIPTION
This fixes bug with the bar being killed when switching VT.

@jwijenbergh @richcarni are there any other bits of code that should be paused when switching to a different VT?