### PR TITLE
wayland: Avoid re-focussing in _focus_by_click

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -511,7 +511,8 @@ class Core(base.Core):
             elif isinstance(win, base.Window):
                 if win.group and win.group.screen is not self.qtile.current_screen:
                     self.qtile.focus_screen(win.group.screen.index, warp=False)
-                self.qtile.current_group.focus(win, False)
+                if not win.has_focus:
+                    self.qtile.current_group.focus(win, False)
 
         else:
             screen = self.qtile.find_screen(


### PR DESCRIPTION
Calling focus and subsequently re-placing windows every time a button is clicked can cause high CPU usage - for example while rapidly scrolling

Only call focus if the window doesn't already have focus

Fixes #5822