### PR TITLE
docs(widgets): explain how to modify text attributes correctly

### DIFF
--- a/docs/manual/howto/widget.rst
+++ b/docs/manual/howto/widget.rst
@@ -211,24 +211,46 @@ Text is displayed by using a ``drawer.TextLayout`` object. If all you are doing 
 displaying text then it's highly recommended that you use the ``base._TextBox``
 superclass as this simplifies adding and updating text.
 
-If you wish to implement this manually then you can create a your own ``drawer.TextLayout``
-by using the ``self.drawer.textlayout`` method of the widget (only available after
-the `_configure` method has been run). object to include in your widget.
+If you wish to implement this manually, you can create your own ``drawer.TextLayout``
+by calling the ``self.drawer.textlayout`` method of the widget (only available after
+the `_configure` method has been run).
 
 Some additional formatting of Text can be displayed using pango markup and ensuring
 the ``markup`` parameter is set to ``True``.
 
 .. code:: python
 
-    self.textlayout = self.drawer.textlayout(
-                         "Text",
-                         "fffff",       # Font colour
-                         "sans",        # Font family
-                         12,            # Font size
-                         None,          # Font shadow
-                         markup=False,  # Pango markup (False by default)
-                         wrap=True      # Wrap long lines (True by default)
-                         )
+    self.layout = self.drawer.textlayout(
+        "Text",
+        "ffffff",      # Font colour
+        "sans",        # Font family
+        12,            # Font size
+        None,          # Font shadow
+        markup=False,  # Pango markup (False by default)
+        wrap=True,     # Wrap long lines (True by default)
+    )
+
+.. note::
+
+    In ``base._TextBox`` inherited widgets, after `_configure` has been run,
+    modifications to the widget's ``font``, ``fontsize``, ``fontshadow``,
+    ``foreground`` and ``markup`` parameters will not be automatically applied
+    to the text layout. You will need to modify these values directly on the
+    ``self.layout.*`` attributes. Since these attributes have different names
+    to the widget parameters, you may use the `set_font` method, available in
+    these widgets, to update the text layout attributes with the advantage of
+    using the same parameter names as with the widget parameters:
+
+    .. code:: python
+
+        # All parameters are optional
+        self.set_font(
+            font="mono",
+            fontsize=14,
+            fontshadow="000000",
+            foreground="ff0000",
+            markup=True
+        )
 
 Displaying icons and images
 ---------------------------

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -701,10 +701,13 @@ class _TextBox(_Widget):
         font: str | None = None,
         fontsize: int = 0,
         fontshadow: ColorType = "",
+        foreground: ColorType = "",
+        markup: bool | None = None,
     ):
         """
-        Change the font used by this widget. If font is None, the current
-        font is used.
+        Change the text layout properties and redraw the widget.
+        This method may also be used sync attributes from the current
+        widget with the text layout.
         """
         if font is not None:
             self.font = font
@@ -712,10 +715,17 @@ class _TextBox(_Widget):
             self.fontsize = fontsize
         if fontshadow != "":
             self.fontshadow = fontshadow
+        if foreground != "":
+            self.foreground = foreground
+        if markup is not None:
+            self.markup = markup
+        # Sync text layout properties
         if self.layout:
             self.layout.font_family = self.font
             self.layout.font_size = self.fontsize
             self.layout.font_shadow = self.fontshadow
+            self.layout.colour = self.foreground
+            self.layout.markup = self.markup
         self.bar.draw()
 
     @expose_command()


### PR DESCRIPTION
This PR expands the documentation to explain why setting the widget's `font`, `fontsize`, `fontshadow`, `foreground` and `markup` parameters will not affect the text in the widget as of changes in #5325. And what users do instead to overcome this.

It also expands a currently implemented function (`set_font`) to accept all the parameters that modify the text layout to act as a setter for the layout attributes.

I write this as per discussion in #5467, so I would want to hear @saviola777 thoughts on this.