### PR TITLE
Rework (JSON) IPC

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -547,7 +547,9 @@ class Qtile(CommandObject):
             for cmd in key.commands:
                 if cmd.check(self):
                     status, val = self.server.call(
-                        (cmd.selectors, cmd.name, cmd.args, cmd.kwargs, False)
+                        ipc.IPCCommandMessage(
+                            cmd.selectors, cmd.name, cmd.args, cmd.kwargs, False
+                        )
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("KB command error %s: %s", cmd.name, val)
@@ -913,7 +915,7 @@ class Qtile(CommandObject):
                 for i in m.commands:
                     if i.check(self):
                         status, val = self.server.call(
-                            (i.selectors, i.name, i.args, i.kwargs, False)
+                            ipc.IPCCommandMessage(i.selectors, i.name, i.args, i.kwargs, False)
                         )
                         if status in (interface.ERROR, interface.EXCEPTION):
                             logger.error("Mouse command error %s: %s", i.name, val)
@@ -925,7 +927,9 @@ class Qtile(CommandObject):
                     self.focus_hovered_window()
                 if m.start:
                     i = m.start
-                    status, val = self.server.call((i.selectors, i.name, i.args, i.kwargs, False))
+                    status, val = self.server.call(
+                        ipc.IPCCommandMessage(i.selectors, i.name, i.args, i.kwargs, False)
+                    )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("Mouse command error %s: %s", i.name, val)
                         continue
@@ -964,7 +968,9 @@ class Qtile(CommandObject):
             for i in cmd:
                 if i.check(self):
                     status, val = self.server.call(
-                        (i.selectors, i.name, i.args + (rx + dx, ry + dy), i.kwargs, False)
+                        ipc.IPCCommandMessage(
+                            i.selectors, i.name, i.args + (rx + dx, ry + dy), i.kwargs, False
+                        )
                     )
                     if status in (interface.ERROR, interface.EXCEPTION):
                         logger.error("Mouse command error %s: %s", i.name, val)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -43,13 +43,11 @@ from libqtile.core.state import QtileState
 from libqtile.dgroups import DGroups
 from libqtile.extension.base import _Extension
 from libqtile.group import _Group
-from libqtile.interactive.repl import repl_server
 from libqtile.log_utils import logger
 from libqtile.resources.sleep import inhibitor
 from libqtile.scratchpad import ScratchPad
 from libqtile.scripts.main import VERSION
 from libqtile.utils import (
-    create_task,
     get_cache_dir,
     lget,
     remove_dbus_rules,
@@ -254,6 +252,7 @@ class Qtile(CommandObject):
                 ipc.Server(
                     self._prepare_socket_path(self.socket_path),
                     self.server.call,
+                    self,
                 ),
             ):
                 await self._stopped_event.wait()
@@ -1958,14 +1957,3 @@ class Qtile(CommandObject):
     def fire_user_hook(self, hook_name: str, *args: Any) -> None:
         """Fire a custom hook."""
         hook.fire(f"user_{hook_name}", *args)
-
-    @expose_command()
-    def start_repl_server(self, locals_dict: dict[str, Any] = dict()) -> None:
-        """Start the REPL server."""
-        _locals = {"qtile": self, **locals_dict}
-        create_task(repl_server.start(locals_dict=_locals))
-
-    @expose_command()
-    def stop_repl_server(self) -> None:
-        """Stop the REPL server."""
-        create_task(repl_server.stop())

--- a/libqtile/interactive/repl.py
+++ b/libqtile/interactive/repl.py
@@ -5,14 +5,11 @@ import contextlib
 import io
 import re
 import traceback
+from typing import Any
 
 from libqtile.log_utils import logger
-from libqtile.utils import create_task
 
 ATTR_MATCH = re.compile(r"([\w\.]+?)(?:\.([\w]*))?$")
-TERMINATOR = "___END___"
-COMPLETION_REQUEST = "___COMPLETE___::"
-REPL_PORT = 41414
 
 
 def mark_unavailable(func):
@@ -81,7 +78,7 @@ def get_completions(text, local_vars):
         return []
 
 
-class QtileREPLServer:
+class QtileREPL:
     """
     Provides a REPL interface to allow users to inspect qtile's internals via
     a more intuitive/familiar interface compared to `qtile shell`.
@@ -90,8 +87,14 @@ class QtileREPLServer:
     def __init__(self):
         self.buffer = ""
         self.compiler = codeop.Compile()
-        self.started = False
-        self.connections = set()
+
+    async def start(self, qtile) -> dict[str, Any]:
+        logger.debug("Starting Qtile REPL")
+
+        self.locals = {"qtile": qtile, **make_safer_env()}
+        self.compiler = codeop.CommandCompiler()
+
+        return {"output": "Connected to Qtile REPL\nPress Ctrl+C to exit.\n"}
 
     def evaluate_code(self, code):
         with io.StringIO() as stdout:
@@ -113,102 +116,20 @@ class QtileREPLServer:
 
             return stdout.getvalue()
 
-    async def handle_client(self, reader, writer):
-        """Method for sending data to REPL client."""
-        q = self.locals.get("qtile", None)
-
-        async def send(message, end=True):
-            """Wrapper to send data to client."""
-            suffix = TERMINATOR if end else ""
-            writer.write(f"{message}{suffix}\n".encode())
-            await writer.drain()
-
-        await send("Connected to Qtile REPL\nPress Ctrl+C to exit.\n")
-
-        # Keep track of the number of connected clients so server is not
-        # stopped while there is still a client connected.
-        task = asyncio.current_task()
-        self.connections.add(task)
-
-        self.compiler = codeop.CommandCompiler()
-
-        while not reader.at_eof():
-            buffer = ""
-            # The client handles checking when a code block is complete and
-            # terminates the code with a marker. Server therefore just reads
-            # until it finds that marker.
-            while True:
-                line = await reader.readline()
-                if not line:
-                    break
-                line = line.decode()
-
-                if line.strip() == TERMINATOR:
-                    break
-
-                buffer += line
-
-            # Handle completion requests
-            if buffer.startswith(COMPLETION_REQUEST):
-                prefix = buffer.split("::", 1)[1]
+    # `request` and the return could potentially be typed more strongly
+    async def handle(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a REPL request by the client. Caller must check that the session isn't locked"""
+        match request:
+            case {"completion": prefix}:
                 matches = get_completions(prefix, self.locals)
-                output = ",".join(matches) + "\n"
-                await send(output)
-                continue
+                return {"matches": matches}
 
-            if not buffer.strip():
-                buffer = ""
-                await send("", end=False)
-                continue
+            case {"code": code}:
+                if not code.strip():
+                    return {"output": ""}
+                else:
+                    output = await asyncio.to_thread(self.evaluate_code, code)
+                    return {"output": output.strip()}
 
-            # Ready to execute
-            output = ""
-
-            # Block interaction if session is locked
-            if q is not None and q.locked:
-                output = "Server is locked."
-            else:
-                # Evaluate code in a thread so blocking calls don't block the eventloop
-                loop = asyncio.get_running_loop()
-                output = await loop.run_in_executor(None, self.evaluate_code, buffer)
-
-            # Send output to client
-            await send(output.strip())
-
-        # Client has disconnected. Tidy up.
-        writer.close()
-        self.connections.remove(task)
-
-    async def start(self, locals_dict=dict()):
-        if self.started:
-            return
-
-        self.locals = {**make_safer_env(), **locals_dict}
-        self.server = await asyncio.start_server(self.handle_client, "localhost", REPL_PORT)
-        logger.info("Qtile REPL server running on localhost:%d", REPL_PORT)
-        self.started = True
-
-        # serve_forever() cannot be stopped except by putting it in a task and
-        # cancelling that task.
-        self.repl_task = create_task(self.server.serve_forever())
-
-        try:
-            await self.repl_task
-        except asyncio.CancelledError:
-            logger.info("Qtile REPL server has been stopped.")
-
-    async def stop(self):
-        if not self.started:
-            return
-
-        if self.connections:
-            logger.debug("Can't close with active connections")
-            return
-
-        self.server.close()
-        await self.server.wait_closed()
-        self.repl_task.cancel()
-        self.started = False
-
-
-repl_server = QtileREPLServer()
+            case _:
+                return {"output": "Internal REPL error\n"}

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -124,10 +124,7 @@ class IPCCommandMessage(IPCMessage):
 
     @classmethod
     def from_json(cls, json: dict) -> IPCCommandMessage:
-        msg = IPCCommandMessage(**json)
-        # Must always lift a message deserialized from JSON
-        msg.lifted = True
-        return msg
+        return IPCCommandMessage(**json)
 
     def __iter__(self):
         return iter((self.selectors, self.name, self.args, self.kwargs, self.lifted))
@@ -199,7 +196,7 @@ class _IPC:
             The unpacked message
         """
         try:
-            obj = json.loads(data.decode())
+            obj = json.loads(data.decode(), object_hook=_IPC._json_tuple_object_hook)
             match obj:
                 case {"message_type": MessageType.COMMAND, "content": content}:
                     return IPCCommandMessage.from_json(content)
@@ -225,15 +222,31 @@ class _IPC:
             "message_type": msg.message_type,
             "content": msg.to_json(),
         }
-        json_obj = json.dumps(tagged_dict, default=_IPC._json_encoder)
+        json_obj = _IPC._HintTuplesJsonEncoder().encode(tagged_dict)
         return json_obj.encode()
 
+    class _HintTuplesJsonEncoder(json.JSONEncoder):
+        def encode(self, o):
+            def hint_tuple(o):
+                if isinstance(o, tuple):
+                    return {"$tuple": list(o)}
+                if isinstance(o, list):
+                    return [hint_tuple(i) for i in o]
+                if isinstance(o, dict):
+                    return {key: hint_tuple(val) for key, val in o.items()}
+                # This is to retain the old `_json_encoder` behavior
+                # of converting a set to a list for serialization
+                if isinstance(o, set):
+                    return hint_tuple(list(o))
+                return o
+
+            return json.JSONEncoder.encode(self, hint_tuple(o))
+
     @staticmethod
-    def _json_encoder(field: Any) -> Any:
-        """Convert non-serializable types to ones understood by stdlib json module"""
-        if isinstance(field, set):
-            return list(field)
-        raise ValueError(f"Tried to JSON serialize unsupported type {type(field)}: {field}")
+    def _json_tuple_object_hook(o):
+        if "$tuple" in o and len(o) == 1:
+            return tuple(o["$tuple"])
+        return o
 
 
 class Client:

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -13,9 +13,10 @@ import json
 import os.path
 import socket
 import struct
+import threading
 import traceback
 from abc import ABCMeta, abstractmethod
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Coroutine, Iterator
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
@@ -89,7 +90,7 @@ class IPCMessage(metaclass=ABCMeta):
     @property
     @abstractmethod
     def message_type(self) -> MessageType:
-        """Discrimantor for the message type of the instance"""
+        """Discriminator for the message type of the instance"""
 
     @abstractmethod
     def to_json(self) -> dict:
@@ -299,7 +300,7 @@ class IPCStreamIO:
         await self.writer.wait_closed()
 
 
-class Client:
+class ReconnectingClient:
     def __init__(self, socket_path: str) -> None:
         """Create a new IPC client
 
@@ -317,7 +318,7 @@ class Client:
     def send(self, msg: tuple) -> IPCReplyMessage:
         """Send the message and return the response from the server
 
-        If any exception is raised by the server, that will propogate out of
+        If any exception is raised by the server, that will propagate out of
         this call.
         """
         return asyncio.run(self.async_send(msg))
@@ -330,6 +331,50 @@ class Client:
         """
         async with AsyncClient(self.socket_path) as c:
             return await c.send(IPCCommandMessage(*msg))
+
+
+class PersistentClient:
+    def __init__(self, socket_path: str) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._client = AsyncClient(socket_path)
+
+    def _run[T](self, coro: Coroutine[Any, Any, T]) -> T:
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def connect(self) -> None:
+        self._run(self._client.connect())
+
+    def close(self) -> None:
+        self._run(self._client.close())
+
+    def send(self, msg: tuple) -> IPCReplyMessage:
+        # Since the PersistentClient retains the connection,
+        # the user should be aware of the need to close it.
+        # This can be done manually via `self.close()`, or
+        # using a with block. However, to remain compatible
+        # with the old `Client` implementation, we're gonna
+        # call `connect` ourselves here
+        if not self._client.is_connected():
+            # This should probably be a warning, but since none of the code
+            # using an IPC client is aware of closing right now, that would
+            # clutter the logs enormously
+            logger.debug("send called on PersistentClient that's not connected")
+            self._run(self._client.connect())
+
+        message = IPCCommandMessage(*msg)
+        return self._run(self._client.send(message))
+
+    def __enter__(self):
+        self.connect()
+
+    def __exit__(self, _exc_type, _exc, _tb):
+        self.close()
+
+
+Client = ReconnectingClient
 
 
 class AsyncClient:
@@ -356,6 +401,9 @@ class AsyncClient:
             raise IPCError(f"Could not open {self.socket_path}")
         except asyncio.TimeoutError:
             raise IPCError("Connection to server timed out")
+
+    def is_connected(self) -> bool:
+        return self.stream is not None
 
     async def send(self, message: IPCCommandMessage) -> IPCReplyMessage:
         """Send the message to the server using the existing connection.

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -269,27 +269,29 @@ class IPCStreamIO:
         self.writer.write(data)
         await self.writer.drain()
 
-    async def read_frame(self) -> bytes:
+    async def read_frame(self) -> bytes | None:
         """Reads the the frame header (length) and then reads and returns the expected
-        number of bytes"""
+        number of bytes. Returns None if underlying stream has closed"""
         try:
             frame_header = await self.reader.readexactly(self.FRAME_HEADER_LENGTH)
             frame_length = struct.unpack(self.FRAME_HEADER_FORMAT, frame_header)[0]
             data = await self.reader.readexactly(frame_length)
             return data
-        except asyncio.IncompleteReadError:
-            raise IPCError("Invalid message framing, couldn't read the data")
+        except asyncio.IncompleteReadError as e:
+            if self.reader.at_eof():
+                return None
+            else:
+                logger.debug(f"Received partial bytes: {e.partial!r}")
+                raise IPCError("Invalid message framing, couldn't read the data")
 
     async def write_message(self, message: IPCMessage):
         await self.write_frame(_IPC.pack(message))
 
-    async def read_message(self, *, timeout: float | None = None) -> IPCMessage:
+    async def read_message(self, *, timeout: float | None = None) -> IPCMessage | None:
         message_bytes = await asyncio.wait_for(self.read_frame(), timeout=timeout)
+        if message_bytes is None:
+            return None
         return _IPC.unpack(message_bytes)
-
-    def at_eof(self) -> bool:
-        """Returns `reader.at_eof()`"""
-        return self.reader.at_eof()
 
     async def close(self):
         """Closes the connection"""
@@ -431,13 +433,18 @@ class Server:
         logger.debug("Connection made to server")
 
         try:
-            while not stream.at_eof():
+            while True:
                 # There is no timeout here to enable long lived connections
                 # by clients, without having to implement a heartbeat protocol
                 # which would impose a huge burden on the current implementation.
                 # Clients are assumed to be trusted, although there is no actual
                 # verification mechanism for this
                 req = await stream.read_message()
+                # EOF
+                if req is None:
+                    logger.debug("Client disconnected")
+                    break
+
                 if not isinstance(req, IPCCommandMessage):
                     logger.error("Expected command message from client")
                     break

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -12,6 +12,7 @@ import fcntl
 import json
 import os.path
 import socket
+import struct
 import traceback
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Iterator
@@ -249,6 +250,53 @@ class _IPC:
         return o
 
 
+class IPCStreamIO:
+    """Wraps an asyncio `StreamReader` and `StreamWriter` and implements
+    a simple framing protocol to handle sending and receiving IPCMessages
+    """
+
+    FRAME_HEADER_FORMAT = "!L"
+    FRAME_HEADER_LENGTH = struct.calcsize(FRAME_HEADER_FORMAT)
+
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        self.reader = reader
+        self.writer = writer
+
+    async def write_frame(self, data: bytes):
+        """Prepends the data with the frame header (length) and writes it to the writer"""
+        frame_header = struct.pack(self.FRAME_HEADER_FORMAT, len(data))
+        self.writer.write(frame_header)
+        self.writer.write(data)
+        await self.writer.drain()
+
+    async def read_frame(self) -> bytes:
+        """Reads the the frame header (length) and then reads and returns the expected
+        number of bytes"""
+        try:
+            frame_header = await self.reader.readexactly(self.FRAME_HEADER_LENGTH)
+            frame_length = struct.unpack(self.FRAME_HEADER_FORMAT, frame_header)[0]
+            data = await self.reader.readexactly(frame_length)
+            return data
+        except asyncio.IncompleteReadError:
+            raise IPCError("Invalid message framing, couldn't read the data")
+
+    async def write_message(self, message: IPCMessage):
+        await self.write_frame(_IPC.pack(message))
+
+    async def read_message(self, *, timeout: float | None = None) -> IPCMessage:
+        message_bytes = await asyncio.wait_for(self.read_frame(), timeout=timeout)
+        return _IPC.unpack(message_bytes)
+
+    def at_eof(self) -> bool:
+        """Returns `reader.at_eof()`"""
+        return self.reader.at_eof()
+
+    async def close(self):
+        """Closes the connection"""
+        self.writer.close()
+        await self.writer.wait_closed()
+
+
 class Client:
     def __init__(self, socket_path: str) -> None:
         """Create a new IPC client
@@ -282,26 +330,21 @@ class Client:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(path=self.socket_path), timeout=3
             )
