### PR TITLE
Made test independent of Xterm.

### DIFF
--- a/test/test_dgroups.py
+++ b/test/test_dgroups.py
@@ -16,10 +16,13 @@ class DGroupsConfig(libqtile.confreader.Config):
     screens = []
 
 
+terminal = libqtile.utils.guess_terminal()
+
+
 class DGroupsSpawnConfig(DGroupsConfig):
     groups = [
         libqtile.config.Group("a"),
-        libqtile.config.Group("b", spawn=["xterm"]),
+        libqtile.config.Group("b", spawn=[terminal]),
     ]
 
 

--- a/test/test_manager.py
+++ b/test/test_manager.py
@@ -15,11 +15,14 @@ from libqtile.config import Match
 from libqtile.confreader import Config
 from libqtile.group import _Group
 from libqtile.lazy import lazy
+from libqtile.utils import guess_terminal
 from test.conftest import dualmonitor, multimonitor
 from test.helpers import BareConfig, Retry, assert_window_died
 from test.layouts.layout_utils import assert_focused
 
 configs_dir = Path(__file__).resolve().parent / "configs"
+
+terminal = guess_terminal()
 
 
 class ManagerConfig(Config):
@@ -408,14 +411,14 @@ def test_spawn_in_group(manager, backend_name):
     def wait_for_window(empty=False):
         assert (len(manager.c.windows()) > 0) is not empty
 
-    manager.c.spawn("xterm")
+    manager.c.spawn(terminal)
     wait_for_window()
     assert manager.c.group["a"].info()["windows"]
     assert not manager.c.group["b"].info()["windows"]
     manager.c.window.kill()
     wait_for_window(empty=True)
 
-    manager.c.spawn("xterm", group="b")
+    manager.c.spawn(terminal, group="b")
     wait_for_window()
     assert manager.c.group["b"].info()["windows"]
     assert not manager.c.group["a"].info()["windows"]

--- a/test/test_qtile_cmd.py
+++ b/test/test_qtile_cmd.py
@@ -13,6 +13,9 @@ import libqtile.widget
 from libqtile.command.base import expose_command
 from libqtile.confreader import Config
 from libqtile.lazy import lazy
+from libqtile.utils import guess_terminal
+
+terminal = guess_terminal()
 
 
 class ServerConfig(Config):
@@ -23,8 +26,8 @@ class ServerConfig(Config):
 
     auto_fullscreen = True
     keys = [
-        libqtile.config.Key(["mod4"], "Return", lazy.spawn("xterm")),
-        libqtile.config.Key(["mod4"], "t", lazy.spawn("xterm"), desc="dummy description"),
+        libqtile.config.Key(["mod4"], "Return", lazy.spawn(terminal)),
+        libqtile.config.Key(["mod4"], "t", lazy.spawn(terminal), desc="dummy description"),
         libqtile.config.Key([], "y", desc="noop"),
         libqtile.config.KeyChord(
             ["mod4"],
@@ -152,9 +155,14 @@ def test_display_kb(manager):
     pprint(table)
     assert table.count("\n") >= 2
     assert re.match(r"(?m)^Mode\s{3,}KeySym\s{3,}Mod\s{3,}Command\s{3,}Desc\s*$", table)
-    assert re.search(r"(?m)^<root>\s{3,}Return\s{3,}mod4\s{3,}spawn\('xterm'\)\s*$", table)
     assert re.search(
-        r"(?m)^<root>\s{3,}t\s{3,}mod4\s{3,}spawn\('xterm'\)\s{3,}dummy description\s*$", table
+        r"(?m)^<root>\s{3,}Return\s{3,}mod4\s{3,}spawn\('" + terminal + r"'\)\s*$", table
+    )
+    assert re.search(
+        r"(?m)^<root>\s{3,}t\s{3,}mod4\s{3,}spawn\('"
+        + terminal
+        + r"'\)\s{3,}dummy description\s*$",
+        table,
     )
     assert re.search(r"(?m)^<root>\s{3,}q\s{3,}mod4\s{13,}Enter named mode\s*$", table)
     assert re.search(r"(?m)^named\s{3,}q\s{13,}Enter <unnamed> mode\s*$", table)


### PR DESCRIPTION
I am on a mission to make the tests work on NixOS using the provided flake. These changes were made to help with this goal, but are also good practice in other cases.

Some tests were dependent on Xterm being available. It was used as a dummy window. I changed them to use the `guess_terminal()` function instead. (This was discussed in Discord with @Gurjaka and @jwijenbergh)

One small change was made to a test launching an external python script with extra environment variables. It was not adding new environment variables, but overriding all of the existing ones. Therefore it would work if no `env` was provided to the function but would not work if `env` was provided. Now it adds the `env` dictionary to the default ones, with the parameter being the stronger one, and therefore overriding the existing ones if present.

I tested all of these changes locally.

I have not squashed the commits on purpose, as I believe they form better small change units this way, but I am happy to merge them if you find that better. 
