### PR TITLE
Log coredump back traces in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
             - name: Run Tests
               run: |
                 [ "$(grep -c -P '\t' CHANGELOG)" = "0" ]
+                dump_cores() {
+                  echo "=== Listing coredumps ==="
+                  coredumpctl list || true
+                  echo "=== Stack trace for last coredump ==="
+                  coredumpctl debug --debugger-arguments="-batch -ex 'set pagination off' -ex 'bt full' -ex 'quit'" || true
+                }
+                trap dump_cores ERR
                 make QTILE_CI_PYTHON=${QTILE_CI_PYTHON} QTILE_CI_BACKEND=${{ matrix.backend }} check check-packaging
                 uv run coverage combine -q
                 uv run coverage report -m

--- a/scripts/ubuntu_wayland_setup
+++ b/scripts/ubuntu_wayland_setup
@@ -59,7 +59,9 @@ sudo apt-get install -y --no-install-recommends \
      xfonts-utils \
      xserver-xorg-dev \
      ninja-build \
-     meson
+     meson \
+     systemd-coredump \
+     gdb
 
 # Build wayland
 tarball="wayland-$WAYLAND.tar.xz"


### PR DESCRIPTION
Allows us to get a full back trace for core dumps originating from the wayc backend, which is particularly useful for intermittent issues caused by race conditions

Adds dependencies on systemd-coredump and gdb