### PR TITLE
fix(ci): create own systray icon script

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -33,8 +33,7 @@ build:
     - libxcb-cursor0
     - git
     - xterm
-    - vlc
-    - volumeicon-alsa
+    - libpulse0
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/test/scripts/systray.py
+++ b/test/scripts/systray.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+This creates a minimal system tray icon using GTK.
+
+GTK sets the systray class via `--name <class>` like:
+
+    python systray.py --name <class>
+
+The window will close itself when clicked.
+"""
+# flake8: noqa
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+systray = Gtk.StatusIcon()
+systray.connect("activate", Gtk.main_quit)
+
+Gtk.main()

--- a/test/widgets/test_systray.py
+++ b/test/widgets/test_systray.py
@@ -1,4 +1,5 @@
-import shutil
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -88,9 +89,7 @@ def test_systray_icons(manager_nospawn, minimal_conf_noscreen, backend_name):
     if backend_name == "wayland":
         pytest.skip("Skipping test on Wayland.")
 
-    for prog in ("volumeicon", "vlc"):
-        if shutil.which(prog) is None:
-            pytest.skip(f"{prog} must be installed. Skipping test.")
+    script = Path(__file__).parent.parent / "scripts" / "systray.py"
 
     config = minimal_conf_noscreen
     config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([widget.Systray()], 40))]
@@ -100,8 +99,8 @@ def test_systray_icons(manager_nospawn, minimal_conf_noscreen, backend_name):
     # No icons at this stage so length is 0
     assert manager_nospawn.c.widget["systray"].info()["widget"]["length"] == 0
 
-    manager_nospawn.c.spawn("volumeicon")
-    manager_nospawn.c.spawn("vlc")
+    manager_nospawn.c.spawn(f"{sys.executable} {script.as_posix()} --name qtile")
+    manager_nospawn.c.spawn(f"{sys.executable} {script.as_posix()} --name systray")
 
     wait_for_icons()
 
@@ -118,4 +117,4 @@ def test_systray_icons(manager_nospawn, minimal_conf_noscreen, backend_name):
     # Icons should be in alphabetical order
     _, order = manager_nospawn.c.widget["systray"].eval("[i.name for i in self.tray_icons]")
 
-    assert order == "['vlc', 'volumeicon']"
+    assert order == "['qtile', 'systray']"


### PR DESCRIPTION
Remove volumeicon and vlc from dependecies
Prevent faulty workflows due to ALSA card not found
Use minimal systray script as a replacement

Here is the workflow error:
```py
=================================== FAILURES ===================================
______________________ test_tasklist_defaults[1-x11-top] _______________________

tasklist_manager = <test.helpers.TestManager object at 0x7f05c137f610>

    @horizontal_and_vertical
    def test_tasklist_defaults(tasklist_manager):
        widget = tasklist_manager.c.widget["tasklist"]
    
        tasklist_manager.test_window("One")
        tasklist_manager.test_window("Two")
>       assert widget.info()["text"] == "One|Two"
E       AssertionError: assert 'volumeicon|One|Two' == 'One|Two'
E         
E         - One|Two
E         + volumeicon|One|Two

test/widgets/test_tasklist.py:84: AssertionError
----------------------------- Captured stderr call -----------------------------
ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_card_inum returned error: No such file or directory
ALSA lib confmisc.c:422:(snd_func_concat) error evaluating strings
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_concat returned error: No such file or directory
ALSA lib confmisc.c:1342:(snd_func_refer) error evaluating name
ALSA lib conf.c:5204:(_snd_config_evaluate) function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5727:(snd_config_expand) Evaluate error: No such file or directory
ALSA lib control.c:1570:(snd_ctl_open_noupdate) Invalid CTL default
Failed to open sound device with name: default
--------------------------- Captured stdout teardown ---------------------------
2025-11-05 00:53:27,370 libqtile lifecycle.py:_atexit():L38  Qtile will now terminate
=========================== short test summary info ============================
FAILED test/widgets/test_tasklist.py::test_tasklist_defaults[1-x11-top] - AssertionError: assert 'volumeicon|One|Two' == 'One|Two'
  
  - One|Two
  + volumeicon|One|Two
====== 1 failed, 1357 passed, 3 skipped, 2 xpassed in 1192.93s (0:19:52) =======
make: *** [Makefile:28: check] Error 1
```