### PR TITLE
bar: preserve bar and widget references during finalization

### DIFF
--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -377,6 +377,10 @@ class RandR:
         for output in self.ext.GetScreenResources(root).reply().outputs:
             info = self.ext.GetOutputInfo(output, xcffib.CurrentTime).reply()
 
+            # ignore disconnected monitors
+            if info.connection != xcffib.randr.Connection.Connected:
+                continue
+
             # ignore outputs with no monitor plugged in
             if not info.crtc:
                 continue

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -409,13 +409,14 @@ class Bar(Gap, configurable.Configurable, CommandObject):
     def finalize(self) -> None:
         if self.future:
             self.future.cancel()
+        for widget in self.widgets:
+            widget.finalize()
         if hasattr(self, "drawer"):
             self.drawer.finalize()
             del self.drawer
         if self.window:
             self.window.kill()
             self.window = None
-        self.widgets.clear()
 
     def _resize(self, length: int, widgets: list[_Widget]) -> None:
         """

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -514,7 +514,6 @@ class Screen(CommandObject):
     def finalize_gap(self, position: str) -> None:
         gap = getattr(self, position, None)
         if gap is not None:
-            setattr(self, position, None)
             gap.finalize()
 
     def finalize_gaps(self) -> None:


### PR DESCRIPTION
The core insight here is: finalization is for the resources allocated by a bar or widget, not deleting the bar or widgets themselves. If we do that, then when people turn their monitors back on, we will have mutilated their configs, deleting the bars.

Instead, we should finalize these python objects, since they know how to re-allocate the resources as necessary on _configure() again if someone re-attaches a screen. However, we do not do silly things like widgets.clear() (deleting all the widgets from a bar), or screen.top = None, removing the widget from the Screen.

This lets us revert 99c8a54b026d ("x11: don't ignore powered off monitors"), since we really do want to ignore powered off monitors, but we couldn't before because we were deleting widgets and bars from configs when the monitors were disconnected.

Fixes #5436