### PR TITLE
nix: expose `pytest-asyncio` and `anyio` in flake devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
           coverage
           pytest
           isort
+          pytest-asyncio
+          anyio
         ];
 
         tests = {


### PR DESCRIPTION
**Summary**: Expose `pytest-asyncio` and `anyio` in flake devShell.

**Details**: Following a report by *Samunemeth* on discord regarding missing test dependencies when running the suite locally.
This PR updates the flake to include `pytest-asyncio` and `anyio`.
This streamlines the local dev workflow and prevents environment drift.

Addresses part of #5766