### PR TITLE
Allow idle_inhibitors to run functions

### DIFF
--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -572,7 +572,7 @@ class Window(_Window, metaclass=ABCMeta):
 
     def add_config_inhibitors(self) -> None:
         for rule in self.qtile.config.idle_inhibitors:
-            if rule.match is None or rule.match.compare(self):
+            if rule.function is None and (rule.match is None or rule.match.compare(self)):
                 self.add_idle_inhibitor(rule.when)
 
     @expose_command()

--- a/libqtile/backend/wayland/idle_inhibit.py
+++ b/libqtile/backend/wayland/idle_inhibit.py
@@ -11,6 +11,7 @@ except ModuleNotFoundError:
     from libqtile.backend.wayland.ffi_stub import ffi, lib
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
 
     from libqtile.backend.base.window import Window
@@ -22,12 +23,13 @@ class WaylandInhibitor(Inhibitor):
         self,
         qtile: Qtile,
         window: Window | None = None,
+        function: Callable | None = None,
         handle: ffi.CData | None = None,
         inhibitor_type: InhibitorType = InhibitorType.UNSET,
         is_layer_surface: bool = False,
         is_session_lock: bool = False,
     ):
-        super().__init__(qtile, window, inhibitor_type)
+        super().__init__(qtile, window, function, inhibitor_type)
         self.handle = handle
         self.is_layer_surface = is_layer_surface
         self.is_session_lock = is_session_lock
@@ -58,12 +60,14 @@ class WaylandInhibitor(Inhibitor):
 
         return (
             self.window,
+            self.function,
             self.handle,
             self.inhibitor_type,
             self.is_layer_surface,
             self.is_session_lock,
         ) == (
             other.window,
+            other.function,
             other.handle,
             other.inhibitor_type,
             other.is_layer_surface,
@@ -74,10 +78,10 @@ class WaylandInhibitor(Inhibitor):
     def from_base_inhibitor(cls, inhibitor: Inhibitor) -> WaylandInhibitor:
         if isinstance(inhibitor, WaylandInhibitor):
             return inhibitor
-
         return cls(
             qtile=inhibitor.qtile,
             window=inhibitor.window,
+            function=inhibitor.function,
             inhibitor_type=inhibitor.inhibitor_type,
         )
 

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -1220,23 +1220,33 @@ class IdleInhibitor:
     """
     Create rules for when the compositor should not go into an idle state.
 
-    IdleInhibitor take two arguments:
+    IdleInhibitor takes three arguments:
       -  match: a ``Match`` object to define which windows the rule should apply to. If unset, it will apply to all windows.
                 Note: qtile evaluates whether a rule matches a window once, when the window is first created.
+      -  function: a callable object which should return True if the inhibitor should be activated. The function should receive
+                   a single argument which is the qtile instance.
       -  when: one of the following strings:
         - "focus" (default): Inhibitor is active when the matching window is the currently focused window
         - "fullscreen": Inhibitor is active when the matching window is fullscreen
         - "visible": Inhibitor is active when the matching window is visible on any screen
                      (still applies if window is completely covered by a floating window)
         - "open": Inhibitor is active when the matching window is open (even if hidden)
+
+    .. note::
+
+      ``match`` should be used to apply a rule to a matching window while ``function`` is not evaluated against a window.
+      Setting both ``match`` and ``function`` will result in an error.
+
     """
 
     def __init__(
         self,
         match: _Match | None = None,
+        function: Callable | None = None,
         when: Literal["focus" | "fullscreen" | "visible" | "open"] = "open",
     ):
         self.match = match
+        self.function = function
         self.when = when
 
 

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -168,6 +168,11 @@ class Qtile(CommandObject):
         if self.config.reconfigure_screens:
             hook.subscribe.screen_change(self.reconfigure_screens)
 
+        # Idle inhibitor listens for "startup" hook so we need to set this
+        # before the hook is fired
+        if self.config.idle_inhibitors:
+            self.core.idle_inhibitor_manager.set_hooks()
+
         # no_spawn is set after the very first startup; we only want to run the
         # startup hook once. Note that this needs to happen *after* the config
         # is loaded and we have subscribed reconfigure_screens() in case people
@@ -189,9 +194,6 @@ class Qtile(CommandObject):
         # NB: the inhibitor will only connect to the dbus service if the
         # user has used the "suspend" or "resume" hooks in their config.
         inhibitor.start()
-
-        if self.config.idle_inhibitors:
-            self.core.idle_inhibitor_manager.set_hooks()
 
         self.core.idle_notifier.clear_timers()
         if self.config.idle_timers:

--- a/test/backend/test_idle_inhibit.py
+++ b/test/backend/test_idle_inhibit.py
@@ -23,12 +23,17 @@ class FakeCore:
         self._inhibited = value
 
 
+def has_five_windows(qtile):
+    return len(qtile.windows()) > 4
+
+
 class InhibitorConfig(Config):
     idle_inhibitors = [
         IdleInhibitor(when="fullscreen"),  # Any fullscreen window
         IdleInhibitor(match=Match(title="One"), when="focus"),
         IdleInhibitor(match=Match(title="Two"), when="visible"),
         IdleInhibitor(match=Match(title="Three"), when="open"),
+        IdleInhibitor(function=has_five_windows),
     ]
 
 
@@ -147,3 +152,16 @@ def test_inhibitor_global(manager):
 
     manager.c.core.remove_idle_inhibitor()
     assert not is_inhibited(manager)
+
+
+@inhibitor_config
+def test_inhibitor_function(manager):
+    assert not is_inhibited(manager)
+
+    for n in range(4):
+        manager.test_window(f"window_{n}")
+        assert not is_inhibited(manager)
+
+    manager.test_window("window_five")
+    wait_for_windows(manager, 5)
+    assert is_inhibited(manager)


### PR DESCRIPTION
A function returning `True` will treat the inhibitor as being active. The function will only be run immediately before an idle timer is due to be triggered.