### PR TITLE
Fix confusion/typo in DF widget format description

### DIFF
--- a/libqtile/widget/df.py
+++ b/libqtile/widget/df.py
@@ -19,7 +19,7 @@ class DF(base.InLoopPollText):
             "format",
             "{p} ({uf}{m}|{r:.0f}%)",
             "String format (p: partition, s: size, "
-            "f: free space, uf: used free space, m: measure, r: ratio (uf/s))",
+            "f: free space, uf: used space, m: measure, r: ratio (uf/s))",
         ),
         ("update_interval", 60, "The update interval."),
     ]


### PR DESCRIPTION
### Fix confusion/typo in DF widget format description:
"uf" should be "used free space", not "user free space", to prevent confusion.