### PR TITLE
fix(launchbar): icon_size AttributeError when not None

### DIFF
--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -111,8 +111,8 @@ class LaunchBar(base._Widget):
     def setup_images(self):
         """Create image structures for each icon files."""
         if self.icon_size is None:
-            self._icon_size = self.bar.size - 4
-        self._icon_padding = (self.bar.size - self._icon_size) // 2
+            self.icon_size = self.bar.size - 4
+        self.icon_padding = (self.bar.size - self.icon_size) // 2
 
         for img_name, iconfile in self.icons_files.items():
             if iconfile is None or self.text_only:
@@ -148,7 +148,7 @@ class LaunchBar(base._Widget):
             input_width = img.width
             input_height = img.height
 
-            sp = input_height / (self._icon_size)
+            sp = input_height / (self.icon_size)
             width = int(input_width / sp)
 
             imgpat = cairocffi.SurfacePattern(img.surface)
@@ -247,7 +247,7 @@ class LaunchBar(base._Widget):
             else:
                 # display an icon
                 # Translate to vertically centre the icon
-                self.drawer.ctx.translate(0, self._icon_padding)
+                self.drawer.ctx.translate(0, self.icon_padding)
                 self.drawer.ctx.set_source(self.surfaces[name])
                 self.drawer.ctx.paint()
 


### PR DESCRIPTION
```py
ERROR libqtile bar.py:_configure_widget():L390 LaunchBar widget crashed during _configure with error: Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/libqtile/bar.py", line 381, in _configure_widget
    widget._configure(self.qtile, self)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/libqtile/widget/launchbar.py", line 108, in _configure
    self.setup_images()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/libqtile/widget/launchbar.py", line 115, in setup_images
    self._icon_padding = (self.bar.size - self._icon_size) // 2
                                          ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/libqtile/command/base.py", line 273, in __getattr__
    raise AttributeError(f"{self.__class__} has no attribute {name}")
AttributeError: <class 'libqtile.widget.launchbar.LaunchBar'> has no attribute _icon_size. Did you mean: 'icon_size'?
```

Found by @rocha https://github.com/qtile/qtile/commit/09c999d6ce905c71d65153843712d931823526a9#r172339137