### PR TITLE
[wayc] Add more xwayland window properties

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -349,6 +349,10 @@ class Core(base.Core):
             win.name = ffi.string(view.title).decode()
         if view.app_id != ffi.NULL:
             win._wm_class = ffi.string(view.app_id).decode()
+        if view.instance != ffi.NULL:
+            win._wm_instance = ffi.string(view.instance).decode()
+        if view.role != ffi.NULL:
+            win._wm_role = ffi.string(view.role).decode()
         win._float_width = win.width  # todo: should we be using getter/setter for _float_width
         win._float_height = win.height
 

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -83,6 +83,8 @@ struct qw_view {
     char *title;
     char *app_id;
     bool urgent;
+    char *instance;                      // XWayland only
+    char *role;                          // XWayland only
     struct wlr_scene_tree *content_tree; // Scene tree holding the view's content
     struct wlr_foreign_toplevel_handle_v1 *ftl_handle;
 

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -517,6 +517,8 @@ static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data
 
     xwayland_view->base.title = xwayland_surface->title;
     xwayland_view->base.app_id = xwayland_surface->class;
+    xwayland_view->base.instance = xwayland_surface->instance;
+    xwayland_view->base.role = xwayland_surface->role;
 
     // Set properties for foreign toplevel manager
     if (xwayland_view->base.ftl_handle != NULL) {

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -34,6 +34,8 @@ class Base(base._Window):
         self._ptr = ptr
         self._wid = wid
         self._wm_class: str | None = None
+        self._wm_instance: str | None = None
+        self._wm_role: str | None = None
         self.bordercolor: ColorsType | None = None
         self.borderwidth = 0
         # TODO: what is this?
@@ -431,9 +433,16 @@ class Window(Base, base.Window):
         # TODO: Handle foreign-toplevel-management?
 
     def get_wm_class(self) -> list | None:
+        wm_class = []
+        if self._wm_instance:
+            wm_class.append(self._wm_instance)
         if self._wm_class:
-            return [self._wm_class]
-        return None
+            wm_class.append(self._wm_class)
+
+        return wm_class or None
+
+    def get_wm_role(self) -> str | None:
+        return self._wm_role or None
 
     @expose_command()
     def is_visible(self) -> bool:


### PR DESCRIPTION
Adds "instance" and "role".

"instance" is used to extend `get_wm_class()` so it now returns the equivalent result to X11 being a list of `[instance, class]`.

"role" is a string such as `GtkFileChooserDialog` which can be used by users for floating rules.