### PR TITLE
Getting tests to work on NixOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "01f116e4df6a15f4ccdffb1bcd41096869fb",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,11 @@
 {
   description = "Qtile's flake, full-featured, hackable tiling window manager written and configured in Python";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    # This pins the flake to a previous version. This is added at the moment
+    # in this pull request as a temporary fix to allow running of all tests
+    # from this flakes development shell. After figuring out what is causing
+    # the issue in the newest version, this SHOULD BE REMOVED BEFORE MERGING.
+    nixpkgs.url = "github:nixos/nixpkgs?ref=01f116e4df6a15f4ccdffb1bcd41096869fb";
   };
   outputs =
     {


### PR DESCRIPTION
I am trying to get tests working on NixOS, so is trying to be a fix for https://github.com/qtile/qtile/issues/5766 .

I made some fixes to the tests themselves in https://github.com/qtile/qtile/pull/5780 .
Here I will make required changes to the flake and nix configurations.

I added `pytest-httpbin` to the python dependencies, as it is required by the poll text widgets tests. I added Qtile itself to the dependencies, as some tests run separate python scripts that need Qtile. (Credit to @Gurjaka for helping with the styling here.)

For the time being, I pinned the flake back to November 2025. This fixes the issue described in the second part of https://github.com/qtile/qtile/issues/5766 .
This is a draft, as pinning the flake back is not a proper solution, it is just helpful for debugging all the other issues.

I am trying to fix this, and hopefully make this pull request ready in the near future.