### PR TITLE
[wayland] Add xwayland override_redirect support

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -422,7 +422,11 @@ static void qw_server_handle_new_layer_surface(struct wl_listener *listener, voi
 static void qw_server_handle_new_xwayland_surface(struct wl_listener *listener, void *data) {
     struct qw_server *server = wl_container_of(listener, server, new_xwayland_surface);
     struct wlr_xwayland_surface *xwayland_surface = data;
-    qw_server_xwayland_view_new(server, xwayland_surface);
+    if (xwayland_surface->override_redirect) {
+        qw_server_xwayland_static_view_new(server, xwayland_surface);
+    } else {
+        qw_server_xwayland_view_new(server, xwayland_surface);
+    }
 }
 
 const char *qw_server_xwayland_display_name(struct qw_server *server) {

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -52,6 +52,184 @@ static void qw_xwayland_view_do_focus(struct qw_xwayland_view *xwayland_view,
     }
 }
 
+static void qw_xwayland_view_focus(void *self, int above) {
+    UNUSED(above);
+    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
+    if (!xwayland_view->xwayland_surface->surface->mapped) {
+        return; // Can't focus if not mapped
+    }
+    qw_xwayland_view_do_focus(xwayland_view, xwayland_view->xwayland_surface->surface);
+}
+
+static void static_view_handle_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, destroy);
+
+    wl_list_remove(&static_view->destroy.link);
+    wl_list_remove(&static_view->associate.link);
+    wl_list_remove(&static_view->dissociate.link);
+    wl_list_remove(&static_view->request_configure.link);
+    wl_list_remove(&static_view->request_activate.link);
+    wl_list_remove(&static_view->override_redirect.link);
+
+    free(static_view);
+}
+
+static void static_view_handle_set_geometry(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, map);
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    wlr_scene_node_set_position(&static_view->scene_surface->buffer->node, xwayland_surface->x,
+                                xwayland_surface->y);
+}
+
+static void static_view_handle_map(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, map);
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    static_view->scene_surface =
+        wlr_scene_surface_create(static_view->base.server->scene_windows_layers[LAYER_BRINGTOFRONT],
+                                 xwayland_surface->surface);
+    if (static_view->scene_surface != NULL) {
+        wlr_scene_node_set_position(&static_view->scene_surface->buffer->node, xwayland_surface->x,
+                                    xwayland_surface->y);
+        wl_signal_add(&xwayland_surface->events.set_geometry, &static_view->set_geometry);
+        static_view->set_geometry.notify = static_view_handle_set_geometry;
+    }
+
+    if (wlr_xwayland_surface_override_redirect_wants_focus(xwayland_surface)) {
+        qw_xwayland_view_focus(static_view->scene_surface, true);
+    }
+}
+
+static void static_view_handle_unmap(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, unmap);
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    if (static_view->scene_surface != NULL) {
+        wl_list_remove(&static_view->set_geometry.link);
+        wlr_scene_node_destroy(&static_view->scene_surface->buffer->node);
+        static_view->scene_surface = NULL;
+    }
+
+    struct wlr_seat *seat = static_view->base.server->seat;
+    if (seat->keyboard_state.focused_surface == xwayland_surface->surface) {
+        // This simply returns focus to the parent surface if there's one available.
+        // This seems to handle JetBrains issues.
+        if (xwayland_surface->parent && xwayland_surface->parent->surface &&
+            wlr_xwayland_surface_override_redirect_wants_focus(xwayland_surface->parent)) {
+            qw_xwayland_view_focus(xwayland_surface->parent, true);
+            return;
+        }
+
+        // Restore focus
+        static_view->base.server->focus_current_window_cb(static_view->base.server->cb_data);
+    }
+}
+
+static void static_view_handle_associate(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, associate);
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    // Attach map and unmap listeners to the new surface events.
+    wl_signal_add(&xwayland_surface->surface->events.unmap, &static_view->unmap);
+    static_view->unmap.notify = static_view_handle_unmap;
+    wl_signal_add(&xwayland_surface->surface->events.map, &static_view->map);
+    static_view->map.notify = static_view_handle_map;
+}
+
+static void static_view_handle_dissociate(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, dissociate);
+    wl_list_remove(&static_view->map.link);
+    wl_list_remove(&static_view->unmap.link);
+}
+
+static void static_view_handle_request_configure(struct wl_listener *listener, void *data) {
+    struct qw_xwayland_view *static_view =
+        wl_container_of(listener, static_view, request_configure);
+    struct wlr_xwayland_surface_configure_event *event = data;
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    wlr_xwayland_surface_configure(xwayland_surface, event->x, event->y, event->width,
+                                   event->height);
+}
+
+static void static_view_handle_request_activate(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, request_activate);
+    struct wlr_xwayland_surface *surface = static_view->xwayland_surface;
+
+    wlr_xwayland_surface_activate(surface, true);
+}
+
+// forward declarations
+void qw_server_xwayland_view_new(struct qw_server *server,
+                                 struct wlr_xwayland_surface *xwayland_surface);
+static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data);
+static void qw_xwayland_view_handle_associate(struct wl_listener *listener, void *data);
+
+static void static_view_handle_override_redirect(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *static_view = wl_container_of(listener, static_view, request_activate);
+    struct wlr_xwayland_surface *xwayland_surface = static_view->xwayland_surface;
+
+    bool associated = xwayland_surface->surface != NULL;
+    bool mapped = associated && xwayland_surface->surface->mapped;
+    if (mapped) {
+        static_view_handle_unmap(&static_view->unmap, NULL);
+    }
+    if (associated) {
+        static_view_handle_dissociate(&static_view->dissociate, NULL);
+    }
+
+    static_view_handle_destroy(&static_view->destroy, NULL);
+    xwayland_surface->data = NULL;
+
+    qw_server_xwayland_view_new(static_view->base.server, xwayland_surface);
+    struct qw_xwayland_view *xwayland_view = xwayland_surface->data;
+    if (associated) {
+        qw_xwayland_view_handle_associate(&xwayland_view->associate, NULL);
+    }
+    if (mapped) {
+        qw_xwayland_view_handle_map(&xwayland_view->map, xwayland_surface);
+    }
+}
+
+void qw_server_xwayland_static_view_new(struct qw_server *server,
+                                        struct wlr_xwayland_surface *xwayland_surface) {
+    struct qw_xwayland_view *static_view = calloc(1, sizeof(*static_view));
+    if (!static_view) {
+        wlr_log(WLR_ERROR, "failed to create qw_xwayland_static_view struct");
+        return;
+    }
+
+    static_view->xwayland_surface = xwayland_surface;
+    static_view->base.server = server;
+
+    wl_signal_add(&xwayland_surface->events.destroy, &static_view->destroy);
+    static_view->destroy.notify = static_view_handle_destroy;
+
+    wl_signal_add(&xwayland_surface->events.associate, &static_view->associate);
+    static_view->associate.notify = static_view_handle_associate;
+
+    wl_signal_add(&xwayland_surface->events.dissociate, &static_view->dissociate);
+    static_view->dissociate.notify = static_view_handle_dissociate;
+
+    wl_signal_add(&xwayland_surface->events.request_configure, &static_view->request_configure);
+    static_view->request_configure.notify = static_view_handle_request_configure;
+
+    wl_signal_add(&xwayland_surface->events.request_activate, &static_view->request_activate);
+    static_view->request_activate.notify = static_view_handle_request_activate;
+
+    wl_signal_add(&xwayland_surface->events.set_override_redirect, &static_view->override_redirect);
+    static_view->override_redirect.notify = static_view_handle_override_redirect;
+}
+
 static struct wlr_scene_node *qw_xwayland_view_get_tree_node(void *self) {
     struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
 
@@ -453,9 +631,6 @@ static void qw_xwayland_view_handle_set_hints(struct wl_listener *listener, void
 
 static void qw_xwayland_view_handle_dissociate(struct wl_listener *listener, void *data) {
     UNUSED(data);
-    // TODO: implement
-    // reference:
-    // https://github.com/swaywm/sway/blob/357d341f8fd68cd6902ea029a46baf5ce3411336/sway/desktop/xwayland.c#L783
     struct qw_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, dissociate);
     wl_list_remove(&xwayland_view->map.link);
     wl_list_remove(&xwayland_view->unmap.link);
@@ -471,19 +646,40 @@ static void qw_xwayland_view_handle_destroy(struct wl_listener *listener, void *
     wl_list_remove(&xwayland_view->request_configure.link);
     wl_list_remove(&xwayland_view->request_activate.link);
     wl_list_remove(&xwayland_view->set_hints.link);
+    wl_list_remove(&xwayland_view->override_redirect.link);
     qw_view_ftl_manager_handle_destroy(&xwayland_view->base);
     wlr_scene_node_destroy(&xwayland_view->base.content_tree->node);
 
     free(xwayland_view);
 }
 
-static void qw_xwayland_view_focus(void *self, int above) {
-    UNUSED(above);
-    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
-    if (!xwayland_view->xwayland_surface->surface->mapped) {
-        return; // Can't focus if not mapped
+static void qw_xwayland_view_handle_request_override_redirect(struct wl_listener *listener,
+                                                              void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, destroy);
+
+    struct wlr_xwayland_surface *xwayland_surface = xwayland_view->xwayland_surface;
+
+    bool associated = xwayland_surface->surface != NULL;
+    bool mapped = associated && xwayland_surface->surface->mapped;
+    if (mapped) {
+        qw_xwayland_view_handle_unmap(&xwayland_view->unmap, NULL);
     }
-    qw_xwayland_view_do_focus(xwayland_view, xwayland_view->xwayland_surface->surface);
+    if (associated) {
+        qw_xwayland_view_handle_dissociate(&xwayland_view->dissociate, NULL);
+    }
+
+    qw_xwayland_view_handle_destroy(&xwayland_view->destroy, xwayland_view);
+    xwayland_surface->data = NULL;
+
+    qw_server_xwayland_static_view_new(xwayland_view->base.server, xwayland_surface);
+    struct qw_xwayland_view *static_view = xwayland_surface->data;
+    if (associated) {
+        static_view_handle_associate(&static_view->associate, NULL);
+    }
+    if (mapped) {
+        static_view_handle_map(&static_view->map, xwayland_surface);
+    }
 }
 
 static bool qw_xwayland_view_has_fixed_size(void *self) {
@@ -567,6 +763,10 @@ void qw_server_xwayland_view_new(struct qw_server *server,
 
     wl_signal_add(&xwayland_surface->events.set_hints, &xwayland_view->set_hints);
     xwayland_view->set_hints.notify = qw_xwayland_view_handle_set_hints;
+
+    wl_signal_add(&xwayland_surface->events.set_override_redirect,
+                  &xwayland_view->override_redirect);
+    xwayland_view->override_redirect.notify = qw_xwayland_view_handle_request_override_redirect;
 
     // Assign function pointers for base view operations
     xwayland_view->base.get_tree_node = qw_xwayland_view_get_tree_node;

--- a/libqtile/backend/wayland/qw/xwayland-view.h
+++ b/libqtile/backend/wayland/qw/xwayland-view.h
@@ -10,7 +10,6 @@
 
 struct qw_xwayland_view {
     struct qw_view base;
-    struct qw_server *server;
 
     struct wlr_scene_tree *scene_tree;
     struct wlr_scene_surface *scene_surface;
@@ -34,11 +33,14 @@ struct qw_xwayland_view {
     struct wl_listener map;
     struct wl_listener unmap;
     struct wl_listener destroy;
+    struct wl_listener set_geometry;
+    struct wl_listener override_redirect;
 
     struct wl_listener scene_tree_destroy;
 };
 
-struct qw_xwayland_view *create_xwayland_view(struct wlr_xwayland_surface *qw_xsurface);
+void qw_server_xwayland_static_view_new(struct qw_server *server,
+                                        struct wlr_xwayland_surface *xwayland_surface);
 void qw_server_xwayland_view_new(struct qw_server *server,
                                  struct wlr_xwayland_surface *xwayland_surface);
 


### PR DESCRIPTION
Xwayland surfaces where override_redirect is true should not be managed but instead placed at the given location. These surfaces are usually things like menus or popups

Follows sway's implementation pretty closely

Addresses #5573

Outstanding issues:
- Menu doesn't move if window is moved
- ~~If main xwayland window loses and regains focus, the menu goes beneath the main window~~
- Since these surfaces aren't  managed, they are visible on all groups