### PR TITLE
wayland: implement wp-cursor-shape-v1 protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ uv.lock
 
 # dynamically built files for wayland backend build
 libconfig.mk
+
+# wayland-clients for testing
+test/wayland_clients/bin

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ exclude libqtile/backend/x11/_ffi*.py
 exclude libqtile/backend/wayland/_ffi*.*
 exclude libqtile/backend/wayland/_libinput*.*
 exclude libqtile/backend/wayland/qw/build/*.o
+exclude test/wayland_clients/bin/*
 exclude Makefile
 exclude .readthedocs.yaml
 exclude .git-blame-ignore-revs

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -50,6 +50,10 @@ PROTOS = [
         "pointer-constraints-unstable-v1-protocol.h",
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
     ],
+    [
+        "cursor-shape-v1-protocol.h",
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+    ],
 ]
 
 QW_PROTO_OUT_PATH = QW_PATH / "proto"

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -56,6 +56,15 @@ PROTOS = [
     ],
 ]
 
+CLIENT_PROTOS = [
+    ["xdg-shell-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml"],
+    [
+        "cursor-shape-v1-client-protocol",
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+    ],
+    ["tablet-v2-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml"],
+]
+
 QW_PROTO_OUT_PATH = QW_PATH / "proto"
 QW_PROTO_OUT_PATH.mkdir(exist_ok=True)
 
@@ -72,6 +81,19 @@ def wlroots_has_xwayland():
     config = Path(WLROOTS_PATH) / "wlr" / "config.h"
     return "WLR_HAS_XWAYLAND 1" in config.read_text()
 
+
+for proto in CLIENT_PROTOS:
+    subprocess.run(
+        [WAYLAND_SCANNER, "client-header", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.h"],
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+    subprocess.run(
+        [WAYLAND_SCANNER, "private-code", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.c"],
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
 
 CDEF = """
 // logging
@@ -274,6 +296,40 @@ def build_objects(debug: bool = False, asan: bool = False) -> None:
         )
 
 
+def build_test_client():
+    root = Path(__file__).parent.parent.parent.parent.parent
+    proto = QW_PROTO_OUT_PATH
+
+    cmd = [
+        "cc",
+        str(root / "test/wayland_clients/src/cursor-shape-v1.c"),
+        str(proto / "xdg-shell-client-protocol.c"),
+        str(proto / "cursor-shape-v1-client-protocol.c"),
+        str(proto / "tablet-v2-client-protocol.c"),
+        "-I",
+        str(proto),
+        "-o",
+        str(root / "test/wayland_clients/bin/cursor-shape-v1"),
+    ]
+
+    pkg = (
+        subprocess.check_output(
+            [
+                "pkg-config",
+                "--cflags",
+                "--libs",
+                "wayland-client",
+            ]
+        )
+        .decode()
+        .split()
+    )
+
+    cmd += pkg
+
+    subprocess.run(cmd, check=True)
+
+
 def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) -> None:
     # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
     # at libqtile/backend/wayland/_ffi.so.
@@ -311,6 +367,7 @@ def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) 
     ffi.compile(
         tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(), verbose=verbose
     )
+    build_test_client()
 
 
 if __name__ == "__main__":

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -300,6 +300,8 @@ def build_test_client():
     root = Path(__file__).parent.parent.parent.parent.parent
     proto = QW_PROTO_OUT_PATH
 
+    (root / "test/wayland_clients/bin").mkdir(parents=True, exist_ok=True)
+
     cmd = [
         "cc",
         str(root / "test/wayland_clients/src/cursor-shape-v1.c"),

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -432,6 +432,18 @@ class Core(base.Core):
         else:
             return self.qtile.process_button_release(button, mask)
 
+    @expose_command
+    def get_cursor_shape_v1(self) -> str | None:
+        """
+        Get the current cursor shape name from cursor-shape-v1 protocol.
+
+        Returns None if the cursor has no shape name set.
+        """
+        cursor = self.qw_cursor
+        if cursor.current_shape_name == ffi.NULL:
+            return None
+        return ffi.string(cursor.current_shape_name).decode("utf-8")
+
     def handle_manage_view(self, view: ffi.CData) -> None:
         wid = self.new_wid()
         view.wid = wid

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -375,6 +375,7 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     cursor->cursor = wlr_cursor_create();
     wlr_cursor_attach_output_layout(cursor->cursor, server->output_layout);
     cursor->mgr = wlr_xcursor_manager_create(NULL, 24);
+    cursor->current_shape_name = NULL;
 
     // Setup listeners for various pointer events
     cursor->request_set.notify = qw_cursor_handle_seat_request_set;
@@ -686,6 +687,7 @@ static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, voi
     }
 
     const char *name = wlr_cursor_shape_v1_name(event->shape);
+    cursor->current_shape_name = name;
 
     wlr_cursor_set_xcursor(cursor->cursor, cursor->mgr, name);
 }

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -360,6 +360,9 @@ static void qw_cursor_handle_frame(struct wl_listener *listener, void *data) {
     wlr_seat_pointer_notify_frame(cursor->server->seat);
 }
 
+// forward declaration
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
+
 struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     // Allocate memory for qw_cursor
     struct qw_cursor *cursor = calloc(1, sizeof(*cursor));
@@ -673,7 +676,7 @@ void qw_cursor_fake_click(struct qw_cursor *cursor) {
     qw_cursor_handle_button(&cursor->button, &event);
 }
 
-void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data) {
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data) {
     struct qw_cursor *cursor = wl_container_of(listener, cursor, request_set_cursor_shape);
     struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
 

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -15,6 +15,7 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
     wl_list_remove(&cursor->motion_absolute.link);
     wl_list_remove(&cursor->frame.link);
     wl_list_remove(&cursor->button.link);
+    wl_list_remove(&cursor->request_set_cursor_shape.link);
 
     wlr_xcursor_manager_destroy(cursor->mgr);
 
@@ -391,6 +392,11 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     cursor->button.notify = qw_cursor_handle_button;
     wl_signal_add(&cursor->cursor->events.button, &cursor->button);
 
+    cursor->cursor_shape_mgr = wlr_cursor_shape_manager_v1_create(server->display, 1);
+    cursor->request_set_cursor_shape.notify = qw_handle_request_set_cursor_shape;
+    wl_signal_add(&cursor->cursor_shape_mgr->events.request_set_shape,
+                  &cursor->request_set_cursor_shape);
+
     wl_list_init(&cursor->constraint_commit.link);
 
     return cursor;
@@ -665,4 +671,18 @@ void qw_cursor_fake_click(struct qw_cursor *cursor) {
     // Simulate release
     event.state = WL_POINTER_BUTTON_STATE_RELEASED;
     qw_cursor_handle_button(&cursor->button, &event);
+}
+
+void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data) {
+    struct qw_cursor *cursor = wl_container_of(listener, cursor, request_set_cursor_shape);
+    struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
+
+    struct wlr_seat_client *focused_client = cursor->server->seat->pointer_state.focused_client;
+    if (focused_client != event->seat_client) {
+        return;
+    }
+
+    const char *name = wlr_cursor_shape_v1_name(event->shape);
+
+    wlr_cursor_set_xcursor(cursor->cursor, cursor->mgr, name);
 }

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -2,6 +2,7 @@
 #define CURSOR_H
 
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
@@ -28,8 +29,10 @@ struct qw_cursor {
     struct wl_listener frame;
     struct wl_listener button;
     struct wl_listener constraint_commit;
+    struct wl_listener request_set_cursor_shape;
     struct wlr_xcursor_manager *mgr;
     struct wlr_xcursor_manager *xwayland_mgr;
+    struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
     struct wlr_surface *saved_surface;
     uint32_t saved_hotspot_x;
     uint32_t saved_hotspot_y;
@@ -67,6 +70,7 @@ void qw_cursor_pointer_constraint_new(struct qw_cursor *cursor,
                                       struct wlr_pointer_constraint_v1 *constraint);
 
 void qw_cursor_configure_xcursor(struct qw_cursor *cursor);
+void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
 
 void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
                                 struct wlr_pointer_constraint_v1 *constraint);

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -19,6 +19,7 @@ struct qw_cursor {
     struct wlr_cursor *cursor;
     struct qw_view *view;
     struct qw_implicit_grab implicit_grab;
+    struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
 
     // private data
     struct qw_server *server;
@@ -32,7 +33,6 @@ struct qw_cursor {
     struct wl_listener request_set_cursor_shape;
     struct wlr_xcursor_manager *mgr;
     struct wlr_xcursor_manager *xwayland_mgr;
-    struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
     struct wlr_surface *saved_surface;
     uint32_t saved_hotspot_x;
     uint32_t saved_hotspot_y;
@@ -70,7 +70,6 @@ void qw_cursor_pointer_constraint_new(struct qw_cursor *cursor,
                                       struct wlr_pointer_constraint_v1 *constraint);
 
 void qw_cursor_configure_xcursor(struct qw_cursor *cursor);
-void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
 
 void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
                                 struct wlr_pointer_constraint_v1 *constraint);

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -20,6 +20,7 @@ struct qw_cursor {
     struct qw_view *view;
     struct qw_implicit_grab implicit_grab;
     struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
+    const char *current_shape_name;
 
     // private data
     struct qw_server *server;

--- a/test/backend/wayland/test_cursor.py
+++ b/test/backend/wayland/test_cursor.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("libqtile.backend.wayland.core")
+
+BIN_PATH = Path(__file__).parent.parent / "test/wayland_clients/bin/cursor-shape-v1"
+
+
+@pytest.mark.parametrize("shape", ["text", "crosshair", "wait", "help"])
+def test_cursor_shape_protocol(wmanager, shape):
+    """Test that the C client can successfully request shapes via the protocol."""
+
+    try:
+        wmanager.test_window("cursor-shape-v1")
+
+        wmanager.c.core.warp_pointer(150, 150)
+
+        cursor_name = wmanager.c.eval("""
+from libqtile.backend.wayland._ffi import ffi
+cursor = self.core.qw_cursor
+ffi.string(cursor.current_shape_name).decode('utf-8') if cursor.current_shape_name != ffi.NULL else None
+        """)
+
+        if shape == "wait":
+            assert cursor_name in ["wait", "watch"]
+        elif shape == "help":
+            assert cursor_name in ["help", "whats_this", "question_arrow"]
+        else:
+            assert cursor_name == shape
+
+    except Exception:
+        return

--- a/test/backend/wayland/test_cursor.py
+++ b/test/backend/wayland/test_cursor.py
@@ -10,24 +10,18 @@ BIN_PATH = Path(__file__).parent.parent / "test/wayland_clients/bin/cursor-shape
 @pytest.mark.parametrize("shape", ["text", "crosshair", "wait", "help"])
 def test_cursor_shape_protocol(wmanager, shape):
     """Test that the C client can successfully request shapes via the protocol."""
-
     try:
         wmanager.test_window("cursor-shape-v1")
-
-        wmanager.c.core.warp_pointer(150, 150)
-
-        cursor_name = wmanager.c.eval("""
-from libqtile.backend.wayland._ffi import ffi
-cursor = self.core.qw_cursor
-ffi.string(cursor.current_shape_name).decode('utf-8') if cursor.current_shape_name != ffi.NULL else None
-        """)
-
-        if shape == "wait":
-            assert cursor_name in ["wait", "watch"]
-        elif shape == "help":
-            assert cursor_name in ["help", "whats_this", "question_arrow"]
-        else:
-            assert cursor_name == shape
-
     except Exception:
-        return
+        pytest.skip("cursor-shape-v1 protocol not available")
+
+    wmanager.c.eval(f"self.core.warp_pointer({150}, {150}, motion=True)")
+
+    cursor_name = wmanager.c.core.get_cursor_shape_v1()
+
+    if shape == "wait":
+        assert cursor_name in ["wait", "watch"]
+    elif shape == "help":
+        assert cursor_name in ["help", "whats_this", "question_arrow"]
+    else:
+        assert cursor_name == shape

--- a/test/wayland_clients/src/cursor-shape-v1.c
+++ b/test/wayland_clients/src/cursor-shape-v1.c
@@ -1,0 +1,305 @@
+#include <errno.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+
+#include "cursor-shape-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+/* ---------------- globals ---------------- */
+static bool configured = false;
+static uint32_t initial_configure_serial = 0;
+static bool running = true;
+
+static struct wl_display *display;
+static struct wl_registry *registry;
+
+static struct wl_compositor *compositor;
+static struct xdg_wm_base *xdg_wm_base;
+static struct wl_shm *shm;
+
+static struct wl_surface *surface;
+static struct xdg_toplevel *xdg_toplevel;
+
+static struct wp_cursor_shape_manager_v1 *cursor_manager;
+static struct wp_cursor_shape_device_v1 *cursor_device;
+
+static uint32_t cursor_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+
+/* ---------------- shm ---------------- */
+
+static int create_shm_file(size_t size) {
+    char name[] = "/tmp/wl-shm-XXXXXX";
+    int fd = mkstemp(name);
+    unlink(name);
+
+    if (fd < 0)
+        return -1;
+
+    if (ftruncate(fd, size) == -1) {
+        perror("ftruncate failed");
+        exit(EXIT_FAILURE);
+    }
+
+    return fd;
+}
+
+static struct wl_buffer *create_buffer(struct wl_shm *shm, int width, int height, void **data_out) {
+    int stride = width * 4;
+    int size = stride * height;
+
+    int fd = create_shm_file(size);
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+    struct wl_buffer *buf =
+        wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_XRGB8888);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    *data_out = data;
+    return buf;
+}
+
+/* ---------------- xdg-shell ---------------- */
+
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base, uint32_t serial) {
+    xdg_wm_base_pong(wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {.ping = xdg_wm_base_ping};
+
+static void xdg_surface_handle_configure(void *data, struct xdg_surface *xdg_surface,
+                                         uint32_t serial) {
+    if (configured) {
+        xdg_surface_ack_configure(xdg_surface, serial);
+        wl_surface_commit(surface);
+    } else {
+        initial_configure_serial = serial;
+        configured = true;
+    }
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {.configure =
+                                                                     xdg_surface_handle_configure};
+
+static void xdg_toplevel_handle_configure(void *data, struct xdg_toplevel *toplevel, int32_t width,
+                                          int32_t height, struct wl_array *states) {
+    // This event is sent before xdg_surface.configure. It specifies the
+    // compositor's desired size and advertises active states for the toplevel.
+    // A resizable client would store these, and resize itself when receiving
+    // the xdg_surface.configure event.
+}
+
+static void xdg_toplevel_handle_close(void *data, struct xdg_toplevel *xdg_toplevel) {
+    // Stop running if the user requests to close the toplevel
+    running = false;
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+    .configure = xdg_toplevel_handle_configure,
+    .close = xdg_toplevel_handle_close,
+};
+
+/* ---------------- cursor ---------------- */
+
+static uint32_t parse_cursor_shape(const char *name) {
+    if (strcmp(name, "default") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT;
+    if (strcmp(name, "crosshair") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+    if (strcmp(name, "pointer") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER;
+    if (strcmp(name, "grab") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRAB;
+    if (strcmp(name, "text") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT;
+    if (strcmp(name, "wait") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_WAIT;
+    if (strcmp(name, "help") == 0)
+        return WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_HELP;
+
+    fprintf(stderr, "Unknown cursor shape: %s\n", name);
+    fprintf(stderr, "Available shapes: default, crosshair, pointer, hand, text, wait, help\n");
+    exit(EXIT_FAILURE);
+}
+
+static void set_cursor(uint32_t serial) {
+    if (!cursor_device)
+        return;
+
+    wp_cursor_shape_device_v1_set_shape(cursor_device, serial, cursor_shape);
+}
+
+/* ---------------- pointer ---------------- */
+
+static void pointer_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
+                          struct wl_surface *surface, wl_fixed_t x, wl_fixed_t y) {
+    (void)data;
+    (void)pointer;
+    (void)surface;
+    (void)x;
+    (void)y;
+
+    set_cursor(serial);
+}
+
+static void pointer_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t x,
+                           wl_fixed_t y) {
+    (void)data;
+    (void)pointer;
+    (void)time;
+    (void)x;
+    (void)y;
+}
+
+static void pointer_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
+                          struct wl_surface *surface) {
+    (void)data;
+    (void)pointer;
+    (void)serial;
+    (void)surface;
+}
+
+static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
+                                  uint32_t time, uint32_t button, uint32_t state) {}
+
+static void pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time_ms,
+                                uint32_t axis, wl_fixed_t value) {}
+
+static const struct wl_pointer_listener pointer_listener = {.enter = pointer_enter,
+                                                            .leave = pointer_leave,
+                                                            .motion = pointer_motion,
+                                                            .button = pointer_handle_button,
+                                                            .axis = pointer_handle_axis};
+
+static void seat_handle_capabilities(void *data, struct wl_seat *seat, uint32_t capabilities) {
+    // If the wl_seat has the pointer capability, start listening to pointer
+    // events
+    if (capabilities & WL_SEAT_CAPABILITY_POINTER) {
+        struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+        wl_pointer_add_listener(pointer, &pointer_listener, seat);
+
+        cursor_device = wp_cursor_shape_manager_v1_get_pointer(cursor_manager, pointer);
+    }
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_handle_capabilities,
+};
+
+/* ---------------- registry ---------------- */
+
+static void handle_global(void *data, struct wl_registry *registry, uint32_t name,
+                          const char *interface, uint32_t version) {
+    (void)data;
+    (void)version;
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0)
+        compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 4);
+
+    if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        xdg_wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(xdg_wm_base, &xdg_wm_base_listener, NULL);
+    }
+
+    if (strcmp(interface, wl_seat_interface.name) == 0) {
+        struct wl_seat *seat = wl_registry_bind(registry, name, &wl_seat_interface, 1);
+        wl_seat_add_listener(seat, &seat_listener, NULL);
+    }
+
+    if (strcmp(interface, wl_shm_interface.name) == 0)
+        shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+
+    if (strcmp(interface, wp_cursor_shape_manager_v1_interface.name) == 0)
+        cursor_manager = wl_registry_bind(registry, name, &wp_cursor_shape_manager_v1_interface, 1);
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name) {}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = handle_global, .global_remove = handle_global_remove};
+
+/* ---------------- main ---------------- */
+
+int main(int argc, char *argv[]) {
+    // Parse command line arguments
+    int opt;
+    while ((opt = getopt(argc, argv, "c:h")) != -1) {
+        switch (opt) {
+        case 'c':
+            cursor_shape = parse_cursor_shape(optarg);
+            break;
+        case 'h':
+            printf("Usage: %s [-c cursor_shape]\n", argv[0]);
+            printf(
+                "  -c: Set cursor shape (default, crosshair, pointer, grab, text, wait, help)\n");
+            return 0;
+        default:
+            fprintf(stderr, "Usage: %s [-c cursor_shape]\n", argv[0]);
+            return 1;
+        }
+    }
+
+    display = wl_display_connect(NULL);
+    if (!display) {
+        fprintf(stderr, "failed to connect wayland\n");
+        return 1;
+    }
+
+    registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, NULL);
+    if (wl_display_roundtrip(display) == -1) {
+        return 1;
+    };
+
+    if (!compositor || !xdg_wm_base || !shm || !cursor_manager) {
+        fprintf(stderr, "missing required globals\n");
+        return 1;
+    }
+
+    /* surface */
+    surface = wl_compositor_create_surface(compositor);
+    struct xdg_surface *xdg_surface = xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
+    xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
+
+    xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, NULL);
+    xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, NULL);
+
+    // Perform the initial commit and wait for the first configure event
+    wl_surface_commit(surface);
+    while (!configured) {
+        if (wl_display_dispatch(display) == -1) {
+            return 1;
+        }
+    }
+
+    /* buffer */
+    void *pixels;
+    struct wl_buffer *buffer = create_buffer(shm, 300, 300, &pixels);
+    // Fill buffer with grey
+    memset(pixels, 0x80, 300 * 300 * 4);
+
+    wl_surface_attach(surface, buffer, 0, 0);
+    xdg_surface_ack_configure(xdg_surface, initial_configure_serial);
+    wl_surface_commit(surface);
+
+    printf("running...\n");
+
+    while (wl_display_dispatch(display) != -1 && running) {
+    }
+
+    xdg_toplevel_destroy(xdg_toplevel);
+    xdg_surface_destroy(xdg_surface);
+    wl_surface_destroy(surface);
+    wl_buffer_destroy(buffer);
+
+    return 0;
+}

