### PR TITLE
wayland: Fix blurry icons on hidpi displays [redo]

### DIFF
--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import collections
 import math
 import typing
+from copy import copy
 
 import cairocffi
 
 from libqtile import pangocffi, utils
+from libqtile.images import Img
 from libqtile.log_utils import logger
 from libqtile.utils import ColorsType
 
@@ -329,6 +331,29 @@ class Drawer:
         self.ctx.line_to(x2, y)
         self.ctx.set_line_width(linewidth)
         self.ctx.stroke()
+
+    @property
+    def output_scale(self):
+        return getattr(self._win, "scale", 1)
+
+    def draw_image(self, img: Img, offsetx: int = 0, offsety: int = 0) -> None:
+        # Some widgets cache images, so perform the following operations on a copy
+        img = copy(img)
+
+        applied_scale = img.width / img.default_size.width
+        combined_scale = applied_scale * self.output_scale
+        img.scale(combined_scale, combined_scale)
+        pattern = img.pattern
+
+        # If the image has been scaled for HiDPI, we downscale here for
+        # compositing. Quality isn't degraded because the context uses a
+        # recording surface.
+        self.ctx.save()
+        self.ctx.translate(offsetx, offsety)
+        self.ctx.scale(1 / self.output_scale, 1 / self.output_scale)
+        self.ctx.set_source(pattern)
+        self.ctx.paint()
+        self.ctx.restore()
 
 
 class TextLayout:

--- a/libqtile/images.py
+++ b/libqtile/images.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import os
 from collections import namedtuple
+from copy import copy
 from math import pi
 
 import cairocffi
 import cairocffi.pixbuf
 
-from libqtile.utils import scan_files
+from libqtile import utils
+from libqtile.utils import ColorsType, scan_files
 
 
 class LoadingError(Exception):
@@ -29,6 +33,11 @@ def get_cairo_surface(bytes_img, width=None, height=None):
         )
         surf, fmt = cairocffi.pixbuf.decode_to_image_surface(bytes_img)
         return _SurfaceInfo(surf, fmt)
+
+
+def get_cairo_surface_for_data(data, format, width, height):
+    surf = cairocffi.ImageSurface.create_for_data(data, format, width, height)
+    return _SurfaceInfo(surf, format)
 
 
 def get_cairo_pattern(surface, width=None, height=None, theta=0.0):
@@ -119,10 +128,59 @@ class _Rotation(_Resetter):
 _ImgSize = namedtuple("_ImgSize", ("width", "height"))
 
 
+class ImageFileBackend:
+    """Backend for encoded image files (PNG, JPEG, etc)"""
+
+    def __init__(self, bytes_img):
+        self.bytes_img = bytes_img
+
+    def get_surface(self, width=None, height=None):
+        surf, _ = get_cairo_surface(self.bytes_img, width, height)
+        return surf
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ImageFileBackend):
+            return False
+        return self.bytes_img == other.bytes_img
+
+
+class ImageBufferBackend:
+    """Backend for raw pixel data"""
+
+    def __init__(self, data, format, width, height):
+        self.data = data
+        self.format = format
+        self.width = width
+        self.height = height
+
+    def get_surface(self, width=None, height=None):
+        surf, _ = get_cairo_surface_for_data(self.data, self.format, self.width, self.height)
+        if width is None or (width == self.width and height == self.height):
+            return surf
+        scaled = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, width, height)
+        with cairocffi.Context(scaled) as ctx:
+            ctx.scale(width / self.width, height / self.height)
+            pattern = cairocffi.SurfacePattern(surf)
+            pattern.set_filter(cairocffi.FILTER_BEST)
+            ctx.set_source(pattern)
+            ctx.paint()
+        return scaled
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ImageBufferBackend):
+            return False
+        return (
+            self.data == other.data
+            and self.format == other.format
+            and self.width == other.width
+            and self.height == other.height
+        )
+
+
 class Img:
     """Img is a class which creates & manipulates cairo SurfacePatterns from an image
 
-    There are two constructors Img(...) and Img.from_path(...)
+    There are three constructors Img(...), Img.from_path(...) and Img.from_data(...)
 
     The cairo surface pattern is at img.pattern.
     Changing any of the attributes width, height, or theta will update the pattern.
@@ -133,10 +191,53 @@ class Img:
     Pattern is first stretched, then rotated.
     """
 
