### PR TITLE
feat: Add screen-output bindings

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -512,9 +512,10 @@ class Core(base.Core):
     def get_screen_info(self) -> list[ScreenRect]:
         rects = []
 
-        @ffi.callback("void(int, int, int, int)")
-        def loop(x: int, y: int, width: int, height: int) -> None:
-            rects.append(ScreenRect(x, y, width, height))
+        @ffi.callback("void(int, int, int, int, char*)")
+        def loop(x: int, y: int, width: int, height: int, name_ptr: str) -> None:
+            name = ffi.string(name_ptr).decode()
+            rects.append(ScreenRect(x, y, width, height, name))
 
         lib.qw_server_loop_output_dims(self.qw, loop)
 

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -90,7 +90,7 @@ void qw_server_loop_output_dims(struct qw_server *server, output_dims_cb_t cb) {
         }
         int width, height;
         wlr_output_effective_resolution(o->wlr_output, &width, &height);
-        cb(o->x, o->y, width, height);
+        cb(o->x, o->y, width, height, o->wlr_output->name);
     }
 }
 

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -91,7 +91,7 @@ typedef int (*cursor_button_cb_t)(int button, uint32_t mask, bool pressed, int x
                                   void *userdata);
 
 // Output dimensions callback: x, y, width, height of output
-typedef void (*output_dims_cb_t)(int x, int y, int width, int height);
+typedef void (*output_dims_cb_t)(int x, int y, int width, int height, char *name);
 
 // Query tree node wid callback
 typedef void (*node_wid_cb_t)(int wid);

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -356,6 +356,7 @@ class ScreenRect:
     y: int
     width: int
     height: int
+    name: str | None = None
 
     def hsplit(self, columnwidth: int) -> tuple[ScreenRect, ScreenRect]:
         assert 0 < columnwidth < self.width
@@ -415,6 +416,7 @@ class Screen(CommandObject):
         y: int | None = None,
         width: int | None = None,
         height: int | None = None,
+        output: str | list[str] | None = None,
     ) -> None:
         self.top = top
         self.bottom = bottom
@@ -431,6 +433,7 @@ class Screen(CommandObject):
         self.y = y if y is not None else 0
         self.width = width if width is not None else 0
         self.height = height if height is not None else 0
+        self.output = output
         self.previous_group: _Group | None = None
 
     def __eq__(self, other: object) -> bool:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -386,18 +386,18 @@ class Qtile(CommandObject):
 
         if hasattr(self.config, "fake_screens"):
             screen_info = [
-                ScreenRect(s.x, s.y, s.width, s.height) for s in self.config.fake_screens
+                ScreenRect(s.x, s.y, s.width, s.height, None) for s in self.config.fake_screens
             ]
             config = self.config.fake_screens
         else:
             # Alias screens with the same x and y coordinates, taking largest
-            xywh = {}  # type: dict[tuple[int, int], tuple[int, int]]
+            xywh = {}  # type: dict[tuple[int, int], tuple[int, int, str]]
             for info in self.core.get_screen_info():
                 pos = (info.x, info.y)
-                width, height = xywh.get(pos, (0, 0))
-                xywh[pos] = (max(width, info.width), max(height, info.height))
+                width, height, name = xywh.get(pos, (0, 0, None))
+                xywh[pos] = (max(width, info.width), max(height, info.height), info.name)
 
-            screen_info = [ScreenRect(x, y, w, h) for (x, y), (w, h) in xywh.items()]
+            screen_info = [ScreenRect(x, y, w, h, name) for (x, y), (w, h, name) in xywh.items()]
             config = self.config.screens
 
         for i, info in enumerate(screen_info):
@@ -405,6 +405,15 @@ class Qtile(CommandObject):
                 scr = Screen()
             else:
                 scr = config[i]
+
+            for screen in config:
+                outputs = [screen.output] if isinstance(screen.output, str) else screen.output
+                if outputs is not None:
+                    # logger.warning(f"{info.name} {outputs}")
+                    if info.name in outputs:
+                        logger.warning("screen match!")
+                        scr = screen
+                        break
 
             if not hasattr(self, "current_screen") or reloading:
                 self.current_screen = scr


### PR DESCRIPTION
Add a config option to Screen to bind it to a specified output (display/monitor)

More than one output can be specified in a list

Any unmatched screens/outputs will be bound with no guarantee as to their order

### **This is a currently a super crude implementation for the purposes of getting early feedback**

The final implementation would try to match outputs to screens based on output preference, using screen order if multiple screen share the same preference.
Finally any unmatched outputs would be bound as they currently are - by screen order

Config looks like:
```
screens = [
    Screen(
        output="DP-2",
        bottom=bar.Bar(
            [
                widget.CurrentLayout(),
```

My first question is should this be a general (x11 + wayland) feature? I have assumed yes

I don't like that I have extended `ScreenRect` to "carry" output name. Maybe there should be a `ScreenInfo` that could include a `ScreenRect`? Maybe I am overthinking it?

Not sure what to do with aliased outputs? Not sure what aliased outputs are tbh

Other thoughts and suggestions?

