### PR TITLE
Add option for section linewidth in TreeTab layout

### DIFF
--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -204,9 +204,10 @@ class Section(TreeNode):
     def draw(self, layout, top, level=0):
         layout._layout.reset_width()  # no centering
         # draw a horizontal line above the section
-        layout._drawer.draw_hbar(
-            layout.section_fg, 0, layout.panel_width, top, linewidth=layout.section_linewidth
-        )
+        if layout.section_linewidth:
+            layout._drawer.draw_hbar(
+                layout.section_fg, 0, layout.panel_width, top, linewidth=layout.section_linewidth
+            )
         # draw the section title
         layout._layout.font_size = layout.section_fontsize
         layout._layout.text = self.add_superscript(self.title)


### PR DESCRIPTION
I added a linewidth parameter to the TreeTab layout. This allows setting the width of the line between sections. If set to 0, the line is disabled.