### PR TITLE
[wayland] fix timing of foreign toplevel handle creation

### DIFF
--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -444,6 +444,11 @@ static void qw_xdg_view_handle_map(struct wl_listener *listener, void *data) {
 
     struct wlr_xdg_toplevel *xdg_toplevel = xdg_view->xdg_toplevel;
 
+    // Create foreign toplevel manager and listeners
+    if (xdg_view->base.ftl_handle == NULL) {
+        qw_view_ftl_manager_handle_create(&xdg_view->base);
+    }
+
     // Set foreign top level attributes
     if (xdg_view->base.ftl_handle != NULL) {
         if (xdg_view->base.title != NULL) {
@@ -658,9 +663,6 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
     xdg_view->scene_tree =
         wlr_scene_xdg_surface_create(xdg_view->base.content_tree, xdg_toplevel->base);
     xdg_toplevel->base->data = xdg_view;
-
-    // Create foreign toplevel manager and listeners
-    qw_view_ftl_manager_handle_create(&xdg_view->base);
 
     // Assign function pointers for base view operations
     xdg_view->base.get_tree_node = qw_xdg_view_get_tree_node;

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -565,6 +565,11 @@ static void qw_xwayland_view_handle_map(struct wl_listener *listener, void *data
 
     xwayland_view->base.skip_taskbar = xwayland_surface->skip_taskbar;
 
+    // Create foreign toplevel manager and listeners
+    if (xwayland_view->base.ftl_handle == NULL) {
+        qw_view_ftl_manager_handle_create(&xwayland_view->base);
+    }
+
     // Set properties for foreign toplevel manager
     if (xwayland_view->base.ftl_handle != NULL) {
         if (xwayland_view->base.title != NULL) {
@@ -862,10 +867,6 @@ void qw_server_xwayland_view_new(struct qw_server *server,
         wlr_scene_tree_create(server->scene_windows_layers[LAYER_LAYOUT]);
     xwayland_view->base.content_tree->node.data = xwayland_view;
     xwayland_view->base.layer = LAYER_LAYOUT;
-
-    // Create foreign toplevel manager and listeners
-    // Needs to be after content tree is created as we create an output tracking scene buffer
-    qw_view_ftl_manager_handle_create(&xwayland_view->base);
 
     wl_signal_add(&xwayland_surface->events.destroy, &xwayland_view->destroy);
     xwayland_view->destroy.notify = qw_xwayland_view_handle_destroy;


### PR DESCRIPTION
Pagers like `rofi` use the foreign toplevel managament extension to get a list of active windows. A bug existed where handles were created for windows that weren't mapped, resulting in blank entries in `rofi`. We now only create the handle when the window is first mapped.

Fixes #5762