### PR TITLE
wayland: Fix pointer constraints focus and warp

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -290,8 +290,8 @@ class Core(base.Core):
         lib.qw_log_init(get_wlr_log_level(), lib.log_cb)
 
     def clear_focus(self) -> None:
-        """Clear TODO so that there is no focused window"""
-        # TODO
+        """Clear focus so that there is no focused window"""
+        lib.qw_server_keyboard_clear_focus(self.qw)
 
     def new_wid(self) -> int:
         """Get a new unique window ID"""

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -473,6 +473,11 @@ static void check_constraint_region(struct qw_cursor *cursor) {
     if (cursor->active_confine_requires_warp && view) {
         cursor->active_confine_requires_warp = false;
 
+        // We may be over the constrained surface but haven't got pointer focus yet
+        if (cursor->server->seat->pointer_state.focused_surface != constraint->surface) {
+            qw_cursor_update_pointer_focus(cursor);
+        }
+
         double sx = cursor->cursor->x - view->x;
         double sy = cursor->cursor->y - view->y;
 
@@ -505,8 +510,8 @@ static void qw_cursor_handle_constraint_commit(struct wl_listener *listener, voi
     check_constraint_region(cursor);
 }
 
-static void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
-                                       struct wlr_pointer_constraint_v1 *constraint) {
+void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
+                                struct wlr_pointer_constraint_v1 *constraint) {
     if (cursor->active_constraint == constraint) {
         return;
     }

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -68,4 +68,7 @@ void qw_cursor_pointer_constraint_new(struct qw_cursor *cursor,
 
 void qw_cursor_configure_xcursor(struct qw_cursor *cursor);
 
+void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
+                                struct wlr_pointer_constraint_v1 *constraint);
+
 #endif /* CURSOR_H */

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -130,6 +130,8 @@ xkb_keysym_t qw_server_get_sym_from_code(struct qw_server *server, int code) {
 void qw_server_keyboard_clear_focus(struct qw_server *server) {
     struct wlr_seat *seat = server->seat;
     wlr_seat_keyboard_clear_focus(seat);
+    // Deactivate any existing pointer constraints
+    qw_cursor_constrain_cursor(server->cursor, NULL);
 }
 
 // Handle when a new output (monitor/display) is connected.

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -1,4 +1,5 @@
 #include "xdg-view.h"
+#include "cursor.h"
 #include "server.h"
 #include "session-lock.h"
 #include "util.h"
@@ -68,6 +69,12 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
                                        keyboard->keycodes, keyboard->num_keycodes,
                                        &keyboard->modifiers);
     }
+
+    // Activate/deactivate pointer constraints
+    struct wlr_pointer_constraint_v1 *constraint =
+        wlr_pointer_constraints_v1_constraint_for_surface(server->pointer_constraints, surface,
+                                                          server->seat);
+    qw_cursor_constrain_cursor(server->cursor, constraint);
 }
 
 // Handle the unmap event for the xdg_view (when it's hidden/unmapped)

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -1,4 +1,5 @@
 #include "xwayland-view.h"
+#include "cursor.h"
 #include "server.h"
 #include "session-lock.h"
 #include "util.h"
@@ -55,6 +56,12 @@ static void qw_xwayland_view_do_focus(struct qw_xwayland_view *xwayland_view,
                                        keyboard->keycodes, keyboard->num_keycodes,
                                        &keyboard->modifiers);
     }
+
+    // Activate/deactivate pointer constraints
+    struct wlr_pointer_constraint_v1 *constraint =
+        wlr_pointer_constraints_v1_constraint_for_surface(server->pointer_constraints, surface,
+                                                          server->seat);
+    qw_cursor_constrain_cursor(server->cursor, constraint);
 }
 
 static void qw_xwayland_view_focus(void *self, int above) {


### PR DESCRIPTION
When we constrain the cursor, it's possible the constrained surface hasn't received pointer focus yet, even if has been placed over the cursor. So check for pointer focus and update as required. (And if we're not over the surface we already warp and focus). Also ensure constraints are updated when we change focus

Fix incorrect coordinate transforms affecting warping

Fix implicit grab behaviour when using pointer constraints

Fixes #5718 and #5757