### PR TITLE
[wayland] add idle notify/inhibit support

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -119,6 +119,9 @@ extern "Python" void on_input_device_added_cb(void *userdata);
 extern "Python" bool focus_current_window_cb(void *userdata);
 extern "Python" void on_session_lock_cb(bool locked, void *userdata);
 extern "Python" struct wlr_box get_current_output_dims_cb(void *userdata);
+extern "Python" bool add_idle_inhibitor_cb(void *userdata, void *inhibitor, void *view, bool is_layer_surface, bool is_session_lock_surface);
+extern "Python" bool remove_idle_inhibitor_cb(void *userdata, void *inhibitor);
+extern "Python" bool check_inhibited_cb(void *userdata);
 
 extern "Python" int request_focus_cb(void *userdata);
 extern "Python" int request_close_cb(void *userdata);

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -52,6 +52,7 @@ from typing import TYPE_CHECKING, Any
 from libqtile import hook
 from libqtile.backend import base
 from libqtile.backend.wayland import inputs
+from libqtile.backend.wayland.idle_inhibit import InhibitorManager
 from libqtile.backend.wayland.window import Internal, Static, Window
 from libqtile.command.base import allow_when_locked, expose_command
 from libqtile.config import ScreenRect
@@ -182,6 +183,36 @@ def get_current_output_dims_cb(userdata: ffi.CData) -> ffi.CData:
     return core.handle_get_current_output_dims()
 
 
+@ffi.def_extern()
+def add_idle_inhibitor_cb(
+    userdata: ffi.CData,
+    inhibitor: ffi.CData,
+    view: ffi.CData,
+    is_layer_surface: bool,
+    is_session_lock_surface: bool,
+) -> bool:
+    core = ffi.from_handle(userdata)
+    if view != ffi.NULL:
+        window = ffi.from_handle(view)
+    else:
+        window = None
+    return core.handle_new_idle_inhibitor(
+        inhibitor, window, is_layer_surface, is_session_lock_surface
+    )
+
+
+@ffi.def_extern()
+def remove_idle_inhibitor_cb(userdata: ffi.CData, inhibitor: ffi.CData) -> bool:
+    core = ffi.from_handle(userdata)
+    return core.handle_remove_idle_inhibitor(inhibitor)
+
+
+@ffi.def_extern()
+def check_inhibited_cb(userdata: ffi.CData) -> bool:
+    core = ffi.from_handle(userdata)
+    return core.check_inhibited()
+
+
 def get_wlr_log_level() -> int:
     if logger.level <= logging.DEBUG:
         return lib.WLR_DEBUG
@@ -226,12 +257,17 @@ class Core(base.Core):
         self.qw.focus_current_window_cb = lib.focus_current_window_cb
         self.qw.on_session_lock_cb = lib.on_session_lock_cb
         self.qw.get_current_output_dims_cb = lib.get_current_output_dims_cb
+        self.qw.add_idle_inhibitor_cb = lib.add_idle_inhibitor_cb
+        self.qw.remove_idle_inhibitor_cb = lib.remove_idle_inhibitor_cb
+        self.qw.check_inhibited_cb = lib.check_inhibited_cb
         lib.qw_server_start(self.qw)
         os.environ["WAYLAND_DISPLAY"] = self.display_name
         self.qw_cursor = lib.qw_server_get_cursor(self.qw)
 
         self.painter = Painter(self)
         self._locked = False
+        self.inhibitor_manager = InhibitorManager(self)
+        self._inhibited = False
 
     def update_backend_log_level(self) -> None:
         """Update the wlr log level based on Qtile's log level."""
@@ -377,12 +413,16 @@ class Core(base.Core):
         win._float_width = win.width  # todo: should we be using getter/setter for _float_width
         win._float_height = win.height
 
+        # Check if any user-defined inhibitor rules match the window
+        win.add_config_inhibitors()
+
         self.qtile.manage(win)
         if win.group and win.group.screen:
             self.check_screen_fullscreen_background(win.group.screen)
 
     def handle_unmanage_view(self, view: ffi.CData) -> None:
         assert self.qtile is not None
