### PR TITLE
[Wayland] Compiler warnings

### DIFF
--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -481,8 +481,8 @@ static void check_constraint_region(struct qw_cursor *cursor) {
             int nboxes;
             pixman_box32_t *boxes = pixman_region32_rectangles(region, &nboxes);
             if (nboxes > 0) {
-                double sx = (boxes[0].x1 + boxes[0].x2) / 2.;
-                double sy = (boxes[0].y1 + boxes[0].y2) / 2.;
+                sx = (boxes[0].x1 + boxes[0].x2) / 2.;
+                sy = (boxes[0].y1 + boxes[0].y2) / 2.;
 
                 wlr_cursor_warp_closest(cursor->cursor, NULL, sx - view->x, sy - view->y);
 

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -1,9 +1,13 @@
 #ifndef CURSOR_H
 #define CURSOR_H
 
+#include <pixman.h>
+#include <wayland-server-core.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+
+#include <stdint.h>
 
 struct qw_server; // Forward declaration to avoid circular dependency
 

--- a/libqtile/backend/wayland/qw/output.h
+++ b/libqtile/backend/wayland/qw/output.h
@@ -9,9 +9,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 
-struct qw_server;
-
-enum qw_wallpaper_mode;
+#include "server.h"
 
 struct qw_output_background_wallpaper {
     struct wlr_scene_buffer *buffer;

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -21,7 +21,6 @@
 #include "util.h"
 #include "view.h"
 #include "wayland-server-core.h"
-#include "wayland-server-protocol.h"
 #include "wayland-util.h"
 #include "wlr/util/log.h"
 #include "xdg-view.h"
@@ -728,7 +727,7 @@ static void qw_server_handle_output_power_set_mode(struct wl_listener *listener,
 }
 
 // Create and initialize the server object with all components and listeners.
-struct qw_server *qw_server_create() {
+struct qw_server *qw_server_create(void) {
     struct qw_server *server = calloc(1, sizeof(*server));
     if (!server) {
         wlr_log(WLR_ERROR, "failed to create qw_server struct");


### PR DESCRIPTION
- Fix variable shadowing in cursor.c by reusing existing sx/sy variables
  instead of redeclaring them in inner scope
- Add missing includes in cursor.h for wayland-server-core.h, pixman.h,
  and stdint.h to resolve incomplete type errors
- Move qw_wallpaper_mode enum definition to server.h and include it in
  output.h instead of forward declaring (ISO C forbids enum forward refs)
- Remove unused wayland-server-protocol.h include from server.c
- Add void parameter to qw_server_create() for proper C function prototype
