### PR TITLE
Fix groupbox crash when padding is None

### DIFF
--- a/libqtile/widget/groupbox.py
+++ b/libqtile/widget/groupbox.py
@@ -24,7 +24,7 @@ class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
         return width + self.padding_x * 2 + self.borderwidth * 2
 
     def _configure(self, qtile, bar):
-        base._Widget._configure(self, qtile, bar)
+        base._TextBox._configure(self, qtile, bar)
 
         if self.fontsize is None:
             calc = self.bar.size - self.margin_y * 2 - self.borderwidth * 2 - self.padding_y * 2


### PR DESCRIPTION
The GroupBox widget inherits from `base._TextBox` and, as a result, the docs explain that setting a `padding` value of `None` will cause the widget to calculate the padding. However, `GroupBox._configure` does not call `base._TextBox._configure` and so the calculation is never performed. This can result in a crash as the widget tries to calculate positions by including the padding value, resulting in a `TypeError`.

Fixes #5752