### PR TITLE
Don't finalise widgets twice

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -410,7 +410,8 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         if self.future:
             self.future.cancel()
         for widget in self.widgets:
-            widget.finalize()
+            if not widget.finalized:
+                widget.finalize()
         if hasattr(self, "drawer"):
             self.drawer.finalize()
             del self.drawer

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -349,7 +349,8 @@ class Qtile(CommandObject):
         """
         try:
             for widget in self.widgets_map.values():
-                widget.finalize()
+                if not widget.finalized:
+                    widget.finalize()
             self.widgets_map.clear()
 
             # For layouts we need to finalize each clone of a layout in each group


### PR DESCRIPTION
`Qtile._finalize_configurables` finalises every widget in `widgets_map`. It then finalises every `Bar` and `Gap` instance. `Bar.finalize` will try to finalise every widget in the bar. This can result in log noise where widgets have subscribed to hooks and tries to unsubscribe having already unsubscribed.

Widgets have a `finalized` flag so let's just check the widget hasn't been finalised before calling `finalize()`.

Fixes #5753
