### PR TITLE
wayland - add `skip_taskbar` property

### DIFF
--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -135,6 +135,7 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
         .border_count = 0,
         .state = NOT_FLOATING,
         .wid = -1, // Window ID, to be set by compositor
+        .skip_taskbar = true,
         .content_tree = wlr_scene_tree_create(&server->scene->tree),
         .get_tree_node = qw_internal_view_get_tree_node,
         .place = qw_internal_view_place,

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -83,8 +83,9 @@ struct qw_view {
     char *title;
     char *app_id;
     bool urgent;
-    char *instance;                      // XWayland only
-    char *role;                          // XWayland only
+    char *instance; // XWayland only
+    char *role;     // XWayland only
+    bool skip_taskbar;
     struct wlr_scene_tree *content_tree; // Scene tree holding the view's content
     struct wlr_foreign_toplevel_handle_v1 *ftl_handle;
 

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -575,6 +575,8 @@ static struct qw_xdg_popup *qw_server_xdg_popup_new(struct wlr_xdg_popup *wlr_po
         return NULL;
     }
 
+    popup->base.skip_taskbar = true;
+
     wl_signal_add(&surface->surface->events.commit, &popup->surface_commit);
     popup->surface_commit.notify = qw_xdg_popup_handle_surface_commit;
     wl_signal_add(&surface->events.new_popup, &popup->new_popup);

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -547,6 +547,8 @@ static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data
     xwayland_view->base.instance = xwayland_surface->instance;
     xwayland_view->base.role = xwayland_surface->role;
 
+    xwayland_view->base.skip_taskbar = xwayland_surface->skip_taskbar;
+
     // Set properties for foreign toplevel manager
     if (xwayland_view->base.ftl_handle != NULL) {
         if (xwayland_view->base.title != NULL) {
@@ -725,6 +727,13 @@ static void qw_xwayland_view_handle_set_hints(struct wl_listener *listener, void
                                                xwayland_view->base.server->cb_data);
 }
 
+static void qw_xwayland_view_handle_request_skip_taskbar(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_xwayland_view *xwayland_view =
+        wl_container_of(listener, xwayland_view, request_activate);
+    xwayland_view->base.skip_taskbar = xwayland_view->xwayland_surface->skip_taskbar;
+}
+
 static void qw_xwayland_view_handle_dissociate(struct wl_listener *listener, void *data) {
     UNUSED(data);
     struct qw_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, dissociate);
@@ -745,6 +754,7 @@ static void qw_xwayland_view_handle_destroy(struct wl_listener *listener, void *
     wl_list_remove(&xwayland_view->override_redirect.link);
     wl_list_remove(&xwayland_view->request_above.link);
     wl_list_remove(&xwayland_view->request_below.link);
+    wl_list_remove(&xwayland_view->request_skip_taskbar.link);
     qw_view_ftl_manager_handle_destroy(&xwayland_view->base);
     wlr_scene_node_destroy(&xwayland_view->base.content_tree->node);
 
@@ -872,6 +882,10 @@ void qw_server_xwayland_view_new(struct qw_server *server,
 
     wl_signal_add(&xwayland_surface->events.request_below, &xwayland_view->request_below);
     xwayland_view->request_below.notify = qw_xwayland_view_handle_request_below;
+
+    wl_signal_add(&xwayland_surface->events.request_skip_taskbar,
+                  &xwayland_view->request_skip_taskbar);
+    xwayland_view->request_activate.notify = qw_xwayland_view_handle_request_skip_taskbar;
 
     // Assign function pointers for base view operations
     xwayland_view->base.get_tree_node = qw_xwayland_view_get_tree_node;

--- a/libqtile/backend/wayland/qw/xwayland-view.h
+++ b/libqtile/backend/wayland/qw/xwayland-view.h
@@ -27,6 +27,7 @@ struct qw_xwayland_view {
     struct wl_listener request_close;
     struct wl_listener request_above;
     struct wl_listener request_below;
+    struct wl_listener request_skip_taskbar;
     struct wl_listener set_title;
     struct wl_listener set_class;
     struct wl_listener set_hints;

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -586,6 +586,14 @@ class Window(Base, base.Window):
     def group(self, group: _Group | None) -> None:
         self._group = group
 
+    @property
+    def skip_taskbar(self) -> bool:
+        return bool(self._ptr.skip_taskbar)
+
+    @skip_taskbar.setter
+    def skip_taskbar(self, value: bool) -> None:
+        self._ptr.skip_taskbar = value
+
     @expose_command()
     def get_position(self) -> tuple[int, int]:
         return int(self._ptr.x), int(self._ptr.y)

--- a/libqtile/scratchpad.py
+++ b/libqtile/scratchpad.py
@@ -170,6 +170,8 @@ class DropDownToggler(WindowVisibilityToggler):
             else:
                 net_wm_state = [skip_taskbar]
             window.window.set_property("_NET_WM_STATE", net_wm_state)
+        else:
+            window.skip_taskbar = True
 
         # Let's add the window to the scratchpad group.
         window.togroup(scratchpad_name)

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -250,15 +250,19 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
     @property
     def windows(self):
+        windows = []
         if self.qtile.core.name == "x11":
-            windows = []
             for w in self.bar.screen.group.windows:
                 wm_states = list(w.window.get_property("_NET_WM_STATE", "ATOM", unpack=int))
                 skip_taskbar = w.qtile.core.conn.atoms["_NET_WM_STATE_SKIP_TASKBAR"]
                 if w.window.get_wm_type() in ("normal", None) and skip_taskbar not in wm_states:
                     windows.append(w)
-            return windows
-        return self.bar.screen.group.windows
+        else:
+            for w in self.bar.screen.group.windows:
+                if w.get_wm_type() in ("normal", None) and not w.skip_taskbar:
+                    windows.append(w)
+
+        return windows
 
     @property
     def max_width(self):


### PR DESCRIPTION
This is set to `False` by default for XDG windows but can be set manually (e.g. scratchpads set this atom on X11).

For xwayland views, we set this depending on the the `skip_taskbar` attribute (which corresponds to the `NET_WM_STATE_SKIP_TASKBAR` atom) and subscribe to signals advertising a change of status.