### PR TITLE
feat(window): share activation logic across backends

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -471,7 +471,7 @@ class Core(base.Core):
         win = self.qtile.windows_map.get(wid)
 
         if win:
-            win.handle_window_activation()
+            win.activate_by_config()
 
     def finalize(self) -> None:
         lib.qw_server_finalize(self.qw)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -399,14 +399,8 @@ class Window(Base, base.Window):
         ptr.set_app_id_cb = lib.set_app_id_cb
 
     def handle_request_focus(self) -> bool:
-        if self.group is None:
-            return False
-
         logger.debug("Focusing window from external request")
-        self.qtile.current_screen.set_group(self.group)
-        self.group.focus(self)
-        self.bring_to_front()
-        return True
+        return self.activate()
 
     def handle_request_close(self) -> bool:
         self.kill()

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1242,7 +1242,7 @@ class _Window:
     def can_steal_focus(self, can_steal_focus: bool) -> None:
         self._can_steal_focus = can_steal_focus
 
-    def _do_focus(self):
+    def _do_focus(self) -> bool:
         """
         Focus the window if we can, and return whether or not it was successful.
         """
@@ -2143,11 +2143,9 @@ class Window(_Window, base.Window):
             source = data.data32[0]
             if source == 2:  # Request from a pager should immediately focus the window
                 logger.debug("Focusing window by pager")
-                self.qtile.current_screen.set_group(self.group)
-                self.group.focus(self)
-                self.bring_to_front()
+                self.activate()
             else:  # Request from the application
-                self.handle_window_activation()
+                self.activate_by_config()
         elif atoms["_NET_CLOSE_WINDOW"] == opcode:
             self.kill()
         elif atoms["WM_CHANGE_STATE"] == opcode:


### PR DESCRIPTION
As discussed in #5632, this puts the window activation logic into `base/window.py` so now it is the same across X11 and Wayland backends.