-    def __init__(self, bytes_img, name="", path=""):
-        self.bytes_img = bytes_img
+    def __init__(self, bytes_img=None, name="", path=""):
+        if bytes_img:
+            self._common_init(ImageFileBackend(bytes_img), name=name, path=path)
+        else:
+            self._common_init(None, name=name, path=path)
+
+    def __copy__(self):
+        new = self.__class__.__new__(self.__class__)
+        new.__dict__.update(self.__dict__)
+        new._operations = list(self._operations)
+        new._resources = [copy(r) for r in self._resources]
+        new.__dict__.pop("_surface", None)
+        new.__dict__.pop("_pattern", None)
+        return new
+
+    def _common_init(self, backend, name="", path=""):
+        self.backend = backend
         self.name = name
         self.path = path
+        self._operations = []
+        self._resources = []
+
+    @classmethod
+    def from_data(cls, data, format, width, height):
+        "Create an Img instance from image data"
+        img = cls.__new__(cls)
+        img._common_init(ImageBufferBackend(data, format, width, height))
+        return img
+
+    @classmethod
+    def blank(cls, format, width, height):
+        stride = cairocffi.ImageSurface.format_stride_for_width(format, width)
+        data = bytearray(stride * height)
+        img = cls.__new__(cls)
+        img._common_init(ImageBufferBackend(data, format, width, height))
+        return img
+
+    @classmethod
+    def from_path(cls, image_path):
+        "Create an Img instance from image_path"
+        with open(image_path, "rb") as fobj:
+            bytes_img = fobj.read()
+        name = os.path.basename(image_path)
+        name, file_type = os.path.splitext(name)
+        img = cls.__new__(cls)
+        img._common_init(ImageFileBackend(bytes_img), name=name, path=image_path)
+        return img
 
     def _reset(self):
         if hasattr(self, "surface"):
@@ -146,21 +247,12 @@ class Img:
             # patterns do not need to be finish()ed, only surfaces do
             del self.pattern
 
-    @classmethod
-    def from_path(cls, image_path):
-        "Create an Img instance from image_path"
-        with open(image_path, "rb") as fobj:
-            bytes_img = fobj.read()
-        name = os.path.basename(image_path)
-        name, file_type = os.path.splitext(name)
-        return cls(bytes_img, name=name, path=image_path)
-
     @property
     def default_surface(self):
         try:
             return self._default_surface
         except AttributeError:
-            surf, fmt = get_cairo_surface(self.bytes_img)
+            surf = self.backend.get_surface()
             self._default_surface = surf
             return surf
 
@@ -192,6 +284,10 @@ class Img:
             return self.scale(width_factor, height_factor, lock_aspect_ratio=True)
 
     def scale(self, width_factor=None, height_factor=None, lock_aspect_ratio=False):
+        # First scale any attached image resources
+        for resource in self._resources:
+            resource.scale(width_factor, height_factor)
+
         if width_factor is None and height_factor is None:
             raise ValueError("You must supply width_factor or height_factor")
         if lock_aspect_ratio:
@@ -220,12 +316,58 @@ class Img:
         width0, height0 = initial_size
         return _ImgSize(width0 * width_factor, height0 * height_factor)
 
