### PR TITLE
Expose command to reset idle timers

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -874,6 +874,10 @@ class Core(base.Core):
             self._inhibited = value
             hook.fire("idle_inhibitor_change", value)
 
+    @expose_command
+    def idle_notify_activity(self) -> None:
+        lib.qw_server_idle_notify_activity(self.qw)
+
 
 class Painter:
     """

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -19,6 +19,7 @@ from libqtile.backend.base.idle_inhibit import IdleInhibitorManager, Inhibitor
 from libqtile.backend.x11 import window, xcbq
 from libqtile.backend.x11.idle_notify import IdleNotifier
 from libqtile.backend.x11.xkeysyms import keysyms
+from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
 
@@ -948,3 +949,7 @@ class Core(base.Core):
             self.last_focused.change_layer()
 
         self.last_focused = win
+
+    @expose_command
+    def idle_notify_activity(self) -> None:
+        self._fake_input(xcbq.XCB_MOTION_NOTIFY, 0, 0, 0)


### PR DESCRIPTION
Adds a new `idle_notify_activity` command which has the effect of resetting idle timers. This is useful for people scripting who want to reset timers without user input.

On wayland, we call `qw_server_idle_notify_activity` while, on x11, we send a fake motion event.

Closes #5847