### PR TITLE
tests: fix test_restart_hook_and_state

### DIFF
--- a/test/test_restart.py
+++ b/test/test_restart.py
@@ -110,6 +110,8 @@ def test_restart_hook_and_state(manager_nospawn, request, backend, backend_name)
     # Stop the manager
     manager.c.eval("self._do_stop()")
 
+    manager.proc.join(10)
+
     # Manager should have shutdown now so trying to access it will raise an error
     with pytest.raises((IPCError, ConnectionResetError)):
         assert manager.c.status()


### PR DESCRIPTION
CI just failed at:

    # Set up a new manager which takes our state file
    with BareManager(backend, request.config.getoption("--debuglog")) as restarted_manager:
    >       restarted_manager.start(TwoScreenConfig, state=state_file)

with:

    FAILED test/test_restart.py::test_restart_hook_and_state[1-x11] - AssertionError: Error launching qtile, traceback:
    Traceback (most recent call last):
      File "/home/runner/work/qtile/qtile/test/helpers.py", line 194, in run_qtile
        kore = self.backend.create()
      File "/home/runner/work/qtile/qtile/test/helpers.py", line 111, in create
        return self.core(*self.args)
               ~~~~~~~~~^^^^^^^^^^^^
      File "/home/runner/work/qtile/qtile/libqtile/backend/x11/core.py", line 106, in __init__
        raise ExistingWMException(existing_wmname)
    libqtile.backend.x11.core.ExistingWMException: LG3D

This is because we just wait for IPC disconnect, but in async_loop() that's one of the first things that happens. Later, we finalize the x11 core, which removes the _NET_SUPPORTTING_WM_CHECK window and would stop this exception, but by then it's too late and we've started another one.

Fix this by joining with the manager process to make sure all of qtile's finalization is done before starting a separate BareManager.