+    def paste(self, overlay: Img, offsetx: int = 0, offsety: int = 0) -> Img:
+        overlay = copy(overlay)  # Snapshot overlay when paste is called
+        self._resources.append(overlay)
+        resource_idx = len(self._resources) - 1
+
+        def func(img, surface):
+            with cairocffi.Context(surface) as ctx:
+                ctx.translate(offsetx, offsety)
+                ctx.set_source(cairocffi.SurfacePattern(img._resources[resource_idx].surface))
+                ctx.paint()
+
+        self._operations.append(func)
+        self._reset()
+        return self
+
+    def paint_mask(self, colour: ColorsType) -> Img:
+        def func(img, surface):
+            with cairocffi.Context(surface) as ctx:
+                if isinstance(colour, list):
+                    if len(colour) == 0:
+                        # defaults to black
+                        ctx.set_source_rgba(0.0, 0.0, 0.0, 1.0)
+                    elif len(colour) == 1:
+                        ctx.set_source_rgba(*utils.rgb(colour[0]))
+                    else:
+                        linear = cairocffi.LinearGradient(0.0, 0.0, 0.0, img.height)
+                        step_size = 1.0 / (len(colour) - 1)
+                        step = 0.0
+                        for c in colour:
+                            linear.add_color_stop_rgba(step, *utils.rgb(c))
+                            step += step_size
+                        ctx.set_source(linear)
+                else:
+                    ctx.set_source_rgba(*utils.rgb(colour))
+
+                ctx.set_operator(cairocffi.OPERATOR_SOURCE)
+                ctx.mask(cairocffi.SurfacePattern(surface))
+                ctx.fill()
+
+        self._operations.append(func)
+        self._reset()
+        return self
+
     @property
     def surface(self):
         try:
             return self._surface
         except AttributeError:
-            surf, fmt = get_cairo_surface(self.bytes_img, self.width, self.height)
+            surf = self.backend.get_surface(self.width, self.height)
+            for operation in self._operations:
+                operation(self, surf)
+
             self._surface = surf
             return surf
 
@@ -258,9 +400,12 @@ class Img:
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        s0 = (self.bytes_img, self.theta, self.width, self.height)
-        s1 = (other.bytes_img, other.theta, other.width, other.height)
-        return s0 == s1
+        return (
+            self.backend == other.backend
+            and self.theta == other.theta
+            and self.width == other.width
+            and self.height == other.height
+        )
 
 
 class Loader:

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -650,11 +650,7 @@ class BatteryIcon(base._Widget):
     def draw(self) -> None:
         self.drawer.clear(self.background or self.bar.background)
         image = self.images[self.current_icon]
