### PR TITLE
Fix wayland build error

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -28,7 +28,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         try:
             from libqtile.backend.wayland.cffi.build import ffi_compile
 
-            ffi_compile(verbose=wayland_requested)
+            ffi_compile(verbose=bool(wayland_requested))
         except Exception as e:
             if wayland_requested:
                 sys.exit(f"Wayland backend requested but backend could not be built: {e}")


### PR DESCRIPTION
In `builder.py`, `wants_wayland` defaults to `None` if we don't specify a backend. The wayland backend will always try to build unless `wants_wayland` is `False`. However, when it builds, we set `verbose=wants_wayland` which causes the build to fail as this needs to be a boolean value.