### PR TITLE
wayland: plasma layout check payload when removing window

### DIFF
--- a/libqtile/layout/plasma.py
+++ b/libqtile/layout/plasma.py
@@ -944,7 +944,9 @@ class Plasma(Layout):
         self.add_mode = None
 
     def remove(self, client):
-        self.root.find_payload(client).remove()
+        payload = self.root.find_payload(client)
+        if payload is not None:
+            payload.remove()
 
     def configure(self, client, screen_rect):
         self.root.x = screen_rect.x


### PR DESCRIPTION
When a plasma window is made floating, it is removed from the plasma layout. When this window is killed, qtile.unmanage() will call the layouts's remove function, but since the window has already been removed, it ends up calling remove on None

This issue manifests on wayland when the floating window has been fullscreened, because the fullscreen background is subsequently not removed

Fix by checking for None before calling remove

Fixes #5734