### PR TITLE
Normalize version for setuptools to stop complaining

### DIFF
--- a/nix/qtile.nix
+++ b/nix/qtile.nix
@@ -17,7 +17,7 @@ let
         head
       ];
     in
-    "${symver}+${flakever}-wayc.flake";
+    "${symver}+${flakever}.wayc.flake";
 
   removeOldDeps =
     dep:


### PR DESCRIPTION
Fixes:
```
setuptools/dist.py:332: InformationOnly: Normalizing '0.33.0+dev-wayc.flake' to '0.33.0+dev.wayc.flake'
```