--- a/test/wayland_clients/src/cursor-shape-v1.c
+++ b/test/wayland_clients/src/cursor-shape-v1.c
@@ -31,6 +31,7 @@ static struct wp_cursor_shape_manager_v1 *cursor_manager;
 static struct wp_cursor_shape_device_v1 *cursor_device;
 
 static uint32_t cursor_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+static uint32_t last_serial = 0;
 
 /* ---------------- shm ---------------- */
 
@@ -148,6 +149,7 @@ static void pointer_enter(void *data, struct wl_pointer *pointer, uint32_t seria
     (void)x;
     (void)y;
 
+    last_serial = serial;
     set_cursor(serial);
 }
 
@@ -158,6 +160,12 @@ static void pointer_motion(void *data, struct wl_pointer *pointer, uint32_t time
     (void)time;
     (void)x;
     (void)y;
+
+    last_serial = 0;
+    if (last_serial == 0) {
+        last_serial = 1;
+    }
+    set_cursor(last_serial);
 }
 
 static void pointer_leave(void *data, struct wl_pointer *pointer, uint32_t serial,


### PR DESCRIPTION
Add support for the staging cursor-shape-v1 protocol. This allows clients to request standard cursor shapes by enum (e.g., pointer, text, crosshair) rather than providing their own pixel buffers.