+            stream = IPCStreamIO(reader, writer)
         except (ConnectionRefusedError, FileNotFoundError):
             raise IPCError(f"Could not open {self.socket_path}")
 
         try:
-            send_data = _IPC.pack(IPCCommandMessage(*msg))
-            writer.write(send_data)
-            writer.write_eof()
-
-            read_data = await asyncio.wait_for(reader.read(), timeout=10)
-        except TimeoutError:
+            await stream.write_message(IPCCommandMessage(*msg))
+            response = await stream.read_message(timeout=10.0)
+        except asyncio.TimeoutError:
             raise IPCError("Server not responding")
         finally:
-            # see the note in Server._server_callback()
-            writer.close()
-            await writer.wait_closed()
+            await stream.close()
 
-        data = _IPC.unpack(read_data)
-        if not isinstance(data, IPCReplyMessage):
+        if not isinstance(response, IPCReplyMessage):
             raise IPCError("Expected a reply message from the server")
-        return data
+        return response
 
 
 class Server:
@@ -339,12 +382,12 @@ class Server:
         Read the data sent from the client, execute the requested command, and
         send the reply back to the client.
         """
+        stream = IPCStreamIO(reader, writer)
         try:
             logger.debug("Connection made to server")
-            data = await reader.read()
-            logger.debug("EOF received by server")
+            # TODO: Add timeout
+            req = await stream.read_message()
 
-            req = _IPC.unpack(data)
             if not isinstance(req, IPCCommandMessage):
                 logger.error("Expected command message from client")
                 return
@@ -358,15 +401,11 @@ class Server:
             else:
                 rep = self.handler(req)
 
-            result = _IPC.pack(rep)
-
-            logger.debug("Sending result on receive EOF")
-            writer.write(result)
-            logger.debug("Closing connection on receive EOF")
-            writer.write_eof()
+            logger.debug("Sending result")
+            await stream.write_message(rep)
         finally:
-            writer.close()
-            await writer.wait_closed()
+            logger.debug("Closing connection")
+            await stream.close()
 
     async def __aenter__(self) -> Server:
         """Start and return the server"""

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -326,25 +326,70 @@ class Client:
         Connect to the server, then pack and send the message to the server,
         then wait for and return the response from the server.
         """