+        self.inhibitor_manager.remove_window_inhibitor_by_wid(view.wid)
         self.qtile.unmanage(view.wid)
         self.check_screen_fullscreen_background()
 
@@ -745,6 +785,48 @@ class Core(base.Core):
                 continue
             enabled = any(w.fullscreen for w in s.group.windows)
             lib.qw_server_set_output_fullscreen_background(self.qw, s.x, s.y, enabled)
+
+    def handle_new_idle_inhibitor(
+        self,
+        inhibitor: ffi.CData,
+        window: Window,
+        is_layer_surface: bool,
+        is_session_lock_surface: bool,
+    ) -> bool:
+        return self.inhibitor_manager.add_extension_inhibitor(
+            inhibitor, window, is_layer_surface, is_session_lock_surface
+        )
+
+    def handle_remove_idle_inhibitor(self, inhibitor: ffi.CData) -> bool:
+        return self.inhibitor_manager.remove_extension_inhibitor(inhibitor)
+
+    def check_inhibited(self) -> None:
+        self.inhibitor_manager.check()
+
+    def set_inhibited(self, inhibited: bool) -> None:
+        if inhibited != self._inhibited:
+            hook.fire("idle_inhibitor_change", inhibited)
+            self._inhibited = inhibited
+            lib.qw_server_set_inhibited(self.qw, inhibited)
+
+    @expose_command()
+    def set_idle_inhibitor(self) -> None:
+        """Create a global idle inhibitor."""
+        self.inhibitor_manager.add_global_inhibitor()
+
+    @expose_command()
+    def remove_idle_inhibitor(self) -> None:
+        """Remove global idle inhibitor."""
+        self.inhibitor_manager.remove_global_inhibitor()
+
+    @expose_command()
+    def get_idle_inhibitors(self, active_only: bool = False) -> list[str]:
+        """Return list of inhibitors."""
+        return [
+            f"{inhibitor!r}"
+            for inhibitor in self.inhibitor_manager.inhibitors
+            if not active_only or (active_only and inhibitor.check())
+        ]
 
 
 class Painter:

