### PR TITLE
unify hovered_window calculation logic

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -190,8 +190,6 @@ class Core(base.Core):
     supports_restarting: bool = False
 
     def __init__(self) -> None:
-        # This is the window under the pointer
-        self._hovered_window: base.WindowType | None = None
         # this Internal window receives keyboard input, e.g. via the Prompt widget.
         self.focused_internal: base.Internal | None = None
 
@@ -333,10 +331,10 @@ class Core(base.Core):
 
             handled = self.qtile.process_button_click(int(button), int(mask), x, y)
 
-            if isinstance(self._hovered_window, Internal):
-                self._hovered_window.process_button_click(
-                    int(self.qw_cursor.cursor.x - self._hovered_window.x),
-                    int(self.qw_cursor.cursor.y - self._hovered_window.y),
+            if isinstance(self.qtile.hovered_window, Internal):
+                self.qtile.hovered_window.process_button_click(
+                    int(self.qw_cursor.cursor.x - self.qtile.hovered_window.x),
+                    int(self.qw_cursor.cursor.y - self.qtile.hovered_window.y),
                     int(button),
                 )
 
@@ -446,9 +444,9 @@ class Core(base.Core):
 
         win = self.qtile.windows_map.get(view.wid)
 
-        if self._hovered_window is not win:
+        if self.qtile.hovered_window is not win:
             # We only want to fire client_mouse_enter once, so check
-            # self._hovered_window.
+            # self.qtile.hovered_window.
             hook.fire("client_mouse_enter", win)
 
         if win is not self.qtile.current_window:
@@ -465,7 +463,7 @@ class Core(base.Core):
                     ):
                         self.qtile.focus_screen(win.group.screen.index, False)
 
-        self._hovered_window = win
+        self.qtile.hovered_window = win
 
     def handle_view_activation(self, view: ffi.CData) -> None:
         """Handle view urgency notification"""

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -920,8 +920,3 @@ class Core(base.Core):
             self.last_focused.change_layer()
 
         self.last_focused = win
-
-    @property
-    def hovered_window(self) -> base.WindowType | None:
-        _hovered_window = self.conn.conn.core.QueryPointer(self._root.wid).reply().child
-        return self.qtile.windows_map.get(_hovered_window)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1543,6 +1543,7 @@ class Internal(_Window, base.Internal):
         return True
 
     def handle_EnterNotify(self, e):  # noqa: N802
+        self.qtile.hovered_window = self
         self.process_pointer_enter(e.event_x, e.event_y)
 
     def handle_LeaveNotify(self, e):  # noqa: N802
@@ -2042,6 +2043,7 @@ class Window(_Window, base.Window):
             return False
 
     def handle_EnterNotify(self, e):  # noqa: N802
+        self.qtile.hovered_window = self
         hook.fire("client_mouse_enter", self)
         if self.qtile.config.follow_mouse_focus is True:
             if self.group.current_window != self:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -86,6 +86,7 @@ class Qtile(CommandObject):
         self.renamed_widgets: list[str]
         self.groups_map: dict[str, _Group] = {}
         self.groups: list[_Group] = []
+        self.hovered_window: base.WindowType | None = None
 
         self.keys_map: dict[tuple[int, int], Key | KeyChord] = {}
         self.chord_stack: list[KeyChord] = []
@@ -835,8 +836,8 @@ class Qtile(CommandObject):
                 closest_screen = s
         return closest_screen or self.screens[0]
 
-    def _focus_hovered_window(self) -> None:
-        window = self.core.hovered_window
+    def focus_hovered_window(self) -> None:
+        window = self.hovered_window
         if window:
             if isinstance(window, base.Window):
                 window.focus()
@@ -849,7 +850,7 @@ class Qtile(CommandObject):
 
             if isinstance(m, Click):
                 if self.config.follow_mouse_focus == "click_or_drag_only":
-                    self._focus_hovered_window()
+                    self.focus_hovered_window()
                 for i in m.commands:
                     if i.check(self):
                         status, val = self.server.call(
@@ -862,7 +863,7 @@ class Qtile(CommandObject):
                 isinstance(m, Drag) and self.current_window and not self.current_window.fullscreen
             ):
                 if self.config.follow_mouse_focus == "click_or_drag_only":
-                    self._focus_hovered_window()
+                    self.focus_hovered_window()
                 if m.start:
                     i = m.start
                     status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs, False))


### PR DESCRIPTION
X11's logic seems flawed when the window straddles two monitors. Rather than try and fix this up, let's just do the same thing wayland does: keep track of the last window we entered, because that's the one the mouse is currently over.

Since we're doing the same thing wayland is, we can do it on the core object, and get rid of some backend specific code for x11 here.

This hopefully:

Fixes #1413

...I'm making this PR just because I don't want to lose the change. I think it's a nice improvement, but I haven't been able to verify yet, nor has anyone on that bug.