+        async with AsyncClient(self.socket_path) as c:
+            return await c.send(IPCCommandMessage(*msg))
+
+
+class AsyncClient:
+    def __init__(self, socket_path: str) -> None:
+        """Create a new asynchronous IPC client
+
+        Parameters
+        ----------
+        socket_path: str
+            The file path to the file that is used to open the connection to
+            the running IPC server.
+        """
+        self.socket_path = socket_path
+        self.stream: IPCStreamIO | None = None
+
+    async def connect(self):
+        """Open the unix domain socket connection to the IPC server"""
         try:
             reader, writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(path=self.socket_path), timeout=3
             )
-            stream = IPCStreamIO(reader, writer)
+            self.stream = IPCStreamIO(reader, writer)
         except (ConnectionRefusedError, FileNotFoundError):
             raise IPCError(f"Could not open {self.socket_path}")
+        except asyncio.TimeoutError:
+            raise IPCError("Connection to server timed out")
+
+    async def send(self, message: IPCCommandMessage) -> IPCReplyMessage:
+        """Send the message to the server using the existing connection.
+        `connect` must have been called, it is recommended to use async with:
+
+        ```
+        async with AsyncClient(sock_path) as c:
+            c.send(my_message)
+        ```
+        """
+        if self.stream is None:
+            raise IPCError("AsyncClient is not connected, use 'async with' or call 'connect'")
 
         try:
-            await stream.write_message(IPCCommandMessage(*msg))
-            response = await stream.read_message(timeout=10.0)
+            await self.stream.write_message(message)
+
+            response = await self.stream.read_message(timeout=10.0)
+            if not isinstance(response, IPCReplyMessage):
+                raise IPCError("Expected a reply message from the server")
+
+            return response
         except asyncio.TimeoutError:
             raise IPCError("Server not responding")
-        finally:
-            await stream.close()
 
-        if not isinstance(response, IPCReplyMessage):
-            raise IPCError("Expected a reply message from the server")
-        return response
+    async def close(self):
+        if self.stream is not None:
+            await self.stream.close()
+            self.stream = None
+
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        assert self.stream is not None
+        await self.stream.close()
 
 
 class Server:
@@ -383,26 +428,35 @@ class Server:
         send the reply back to the client.
         """
         stream = IPCStreamIO(reader, writer)
-        try:
-            logger.debug("Connection made to server")
-            # TODO: Add timeout
-            req = await stream.read_message()
+        logger.debug("Connection made to server")
 
-            if not isinstance(req, IPCCommandMessage):
-                logger.error("Expected command message from client")
-                return
+        try:
+            while not stream.at_eof():
+                # There is no timeout here to enable long lived connections
+                # by clients, without having to implement a heartbeat protocol
+                # which would impose a huge burden on the current implementation.
+                # Clients are assumed to be trusted, although there is no actual
+                # verification mechanism for this
+                req = await stream.read_message()
+                if not isinstance(req, IPCCommandMessage):
+                    logger.error("Expected command message from client")
+                    break
+
+                # Don't handle requests when session is locked
+                if self.locked.is_set():
+                    rep = IPCReplyMessage.error({"error": "Session locked."})
+                else:
+                    # The handler shouldn't throw, but return an
+                    # `IPCReplyMessage` with `IPCStatus.EXCEPTION`
+                    rep = self.handler(req)
+
+                logger.debug("Sending result")
+                await stream.write_message(rep)
+        # Consider trying to send the client an
+        # `IPCReplyMessage` with `IPCStatus.EXCEPTION`
         except IPCError as e:
             logger.warning("Invalid data received, closing connection")
             logger.debug(e)
-        else:
-            # Don't handle requests when session is locked
-            if self.locked.is_set():
-                rep = IPCReplyMessage.error({"error": "Session locked."})
-            else:
-                rep = self.handler(req)
-
-            logger.debug("Sending result")
-            await stream.write_message(rep)
         finally:
             logger.debug("Closing connection")
             await stream.close()

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -21,6 +21,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Self
 
 from libqtile import hook
+from libqtile.interactive.repl import QtileREPL
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
 
@@ -81,7 +82,14 @@ class IPCStatus(enum.IntEnum):
 
 class MessageType(enum.StrEnum):
     COMMAND = "command"
+    # Since this is just a `dict[Any]` bundled with a status,
+    # it can be used for both the repl and command results. This
+    # also simplifies the server's handler code, since it can always
+    # return a `REPLY` message, e.g. on error.
     REPLY = "reply"
+    # Maybe this could just be a repl_request?
+    REPL_START = "repl_start"
+    REPL_REQUEST = "repl_request"
 
 
 class IPCMessage(metaclass=ABCMeta):
@@ -180,6 +188,46 @@ class IPCReplyMessage(IPCMessage):
         return IPCReplyMessage(status=IPCStatus.EXCEPTION, data=data)
 
 
+@dataclass
+class IPCReplStartMessage(IPCMessage):
+    @property
+    def message_type(self):
+        return MessageType.REPL_START
+
+    # This message doesn't carry any data
+    def to_json(self) -> dict:
+        return dict()
+
+    @classmethod
+    def from_json(cls, _json: dict) -> IPCReplStartMessage:
+        return IPCReplStartMessage()
+
+    def __iter__(self):
+        return iter(())
+
+
+@dataclass
+class IPCReplRequestMessage(IPCMessage):
+    # We let the repl implementation decide what/how to
+    # represent their messages, so we just pass them a dict
+    data: dict[str, Any]
+
+    @property
+    def message_type(self):
+        return MessageType.REPL_REQUEST
+
+    # This message doesn't carry any data
+    def to_json(self) -> dict:
+        return self.data
+
+    @classmethod
+    def from_json(cls, json: dict) -> IPCReplRequestMessage:
+        return IPCReplRequestMessage(json)
+
+    def __iter__(self):
+        return iter(())
+
+
 class _IPC:
     """A helper class to handle properly packing and unpacking messages"""
 
@@ -200,11 +248,21 @@ class _IPC:
         try:
             obj = json.loads(data.decode(), object_hook=_IPC._json_tuple_object_hook)
             match obj:
+                # This could be made more succinct by mapping the `MessageType`
+                # to the class, and then just calling `map[type].from_json(content)`.
+                # On first pass, the implementation required special handling for
+                # different message types, perhaps this might be useful in the future too.
                 case {"message_type": MessageType.COMMAND, "content": content}:
                     return IPCCommandMessage.from_json(content)
 
                 case {"message_type": MessageType.REPLY, "content": content}:
                     return IPCReplyMessage.from_json(content)
+
+                case {"message_type": MessageType.REPL_START, "content": content}:
+                    return IPCReplStartMessage.from_json(content)
+
+                case {"message_type": MessageType.REPL_REQUEST, "content": content}:
+                    return IPCReplRequestMessage.from_json(content)
 
                 case {"message_type": typ, "content": _}:
                     raise IPCError(f"Unknown message type: '{typ}'")
@@ -330,7 +388,7 @@ class ReconnectingClient:
         then wait for and return the response from the server.
         """
         async with AsyncClient(self.socket_path) as c:
