### PR TITLE
Update default_config.py

### DIFF
--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -195,6 +195,8 @@ auto_minimize = True
 wl_input_rules = None
 
 # xcursor theme (string or None) and size (integer) for Wayland backend
+# If deviating from the default values it's recommended to also set
+# the XCURSOR_THEME & XCURSOR_SIZE env vars before running qtile.
 wl_xcursor_theme = None
 wl_xcursor_size = 24
 


### PR DESCRIPTION
Added a helpful reminder so that users would know that to achieve consistent results, they also need to set XCURSOR_SIZE & XCURSOR_THEME env vars when theming their cursors in qtile wayland.

I thought the default config is a good place to put this, since changing just the settings already in the default config may lead to inconsistent results & bug reports. 