### PR TITLE
github: ignore *all* branch names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish to PyPI
 on:
   push:
-    branches-ignore: ['*']
+    branches-ignore: ['**']
     tags: ['*']
   release:
     types: [published]


### PR DESCRIPTION
Don't try to publish to branches with / in them. * explicitly does not ignore '/'s:

    *: Matches zero or more characters, but does not match the / character. For example, Octo* matches Octocat.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet