### PR TITLE
Add auto_group config variable [Draft]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
+    - Add `auto_group` config variable
     * bugfixes
 
 Qtile 0.34.1, released 2025-12-14:

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -79,6 +79,10 @@ configuration variables that control specific aspects of Qtile's behavior:
       - ``True``
       - If things like steam games want to auto-minimize themselves when losing
         focus, should we respect this or not?
+    * - ``auto_group``
+      - ``True``
+      - If things like browsers want to start in their previous workspaces,
+        should we respect this or not?
     * - ``bring_front_click``
       - ``False``
       - When clicked, should the window be brought to the front or not. If this

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -48,6 +48,7 @@ class Config:
     reconfigure_screens: bool
     wmname: str
     auto_minimize: bool
+    auto_group: bool
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but
     # doing so forces the import, creating a hard dependency for wlroots.
     wl_input_rules: dict[str, Any] | None

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -798,6 +798,12 @@ class Qtile(CommandObject):
         if win.wid in self.windows_map:
             return
 
+        if self.current_screen and isinstance(win, base.Window):
+            # Window may already be bound to a group.
+            if win.group and not getattr(self.config, "auto_group", True):
+                win.group.remove(win)
+                win.group = None
+
         hook.fire("client_new", win)
 
         # Window may be defunct because

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -191,6 +191,10 @@ reconfigure_screens = True
 # focus, should we respect this or not?
 auto_minimize = True
 
+# If things like browsers want to start in their previous workspaces,
+# should we respect this or not?
+auto_group = True
+
 # When using the Wayland backend, this can be used to configure input devices.
 wl_input_rules = None
 


### PR DESCRIPTION
This PR adds the `auto_group` variable to
the config.  Usually, programs like Brave
remember the workspaces of each of it's windows
after restarting. If this variable is set to
`False`, this is ignored and instead all windows
are opened in the current workspace.

This was discussed in the [discord](https://discord.com/channels/955163559086665728/1166312212223250482/1454161866342400216).

It's a draft for now, since I want to get feedback and possibly add some tests, to make sure it works as intended and doesn't break any existing setups that use hooks to manually change the group.  