### PR TITLE
Fix graph widgets border size issue

### DIFF
--- a/libqtile/widget/graph.py
+++ b/libqtile/widget/graph.py
@@ -120,7 +120,7 @@ class _Graph(base._Widget, base.MarginMixin):
                 self.margin_x + self.border_width / 2.0,
                 self.margin_y + self.border_width / 2.0,
                 self.graphwidth + self.border_width,
-                self.graphheight - self.border_width,
+                self.graphheight + self.border_width,
             )
             self.drawer.ctx.stroke()
         x = self.margin_x + self.border_width


### PR DESCRIPTION
09c999d6ce905c71d65153843712d931823526a9 contained an error where the graph border size was adjusted incorrectly, making the border too small.

We can verify the fix by comparing latest docs against docs built in this PR.