### PR TITLE
docs: update Qtile flake guide URL and description

### DIFF
--- a/docs/manual/install/nixos.rst
+++ b/docs/manual/install/nixos.rst
@@ -139,7 +139,7 @@ Gives you a script to run that runs Qemu to test your config. For this to work y
 
 .. seealso::
 
-   For a more granular breakdown of using Qtile with flakes—especially for those new to the Nix ecosystem—refer to `Gurjaka's Qtile Flake Guide <https://gurjaka.codeberg.page/Dotfiles/wiki/qtile-flake.html>`_.
+   For a detailed walkthrough on setting up Qtile with flakes—from basic installation to package overrides, see `Gurjaka's Qtile Flake Guide <https://gurjaka.codeberg.page/blog.html?post=qtile-flake>`_.
 
 To hack on Qtile with Nix, simply run `nix develop` in a checkout of the repo.
 In the development shell, there are a few useful things:


### PR DESCRIPTION
Migrated my flake guide to a new personal blog for better maintenance and clarity. Updated the description to better reflect the guide's coverage of package overrides and extensions.