-            return await c.send(IPCCommandMessage(*msg))
+            return await c.command(IPCCommandMessage(*msg))
 
 
 class PersistentClient:
@@ -365,10 +423,17 @@ class PersistentClient:
             self._run(self._client.connect())
 
         message = IPCCommandMessage(*msg)
-        return self._run(self._client.send(message))
+        return self._run(self._client.command(message))
 
-    def __enter__(self):
+    def repl_start(self) -> IPCReplyMessage:
+        return self._run(self._client.repl_start())
+
+    def repl_request(self, data: dict[str, Any]) -> IPCReplyMessage:
+        return self._run(self._client.repl_request(data))
+
+    def __enter__(self) -> PersistentClient:
         self.connect()
+        return self
 
     def __exit__(self, _exc_type, _exc, _tb):
         self.close()
@@ -405,7 +470,7 @@ class AsyncClient:
     def is_connected(self) -> bool:
         return self.stream is not None
 
-    async def send(self, message: IPCCommandMessage) -> IPCReplyMessage:
+    async def send(self, message: IPCMessage) -> IPCReplyMessage:
         """Send the message to the server using the existing connection.
         `connect` must have been called, it is recommended to use async with:
 
@@ -428,6 +493,15 @@ class AsyncClient:
         except asyncio.TimeoutError:
             raise IPCError("Server not responding")
 
+    async def command(self, command: IPCCommandMessage) -> IPCReplyMessage:
+        return await self.send(command)
+
+    async def repl_start(self) -> IPCReplyMessage:
+        return await self.send(IPCReplStartMessage())
+
+    async def repl_request(self, data: dict[str, Any]) -> IPCReplyMessage:
+        return await self.send(IPCReplRequestMessage(data))
+
     async def close(self):
         if self.stream is not None:
             await self.stream.close()
@@ -444,10 +518,15 @@ class AsyncClient:
 
 class Server:
     def __init__(
-        self, socket_path: str, handler: Callable[[IPCCommandMessage], IPCReplyMessage]
+        self, socket_path: str, handler: Callable[[IPCCommandMessage], IPCReplyMessage], qtile
     ) -> None:
         self.socket_path = socket_path
         self.handler = handler
+        # Needed to initiate a QtileREPL. This feels a bit dirty,
+        # especially since we already pass an indirect reference to
+        # the qtile instance in `handler`, because `IPCCommandServer`
+        # holds a reference to `qtile` as well
+        self.qtile = qtile
         self.server = None  # type: asyncio.AbstractServer | None
 
         # Use a flag to indicate if session is locked
@@ -479,7 +558,7 @@ class Server:
         """
         stream = IPCStreamIO(reader, writer)
         logger.debug("Connection made to server")
-
+        repl = None
         try:
             while True:
                 # There is no timeout here to enable long lived connections
@@ -488,22 +567,42 @@ class Server:
                 # Clients are assumed to be trusted, although there is no actual
                 # verification mechanism for this
                 req = await stream.read_message()
+
                 # EOF
                 if req is None:
                     logger.debug("Client disconnected")
                     break
 
-                if not isinstance(req, IPCCommandMessage):
-                    logger.error("Expected command message from client")
-                    break
-
                 # Don't handle requests when session is locked
+                # Note: this check is done by `IPCCommandServer` as well
                 if self.locked.is_set():
                     rep = IPCReplyMessage.error({"error": "Session locked."})
                 else:
-                    # The handler shouldn't throw, but return an
-                    # `IPCReplyMessage` with `IPCStatus.EXCEPTION`
-                    rep = self.handler(req)
+                    match req:
+                        case IPCCommandMessage():
+                            # The handler shouldn't throw, but return an
+                            # `IPCReplyMessage` with `IPCStatus.EXCEPTION`
+                            rep = self.handler(req)
+
+                        case IPCReplStartMessage():
+                            # Intentionally ignore if the repl was
+                            # already started like the original code did
+                            if repl is None:
+                                repl = QtileREPL()
+                                rep = IPCReplyMessage.success(await repl.start(self.qtile))
+
+                        # As mentioned in `MessageType`, it's possible to handle
+                        # the repl being None by just creating one on demand,
+                        # as the repl isn't really "running" at all, and getting
+                        # rid of the `REPL_START` message type
+                        case IPCReplRequestMessage():
+                            if repl is None:
+                                rep = IPCReplyMessage.error({"error": "REPL isn't running"})
+                            else:
+                                rep = IPCReplyMessage.success(await repl.handle(req.data))
+
+                        case _:
+                            raise IPCError(f"Invalid request received: {req.message_type}")
 
                 logger.debug("Sending result")
                 await stream.write_message(rep)

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -1,27 +1,29 @@
 """
-A simple IPC mechanism for communicating between two local processes. We
-use marshal to serialize data - this means that both client and server must
-run the same Python version, and that clients must be trusted (as
-un-marshalling untrusted data can result in arbitrary code execution).
+A simple IPC mechanism for communicating between two local processes. Clients
+must be trusted, as IPC commands such as `eval`, or the repl allow arbitrary
+code execution.
 """
 
 from __future__ import annotations
 
 import asyncio
+import enum
 import fcntl
 import json
-import marshal
 import os.path
 import socket
-import struct
-from typing import Any
+import traceback
+from abc import ABCMeta, abstractmethod
+from collections.abc import Callable, Iterator
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Self
 
 from libqtile import hook
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
 
-HDRFORMAT = "!L"
-HDRLEN = struct.calcsize(HDRFORMAT)
+if TYPE_CHECKING:
+    from libqtile.command.graph import SelectorType
 
 SOCKBASE = "qtilesocket.%s"
 
@@ -69,53 +71,162 @@ def find_sockfile(display: str | None = None):
     raise IPCError("Could not find socket file.")
 
 
