### PR TITLE
bar: protect all widgets from individual draw failures

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -693,7 +693,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                 )
 
         for i in self.widgets:
-            i.draw()
+            try:
+                i.draw()
+            except Exception:
+                logger.exception("Widget failed to draw")
 
         # We need to check if there is any unoccupied space in the bar
         # This can happen where there are no SPACER-type widgets to fill


### PR DESCRIPTION
If a single widget fails to draw, we should not abort this entire loop, otherwise all the other widgets will fail to draw.