### PR TITLE
New cursor types for the prompt widget.

### DIFF
--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -511,18 +511,19 @@ class Prompt(base._TextBox):
     def _update(self) -> None:
         if self.active:
             self.text = self.archived_input or self.user_input
-            cursor = pangocffi.markup_escape_text(" ")
             if self.cursor_position < len(self.text):
+                # Escaping after slicing to preserve the cursor position
                 txt1 = self.text[: self.cursor_position]
+                txt1 = pangocffi.markup_escape_text(txt1)
                 txt2 = self.text[self.cursor_position]
-                txt3 = self.text[self.cursor_position + 1 :]
-                for text in (txt1, txt2, txt3):
-                    text = pangocffi.markup_escape_text(text)
+                txt2 = pangocffi.markup_escape_text(txt2)
                 txt2 = self._highlight_text(txt2)
-                self.text = f"{txt1}{txt2}{txt3}{cursor}"
+                txt3 = self.text[self.cursor_position + 1 :]
+                txt3 = pangocffi.markup_escape_text(txt3)
+                self.text = f"{txt1}{txt2}{txt3}"
             else:
                 self.text = pangocffi.markup_escape_text(self.text)
-                self.text += self._highlight_text(cursor)
+                self.text += self._highlight_text(" ")
             self.text = self.display + self.text
         else:
             self.text = ""

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -316,6 +316,15 @@ class Prompt(base._TextBox):
     defaults = [
         ("cursor", True, "Show a cursor"),
         ("cursorblink", 0.5, "Cursor blink rate. 0 to disable."),
+        (
+            "cursor_type",
+            "line",
+            "The visual appearance of the cursor. Possible values: "
+            + "'line': A line under the selected character. "
+            + "'block': A block in the place of the selected character. "
+            + "'bar': A vertical bar. Only looks good at the end of text. "
+            + "'none': Only the color appears.",
+        ),
         ("cursor_color", "bef098", "Color for the cursor and text over it."),
         ("prompt", "{prompt}: ", "Text displayed at the prompt"),
         ("record_history", True, "Keep a record of executed commands"),
@@ -479,10 +488,24 @@ class Prompt(base._TextBox):
             self.timeout_add(self.cursorblink, self._blink)
 
     def _highlight_text(self, text) -> str:
+        self.cursor_type: str
         color = utils.hex(self.cursor_color)
-        text = f'<span foreground="{color}">{text}</span>'
-        if self.show_cursor:
-            text = f"<u>{text}</u>"
+        if self.cursor_type == "block":
+            if self.show_cursor:
+                text = f'<span background="{color}" foreground="#00000000">{text}</span>'
+            else:
+                text = f'<span foreground="{color}">{text}</span>'
+        elif self.cursor_type == "line":
+            text = f'<span foreground="{color}">{text}</span>'
+            if self.show_cursor:
+                text = f"<u>{text}</u>"
+        elif self.cursor_type == "bar":
+            if self.show_cursor:
+                text = f'<span foreground="{color}">▏</span>{text}'
+            else:
+                text = f" {text}"
+        elif self.cursor_type == "none" or self.cursor_type is None:
+            text = f'<span foreground="{color}">{text}</span>'
         return text
 
     def _update(self) -> None:

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -301,7 +301,29 @@ class CommandCompleter:
 class Prompt(base._TextBox):
     """A widget that prompts for user input
 
+    This widget is used when any one of
+    ``lazy.spawncmd()``, ``lazy.findwindow()``, ``lazy.labelgroup()``,
+    ``lazy.qtilecmd()``, ``lazy.spawncmd()``, ``lazy.switchgroup()``,
+    ``lazy.togroup()``
+    is called.
+
     Input should be started using the ``.start_input()`` method on this class.
+    A minimal example of a custom prompt using this method is provided below.
+
+    .. code-block:: python
+
+        from libqtile.lazy import lazy
+
+        def my_action(input_text):
+            # Do something with the entered text here.
+
+        @lazy.function
+        def my_prompt(qtile):
+            qtile.widgets_map["prompt"].start_input("my action", my_action)
+
+        keys = [
+            Key([mod], "s", my_prompt)
+        ]
     """
 
     completers = {
@@ -452,7 +474,7 @@ class Prompt(base._TextBox):
         complete :
             completer to use.
         strict_completer :
-            When True the return value wil be the exact completer result where
+            When True the return value will be the exact completer result where
             available.
         allow_empty_input :
             When True, an empty value will still call the callback function
@@ -674,7 +696,7 @@ class Prompt(base._TextBox):
             return self.keyhandlers[k]
 
     def process_key_press(self, keysym: int):
-        """Key press handler for the minibuffer.
+        """Key press handler for the prompt widget.
 
         Currently only supports ASCII characters.
         """
@@ -687,6 +709,7 @@ class Prompt(base._TextBox):
 
     @expose_command()
     def fake_keypress(self, key: str) -> None:
+        """Send a key press to the widget."""
         self.process_key_press(self.qtile.core.keysym_from_name(key))
 
     @expose_command()

--- a/test/widgets/test_prompt.py
+++ b/test/widgets/test_prompt.py
@@ -1,0 +1,112 @@
+import pytest
+
+import libqtile.bar
+import libqtile.config
+from libqtile import widget
+
+
+def get_cursor_markup(cursor_type, selected_char):
+    """Get the supposedly generated markup for the different cursors."""
+
+    if cursor_type == "line":
+        return f'<u><span foreground="#ff0000">{selected_char}</span></u>'
+    if cursor_type == "block":
+        return f'<span background="#ff0000" foreground="#00000000">{selected_char}</span>'
+    if cursor_type == "bar":
+        return f'<span foreground="#ff0000">▏</span>{selected_char}'
+    if cursor_type == "none":
+        return f'<span foreground="#ff0000">{selected_char}</span>'
+    return None
+
+
+def test_prompt_focus(manager_nospawn, minimal_conf_noscreen):
+    """Test if focusing the prompt works properly."""
+
+    prompt_widget = widget.Prompt()
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([prompt_widget], 10))]
+
+    manager_nospawn.start(config)
+    pwidget = manager_nospawn.c.widget["prompt"]
+
+    # Test if the unfocused default state is reasonable.
+    unfocus_info = pwidget.info()
+    assert unfocus_info["text"] == ""
+    assert unfocus_info["width"] == 0
+    assert not unfocus_info["active"]
+
+    # Start the input to the widget.
+    pwidget.eval('self.start_input("test", lambda _: True)')
+
+    # Test if the widget is visible and active.
+    focus_info = pwidget.info()
+    assert focus_info["width"] != 0
+    assert focus_info["active"]
+
+
+@pytest.mark.parametrize("cursor_type", ["line", "block", "bar", "none"])
+def test_prompt_input(manager_nospawn, minimal_conf_noscreen, cursor_type):
+    """Test if input is working correctly."""
+
+    prompt_widget = widget.Prompt(
+        cursor_color="#ff0000", cursor_type=cursor_type, cursorblink=False
+    )
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([prompt_widget], 10))]
+
+    manager_nospawn.start(config)
+    pwidget = manager_nospawn.c.widget["prompt"]
+
+    # Start the input to the widget and add some text.
+    pwidget.eval('self.start_input("test", lambda _: True)')
+    pwidget.fake_keypress("a")
+    pwidget.fake_keypress("b")
+    pwidget.fake_keypress("c")
+
+    input_info = pwidget.info()
+    assert input_info["text"] == f"test: abc{get_cursor_markup(cursor_type, ' ')}"
+
+    # Move the cursor and add a new character.
+    pwidget.fake_keypress("Left")
+    pwidget.fake_keypress("Left")
+    pwidget.fake_keypress("x")
+
+    move_info = pwidget.info()
+    assert move_info["text"] == f"test: ax{get_cursor_markup(cursor_type, 'b')}c"
+
+
+@pytest.mark.parametrize("cursor_type", ["line", "block", "bar", "none"])
+def test_prompt_text_escape(manager_nospawn, minimal_conf_noscreen, cursor_type):
+    """Test if special charters are escaped properly."""
+
+    prompt_widget = widget.Prompt(
+        cursor_color="#ff0000", cursor_type=cursor_type, cursorblink=False
+    )
+
+    config = minimal_conf_noscreen
+    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([prompt_widget], 10))]
+
+    manager_nospawn.start(config)
+    pwidget = manager_nospawn.c.widget["prompt"]
+
+    # Start the input to the widget, input some text, and move the cursor.
+    pwidget.eval('self.start_input("test", lambda _: True)')
+    pwidget.fake_keypress("a")
+    pwidget.fake_keypress("b")
+    pwidget.fake_keypress("c")
+    pwidget.fake_keypress("Left")
+    pwidget.fake_keypress("Left")
+
+    # Add a "<" character. This should become "&lt;" in the sanitised output.
+    pwidget.fake_keypress("less")
+
+    special_info = pwidget.info()
+    assert special_info["text"] == f"test: a&lt;{get_cursor_markup(cursor_type, 'b')}c"
+
+    # Move the cursor on top of the special character.
+    pwidget.fake_keypress("Left")
+
+    special_move_info = pwidget.info()
+    assert special_move_info["text"] == f"test: a{get_cursor_markup(cursor_type, '&lt;')}bc"


### PR DESCRIPTION
I have added a new option `cursor_type` to the prompt widget. Depending on the value, the visual of the cursor is different. There are 4 options:

  - `line`: The original underline, and colored character.
  - `block`: A block cursor, that works similarly to the underline. It sets the background to the desired cursor color, and makes the foreground transparent, basically inverting the colors in this way. It supports blinking with `cursorblink`.
  - `none`: A cursor with no visual, except the color. This might be useful for a minimalist setup. Just the color is maybe enough if you only occasionally go back to edit stuff. It does not blink, respecting that the color did not blink in the original scenario. (Maybe it would be more feature full to make it blink, but I think it just makes it more confusing.)
  - `bar`: A vertical cursor bar simulated with a Unicode character. It looks nice if you have it at the end of the input, but the illusion break if you move it inside the text. Supports blinking, but the color only applies to the cursor itself and not to characters.

I think the `block` and `none` options are nice. I'm honestly a bit conflicted on the `bar` version. Please let me know what you think. I tried to execute some black magic with the `letter_spacing` argument I found in the [Pango markup refrence](https://docs.gtk.org/Pango/pango_markup.html) by setting it to a negative value. This does not cause any errors, and does shift the next character left, but getting the spacing right is probably impossible, as the width of a single character is not easily calculated from the height of said character. If it is possible, it would probably be really hacky.

I have not squashed the commits yet on purpose, so that I can separate them easily if I need to.

I have a few question:
  - Is the documentation style that I used acceptable?
  - Should I have some fallback value in the *if ... elif* statement? (I did not see any in similar cases, that is why I did it this way, but I'm happy to change it.)
  - Is the naming of the options alright? This seemed logical to me, but I guess it might be a bit confusing...

I have tested these changes in a virtual machine first, then on my main system with a lot of different setting combinations. I have not found any issues with it. Please mess around with it a bit and see if I have missed something.