+class IPCStatus(enum.IntEnum):
+    SUCCESS = 0
+    ERROR = 1
+    EXCEPTION = 2
+
+
+class MessageType(enum.StrEnum):
+    COMMAND = "command"
+    REPLY = "reply"
+
+
+class IPCMessage(metaclass=ABCMeta):
+    """Abstract base class for all IPC messages"""
+
+    @property
+    @abstractmethod
+    def message_type(self) -> MessageType:
+        """Discrimantor for the message type of the instance"""
+
+    @abstractmethod
+    def to_json(self) -> dict:
+        """Return the message content as a dict suitable for JSON serialization"""
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json: dict) -> Self:
+        """Construct the message from a json dict"""
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[Any]:
+        """Enable unpacking syntax for the message"""
+
+
+@dataclass
+class IPCCommandMessage(IPCMessage):
+    """Represents a command invoked via IPC"""
+
+    selectors: list[SelectorType]
+    name: str
+    args: tuple
+    kwargs: dict
+    lifted: bool
+
+    @property
+    def message_type(self) -> MessageType:
+        return MessageType.COMMAND
+
+    def to_json(self):
+        """A simple mapping with the variable names corresponding to the keys"""
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, json: dict) -> IPCCommandMessage:
+        msg = IPCCommandMessage(**json)
+        # Must always lift a message deserialized from JSON
+        msg.lifted = True
+        return msg
+
+    def __iter__(self):
+        return iter((self.selectors, self.name, self.args, self.kwargs, self.lifted))
+
+
+@dataclass
+class IPCReplyMessage(IPCMessage):
+    """Represents a reply sent by the IPC server"""
+
+    status: IPCStatus
+    data: Any
+
+    @property
+    def message_type(self) -> MessageType:
+        return MessageType.REPLY
+
+    def to_json(self) -> dict:
+        return {
+            # DEV: Arguably, for the JSON_TAGGED format
+            # we could use a string representation here
+            "status": int(self.status),
+            "data": self.data,
+        }
+
+    @classmethod
+    def from_json(cls, json: dict) -> IPCReplyMessage:
+        return IPCReplyMessage(**json)
+
+    def __iter__(self):
+        return iter((self.status, self.data))
+
+    @staticmethod
+    def success(data: Any) -> IPCReplyMessage:
+        """Construct a reply message with status SUCCESS"""
+        return IPCReplyMessage(status=IPCStatus.SUCCESS, data=data)
+
+    @staticmethod
+    def error(error: Any) -> IPCReplyMessage:
+        """Construct a reply message with status ERROR"""
+        return IPCReplyMessage(status=IPCStatus.ERROR, data=error)
+
+    @staticmethod
+    def exception(exception: Exception) -> IPCReplyMessage:
+        """Construct a reply message from an exception
+        with status EXCEPTION. The exception is formatted to
+        provide useful information to the recipient"""
+        # DEV: The original code only returned the last line
+        # of the traceback, whereas this will return a list
+        # containing the whole traceback
+        data = traceback.format_exception(exception)
+        return IPCReplyMessage(status=IPCStatus.EXCEPTION, data=data)
+
+
 class _IPC:
     """A helper class to handle properly packing and unpacking messages"""
 
     @staticmethod
-    def unpack(data: bytes, *, is_json: bool | None = None) -> tuple[Any, bool]:
+    def unpack(data: bytes) -> IPCMessage:
         """Unpack the incoming message
 
         Parameters
         ----------
         data: bytes
             The incoming message to unpack
-        is_json: bool | None
-            If the message should be unpacked as json.  By default, try to
-            unpack json and fallback gracefully to marshalled bytes.
 
         Returns
         -------
-        tuple[Any, bool]
-            A tuple of the unpacked object and a boolean denoting if the
-            message was deserialized using json.  If True, the return message
-            should be packed as json.
+        IPCMessage
+            The unpacked message
         """
-        if is_json is None or is_json:
-            try:
-                return json.loads(data.decode()), True
-            except ValueError as e:
-                if is_json:
-                    raise IPCError("Unable to decode json data") from e
-
         try:
-            assert len(data) >= HDRLEN
-            size = struct.unpack(HDRFORMAT, data[:HDRLEN])[0]
-            assert size >= len(data[HDRLEN:])
-            return marshal.loads(data[HDRLEN : HDRLEN + size]), False
-        except AssertionError as e:
-            raise IPCError("error reading reply! (probably the socket was disconnected)") from e
+            obj = json.loads(data.decode())
+            match obj:
+                case {"message_type": MessageType.COMMAND, "content": content}:
+                    return IPCCommandMessage.from_json(content)
+
+                case {"message_type": MessageType.REPLY, "content": content}:
+                    return IPCReplyMessage.from_json(content)
+
+                case {"message_type": typ, "content": _}:
+                    raise IPCError(f"Unknown message type: '{typ}'")
+
+                case _:
+                    raise IPCError(
+                        "Malformed JSON message. Expected dict with 'message_type' and 'content' keys"
+                    )
+
+        except (ValueError, KeyError) as e:
+            raise IPCError("Unable to decode json data") from e
 
     @staticmethod
-    def pack(msg: Any, *, is_json: bool = False) -> bytes:
+    def pack(msg: IPCMessage) -> bytes:
         """Pack the object into a message to pass"""
-        if is_json:
-            json_obj = json.dumps(msg, default=_IPC._json_encoder)
-            return json_obj.encode()
-
-        msg_bytes = marshal.dumps(msg)
-        size = struct.pack(HDRFORMAT, len(msg_bytes))
-        return size + msg_bytes
+        tagged_dict = {
+            "message_type": msg.message_type,
+            "content": msg.to_json(),
+        }
+        json_obj = json.dumps(tagged_dict, default=_IPC._json_encoder)
+        return json_obj.encode()
 
     @staticmethod
     def _json_encoder(field: Any) -> Any:
@@ -126,7 +237,7 @@ class _IPC:
 
 
 class Client:
-    def __init__(self, socket_path: str, is_json=False) -> None:
+    def __init__(self, socket_path: str) -> None:
         """Create a new IPC client
 
         Parameters
@@ -134,16 +245,13 @@ class Client:
         socket_path: str
             The file path to the file that is used to open the connection to
             the running IPC server.
-        is_json: bool
-            Pack and unpack messages as json
         """
         self.socket_path = socket_path
-        self.is_json = is_json
 
-    def call(self, data: Any) -> Any:
+    def call(self, data: tuple) -> IPCReplyMessage:
         return self.send(data)
 
-    def send(self, msg: Any) -> Any:
+    def send(self, msg: tuple) -> IPCReplyMessage:
         """Send the message and return the response from the server
 
         If any exception is raised by the server, that will propogate out of
@@ -151,7 +259,7 @@ class Client:
         """
         return asyncio.run(self.async_send(msg))
 
