### PR TITLE
fix: add missing imports to config_pyi_header in confreader

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -20,7 +20,8 @@ class ConfigError(Exception):
 config_pyi_header = """
 from typing import Any
 from typing import Literal
-from libqtile.config import Group, Key, Mouse, Rule, Screen
+from types import FunctionType
+from libqtile.config import Group, IdleInhibitor, Key, Mouse, Rule, Screen
 from libqtile.layout.base import Layout
 
 """


### PR DESCRIPTION
## Summary

- `FunctionType` and `IdleInhibitor` are referenced in `Config.__annotations__` but were absent from the `config_pyi_header` string used to generate the temporary `.pyi` stub during `qtile check`
- This caused mypy to bail out with build errors before stub checking could run

## Test plan

- [ ] Run `qtile check` on a config — no more `Name "FunctionType" is not defined` or `Name "IdleInhibitor" is not defined` errors
- [ ] Stub type checking proceeds normally

Fixes #5853

🤖 Generated with [Claude Code](https://claude.com/claude-code)