--- a/libqtile/backend/wayland/idle_inhibit.py
+++ b/libqtile/backend/wayland/idle_inhibit.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from enum import IntEnum, auto
+from typing import TYPE_CHECKING
+
+from libqtile import hook
+from libqtile.log_utils import logger
+
+try:
+    from libqtile.backend.wayland._ffi import ffi, lib
+except ModuleNotFoundError:
+    from libqtile.backend.wayland.ffi_stub import ffi, lib
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from libqtile.backend.base.window import Window
+    from libqtile.backend.wayland.core import Core
+    from libqtile.core.manager import Qtile
+
+
+class InhibitorType(IntEnum):
+    GLOBAL = auto()
+    OPEN = auto()
+    APPLICATION = auto()
+    VISIBLE = auto()
+    FOCUS = auto()
+    FULLSCREEN = auto()
+
+
+inhibitor_map = {
+    "open": InhibitorType.OPEN,
+    "visible": InhibitorType.VISIBLE,
+    "focus": InhibitorType.FOCUS,
+    "fullscreen": InhibitorType.FULLSCREEN,
+}
+
+
+class Inhibitor:
+    def __init__(
+        self,
+        qtile: Qtile,
+        window: Window | None = None,
+        handle: ffi.CData | None = None,
+        inhibitor_type: InhibitorType | None = None,
+        is_layer_surface: bool = False,
+        is_session_lock: bool = False,
+    ):
+        if inhibitor_type != InhibitorType.GLOBAL and (
+            (window is None and handle is None) or inhibitor_type is None
+        ):
+            raise ValueError("Inhibitor created with invalid arguments.")
+
+        self.qtile = qtile
+        self.window = window
+        self.handle = handle
+        self.inhibitor_type = inhibitor_type
+        self.is_layer_surface = is_layer_surface
+        self.is_session_lock = is_session_lock
+
+    def check(self) -> bool:
+        # If a session lock is active we only allow inhibitors from the session lock
+        if self.qtile.locked:
+            return self.is_session_lock and lib.qw_server_inhibitor_surface_visible(
+                self.handle, ffi.NULL
+            )
+
+        match self.inhibitor_type:
+            # Global inhibitor is always active
+            case InhibitorType.GLOBAL:
+                active = True
+            # Application-set inhibitors should apply when the client is visible
+            case InhibitorType.APPLICATION:
+                if self.window is not None:
+                    active = self.window.visible
+                elif self.is_session_lock or self.is_layer_surface:
+                    active = lib.qw_server_inhibitor_surface_visible(self.handle, ffi.NULL)
+                # We shouldn't really get here but, if we do, treat it as active
+                else:
+                    active = True
+            # Inhibitor is removed when client is killed so if it exists in the list then the client
+            # must be open
+            case InhibitorType.OPEN:
+                active = True
+            case InhibitorType.FOCUS:
+                active = bool(
+                    self.qtile.current_window and self.qtile.current_window == self.window
+                )
+            case InhibitorType.FULLSCREEN:
+                active = bool(self.window and self.window.fullscreen)
+            case InhibitorType.VISIBLE:
+                active = bool(self.window and self.window.visible)
+
+        return active
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Inhibitor):
+            raise NotImplementedError
+
+        return (
+            self.window,
+            self.handle,
+            self.inhibitor_type,
+            self.is_layer_surface,
+            self.is_session_lock,
+        ) == (
+            other.window,
+            other.handle,
+            other.inhibitor_type,
+            other.is_layer_surface,
+            other.is_session_lock,
+        )
+
+    def __repr__(self) -> str:
+        name = self.window.name if self.window else "no window"
+        mode = self.inhibitor_type.name.lower()
+        active = "ACTIVE" if self.check() else "inactive"
+        return f"<window={name} type={mode} status={active}>"
+
+
+class InhibitorManager:
+    def __init__(self, core: Core) -> None:
+        self.core = core
+        self.inhibitors: list[Inhibitor] = []
+
+    def set_hooks(self) -> None:
+        hook.subscribe.focus_change(self.check)
+        hook.subscribe.startup(self.update_user_inhibitors)
+
+    def sort(self) -> None:
+        self.inhibitors.sort(key=lambda x: x.inhibitor_type)
+
+    def add_inhibitor_safe(self, inhibitor: Inhibitor) -> bool:
+        if inhibitor not in self.inhibitors:
+            self.inhibitors.append(inhibitor)
+            self.sort()
+            self.check()
+            return True
+
+        return False
+
+    def remove_inhibitor(
+        self, remove: Callable[[Inhibitor], bool], skip_check: bool = False
+    ) -> bool:
+        old = len(self.inhibitors)
+        self.inhibitors = [o for o in self.inhibitors if not remove(o)]
+        removed = len(self.inhibitors) < old
+        if removed and not skip_check:
+            self.check()
+
+        return removed
+
+    def add_window_inhibitor(self, window: Window, inhibitor_type: str) -> None:
+        itype = inhibitor_map.get(inhibitor_type)
+        if itype is None:
+            logger.error("Unexpected inhibitor type {inhibitor_type}.")
+            return
+
+        inhibitor = Inhibitor(qtile=self.core.qtile, window=window, inhibitor_type=itype)
+        self.add_inhibitor_safe(inhibitor)
+
+    def remove_window_inhibitor(self, window: Window) -> None:
+        self.remove_inhibitor(lambda o: o.window == window)
+
+    def remove_window_inhibitor_by_wid(self, wid: int) -> None:
+        def match_window_by_wid(inhibitor: Inhibitor) -> bool:
+            win = inhibitor.qtile.windows_map.get(wid)
+            if not win:
+                return False
+            return win.wid == wid
+
+        self.remove_inhibitor(lambda o: match_window_by_wid(o))
+
+    def add_extension_inhibitor(
+        self,
+        handle: ffi.CData,
+        window: Window | None,
+        is_layer_surface: bool,
+        is_session_lock: bool,
+    ) -> bool:
+        inhibitor = Inhibitor(
+            qtile=self.core.qtile,
+            window=window,
+            handle=handle,
+            inhibitor_type=InhibitorType.APPLICATION,
+        )
+        return self.add_inhibitor_safe(inhibitor)
+
+    def remove_extension_inhibitor(self, pointer: ffi.CData) -> bool:
+        return self.remove_inhibitor(lambda o: o.handle == pointer)
+
+    def add_global_inhibitor(self) -> None:
+        inhibitor = Inhibitor(qtile=self.core.qtile, inhibitor_type=InhibitorType.GLOBAL)
+        self.add_inhibitor_safe(inhibitor)
+
+    def remove_global_inhibitor(self) -> None:
+        self.remove_inhibitor(lambda o: o.inhibitor_type == InhibitorType.GLOBAL)
+
+    def check(self) -> None:
+        inhibited = any(o.check() for o in self.inhibitors)
+        self.core.set_inhibited(inhibited)
+
+    def update_user_inhibitors(self) -> None:
+        """
+        Reloads inhibitor rules for open windows.
+
+        This is triggered whenever the config file is reloaded and ensures that any changes
+        to the config are updated without needing to restart qtile.
+        """
+        self.remove_inhibitor(
+            lambda o: o.inhibitor_type != InhibitorType.APPLICATION, skip_check=True
+        )
+        for win in self.core.qtile.windows_map.values():
+            win.add_config_inhibitors()

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -138,6 +138,8 @@ static void qw_cursor_handle_motion(struct wl_listener *listener, void *data) {
     struct qw_cursor *cursor = wl_container_of(listener, cursor, motion);
     struct wlr_pointer_motion_event *event = data;
 
+    qw_server_idle_notify_activity(cursor->server);
+
     if (cursor->implicit_grab.live) {
         qw_cursor_implicit_grab_motion(cursor, event->time_msec, &event->pointer->base,
                                        event->delta_x, event->delta_y);
@@ -151,6 +153,8 @@ static void qw_cursor_handle_motion_absolute(struct wl_listener *listener, void 
     // Handle absolute pointer motion event
     struct qw_cursor *cursor = wl_container_of(listener, cursor, motion_absolute);
     struct wlr_pointer_motion_absolute_event *event = data;
+
+    qw_server_idle_notify_activity(cursor->server);
 
     double lx, ly;
     wlr_cursor_absolute_to_layout_coords(cursor->cursor, &event->pointer->base, event->x, event->y,
@@ -237,6 +241,8 @@ static void qw_cursor_handle_button(struct wl_listener *listener, void *data) {
     struct qw_cursor *cursor = wl_container_of(listener, cursor, button);
     struct wlr_pointer_button_event *event = data;
 
+    qw_server_idle_notify_activity(cursor->server);
+
     // When the pointer is constrained, skip further processing
     if (cursor->active_constraint && event->pointer->base.type == WLR_INPUT_DEVICE_POINTER) {
         wlr_seat_pointer_notify_button(cursor->server->seat, event->time_msec, event->button,
@@ -286,6 +292,8 @@ static void qw_cursor_handle_axis(struct wl_listener *listener, void *data) {
     // Handle scroll (axis) event
     struct qw_cursor *cursor = wl_container_of(listener, cursor, axis);
     struct wlr_pointer_axis_event *event = data;
+
+    qw_server_idle_notify_activity(cursor->server);
 
     static double displacement = 0;
     static const uint32_t DISPLACEMENT_PER_STEP = 15; // could be configurable

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -50,6 +50,8 @@ static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
     struct wlr_keyboard_key_event *event = data;
     struct wlr_seat *seat = server->seat;
 
+    qw_server_idle_notify_activity(server);
+
     // keycode offset by 8 as per evdev conventions
     uint32_t keycode = event->keycode + 8;
 

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -22,6 +22,8 @@
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
@@ -124,6 +126,12 @@ typedef bool (*focus_current_window_cb_t)(void *userdata);
 // Callback to get output dimensions for qtile's current screen
 typedef struct wlr_box (*get_current_output_dims_cb_t)(void *userdata);
 
+// Callbacks for idle inhibit functions
+typedef bool (*add_idle_inhibitor_cb_t)(void *userdata, void *inhibitor, void *view,
+                                        bool is_layer_surface, bool is_session_lock_surface);
+typedef bool (*remove_idle_inhibitor_cb_t)(void *userdata, void *inhibitor);
+typedef bool (*check_inhibited_cb_t)(void *userdata);
+
 enum {
     LAYER_BACKGROUND,   // background, layer shell
     LAYER_BOTTOM,       // bottom, layer shell
@@ -180,6 +188,9 @@ struct qw_server {
     focus_current_window_cb_t focus_current_window_cb;
     on_session_lock_cb_t on_session_lock_cb;
     get_current_output_dims_cb_t get_current_output_dims_cb;
+    add_idle_inhibitor_cb_t add_idle_inhibitor_cb;
+    remove_idle_inhibitor_cb_t remove_idle_inhibitor_cb;
+    check_inhibited_cb_t check_inhibited_cb;
     void *view_activation_cb_data;
     void *cb_data;
     struct qw_layer_view *exclusive_layer;
@@ -233,6 +244,10 @@ struct qw_server {
     struct wlr_virtual_pointer_manager_v1 *virtual_pointer;
     struct wl_listener virtual_keyboard_new;
     struct wl_listener virtual_pointer_new;
+    struct wlr_idle_inhibit_manager_v1 *idle_inhibit_manager;
+    struct wlr_idle_notifier_v1 *idle_notifier;
+    struct wl_listener new_idle_inhibitor;
+    struct wl_list idle_inhibitors;
 #if WLR_HAS_XWAYLAND
     struct wlr_xwayland *xwayland;
     struct wl_listener xwayland_ready;
@@ -251,6 +266,14 @@ struct qw_drag_icon {
     // Private data
     struct wlr_scene_tree *scene_icon;
     struct wl_listener destroy;
+};
+
+struct qw_idle_inhibitor {
+    struct qw_server *server;
+    // Private data
+    struct wlr_idle_inhibitor_v1 *wlr_inhibitor;
+    struct wl_listener destroy;
+    struct wl_list link; // server->idle_inhibitors
 };
 
 // Utility functions exposed by the server API
@@ -306,5 +329,10 @@ void qw_server_set_output_fullscreen_background(struct qw_server *server, int x,
                                                 bool enabled);
 
 struct wlr_output *qw_server_get_current_output(struct qw_server *server);
+
+void qw_server_idle_notify_activity(struct qw_server *server);
+void qw_server_set_inhibited(struct qw_server *server, bool inhibited);
+bool qw_server_inhibitor_surface_visible(struct qw_idle_inhibitor *inhibitor,
+                                         struct wlr_surface *surface);
 
 #endif /* SERVER_H */

--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -128,43 +128,43 @@ struct qw_view *qw_view_from_wlr_surface(struct wlr_surface *surface, bool *is_l
     *is_layer_surface = false;
     *is_session_lock_surface = false;
 
-    struct wlr_xdg_surface *xdg_surface;
+	struct wlr_xdg_surface *xdg_surface;
     xdg_surface = wlr_xdg_surface_try_from_wlr_surface(surface);
-    if (xdg_surface != NULL) {
+	if (xdg_surface != NULL) {
         struct qw_xdg_view *xdg_view = xdg_surface->data;
         if (xdg_view != NULL) {
             return &xdg_view->base;
         }
-        return NULL;
-    }
+		return NULL;
+	}
 
 #if WLR_HAS_XWAYLAND
-    struct wlr_xwayland_surface *xwayland_surface;
+	struct wlr_xwayland_surface *xwayland_surface;
     xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
-    if (xwayland_surface != NULL) {
+	if (xwayland_surface != NULL) {
         struct qw_xwayland_view *xwayland_view = xwayland_surface->data;
         if (xwayland_view != NULL) {
             return &xwayland_view->base;
         }
-        return NULL;
-    }
+		return NULL;
+	}
 #endif
 
-    struct wlr_subsurface *subsurface;
+	struct wlr_subsurface *subsurface;
     subsurface = wlr_subsurface_try_from_wlr_surface(surface);
-    if (subsurface != NULL) {
-        return qw_view_from_wlr_surface(subsurface->parent, is_layer_surface, is_session_lock_surface);
-    }
+	if (subsurface != NULL) {
+		return qw_view_from_wlr_surface(subsurface->parent, is_layer_surface, is_session_lock_surface);
+	}
 
-    if (wlr_layer_surface_v1_try_from_wlr_surface(surface) != NULL) {
-        *is_layer_surface = true;
+	if (wlr_layer_surface_v1_try_from_wlr_surface(surface) != NULL) {
+		*is_layer_surface = true;
         return NULL;
-    }
+	}
 
-    if (wlr_session_lock_surface_v1_try_from_wlr_surface(surface) != NULL) {
+	if (wlr_session_lock_surface_v1_try_from_wlr_surface(surface) != NULL) {
         *is_session_lock_surface = true;
         return NULL;
     }
 
-    return NULL;
+	return NULL;
 }

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -43,6 +43,7 @@ class Base(base._Window):
         self.defunct = False
         self.group: _Group | None = None
         self._killed = False
+        self.visible = True
 
     def reparent(self, layer: int) -> None:
         if self.layer == layer:
@@ -181,9 +182,13 @@ class Base(base._Window):
 
     def hide(self) -> None:
         self._ptr.hide(self._ptr)
+        self.visible = False
+        self.qtile.core.check_inhibited()
 
     def unhide(self) -> None:
         self._ptr.unhide(self._ptr)
+        self.visible = True
+        self.qtile.core.check_inhibited()
 
     @expose_command()
     def place(
@@ -280,6 +285,9 @@ class Base(base._Window):
             self.group.focus(self)
 
         hook.fire("client_focus", self)
+
+    def add_config_inhibitors(self) -> None:
+        pass
 
 
 class Internal(Base, base.Internal):
@@ -700,6 +708,7 @@ class Window(Base, base.Window):
             screen = None
 
         self.qtile.core.check_screen_fullscreen_background(screen)
+        self.qtile.core.check_inhibited()
 
     @property
     def maximized(self) -> bool:
@@ -880,6 +889,26 @@ class Window(Base, base.Window):
     @expose_command()
     def disable_fullscreen(self) -> None:
         self.fullscreen = False
+
+    def add_config_inhibitors(self) -> None:
+        for rule in self.qtile.config.idle_inhibitors:
+            if rule.match is None or rule.match.compare(self):
+                self.add_idle_inhibitor(rule.when)
+
+    @expose_command()
+    def add_idle_inhibitor(self, inhibitor_type: str = "open") -> None:
+        """
+        Create an inhibitor rule for this window.
+
+        ``inhibitor_type`` should be one of ``"open"``, ``"focus"``, ``"fullscreen"``
+        or ``"visible"``. Default value is ``"open"``.
+        """
+        self.qtile.core.inhibitor_manager.add_window_inhibitor(self, inhibitor_type)
+
+    @expose_command()
+    def remove_idle_inhibitor(self) -> None:
+        """Remove inhibitor rule for this window."""
+        self.qtile.core.inibitor_manager.remove_window_inhibitor(self)
 
 
 class Static(Base, base.Static):

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -13,7 +13,7 @@ from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
-    from typing import Any
+    from typing import Any, Literal
 
     from libqtile.backend import base
     from libqtile.bar import BarType
@@ -1139,6 +1139,32 @@ class Rule:
             self, ["group", "float", "intrusive", "break_on_match"]
         )
         return f"<Rule match={self.matchlist!r} actions=({actions})>"
+
+
+class IdleInhibitor:
+    """
+    Note: Wayland Only
+
+    Create rules for when the compositor should not go into an idle state.
+
+    IdleInhibitor take two arguments:
+      -  match: a ``Match`` object to define which windows the rule should apply to. If unset, it will apply to all windows.
+                Note: qtile evaluates whether a rule mtahces a window once, when the window is first created.
+      -  when: one of the following strings:
+        - "focus" (default): Inhibitor is active when the matching window is the currently focused window
+        - "fullscreen": Inhibitor is active when the matching window is fullscreen
+        - "visible": Inhibitor is active when the matching window is visible on any screen
+                     (still applies if window is completely covered by a floating window)
+        - "open": Inhibitor is active when the matching window is open (even if hidden)
+    """
+
+    def __init__(
+        self,
+        match: _Match | None = None,
+        when: Literal["focus" | "fullscreen" | "visible" | "open"] = "open",
+    ):
+        self.match = match
+        self.when = when
 
 
 class DropDown(configurable.Configurable):

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from types import FunctionType
     from typing import Any, Literal
 
-    from libqtile.config import Group, Key, Mouse, Rule, Screen
+    from libqtile.config import Group, IdleInhibitor, Key, Mouse, Rule, Screen
     from libqtile.layout.base import Layout
 
 
@@ -53,6 +53,7 @@ class Config:
     wl_input_rules: dict[str, Any] | None
     wl_xcursor_theme: str | None
     wl_xcursor_size: int
+    idle_inhibitors: list[IdleInhibitor]
 
     def __init__(self, file_path=None, **settings):
         """Create a Config() object from settings

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -188,6 +188,9 @@ class Qtile(CommandObject):
         # user has used the "suspend" or "resume" hooks in their config.
         inhibitor.start()
 
+        if self.config.idle_inhibitors and hasattr(self.core, "inhibitor_manager"):
+            self.core.inhibitor_manager.set_hooks()
+
         if initial:
             hook.fire("startup_complete")
 

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -1083,6 +1083,26 @@ hooks: list[Hook] = [
 
         """,
     ),
+    Hook(
+        "idle_inhibitor_change",
+        """
+        Called when the wayland backend's idle inhibitor state changes.
+
+        **Arguments**
+
+            ``inhibited`` (bool):  Whether an idle inhibitor is active or not.
+
+        .. code::
+
+          from libqtile import hook
+          from libqtile.log_utils import logger
+
+          @hook.subscribe.idle_inhibitor_change
+          def on_idle_inhibit(inhibited):
+              logger.info(f"Backend inhibitor is {'on' if inhibited else 'off'}")
+
+        """,
+    ),
 ]
 
 

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -198,6 +198,8 @@ wl_input_rules = None
 wl_xcursor_theme = None
 wl_xcursor_size = 24
 
+idle_inhibitors = []  # type: list
+
 # XXX: Gasp! We're lying here. In fact, nobody really uses or cares about this
 # string besides java UI toolkits; you can see several discussions on the
 # mailing lists, GitHub issues, and other WM documentation that suggest setting

--- a/test/backend/wayland/test_idle_inhibit.py
+++ b/test/backend/wayland/test_idle_inhibit.py
@@ -1,0 +1,142 @@
+import pytest
+
+from libqtile.backend.wayland.idle_inhibit import InhibitorManager
+from libqtile.config import IdleInhibitor, Match
+from libqtile.confreader import Config
+from test.helpers import Retry
+
+
+class FakeCore:
+    class FakeQtile:
+        locked = False
+
+    def no_op(*args, **kwargs):
+        pass
+
+    qtile = FakeQtile()
+    set_inhibited = no_op
+
+
+class InhibitorConfig(Config):
+    idle_inhibitors = [
+        IdleInhibitor(when="fullscreen"),  # Any fullscreen window
+        IdleInhibitor(match=Match(title="One"), when="focus"),
+        IdleInhibitor(match=Match(title="Two"), when="visible"),
+        IdleInhibitor(match=Match(title="Three"), when="open"),
+    ]
+
+
+inhibitor_config = pytest.mark.parametrize("manager", [InhibitorConfig], indirect=True)
+
+
+def is_inhibited(manager):
+    return len(manager.c.core.get_idle_inhibitors(active_only=True)) > 0
+
+
+@Retry(ignore_exceptions=(AssertionError,))
+def wait_for_windows(manager, count):
+    assert len(manager.c.windows()) == count
+
+
+def test_inhibitor_manager():
+    manager = InhibitorManager(FakeCore())
+
+    manager.add_window_inhibitor(1, "open")
+    assert len(manager.inhibitors) == 1
+
+    # Same window, different method
+    manager.add_window_inhibitor(1, "fullscreen")
+    assert len(manager.inhibitors) == 2
+
+    # Different window
+    manager.add_window_inhibitor(2, "fullscreen")
+    assert len(manager.inhibitors) == 3
+
+    # Existing window + method combination
+    manager.add_window_inhibitor(1, "fullscreen")
+    assert len(manager.inhibitors) == 3
+
+    manager.add_window_inhibitor(4, "open")
+    assert len(manager.inhibitors) == 4
+
+    # The inhibitor list is sorted first so inhibitors that always return True (e.g. "open")
+    # are checked first
+    sorted_methods = [o.inhibitor_type.name for o in manager.inhibitors]
+    assert sorted_methods == ["OPEN", "OPEN", "FULLSCREEN", "FULLSCREEN"]
+
+
+@inhibitor_config
+def test_inhibitor_open(manager):
+    assert not is_inhibited(manager)
+
+    manager.test_window("NotThree")
+    wait_for_windows(manager, 1)
+    assert not is_inhibited(manager)
+
+    manager.test_window("Three")
+    wait_for_windows(manager, 2)
+    assert is_inhibited(manager)
+
+    manager.c.window.kill()
+    wait_for_windows(manager, 1)
+    assert not is_inhibited(manager)
+
+
+@inhibitor_config
+def test_inhibitor_visible(manager):
+    assert not is_inhibited(manager)
+
+    manager.test_window("One")
+    wait_for_windows(manager, 1)
+    assert is_inhibited(manager)
+
+    # Window is now on a different group
+    manager.c.screen.next_group()
+    assert not is_inhibited(manager)
+
+    # Window is visible again
+    manager.c.screen.prev_group()
+    assert is_inhibited(manager)
+
+
+@inhibitor_config
+def test_inhibitor_focus(manager):
+    assert not is_inhibited(manager)
+
+    manager.test_window("One")
+    wait_for_windows(manager, 1)
+    assert is_inhibited(manager)
+
+    # Window NotOne should be focused
+    manager.test_window("NotOne")
+    wait_for_windows(manager, 2)
+    assert not is_inhibited(manager)
+
+    manager.c.group.prev_window()
+    assert is_inhibited(manager)
+
+
+@inhibitor_config
+def test_inhibitor_fullscreen(manager):
+    assert not is_inhibited(manager)
+
+    manager.test_window("Four")
+    wait_for_windows(manager, 1)
+    assert not is_inhibited(manager)
+
+    manager.c.window.toggle_fullscreen()
+    assert is_inhibited(manager)
+
+    manager.c.window.toggle_fullscreen()
+    assert not is_inhibited(manager)
+
+
+@inhibitor_config
+def test_inhibitor_global(manager):
+    assert not is_inhibited(manager)
+
+    manager.c.core.set_idle_inhibitor()
+    assert is_inhibited(manager)
+
+    manager.c.core.remove_idle_inhibitor()
+    assert not is_inhibited(manager)


### PR DESCRIPTION
Adds support for wayland's idle-notify and idle-inhibit extensions.

Inhibitors can be created in a number of ways:
  - By the application itself
  - In users' configs (via a new `wl_idle_inhibitors` variable)
  - Dynamically (`lazy.window.add_idle_inhibitor()`)
  - Globally (`lazy.core.set_idle_inhibitor()`)

Inhibitors can be set to be active when a window is open, focused, visible or fullscreen.


This is draft for now as I need people to test it.

Known issues (to be updated as people report bugs):
- [ ] ~fd errors when exiting qtile (not 100% certain that's linked to this PR...)~ Not this PR.
- [x] formatting, mypy checks etc
- [x] missing tests
- [ ] missing documentation (could be in a later PR)
- [ ] add a widget to show inhibitor status