-        self.drawer.ctx.save()
-        self.drawer.ctx.translate(self.padding, (self.bar.size - image.height) // 2)
-        self.drawer.ctx.set_source(image.pattern)
-        self.drawer.ctx.paint()
-        self.drawer.ctx.restore()
+        self.drawer.draw_image(image, self.padding, (self.bar.size - image.height) // 2)
         self.draw_at_default_position()
 
     @staticmethod

--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -105,7 +105,7 @@ class StatusNotifierItem:  # noqa: E303
     def __init__(self, bus, service, path=None, icon_theme=None):
         self.bus = bus
         self.service = service
-        self.surfaces = {}
+        self.images = {}
         self._pixmaps = {}
         self._icon = None
         self._overlay_icon = None
@@ -361,7 +361,7 @@ class StatusNotifierItem:  # noqa: E303
             self.on_icon_changed(self)
 
     def _invalidate_icons(self):
-        self.surfaces = {}
+        self.images = {}
 
     def _get_sizes(self):
         """Returns list of available icon sizes."""
@@ -370,19 +370,19 @@ class StatusNotifierItem:  # noqa: E303
 
         return sorted([size for size in self._pixmaps["Icon"]])
 
-    def _get_surfaces(self, size):
+    def _get_images(self, size):
         """
         Creates a Cairo ImageSurface for each available icon
         for the given size.
         """
-        raw_surfaces = {}
+        raw_images = {}
         for icon in self._pixmaps:
             if size in self._pixmaps[icon]:
-                srf = cairocffi.ImageSurface.create_for_data(
+                img = Img.from_data(
                     self._pixmaps[icon][size], cairocffi.FORMAT_ARGB32, size, size
                 )
-                raw_surfaces[icon] = srf
-        return raw_surfaces
+                raw_images[icon] = img
+        return raw_images
 
     def get_icon(self, size):
         """
@@ -391,15 +391,15 @@ class StatusNotifierItem:  # noqa: E303
         Will pick the appropriate icon and add any overlay as required.
         """
         # Use existing icon if generated previously
-        if size in self.surfaces:
-            return self.surfaces[size]
+        if size in self.images:
+            return self.images[size]
 
-        # Create a blank ImageSurface to hold the icon
-        icon = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, size, size)
+        # Create a blank image to hold the icon
+        icon = Img.blank(cairocffi.FORMAT_ARGB32, size, size)
 
         if self.icon:
-            base_icon = self.icon.surface
-            icon_size = base_icon.get_width()
+            base_icon = self.icon
+            icon_size = base_icon.width
             overlay = None
 
         else:
@@ -421,27 +421,23 @@ class StatusNotifierItem:  # noqa: E303
             # we just take the largest icon
             icon_size = sizes[0] if sizes else all_sizes[-1]
 
-            srfs = self._get_surfaces(icon_size)
+            imgs = self._get_images(icon_size)
 
             # TODO: This shouldn't happen...
-            if not srfs:
+            if not imgs:
                 return icon
 
             # TODO: Check spec for when to use "attention"
-            base_icon = srfs.get("Attention", srfs["Icon"])
-            overlay = srfs.get("Overlay", None)
+            base_icon = imgs.get("Attention", imgs["Icon"])
+            overlay = imgs.get("Overlay", None)
 
-        with cairocffi.Context(icon) as ctx:
-            scale = size / icon_size
-            ctx.scale(scale, scale)
-            ctx.set_source_surface(base_icon)
-            ctx.paint()
-            if overlay:
-                ctx.set_source_surface(overlay)
-                ctx.paint()
+        if overlay:
+            icon = base_icon.paste(overlay)
+        else:
+            icon = base_icon
 
-        # Store the surface for next time
-        self.surfaces[size] = icon
+        # Store the image for next time
+        self.images[size] = icon
 
         return icon
 

--- a/libqtile/widget/image.py
+++ b/libqtile/widget/image.py
@@ -52,11 +52,7 @@ class Image(base._Widget, base.MarginMixin):
             return
 
         self.drawer.clear(self.background or self.bar.background)
-        self.drawer.ctx.save()
-        self.drawer.ctx.translate(self.margin_x, self.margin_y)
-        self.drawer.ctx.set_source(self.img.pattern)
-        self.drawer.ctx.paint()
-        self.drawer.ctx.restore()
+        self.drawer.draw_image(self.img, self.margin_x, self.margin_y)
         self.draw_at_default_position()
 
     def calculate_length(self):

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -97,15 +97,7 @@ class StatusNotifier(base._Widget):
             self.mouse_callbacks[name]()
 
     def _draw_icon(self, icon, x, y):
-        # Despite scaling the icon down here for compositing, cairo keeps the higher
-        # res snapshot, which will be used when the whole buffer is scaled up later
-        scale = 1 / getattr(self.bar.window, "scale", 1)
-        self.drawer.ctx.save()
-        self.drawer.ctx.translate(x, y)
-        self.drawer.ctx.scale(scale, scale)
-        self.drawer.ctx.set_source_surface(icon, 0, 0)
-        self.drawer.ctx.paint()
-        self.drawer.ctx.restore()
+        self.drawer.draw_image(icon, x, y)
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)
@@ -113,9 +105,11 @@ class StatusNotifier(base._Widget):
         yoffset = (self.bar.size - self.icon_size) // 2
 
         # Scale icon up by output scale factor
-        scaled_icon_size = int(self.icon_size * getattr(self.bar.window, "scale", 1))
+        scaled_icon_size = int(self.icon_size * self.drawer.output_scale)
         for item in self.available_icons:
+            # Get the icon at its scaled size or larger (if possible)
             icon = item.get_icon(scaled_icon_size)
+            icon.resize(height=self.icon_size)
             if self.bar.horizontal:
                 self._draw_icon(icon, xoffset, yoffset)
             else:

--- a/libqtile/widget/tasklist.py
+++ b/libqtile/widget/tasklist.py
@@ -492,16 +492,16 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         if not getattr(window, "icons", False):
             return None
 
+        # If we have a HiDPI display, we want to find icons at the scaled icon size
+        icon_size_scaled = int(self.drawer.output_scale * self.icon_size)
         icons = sorted(
             iter(window.icons.items()),
-            key=lambda x: abs(self.icon_size - int(x[0].split("x")[0])),
+            key=lambda x: abs(icon_size_scaled - int(x[0].split("x")[0])),
         )
         icon = icons[0]
         width, height = map(int, icon[0].split("x"))
 
-        img = cairocffi.ImageSurface.create_for_data(
-            icon[1], cairocffi.FORMAT_ARGB32, width, height
-        )
+        img = Img.from_data(icon[1], cairocffi.FORMAT_ARGB32, width, height)
 
         return img
 
@@ -530,7 +530,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
         if icon:
             img = Img.from_path(icon)
-            return img.surface
+            return img
 
     def _get_theme_icon(self, window):
         classes = window.get_wm_class()
@@ -554,7 +554,7 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
 
         img = Img.from_path(icon)
 
-        return img.surface
+        return img
 
     def get_window_icon(self, window):
         if not getattr(window, "icons", False) and self.theme_mode is None:
@@ -564,7 +564,6 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
         if cache:
             return cache
 
-        surface = None
         img = None
 
         if self.qtile.core.name == "x11":
@@ -579,33 +578,20 @@ class TaskList(base._Widget, base.PaddingMixin, base.MarginMixin):
                 img = xdg_img
 
         if img is not None:
-            surface = cairocffi.SurfacePattern(img)
-            height = img.get_height()
-            width = img.get_width()
-            scaler = cairocffi.Matrix()
-            if height != self.icon_size:
-                sp = height / self.icon_size
-                height = self.icon_size
-                width /= sp
-                scaler.scale(sp, sp)
-            surface.set_matrix(scaler)
+            img.resize(height=self.icon_size)
 
-        self._icons_cache[window.wid] = surface
-        return surface
+        self._icons_cache[window.wid] = img
+        return img
 
-    def draw_icon(self, surface, offset):
-        if not surface:
+    def draw_icon(self, img, offset):
+        if not img:
             return
 
         x = offset + self.borderwidth + self.padding_side
         size = self.height if self.bar.horizontal else self.width
         y = (size - self.icon_size) // 2
 
-        self.drawer.ctx.save()
-        self.drawer.ctx.translate(x, y)
-        self.drawer.ctx.set_source(surface)
-        self.drawer.ctx.paint()
-        self.drawer.ctx.restore()
+        self.drawer.draw_image(img, offsetx=x, offsety=y)
 
     def draw(self):
         self.drawer.clear(self.background or self.bar.background)

--- a/libqtile/widget/volume.py
+++ b/libqtile/widget/volume.py
@@ -46,7 +46,7 @@ class VolumeBase(base._TextBox):
     def __init__(self, **config):
         base._TextBox.__init__(self, "", **config)
         self.add_defaults(VolumeBase.defaults)
-        self.surfaces = {}
+        self.images = {}
         self.volume = None
         self.is_mute = False
 
@@ -72,8 +72,7 @@ class VolumeBase(base._TextBox):
             else:  # self.volume >= 80:
                 img_name = "audio-volume-high"
 
-            self.drawer.ctx.set_source(self.surfaces[img_name])
-            self.drawer.ctx.paint()
+            self.drawer.draw_image(self.images[img_name])
         elif self.emoji:
             if len(self.emoji_list) < 4:
                 self.emoji_list = ["\U0001f507", "\U0001f508", "\U0001f509", "\U0001f50a"]
@@ -109,7 +108,7 @@ class VolumeBase(base._TextBox):
             img.resize(height=new_height)
             if img.width > self.length:
                 self.length = img.width + self.padding * 2
-            self.surfaces[name] = img.pattern
+            self.images[name] = img
 
     def draw(self):
         if self.theme_path:

--- a/test/backend/wayland/test_drawer.py
+++ b/test/backend/wayland/test_drawer.py
@@ -1,0 +1,136 @@
+from copy import copy
+from unittest.mock import Mock
+
+import cairocffi
+import pytest
+
+from libqtile import images
+from libqtile.backend.wayland.drawer import Drawer
+from test.test_images import SVGS, png_img_24, rgba_pixel_data  # noqa: F401
+
+
+class FakeDrawer(Drawer):
+    def __init__(self, image_surface, output_scale, monkeypatch):
+        self._image_surface = image_surface
+        win = Mock()
+        win.scale = output_scale
+        win.width = image_surface.get_width()
+        win.height = image_surface.get_height()
+        sentinel = object()
+        win.surface = sentinel
+        self._win = win
+        self._width = image_surface.get_width()
+        self._height = image_surface.get_height()
+        self._reset_surface()
+
+        real_from_pointer = cairocffi.Surface._from_pointer
+
+        def fake_from_pointer(ptr, incref=False):
+            if ptr is sentinel:
+                return image_surface
+            return real_from_pointer(ptr, incref)
+
+        monkeypatch.setattr(cairocffi.Surface, "_from_pointer", staticmethod(fake_from_pointer))
+
+
+@pytest.fixture(scope="function")
+def svg_img():
+    return images.Img.from_path(SVGS[0])
+
+
+@pytest.fixture
+def drawer(monkeypatch):
+    image_surface = cairocffi.ImageSurface(cairocffi.FORMAT_ARGB32, 24, 24)
+    d = FakeDrawer(image_surface, 1.5, monkeypatch)
+    return d, image_surface
+
+
+# Lets assume icon size is 16 x 16 and output scale factor is 1.5. Therefore we
+# want to draw the icon at 24 x 24 (16 x 1.5 = 24). if our icon has been scaled
+# correctly, it will exactly match the original image
+def test_hidpi_svg_scaling(svg_img, drawer):
+    assert svg_img.width == 24
+    assert svg_img.height == 24
+    # Snapshot svg_img before any scaling
+    img0 = copy(svg_img)
+    # Set icon image size
+    svg_img.resize(height=16)
+    d, image_surface = drawer
+    d.draw_image(svg_img)
+    d._draw()
+    assert bytes(img0.surface.get_data()) == bytes(image_surface.get_data())
+
+
+def test_hidpi_png_scaling(png_img_24, drawer):  # noqa:F811
+    assert png_img_24.width == 24
+    assert png_img_24.height == 24
+    img0 = copy(png_img_24)
+    png_img_24.resize(height=16)
+    d, image_surface = drawer
+    d.draw_image(png_img_24)
+    d._draw()
+    assert bytes(img0.surface.get_data()) == bytes(image_surface.get_data())
+
+
+def test_hidpi_pixel_data_scaling(rgba_pixel_data, drawer):  # noqa:F811
+    img = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+    assert img.width == 24
+    assert img.height == 24
+    img0 = copy(img)
+    img.resize(height=16)
+    d, image_surface = drawer
+    d.draw_image(img)
+    d._draw()
+    assert bytes(img0.surface.get_data()) == bytes(image_surface.get_data())
+
+
+def test_hidpi_img_paint_mask(svg_img, drawer):
+    assert svg_img.width == 24
+    assert svg_img.height == 24
+    # Snapshot svg_img before any scaling
+    img0 = copy(svg_img)
+    red_img0 = img0.paint_mask("#ff0000")
+    # Set icon image size
+    svg_img.resize(height=16)
+    svg_img.paint_mask("#ff0000")
+    d, image_surface = drawer
+    d.draw_image(svg_img)
+    d._draw()
+    assert bytes(red_img0.surface.get_data()) == bytes(image_surface.get_data())
+
+
+def test_hidpi_img_paste(svg_img, rgba_pixel_data, drawer):  # noqa:F811
+    assert svg_img.width == 24
+    assert svg_img.height == 24
+    overlay = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+    assert overlay.width == 24
+    assert overlay.height == 24
+
+    expected_result = bytearray(svg_img.surface.get_data())
+    overlay_data = bytes(overlay.surface.get_data())
+    for i in range(0, len(overlay_data), 4):
+        if overlay_data[i + 3] != 0:
+            expected_result[i : i + 4] = overlay_data[i : i + 4]
+
+    svg_img.resize(height=16)
+    overlay.resize(height=16)
+    svg_img.paste(overlay)
+    d, image_surface = drawer
+    d.draw_image(svg_img)
+    d._draw()
+    assert bytes(image_surface.get_data()) == expected_result
+
+
+def test_draw_image_does_not_mutate_resources(svg_img, rgba_pixel_data, drawer):  # noqa:F811
+    overlay = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+    svg_img.paste(overlay)
+
+    original_resource_width = svg_img._resources[0].width
+    original_resource_height = svg_img._resources[0].height
+
+    d, image_surface = drawer
+    d.draw_image(svg_img)
+
+    # draw_image should not mutate the original's resources
+    assert svg_img._resources[0].width == original_resource_width
+    assert svg_img._resources[0].height == original_resource_height

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -4,6 +4,7 @@ and its supporting code.
 """
 
 import os
+from copy import copy
 from glob import glob
 from os import path
 
@@ -47,6 +48,24 @@ def png_img():
     return images.Img.from_path(PNGS[0])
 
 
+@pytest.fixture(scope="function")
+def png_img_24():
+    return images.Img.from_path(os.path.join(DATA_DIR, "png", "audio-volume-muted.png"))
+
+
+@pytest.fixture(scope="function")
+def rgba_pixel_data():
+    # ARGB32 format: 4 bytes per pixel, order is B, G, R, A
+    pixels = []
+    for y in range(24):
+        for x in range(24):
+            if x == y:
+                pixels.extend([0, 0, 255, 255])
+            else:
+                pixels.extend([0, 0, 0, 0])
+    return bytearray(pixels)
+
+
 def test_get_cairo_surface(path_n_bytes_image):
     path, bytes_image = path_n_bytes_image
     surf_info = images.get_cairo_surface(bytes_image)
@@ -83,6 +102,14 @@ class TestImg:
         assert img != img2
         img2.theta = 0.0
         assert img == img2
+
+    def test_from_data(self, rgba_pixel_data):
+        data_in = copy(rgba_pixel_data)
+        img = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+        surface = img.surface
+        assert isinstance(surface, cairocffi.ImageSurface)
+        data_out = surface.get_data()
+        assert data_in == bytes(data_out)
 
     def test_setting(self, png_img):
         img = png_img
@@ -147,6 +174,91 @@ class TestImg:
         assert_approx_equal(t_matrix, (s2o2, s2o2, -s2o2, s2o2))
         del img.theta
         assert img.theta == pytest.approx(0.0)
+
+    # Resizing should always resample from the original image source rather than
+    # chaining transformations
+    def test_resize_rasterization(self, png_img_24):
+        img0 = copy(png_img_24)
+        assert png_img_24.width == 24
+        assert png_img_24.height == 24
+        png_img_24.resize(101, 101)
+        assert png_img_24.width == 101
+        assert png_img_24.height == 101
+        png_img_24.resize(24, 24)
+        assert png_img_24 == img0
+        assert bytes(png_img_24.surface.get_data()) == bytes(img0.surface.get_data())
+
+    def test_img_paste(self):
+        img0 = images.Img.from_data(
+            bytearray([0x80, 0x80, 0x80, 0xFF] * 4), cairocffi.FORMAT_ARGB32, 2, 2
+        )
+        # fmt: off
+        img1 = images.Img.from_data(
+            bytearray([0xFF, 0x00, 0x00, 0xFF,
+                       0x00, 0x00, 0x00, 0x00,
+                       0x00, 0x00, 0xFF, 0xFF,
+                       0x00, 0x00, 0x00, 0x00]),
+            cairocffi.FORMAT_ARGB32, 2, 2
+        )
+        expected_result = bytes([0xFF, 0x00, 0x00, 0xFF,
+                                 0x80, 0x80, 0x80, 0xFF,
+                                 0x00, 0x00, 0xFF, 0XFF,
+                                 0x80, 0x80, 0x80, 0xFF])
+        # fmt: on
+
+        img3 = img0.paste(img1)
+        assert bytes(img3.surface.get_data()) == expected_result
+
+    def test_img_paint_mask(self):
+        # fmt: off
+        img = images.Img.from_data(
+            # format is B G R A
+            bytearray([0x80, 0x80, 0x80, 0xFF,
+                       0x00, 0x00, 0x00, 0x00,
+                       0x80, 0x00, 0x80, 0xFF,
+                       0x00, 0x00, 0x00, 0x00]),
+            cairocffi.FORMAT_ARGB32, 2, 2
+        )
+        expected_result = bytes([0x00, 0x00, 0xFF, 0xFF,
+                                 0x00, 0x00, 0x00, 0x00,
+                                 0x00, 0x00, 0xFF, 0XFF,
+                                 0x00, 0x00, 0x00, 0x00])
+        # fmt: on
+
+        img2 = img.paint_mask("#FF0000")
+        assert bytes(img2.surface.get_data()) == expected_result
+
+    def test_copy_operations_independent(self, png_img):
+        img0 = copy(png_img)
+
+        # Appending to img0's operations should not affect png_img
+        img0.paint_mask("#ff0000")
+        assert len(png_img._operations) == 0
+        assert len(img0._operations) == 1
+
+    def test_copy_resources_independent(self, png_img_24, rgba_pixel_data):
+        overlay = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+        png_img_24.paste(overlay)
+
+        img0 = copy(png_img_24)
+
+        # Appending a new resource to img0 should not affect png_img_24
+        overlay2 = images.Img.from_data(rgba_pixel_data, cairocffi.FORMAT_ARGB32, 24, 24)
+        img0.paste(overlay2)
+
+        assert len(png_img_24._resources) == 1
+        assert len(img0._resources) == 2
+
+    def test_operations_applied_after_cache(self, png_img):
+        # Access surface to cache it
+        surface0 = png_img.surface
+
+        # Add an operation after caching
+        png_img.paint_mask("#ff0000")
+
+        # Without invalidation, surface would be the same cached one with no paint_mask applied
+        # With invalidation, surface is rebuilt with paint_mask applied
+        assert png_img.surface is not surface0
 
 
 class TestImgScale:

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -28,9 +28,9 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     vol.length_type = bar.STATIC
     vol.length = 0
     vol.setup_images()
-    assert len(vol.surfaces) == len(names)
-    for name, surfpat in vol.surfaces.items():
-        assert isinstance(surfpat, cairocffi.SurfacePattern)
+    assert len(vol.images) == len(names)
+    for name, image in vol.images.items():
+        assert isinstance(image.pattern, cairocffi.SurfacePattern)
 
 
 def test_emoji():


### PR DESCRIPTION
The technique is:
- Rasterize images at their final physical size (upscale if required)
- Downscale images to their logical size for compositing
- When the entire window is finally upscaled for display, since these
  last two scaling operations are on a recording surface they
  effectively cancel out
  
Attempting to implement this in Img class, rather than Drawer (#5685)
e.g.
```python
img = Img.from_path(icon_path)
img.resize(height=self.icon_size)
self.drawer.draw_image(img, offsetx=x, offsety=y)
```

So this looks like it will require using Img's instead of cairo surfaces and pattern as the primary data type before rendering

Widgets updated:
- [x] TaskList
- [x] Statusnotifer
- [x] Image
- [x] Volume
- [x] BatteryIcon

Additional todos:
- [x] tests