-    async def async_send(self, msg: Any) -> Any:
+    async def async_send(self, msg: tuple) -> IPCReplyMessage:
         """Send the message to the server
 
         Connect to the server, then pack and send the message to the server,
@@ -165,7 +273,7 @@ class Client:
             raise IPCError(f"Could not open {self.socket_path}")
 
         try:
-            send_data = _IPC.pack(msg, is_json=self.is_json)
+            send_data = _IPC.pack(IPCCommandMessage(*msg))
             writer.write(send_data)
             writer.write_eof()
 
@@ -177,13 +285,16 @@ class Client:
             writer.close()
             await writer.wait_closed()
 
-        data, _ = _IPC.unpack(read_data, is_json=self.is_json)
-
+        data = _IPC.unpack(read_data)
+        if not isinstance(data, IPCReplyMessage):
+            raise IPCError("Expected a reply message from the server")
         return data
 
 
 class Server:
-    def __init__(self, socket_path: str, handler) -> None:
+    def __init__(
+        self, socket_path: str, handler: Callable[[IPCCommandMessage], IPCReplyMessage]
+    ) -> None:
         self.socket_path = socket_path
         self.handler = handler
         self.server = None  # type: asyncio.AbstractServer | None
@@ -220,17 +331,21 @@ class Server:
             data = await reader.read()
             logger.debug("EOF received by server")
 
-            req, is_json = _IPC.unpack(data)
-        except IPCError:
+            req = _IPC.unpack(data)
+            if not isinstance(req, IPCCommandMessage):
+                logger.error("Expected command message from client")
+                return
+        except IPCError as e:
             logger.warning("Invalid data received, closing connection")
+            logger.debug(e)
         else:
             # Don't handle requests when session is locked
             if self.locked.is_set():
-                rep = (1, {"error": "Session locked."})
+                rep = IPCReplyMessage.error({"error": "Session locked."})
             else:
                 rep = self.handler(req)
 
-            result = _IPC.pack(rep, is_json=is_json)
+            result = _IPC.pack(rep)
 
             logger.debug("Sending result on receive EOF")
             writer.write(result)

--- a/libqtile/scripts/repl.py
+++ b/libqtile/scripts/repl.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import codeop
 import re
-import socket
 import sys
-from time import sleep
 from typing import TYPE_CHECKING
+
+from libqtile.ipc import PersistentClient, find_sockfile
 
 try:
     from prompt_toolkit import PromptSession
@@ -18,34 +18,8 @@ try:
 except (ImportError, ModuleNotFoundError):
     HAS_PT = False
 
-from libqtile.interactive.repl import COMPLETION_REQUEST, REPL_PORT, TERMINATOR
-from libqtile.scripts.cmd_obj import cmd_obj
-
 if TYPE_CHECKING:
     pass
-
-HOST = "localhost"
-
-
-class Command:
-    """Wrapper to call commands via command interface."""
-
-    def __init__(self, command, obj_spec=["root"], *args, **kwargs):
-        self.function = command
-        self.socket = None
-        self.args = args
-        self.kwargs = kwargs
-        self.obj_spec = obj_spec
-        self.info = False
-
-    def __call__(self):
-        return cmd_obj(self)
-
-
-# Calls to start and stop the qtile REPL server
-# Sends commands via qtile cmd-obj
-start_server = Command("start_repl_server")
-stop_server = Command("stop_repl_server")
 
 
 def is_code_complete(text: str) -> bool:
@@ -64,53 +38,17 @@ def is_code_complete(text: str) -> bool:
         return True
 
 
-def read_full_response(sock, end_marker=f"{TERMINATOR}\n"):
-    """Function to read data from socket until termination marker."""
-    buffer = ""
-    while True:
-        data = sock.recv(4096).decode()
-
-        if not data:
-            # connection closed without end marker
-            break
-
-        buffer += data
-        if end_marker in buffer:
-            # Split off the marker and return only the response text
-            response, _, _ = buffer.partition(end_marker)
-            return response
-
-    # connection closed without end marker
-    return buffer
-
-
 def start_repl(_args):
     if not HAS_PT:
         sys.exit("You need to install prompt_toolkit to use the REPL client.")
 
-    # Start the repl server in qtile and find port number
-    start_server()
+    with PersistentClient(find_sockfile()) as client:
+        welcome_message = client.repl_start().data["output"]
 
-    # We need to wait until server is up an running before continuing
-    retry_count = 0
-    while retry_count < 5:
-        try:
-            sock = socket.create_connection((HOST, REPL_PORT))
-            break
-        except ConnectionRefusedError:
-            retry_count += 1
-            sleep(0.5)
-
-    if retry_count == 5:
-        print("Unable to connect to REPL server. Exiting...")
-        stop_server()
-        return
-
-    try:
         # Create the objects needed for the client
         class SocketCompleter(Completer):
-            def __init__(self, sock):
-                self.sock = sock
+            def __init__(self, client):
+                self.client = client
 
             def get_completions(self, document, _complete_event):
                 text_before_cursor = document.text_before_cursor
@@ -124,11 +62,10 @@ def start_repl(_args):
                 start_position = -len(word)
 
                 # Send only the word to the REPL server
-                self.sock.sendall(f"{COMPLETION_REQUEST}{word}\n{TERMINATOR}\n".encode())
+                matches = self.client.repl_request({"completion": word}).data["matches"]
 
-                # Read completions from server and filter out empty strings
-                data = read_full_response(self.sock)
-                options = list(filter(None, data.strip().split(",")))
+                # Filter out empty strings
+                options = list(filter(None, matches))
 
                 # No suggestions so return early
                 if not options:
@@ -139,7 +76,7 @@ def start_repl(_args):
                     yield Completion(opt, start_position=start_position)
 
         kb = KeyBindings()
-        completer = SocketCompleter(sock)
+        completer = SocketCompleter(client)
 
         # Create a session instance
         session = PromptSession(
@@ -159,10 +96,9 @@ def start_repl(_args):
 
             if is_code_complete(text):
                 # Save input line to print after
-                full_block = f"{text}\n{TERMINATOR}\n"
 
                 # Submit to server
-                sock.sendall(full_block.encode())
+                response = client.repl_request({"code": text}).data["output"]
 
                 # Save our code to the history as `buffer.reset()`
                 # would otherwise prevent that from happening
@@ -170,9 +106,6 @@ def start_repl(_args):
 
                 # Clear buffer before reading response
                 buffer.reset()
-
-                # Read and print server response
-                response = read_full_response(sock)
 
                 # Echo input and response manually
                 text = text.replace("\n", "\n... ")
@@ -184,7 +117,7 @@ def start_repl(_args):
 
         with patch_stdout():
             # Read the welcome message from the server.
-            print(read_full_response(sock), end="", flush=True)
+            print(welcome_message, end="", flush=True)
 
             while True:
                 try:
@@ -192,10 +125,6 @@ def start_repl(_args):
                 except KeyboardInterrupt:
                     print("\nExiting.")
                     break
-
-    finally:
-        sock.close()
-        stop_server()
 
 
 def add_subcommand(subparsers, parents):

--- a/libqtile/scripts/shell.py
+++ b/libqtile/scripts/shell.py
@@ -7,7 +7,7 @@ def qshell(args) -> None:
         socket = ipc.find_sockfile()
     else:
         socket = args.socket
-    client = ipc.Client(socket, is_json=args.is_json)
+    client = ipc.Client(socket)
     cmd_object = interface.IPCCommandInterface(client)
     qsh = sh.QSh(cmd_object)
     if args.command is not None:
@@ -35,13 +35,5 @@ def add_subcommand(subparsers, parents):
         type=str,
         default=None,
         help="Run the specified qshell command and exit.",
-    )
-    parser.add_argument(
-        "-j",
-        "--json",
-        action="store_true",
-        default=False,
-        dest="is_json",
-        help="Use JSON to communicate with Qtile.",
     )
     parser.set_defaults(func=qshell)

--- a/test/shell_scripts/test_repl_client.py
+++ b/test/shell_scripts/test_repl_client.py
@@ -1,22 +1,6 @@
 import pytest
 
-from libqtile.scripts.repl import TERMINATOR, is_code_complete, read_full_response
-
-
-class MockSocket:
-    def recv(self, *args, **kwargs):
-        return (f"Qtile test\nREPL client\n{TERMINATOR}\n").encode()
-
-
-def test_read_full_response_basic():
-    # Create a mock socket with recv method
-    sock = MockSocket()
-
-    response = read_full_response(sock)
-    assert "Qtile test" in response
-    assert "REPL client" in response
-    # The terminator should be stripped off
-    assert TERMINATOR not in response
+from libqtile.scripts.repl import is_code_complete
 
 
 @pytest.mark.parametrize(

--- a/test/shell_scripts/test_repl_server.py
+++ b/test/shell_scripts/test_repl_server.py
@@ -1,14 +1,4 @@
-import asyncio
-import contextlib
-
-import pytest
-
-from libqtile.interactive.repl import (
-    REPL_PORT,
-    TERMINATOR,
-    QtileREPLServer,
-    get_completions,
-)
+from libqtile.interactive.repl import get_completions
 
 
 def test_get_completions_top_level():
@@ -36,42 +26,3 @@ def test_get_completions_attribute():
 def test_get_completions_invalid_expr():
     result = get_completions("invalid..expr", {})
     assert result == []
-
-
-@pytest.mark.anyio
-async def test_repl_server_executes_code():
-    repl = QtileREPLServer()
-    locals_dict = {"x": 123}
-
-    # Start the REPL server in a background task
-    start_task = asyncio.create_task(repl.start(locals_dict=locals_dict))
-
-    # Wait for the server to bind the port
-    await asyncio.sleep(0.1)
-
-    reader, writer = await asyncio.open_connection("localhost", REPL_PORT)
-
-    try:
-        # Read welcome message
-        welcome = await reader.read(4096)
-        assert b"Connected to Qtile REPL" in welcome
-
-        # Send a simple expression to evaluate
-        writer.write(b"x\n" + f"{TERMINATOR}\n".encode())
-        await writer.drain()
-
-        # Read REPL result
-        result = await reader.readuntil(f"{TERMINATOR}\n".encode())
-        assert "123" in result.decode()
-
-    finally:
-        writer.close()
-        await writer.wait_closed()
-
-        # Stop the REPL server
-        await repl.stop()
-
-        # Cancel the server task
-        start_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await start_task

--- a/test/test_ipc.py
+++ b/test/test_ipc.py
@@ -1,29 +1,40 @@
 import pytest
 
-from libqtile.ipc import _IPC
+from libqtile.ipc import _IPC, IPCCommandMessage, IPCMessage, IPCReplyMessage, IPCStatus
 
 
-def test_ipc_json_encoder_supports_sets():
-    serialized = _IPC.pack({"foo": set()}, is_json=True)
-    assert serialized == b'{"foo": []}'
+def test_ipc_identity():
+    def pack_unpack_same(msg: IPCMessage):
+        serialized = _IPC.pack(msg)
+        new_msg = _IPC.unpack(serialized)
+        return msg == new_msg
+
+    cmd_message = IPCCommandMessage([], "commands", (), {}, False)
+    assert pack_unpack_same(cmd_message)
+
+    cmd_message = IPCCommandMessage([("window", 1234)], "info", (), {}, False)
+    assert pack_unpack_same(cmd_message)
+
+    reply_message = IPCReplyMessage(
+        IPCStatus.SUCCESS, ["some", "example", "commands", "returned"]
+    )
+    assert pack_unpack_same(reply_message)
+
+    reply_message = IPCReplyMessage(IPCStatus.ERROR, "Error: Couldn't decode message")
+    assert pack_unpack_same(reply_message)
 
 
-def test_ipc_json_throws_error_on_unsupported_field():
+def test_ipc_encoder_supports_sets():
+    message = IPCReplyMessage(IPCStatus.SUCCESS, set())
+    serialized = _IPC.pack(message)
+    assert serialized == b'{"message_type": "reply", "content": {"status": 0, "data": []}}'
+
+
+def test_ipc_throws_error_on_unsupported_field():
     class NonSerializableType: ...
 
     with pytest.raises(
-        ValueError,
-        match=(
-            "Tried to JSON serialize unsupported type <class '"
-            "test.test_ipc.test_ipc_json_throws_error_on_unsupported_field.<locals>.NonSerializableType"
-            "'>.*"
-        ),
+        TypeError,
+        match=("Object of type NonSerializableType is not JSON serializable"),
     ):
-        _IPC.pack({"foo": NonSerializableType()}, is_json=True)
-
-
-def test_ipc_marshall_error_on_unsupported_field():
-    class NonSerializableType: ...
-
-    with pytest.raises(ValueError, match="unmarshallable object"):
-        _IPC.pack({"foo": NonSerializableType()})
+        _IPC.pack(IPCReplyMessage(IPCStatus.SUCCESS, NonSerializableType()))


### PR DESCRIPTION
This for #5820

To get started with, I extracted IPC messages into their own types. I would welcome any feedback as to whether this goes into the right direction. Since `IPCCommandInterface` now returns `IPCReplyMessage` and takes in an `IPCCommandMessage`, some assumptions for users could be broken. However, most tests passed, (except IPC obviously). I got some weird regressions:

```
FAILED test/backend/test_idle_notify.py::test_idle_timer[1-x11-IdleConfig] - AssertionError: assert 'unset' == 'fired'
FAILED test/backend/test_idle_notify.py::test_idle_timer_inhibited[1-x11-IdleConfig] - AssertionError: assert '1' == '2'
FAILED test/widgets/test_mouse_callback.py::test_lazy_callback[1-x11] - libqtile.command.base.CommandException: ['Traceback (most recent call last):\n', '  File "/d/code/qtile_fork/libqtile/command/interface.py", line 425, in call\n    return ipc.IPCReplyMessage.success(cmd(*args, **kwargs))\n                                       ^^^^...
```
I'll have to look into that. The main advantage of my current approach, is it doesn't break backwards compat since old json format still works, there could be some attributes/warning logs to deprecate it though. I didn't actually add a nicer JSON wire format yet, but with this scaffolding that should be more or less trivial (just convert `IPCMessage` into a dict and `dumps`).

Let me know your thoughts!