### PR TITLE
wayland: Add xcursor configuration

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -126,6 +126,7 @@ extern "Python" struct wlr_box get_current_output_dims_cb(void *userdata);
 extern "Python" bool add_idle_inhibitor_cb(void *userdata, void *inhibitor, void *view, bool is_layer_surface, bool is_session_lock_surface);
 extern "Python" bool remove_idle_inhibitor_cb(void *userdata, void *inhibitor);
 extern "Python" bool check_inhibited_cb(void *userdata);
+extern "Python" struct qw_qtile_config *get_qtile_config_cb(void *userdata);
 
 extern "Python" int request_focus_cb(void *userdata);
 extern "Python" int request_close_cb(void *userdata);

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -29,6 +29,7 @@ struct qw_cursor {
     struct wl_listener button;
     struct wl_listener constraint_commit;
     struct wlr_xcursor_manager *mgr;
+    struct wlr_xcursor_manager *xwayland_mgr;
     struct wlr_surface *saved_surface;
     uint32_t saved_hotspot_x;
     uint32_t saved_hotspot_y;
@@ -64,5 +65,7 @@ void qw_cursor_release_implicit_grab(struct qw_cursor *cursor, uint32_t time);
 
 void qw_cursor_pointer_constraint_new(struct qw_cursor *cursor,
                                       struct wlr_pointer_constraint_v1 *constraint);
+
+void qw_cursor_configure_xcursor(struct qw_cursor *cursor);
 
 #endif /* CURSOR_H */

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -262,6 +262,7 @@ static void qw_server_output_manager_reconfigure(struct qw_server *server,
     }
     wlr_output_configuration_v1_destroy(config);
     if (apply) {
+        qw_cursor_configure_xcursor(server->cursor);
         qw_server_handle_output_layout_change(&server->output_layout_change, NULL);
     }
 }

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -74,6 +74,11 @@ enum {
 };
 #endif
 
+struct qw_qtile_config {
+    char *wl_xcursor_theme;
+    int wl_xcursor_size;
+};
+
 // Callback typedefs for input and view events
 
 // Keyboard key event callback: keysym, modifier mask, and user data
@@ -132,6 +137,8 @@ typedef bool (*add_idle_inhibitor_cb_t)(void *userdata, void *inhibitor, void *v
                                         bool is_layer_surface, bool is_session_lock_surface);
 typedef bool (*remove_idle_inhibitor_cb_t)(void *userdata, void *inhibitor);
 typedef bool (*check_inhibited_cb_t)(void *userdata);
+
+typedef struct qw_qtile_config *(*get_qtile_config_cb_t)(void *userdata);
 
 enum {
     LAYER_BACKGROUND,   // background, layer shell
@@ -192,6 +199,7 @@ struct qw_server {
     add_idle_inhibitor_cb_t add_idle_inhibitor_cb;
     remove_idle_inhibitor_cb_t remove_idle_inhibitor_cb;
     check_inhibited_cb_t check_inhibited_cb;
+    get_qtile_config_cb_t get_qtile_config_cb;
     void *view_activation_cb_data;
     void *cb_data;
     struct qw_layer_view *exclusive_layer;


### PR DESCRIPTION
Set xcursor size and theme from config variables: wl_xcursor_size and
wl_xcursor_theme

Added a general function for reading parameters from qtile config,
for this purpose

Largely following sway's implementation

Fixes #5706

Tested (as best I can):
- [x] Setting base cursor size
- [x] Cursor scales automatically with output scale
- [x] Size updates when changed in config and config reloaded
- [x] Setting cursor theme