### PR TITLE
x11-identify-output: don't fail on duplicate WMs

### DIFF
--- a/libqtile/scripts/x11_identify_output.py
+++ b/libqtile/scripts/x11_identify_output.py
@@ -1,23 +1,26 @@
-import libqtile.backend
+import os
 
 
 def identify_output(opts) -> None:
-    kore = libqtile.backend.get_core("x11")
-    output_info = kore.get_output_info()
-    kore.finalize()
+    from libqtile.backend.x11.xcbq import Connection
+
+    conn = Connection(os.environ.get("DISPLAY"))
 
     print("Output Information:")
 
-    for i, info in enumerate(output_info):
-        name = info.name or "Unknown"
-        serial = info.serial or "N/A"
+    try:
+        for i, info in enumerate(conn.pseudoscreens):
+            name = info.name or "Unknown"
+            serial = info.serial or "N/A"
 
-        print(f"Output {i}:")
-        print(f"  Name: {name}")
-        print(f"  Serial Number: {serial}")
-        print(f"  Position: ({info.rect.x}, {info.rect.y})")
-        print(f"  Resolution: {info.rect.width}x{info.rect.height}")
-        print()
+            print(f"Output {i}:")
+            print(f"  Name: {name}")
+            print(f"  Serial Number: {serial}")
+            print(f"  Position: ({info.rect.x}, {info.rect.y})")
+            print(f"  Resolution: {info.rect.width}x{info.rect.height}")
+            print()
+    finally:
+        conn.finalize()
 
 
 def add_subcommand(subparsers, parents):


### PR DESCRIPTION
When starting a full x11 Core, an ExistingWMException is raised if there is an existing WM, since that check happens in Core's __init__.

Instead, just create a Connection, since that's all we need to query OutputInfo.