### PR TITLE
[wayland] bump layer shell to v5

### DIFF
--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -1,7 +1,6 @@
 #include "output.h"
 #include "cairo-buffer.h"
 #include "layer-view.h"
-#include "proto/wlr-layer-shell-unstable-v1-protocol.h"
 #include "server.h"
 #include "session-lock.h"
 #include "util.h"

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -717,7 +717,7 @@ struct qw_server *qw_server_create() {
     wl_signal_add(&server->xdg_decoration_mgr->events.new_toplevel_decoration,
                   &server->new_decoration);
 
-    server->layer_shell = wlr_layer_shell_v1_create(server->display, 3);
+    server->layer_shell = wlr_layer_shell_v1_create(server->display, 4);
     server->new_layer_surface.notify = qw_server_handle_new_layer_surface;
     wl_signal_add(&server->layer_shell->events.new_surface, &server->new_layer_surface);
     server->renderer_lost.notify = qw_server_handle_renderer_lost;


### PR DESCRIPTION
wlroots 0.19 supports version 5 of the layer shell protocol so we should tell clients that we support it.

~We can also remove the unstable protocol builder as it's part of wlroots.~ No we can't.