### PR TITLE
tests: assume gtk is present

### DIFF
--- a/test/layouts/test_common.py
+++ b/test/layouts/test_common.py
@@ -11,18 +11,6 @@ from test.layouts.layout_utils import (
     assert_focused,
 )
 
-try:
-    # Check to see if we should skip tests using notifications on Wayland
-    import gi
-
-    gi.require_version("Gtk", "3.0")
-    gi.require_version("GtkLayerShell", "0.1")
-    from gi.repository import GtkLayerShell  # noqa: F401
-
-    has_wayland_notifications = True
-except (ImportError, ValueError):
-    has_wayland_notifications = False
-
 
 class AllLayoutsConfig(Config):
     """
@@ -156,7 +144,7 @@ def test_window_order_fullscreen(manager):
 
 @each_layout_config
 def test_window_types(manager):
-    if manager.backend.name == "wayland" and not has_wayland_notifications:
+    if manager.backend.name == "wayland":
         pytest.skip("Notification tests for Wayland need gtk-layer-shell")
 
     manager.test_window("one")
@@ -467,7 +455,7 @@ def test_remove_floating(manager):
 def test_desktop_notifications(manager):
     # Unlike normal floating windows such as dialogs, notifications don't steal
     # focus when they spawn, so test them separately
-    if manager.backend.name == "wayland" and not has_wayland_notifications:
+    if manager.backend.name == "wayland":
         pytest.skip("Notification tests for Wayland need gtk-layer-shell")
 
     # A notification fired in an empty group must not take focus


### PR DESCRIPTION
The import of GtkLayerShell triggers GTK's initialization, which creates 4 threads, which can deadlock my local pytest when doing a run of all the tests, with the cryptic output below.

Instead, don't test this at all, just assume that gtk is present. Since the actual gtk import is done via the test/scripts/window.py in a subprocess, that will not mess with pytest's forking. And if gtk is not present, the script will fail with a reasonable error. It is listed as dev dependency in pyproject.toml, so it will probably always work assuming people have installed the dev dependencies.

    =================================== ERRORS ====================================
    ________ ERROR at setup of test_inhibitor_open[1-x11-InhibitorConfig] _________

    fixturedef = <FixtureDef argname='manager' scope='function' baseid='test'>
    request = <SubRequest 'manager' for <Function test_inhibitor_open[1-x11-InhibitorConfig]>>

        @pytest.hookimpl(wrapper=True)
        def pytest_fixture_setup(fixturedef: FixtureDef, request) -> object | None:
            asyncio_mode = _get_asyncio_mode(request.config)
            if not _is_asyncio_fixture_function(fixturedef.func):
                if asyncio_mode == Mode.STRICT:
                    # Ignore async fixtures without explicit asyncio mark in strict mode
                    # This applies to pytest_trio fixtures, for example
    >               return (yield)
                            ^^^^^

    .venv/lib/python3.13/site-packages/pytest_asyncio/plugin.py:728:
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    test/conftest.py:93: in manager
        manager_nospawn.start(config)
    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    self = <test.helpers.TestManager object at 0x7fd093565160>
    config_class = <class 'test_idle_inhibit.InhibitorConfig'>, no_spawn = False
    state = None

        def start(self, config_class, no_spawn=False, state=None):
            multiprocessing.set_start_method("fork", force=True)
            readlogs, writelogs = os.pipe()
            rpipe, wpipe = multiprocessing.Pipe()

            def run_qtile():
                try:
                    rpipe.close()
                    os.environ.pop("DISPLAY", None)
                    os.environ.pop("WAYLAND_DISPLAY", None)
                    init_log(self.log_level)
                    kore = self.backend.create()
                    os.environ.update(self.backend.env)
                    from libqtile.core.lifecycle import lifecycle

                    os.close(readlogs)
                    formatter = logging.Formatter("%(levelname)s - %(message)s")
                    handler = logging.StreamHandler(os.fdopen(writelogs, "w"))
                    handler.setFormatter(formatter)
                    logger.addHandler(handler)

                    Qtile(
                        kore,
                        config_class(),
                        socket_path=self.sockfile,
                        no_spawn=no_spawn,
                        state=state,
                    ).loop()
                    lifecycle._atexit()
                except Exception:
                    wpipe.send(traceback.format_exc())
                finally:
                    wpipe.close()

            self.proc = multiprocessing.Process(target=run_qtile)
            self.proc.start()
            wpipe.close()
            os.close(writelogs)
            self.logspipe = readlogs

            # First, wait for socket to appear
            try:
                if can_connect_qtile(self.sockfile, ok=lambda: not rpipe.poll()):
                    ipc_client = ipc.Client(self.sockfile)
                    ipc_command = command.interface.IPCCommandInterface(ipc_client)
                    self.c = command.client.InteractiveCommandClient(ipc_command)
                    self.backend.configure(self)
                    return
                if rpipe.poll(0.1):
                    error = rpipe.recv()
                    raise AssertionError(f"Error launching qtile, traceback:\n{error}")
    >           raise AssertionError("Error launching qtile")
    E           AssertionError: Error launching qtile

    test/helpers.py:234: AssertionError
    ============================== warnings summary ===============================