### PR TITLE
[wayland] change foreign toplevel activation callback

### DIFF
--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -253,9 +253,9 @@ static void qw_handle_ftl_request_activate(struct wl_listener *listener, void *d
     if (view == NULL) {
         return;
     }
-    int handled = view->request_focus_cb(view->cb_data);
-    if (!handled) {
-        wlr_log(WLR_ERROR, "Could not focus window from foreign toplevel manager.");
+    struct qw_server *server = view->server;
+    if (server->view_urgent_cb != NULL) {
+        server->view_urgent_cb(view, server->view_urgent_cb_data);
     }
 }
 


### PR DESCRIPTION
Foreign toplevel activation requests just focused the window via the compositor but didn't change the group. This meant input was being directed to a window that may not have been visible.

This PR changes the way we handle activation requests. Instead, we treat them like we do in X11 i.e. an activation request from a third party client (such as `rofi`) will depend on how `focus_on_window_activation` is set in the user's config.