### PR TITLE
[wayland] fix XCB connection

### DIFF
--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -226,6 +226,7 @@ struct qw_server {
     struct wlr_foreign_toplevel_manager_v1 *ftl_mgr;
 #if WLR_HAS_XWAYLAND
     struct wlr_xwayland *xwayland;
+    struct wl_listener xwayland_ready;
     struct wl_listener new_xwayland_surface;
     xcb_atom_t xwayland_atoms[ATOM_LAST];
 #endif


### PR DESCRIPTION
The wayland backend creates a connection to the x server to retrieve atoms in order to determine an xwayland window's _NET_WM_WINDOW_TYPE.

This caused an issue in CI as the connection was being made too soon and tried to connect to the previous test's server. This causes the `xcb_connect` request to hang because, although the socket existed, there was no data being provided. This blocked the code and caused the wayland backend to fail to launch.

The solution is to only create the x server connection once xwayland has fired the `ready` signal.