### PR TITLE
fix prompt widget: exposed start input command

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -413,6 +413,7 @@ class Prompt(base._TextBox):
         if self.bell_style == "visual":
             self.original_background = self.background
 
+    @expose_command()
     def start_input(
         self,
         prompt,


### PR DESCRIPTION
Exposed `start_input()` command for the Prompt widget, as it is mentioned in the documentation, but not available.

It is mentioned in the documentation [here](https://docs.qtile.org/en/stable/manual/ref/widgets.html#prompt).
[Here](https://docs.qtile.org/en/stable/manual/commands/api/widgets.html#libqtile.widget.prompt.Prompt) it is nor present. (But I suspect that this is automatically generated.)
The documentation comment of this function also suggests that it is supposed to be exposed.

Without this command, the prompt widget is only usable for spawning applications with `lazy.spawncmd()`.
Please correct me if I'm misunderstanding the intended usage.

I wonder also: *Is `process_key_press()` also supposed to be exposed?*
(Also there is a small typo there, where the old name *minibuffer* is not changed to prompt, but I do not want to make this commit messy.)
