### PR TITLE
wayland: Fix segfault when cairo surface freed

### DIFF
--- a/libqtile/backend/wayland/drawer.py
+++ b/libqtile/backend/wayland/drawer.py
@@ -45,7 +45,7 @@ class Drawer(drawer.Drawer):
             height = self._win.height - offsety
 
         # Paint recorded operations to our window's underlying ImageSurface
-        # Allocation could have failed, NULL check
+        # Allocation could have failed or surface may have been destroyed, NULL check
         if not self._win.surface:
             return
         surface = cairocffi.Surface._from_pointer(self._win.surface, True)  # type: ignore[attr-defined]

--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -101,6 +101,7 @@ static void qw_internal_view_unhide(void *self) {
 static void qw_internal_view_kill(void *self) {
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     cairo_surface_destroy(view->image_surface);
+    view->image_surface = NULL;
     wlr_buffer_drop(view->buffer);
     wlr_scene_node_destroy(&view->base.content_tree->node);
     free(view);


### PR DESCRIPTION
In #5639, we are crashing in Drawer._draw() when trying to get cairo surface from pointer - it appears the surface reference can be a dangling pointer if the view has been killed and surface destroyed

This can be prevented by NULLing the pointer after destroying the surface

Fixes #5639