### PR TITLE
widget: move GenPollUrl to its own file

### DIFF
--- a/libqtile/widget/__init__.py
+++ b/libqtile/widget/__init__.py
@@ -22,7 +22,7 @@ widgets = {
     "DF": "df",
     "DoNotDisturb": "do_not_disturb",
     "GenPollText": "generic_poll_text",
-    "GenPollUrl": "generic_poll_text",
+    "GenPollUrl": "gen_poll_url",
     "GenPollCommand": "generic_poll_text",
     "GmailChecker": "gmail_checker",
     "GroupBox": "groupbox",

--- a/libqtile/widget/crypto_ticker.py
+++ b/libqtile/widget/crypto_ticker.py
@@ -2,7 +2,7 @@ import locale
 
 from libqtile.confreader import ConfigError
 from libqtile.log_utils import logger
-from libqtile.widget.generic_poll_text import GenPollUrl
+from libqtile.widget.gen_poll_url import GenPollUrl
 
 _DEFAULT_CURRENCY = str(locale.localeconv()["int_curr_symbol"])
 _DEFAULT_SYMBOL = str(locale.localeconv()["currency_symbol"])

--- a/libqtile/widget/gen_poll_url.py
+++ b/libqtile/widget/gen_poll_url.py
@@ -1,0 +1,77 @@
+import json
+from typing import Any
+
+import aiohttp
+
+from libqtile.log_utils import logger
+from libqtile.widget import base
+
+try:
+    import xmltodict
+
+    def xmlparse(body):
+        return xmltodict.parse(body)
+
+except ImportError:
+    # TODO: we could implement a similar parser by hand, but i'm lazy, so let's
+    # punt for now
+    def xmlparse(body):
+        raise Exception("no xmltodict library")
+
+
+class GenPollUrl(base.BackgroundPoll):
+    """A generic text widget that polls an url and parses it using parse function
+
+
+    Widget requirements: aiohttp_.
+
+    .. _aiohttp: https://pypi.org/project/aiohttp/
+    """
+
+    defaults: list[tuple[str, Any, str]] = [
+        ("url", None, "Url"),
+        ("data", None, "Post Data"),
+        ("parse", None, "Parse Function"),
+        ("json", True, "Is Json?"),
+        ("user_agent", "Qtile", "Set the user agent"),
+        ("headers", {}, "Extra Headers"),
+        ("xml", False, "Is XML?"),
+    ]
+
+    def __init__(self, **config):
+        base.BackgroundPoll.__init__(self, "", **config)
+        self.add_defaults(GenPollUrl.defaults)
+
+        self.headers["User-agent"] = self.user_agent
+        if self.json:
+            self.headers["Content-Type"] = "application/json"
+
+        if self.data and not isinstance(self.data, str):
+            self.data = json.dumps(self.data).encode()
+
+    async def apoll(self):
+        if not self.parse or not self.url:
+            return "Invalid config"
+
+        headers = self.headers.copy()
+        data = self.data
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(
+                    method="POST" if data else "GET", url=self.url, data=data, headers=headers
+                ) as response:
+                    if self.json:
+                        body = await response.json()
+                    elif self.xml:
+                        text_body = await response.text()
+                        body = xmlparse(text_body)
+                    else:
+                        body = await response.text()
+
+            text = self.parse(body)
+        except Exception:
+            logger.exception("got exception polling widget")
+            text = "Can't parse"
+
+        return text

--- a/libqtile/widget/generic_poll_text.py
+++ b/libqtile/widget/generic_poll_text.py
@@ -1,26 +1,5 @@
-import json
-from typing import Any
-
-try:
-    import aiohttp
-except ImportError:
-    aiohttp = None
-
-from libqtile.log_utils import logger
 from libqtile.utils import acall_process
 from libqtile.widget import base
-
-try:
-    import xmltodict
-
-    def xmlparse(body):
-        return xmltodict.parse(body)
-
-except ImportError:
-    # TODO: we could implement a similar parser by hand, but i'm lazy, so let's
-    # punt for now
-    def xmlparse(body):
-        raise Exception("no xmltodict library")
 
 
 class GenPollText(base.BackgroundPoll):
@@ -43,64 +22,6 @@ class GenPollText(base.BackgroundPoll):
         if not self.func:
             return "You need a poll function"
         return self.func()
-
-
-class GenPollUrl(base.BackgroundPoll):
-    """A generic text widget that polls an url and parses it using parse function
-
-
-    Widget requirements: aiohttp_.
-
-    .. _aiohttp: https://pypi.org/project/aiohttp/
-    """
-
-    defaults: list[tuple[str, Any, str]] = [
-        ("url", None, "Url"),
-        ("data", None, "Post Data"),
-        ("parse", None, "Parse Function"),
-        ("json", True, "Is Json?"),
-        ("user_agent", "Qtile", "Set the user agent"),
-        ("headers", {}, "Extra Headers"),
-        ("xml", False, "Is XML?"),
-    ]
-
-    def __init__(self, **config):
-        base.BackgroundPoll.__init__(self, "", **config)
-        self.add_defaults(GenPollUrl.defaults)
-
-        self.headers["User-agent"] = self.user_agent
-        if self.json:
-            self.headers["Content-Type"] = "application/json"
-
-        if self.data and not isinstance(self.data, str):
-            self.data = json.dumps(self.data).encode()
-
-    async def apoll(self):
-        if not self.parse or not self.url:
-            return "Invalid config"
-
-        headers = self.headers.copy()
-        data = self.data
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.request(
-                    method="POST" if data else "GET", url=self.url, data=data, headers=headers
-                ) as response:
-                    if self.json:
-                        body = await response.json()
-                    elif self.xml:
-                        text_body = await response.text()
-                        body = xmlparse(text_body)
-                    else:
-                        body = await response.text()
-
-            text = self.parse(body)
-        except Exception:
-            logger.exception("got exception polling widget")
-            text = "Can't parse"
-
-        return text
 
 
 class GenPollCommand(base.BackgroundPoll):

--- a/libqtile/widget/idlerpg.py
+++ b/libqtile/widget/idlerpg.py
@@ -1,6 +1,6 @@
 import datetime
 
-from libqtile.widget.generic_poll_text import GenPollUrl
+from libqtile.widget.gen_poll_url import GenPollUrl
 
 
 class IdleRPG(GenPollUrl):

--- a/libqtile/widget/open_weather.py
+++ b/libqtile/widget/open_weather.py
@@ -2,7 +2,7 @@ import time
 from typing import Any
 from urllib.parse import urlencode
 
-from libqtile.widget.generic_poll_text import GenPollUrl
+from libqtile.widget.gen_poll_url import GenPollUrl
 
 # See documentation: https://openweathermap.org/current
 QUERY_URL = "https://api.openweathermap.org/data/2.5/weather?"

--- a/libqtile/widget/stock_ticker.py
+++ b/libqtile/widget/stock_ticker.py
@@ -2,7 +2,7 @@ import locale
 from urllib.parse import urlencode
 
 from libqtile.log_utils import logger
-from libqtile.widget.generic_poll_text import GenPollUrl
+from libqtile.widget.gen_poll_url import GenPollUrl
 
 
 class StockTicker(GenPollUrl):

--- a/test/widgets/test_generic_poll_text.py
+++ b/test/widgets/test_generic_poll_text.py
@@ -1,7 +1,7 @@
 import pytest
 
 import libqtile
-from libqtile.widget import generic_poll_text
+from libqtile.widget import gen_poll_url, generic_poll_text
 
 
 def test_gen_poll_text():
@@ -14,17 +14,17 @@ def test_gen_poll_text():
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_not_configured():
-    gpurl = generic_poll_text.GenPollUrl()
+    gpurl = gen_poll_url.GenPollUrl()
     assert await gpurl.apoll() == "Invalid config"
 
 
 def test_gen_poll_url_no_json():
-    gpurl = generic_poll_text.GenPollUrl(json=False)
+    gpurl = gen_poll_url.GenPollUrl(json=False)
     assert "Content-Type" not in gpurl.headers
 
 
 def test_gen_poll_url_headers_and_json():
-    gpurl = generic_poll_text.GenPollUrl(
+    gpurl = gen_poll_url.GenPollUrl(
         headers={"fake-header": "fake-value"},
         data={"argument": "data value"},
         user_agent="qtile test",
@@ -38,9 +38,7 @@ def test_gen_poll_url_headers_and_json():
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_text(httpbin):
-    gpurl = generic_poll_text.GenPollUrl(
-        json=False, parse=lambda x: x, url=f"{httpbin.url}/anything"
-    )
+    gpurl = gen_poll_url.GenPollUrl(json=False, parse=lambda x: x, url=f"{httpbin.url}/anything")
     result = await gpurl.apoll()
     assert isinstance(result, str)
     assert "anything" in result
@@ -48,7 +46,7 @@ async def test_gen_poll_url_text(httpbin):
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_json_with_data(httpbin):
-    gpurl = generic_poll_text.GenPollUrl(
+    gpurl = gen_poll_url.GenPollUrl(
         parse=lambda x: x["data"], data={"test": "value"}, url=f"{httpbin.url}/anything"
     )
     result = await gpurl.apoll()
@@ -57,7 +55,7 @@ async def test_gen_poll_url_json_with_data(httpbin):
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_xml_no_xmltodict(httpbin):
-    gpurl = generic_poll_text.GenPollUrl(
+    gpurl = gen_poll_url.GenPollUrl(
         json=False, xml=True, parse=lambda x: x, url=f"{httpbin.url}/anything"
     )
     result = await gpurl.apoll()
@@ -66,7 +64,7 @@ async def test_gen_poll_url_xml_no_xmltodict(httpbin):
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_broken_parse(httpbin):
-    gpurl = generic_poll_text.GenPollUrl(
+    gpurl = gen_poll_url.GenPollUrl(
         json=False, parse=lambda x: x.foo, url=f"{httpbin.url}/anything"
     )
     result = await gpurl.apoll()
@@ -75,7 +73,7 @@ async def test_gen_poll_url_broken_parse(httpbin):
 
 @pytest.mark.asyncio
 async def test_gen_poll_url_custom_headers(httpbin):
-    gpurl = generic_poll_text.GenPollUrl(
+    gpurl = gen_poll_url.GenPollUrl(
         headers={"X-Custom-Header": "test-value", "X-Another-Header": "another-value"},
         parse=lambda x: x["headers"],
         url=f"{httpbin.url}/headers",


### PR DESCRIPTION
The lazy_import() machinery catches all ImportErrors and logs an error if people try to use a particular widget but don't have the dependencies. As a result, we don't need this try/catch ImportError for aiohttp.

However, since there are several widgets that live in this file, and all of them will fail to load if aiohttp is not installed, it's best to move GenPollUrl to its own file, so that only GenPollUrl is unavailable if aiohttp is missing.

Fixes #5785