### PR TITLE
statusnotifier: Show icon name when icon can't be found

### DIFF
--- a/libqtile/widget/helpers/status_notifier/statusnotifier.py
+++ b/libqtile/widget/helpers/status_notifier/statusnotifier.py
@@ -204,7 +204,7 @@ class StatusNotifierItem:  # noqa: E303
 
         if not self.has_icons:
             logger.warning(
-                "Cannot find icon in current theme and no icon provided by StatusNotifierItem."
+                f"Cannot find icon: {self.last_icon_name!r} in current theme and no icon provided by StatusNotifierItem."
             )
             # No "local" icon and no application-provided icons are available.
             # The "local" icon may be updated at a later time, so "_update_local_icon"


### PR DESCRIPTION
When warning that an icon can't be found, also output the name of the icon (or None if no name was provided). This should help the user either select a theme with that icon or provide a custom local icon