### PR TITLE
[wayland] Test window send activation request

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -377,7 +377,8 @@ class TestManager:
             args += ["--new-title", new_title]
         if urgent:
             args.append("--urgent")
-            # GDK urgency hint is only available in x11
+            # Set GDK_BACKEND to x11, since in wayland, the window requieres
+            # of an input event which cannot be passed to the headless session
             os.environ["GDK_BACKEND"] = "x11"
         if export_sni:
             args.append("--export_sni_interface")

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -5,8 +5,7 @@ import pytest
 
 import libqtile.log_utils
 import libqtile.utils
-from libqtile import config, hook, layout
-from libqtile.config import Match
+from libqtile import hook, layout
 from libqtile.resources import default_config
 from test.conftest import BareConfig, dualmonitor
 from test.helpers import Retry
@@ -578,19 +577,18 @@ def test_client_name_updated(manager_nospawn):
 @pytest.mark.usefixtures("hook_fixture")
 def test_client_urgent_hint_changed(manager_nospawn):
     class ClientUrgentHintChangedConfig(BareConfig):
-        groups = [
-            config.Group("a"),
-            config.Group("b", matches=[Match(title="Test Client")]),
-        ]
         test = CallWindow()
         hook.subscribe.client_urgent_hint_changed(test)
 
     manager_nospawn.start(ClientUrgentHintChangedConfig)
     manager_nospawn.test_window("Test Client", urgent=True)
+    manager_nospawn.c.screen.next_group()
     assert_window(manager_nospawn, "Test Client")
     # Get urgency of the window
-    _, urgent = manager_nospawn.c.eval("list(self.windows_map.values())[0].urgent")
-    assert urgent == "True"
+    assert manager_nospawn.c.eval("self.normal_windows()[0].urgent")[1] == "True"
+    # Refocusing the window should clear the urgency
+    manager_nospawn.c.screen.prev_group()
+    assert manager_nospawn.c.eval("self.normal_windows()[0].urgent")[1] == "False"
 
 
 class CallLayoutGroup:


### PR DESCRIPTION
I was trying to make this test `test_client_urgent_hint_changed` use a native wayland window instead of using Xwayland to set the urgency. But gtk makes it difficult to accomplish, it needs of an input event to be send to the window for the **activation token** to be valid.

As far as I could test, there is no way to send such event in the headless backend I think, so unless anyone knows how to send input events in the testing environment, this is as far as the test could get.

Still, this serves for manual testing of **activation token** sent by windows, meaning that the script _(test/scripts/window.py)_ works in a normal qtile wayland session. 🚀 