### PR TITLE
Revert "wayland: Fix output enable+position crash"

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -240,6 +240,12 @@ static void qw_server_output_manager_reconfigure(struct qw_server *server,
             wlr_output_state_set_transform(&state, head->state.transform);
             wlr_output_state_set_scale(&state, head->state.scale);
             wlr_output_state_set_adaptive_sync_enabled(&state, head->state.adaptive_sync_enabled);
+            struct wlr_box box;
+            wlr_output_layout_get_box(server->output_layout, head->state.output, &box);
+            if (box.x != head->state.x || box.y != head->state.y) {
+                wlr_output_layout_add(server->output_layout, head->state.output, head->state.x,
+                                      head->state.y);
+            }
             // TODO rescale the cursor if necessary
             // TODO: cursor_manager.load
             // TODO: set_xcursor if no surface
@@ -250,11 +256,6 @@ static void qw_server_output_manager_reconfigure(struct qw_server *server,
             ok &= wlr_output_test_state(head->state.output, &state);
         }
         wlr_output_state_finish(&state);
-
-        if (apply && ok && head->state.enabled) {
-            wlr_output_layout_add(server->output_layout, head->state.output, head->state.x,
-                                  head->state.y);
-        }
     }
     if (ok) {
         wlr_output_configuration_v1_send_succeeded(config);


### PR DESCRIPTION
This reverts commit 020a87db1d3ccc8f5cd44cef158ea9f3d4e030ad.

We have started seeing crashes after this commit on the wayland backend in CI. It is hard to see how this is related, but such is the life of memory corruption bugs.

Related to (and maybe Fixes:, but not sure...) #5818