### PR TITLE
wayland: Fix formatting in util.c

### DIFF
--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -61,7 +61,7 @@ int qw_util_get_modifier_code(const char *codestr) {
         {"mod4", WLR_MODIFIER_LOGO},
         {"mod5", WLR_MODIFIER_MOD5}
     };
-    //clang-format on
+    // clang-format on
 
     size_t n = sizeof(mappings) / sizeof(mappings[0]);
 
@@ -92,8 +92,9 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
         return;
     }
 
-    #if WLR_HAS_XWAYLAND
-    struct wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
+#if WLR_HAS_XWAYLAND
+    struct wlr_xwayland_surface *xwayland_surface =
+        wlr_xwayland_surface_try_from_wlr_surface(surface);
     if (xwayland_surface != NULL) {
         wlr_xwayland_surface_activate(xwayland_surface, false);
 
@@ -104,7 +105,7 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
         }
         return;
     }
-    #endif
+#endif
 }
 
 bool qw_surfaces_on_same_output(struct wlr_surface *surface_a, struct wlr_surface *surface_b) {
@@ -124,47 +125,49 @@ bool qw_surfaces_on_same_output(struct wlr_surface *surface_a, struct wlr_surfac
     return false;
 }
 
-struct qw_view *qw_view_from_wlr_surface(struct wlr_surface *surface, bool *is_layer_surface, bool *is_session_lock_surface) {
+struct qw_view *qw_view_from_wlr_surface(struct wlr_surface *surface, bool *is_layer_surface,
+                                         bool *is_session_lock_surface) {
     *is_layer_surface = false;
     *is_session_lock_surface = false;
 
-	struct wlr_xdg_surface *xdg_surface;
+    struct wlr_xdg_surface *xdg_surface;
     xdg_surface = wlr_xdg_surface_try_from_wlr_surface(surface);
-	if (xdg_surface != NULL) {
+    if (xdg_surface != NULL) {
         struct qw_xdg_view *xdg_view = xdg_surface->data;
         if (xdg_view != NULL) {
             return &xdg_view->base;
         }
-		return NULL;
-	}
+        return NULL;
+    }
 
 #if WLR_HAS_XWAYLAND
-	struct wlr_xwayland_surface *xwayland_surface;
+    struct wlr_xwayland_surface *xwayland_surface;
     xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface);
-	if (xwayland_surface != NULL) {
+    if (xwayland_surface != NULL) {
         struct qw_xwayland_view *xwayland_view = xwayland_surface->data;
         if (xwayland_view != NULL) {
             return &xwayland_view->base;
         }
-		return NULL;
-	}
+        return NULL;
+    }
 #endif
 
-	struct wlr_subsurface *subsurface;
+    struct wlr_subsurface *subsurface;
     subsurface = wlr_subsurface_try_from_wlr_surface(surface);
-	if (subsurface != NULL) {
-		return qw_view_from_wlr_surface(subsurface->parent, is_layer_surface, is_session_lock_surface);
-	}
+    if (subsurface != NULL) {
+        return qw_view_from_wlr_surface(subsurface->parent, is_layer_surface,
+                                        is_session_lock_surface);
+    }
 
-	if (wlr_layer_surface_v1_try_from_wlr_surface(surface) != NULL) {
-		*is_layer_surface = true;
+    if (wlr_layer_surface_v1_try_from_wlr_surface(surface) != NULL) {
+        *is_layer_surface = true;
         return NULL;
-	}
+    }
 
-	if (wlr_session_lock_surface_v1_try_from_wlr_surface(surface) != NULL) {
+    if (wlr_session_lock_surface_v1_try_from_wlr_surface(surface) != NULL) {
         *is_session_lock_surface = true;
         return NULL;
     }
 
-	return NULL;
+    return NULL;
 }


### PR DESCRIPTION
Fix `// clandg-format on` directive so clang-format formats remainder of file