### PR TITLE
nix: update nixpkgs, fix deprecations, and align qtile deps with upstream

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
       });
     in
     {
-      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
 
       checks = forAllSystems (pkgs: pkgs.python3Packages.qtile.passthru.tests);
 

--- a/nix/build-config.nix
+++ b/nix/build-config.nix
@@ -19,7 +19,7 @@ let
     }
     {
       varname = "XCBCURSOR";
-      pkg = pkgs.xorg.xcbutilcursor;
+      pkg = pkgs.libxcb-cursor;
       libname = "libxcb-cursor.so";
     }
   ];

--- a/nix/qtile.nix
+++ b/nix/qtile.nix
@@ -22,15 +22,6 @@ let
     in
     "${symver}+${flakever}.flake";
 
-  removeOldDeps =
-    dep:
-    !(pkgs.lib.hasAttr "pname" dep)
-    || (
-      dep.pname != pkgs.python3Packages.pywlroots.pname
-      && dep.pname != pkgs.python3Packages.pywayland.pname
-      && dep.pname != pkgs.python3Packages.xkbcommon.pname
-    );
-
   qtile-override-func =
     qtile-prev:
     {
@@ -42,16 +33,6 @@ let
     }
     // {
       env = build-config.resolved-env-vars;
-
-      propagatedBuildInputs =
-        (with pkgs; [
-          wayland-scanner
-          wayland-protocols
-          python3Packages.cffi
-          python3Packages.xcffib
-          python3Packages.aiohttp
-        ])
-        ++ (lib.filter removeOldDeps qtile-prev.propagatedBuildInputs);
 
       pypaBuildFlags = [ "--config-setting=backend=wayland" ] ++ build-config.resolved-config-settings;
     }


### PR DESCRIPTION
- Update nixpkgs input
- Replace deprecated `nixfmt-rfc-style` with `pkgs.nixfmt`
- Replace deprecated `xorg.xcbutilcursor` with `libxcb-cursor`
- Add missing runtime dependency `python3Packages.cairocffi` (fixes: `ERROR Missing dependencies: cairocffi[xcb]>=1.6.0`)

Qtile packaging:
- Drop manual filtering of pywlroots, pywayland, and xkbcommon (pywlroots removed from nixpkgs; deps no longer propagated upstream)
- Simplify propagatedBuildInputs to match current qtile derivation

Also clean up minor formatting in nix expressions.