### PR TITLE
Add missing widget dependencies to qtile check

### DIFF
--- a/libqtile/scripts/check.py
+++ b/libqtile/scripts/check.py
@@ -7,6 +7,7 @@ from os import environ, path
 
 from libqtile import confreader
 from libqtile.utils import get_config_file
+from libqtile.widget.import_error import ImportErrorWidget
 
 
 class CheckError(Exception):
@@ -104,6 +105,25 @@ def check_config(args):
     except Exception:
         print(traceback.format_exc())
         sys.exit("Errors found in config. Exiting check.")
+
+    print("Checking widget dependencies...")
+    widgets = []
+    for screen in config.screens:
+        for bar_name in ("top", "bottom", "left", "right"):
+            bar = getattr(screen, bar_name, None)
+            if bar and hasattr(bar, "widgets"):
+                widgets.extend(bar.widgets)
+
+    errors = {
+        w.widget_class: w.missing_dependencies
+        for w in widgets
+        if isinstance(w, ImportErrorWidget)
+    }
+
+    if errors:
+        print("The following widgets have import errors:")
+    for widget, deps in errors.items():
+        print(f" {widget}: {', '.join(deps)}")
 
     try:
         check_deps()

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -4,7 +4,6 @@ import asyncio
 import glob
 import importlib
 import os
-import traceback
 from collections import defaultdict
 from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError, distribution
@@ -226,10 +225,13 @@ def import_class(
         module = importlib.import_module(module_path, __package__)
         return getattr(module, class_name)
     except ImportError:
-        logger.exception("Unmet dependencies for '%s.%s':", module_path, class_name)
         if fallback:
-            logger.debug("%s", traceback.format_exc())
+            logger.error(
+                "Unmet dependencies for '%s.%s'. Using fallback.", module_path, class_name
+            )
             return fallback(module_path, class_name)
+
+        logger.exception("Unmet dependencies for '%s.%s':", module_path, class_name)
         raise
 
 

--- a/libqtile/widget/import_error.py
+++ b/libqtile/widget/import_error.py
@@ -1,14 +1,81 @@
+import ast
+import importlib
+import importlib.util
+
+from libqtile.log_utils import logger
 from libqtile.widget.base import _TextBox
 
 
+def missing_imports_from_file(file_path):
+    missing = set()
+
+    with open(file_path) as f:
+        source = f.read()
+
+    tree = ast.parse(source, filename=file_path)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for name in node.names:
+                module = name.name
+                root = module.split(".")[0]
+
+                try:
+                    importlib.import_module(root)
+                except ImportError:
+                    missing.add(root)
+
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module
+            if not module:
+                continue
+
+            root = module.split(".")[0]
+
+            try:
+                importlib.import_module(root)
+            except ImportError:
+                missing.add(root)
+
+    return missing
+
+
+def find_missing_widget_dependencies(module_path):
+    spec = importlib.util.find_spec(module_path)
+    if not spec or not spec.origin:
+        return []
+
+    missing = missing_imports_from_file(spec.origin)
+
+    return sorted(missing)
+
+
 class ImportErrorWidget(_TextBox):
-    def __init__(self, class_name, *args, **config):
+    registry: dict[str, list[str]] = {}
+
+    def __init__(self, module_path, class_name, *args, **config):
         _TextBox.__init__(self, **config)
         self.text = f"Import Error: {class_name}"
+        self.module_path = module_path
+        self.widget_class = class_name
+        self.missing_dependencies = find_missing_widget_dependencies(module_path)
+
+        spec = f"{module_path}.{class_name}"
+        if spec not in ImportErrorWidget.registry:
+            logger.error(
+                "%s has missing dependencies: %s.",
+                class_name,
+                ", ".join(self.missing_dependencies),
+            )
+
+    def info(self):
+        inf = super().info()
+        inf["missing_dependencies"] = self.missing_dependencies
+        return inf
 
 
 def make_error(module_path, class_name):
     def import_error_wrapper(*args, **kwargs):
-        return ImportErrorWidget(class_name, *args, **kwargs)
+        return ImportErrorWidget(module_path, class_name, *args, **kwargs)
 
     return import_error_wrapper

--- a/test/widgets/test_import_error.py
+++ b/test/widgets/test_import_error.py
@@ -27,3 +27,5 @@ def test_importerrorwidget(monkeypatch, manager_nospawn, minimal_conf_noscreen, 
     # Check that the widget has been replaced with an ImportError
     assert w["name"] == "importerrorwidget"
     assert w["text"] == "Import Error: TextBox"
+    assert len(w["missing_dependencies"]) > 1
+    assert "libqtile" in w["missing_dependencies"]


### PR DESCRIPTION
When widgets are missing a dependency, the widget is replaced with an `ImportError` mesage in the bar. However, the actual missing dependency is only shown in the log file. In addition, if there are multiple missing dependencies, the log file will only show the first.

This PR adds an additional check to `qtile check`. It reads the config and, where there is an ImportError widget in the bar, it parses the relevant widget's module and checks all import statements, displaying a list of all modules that it cannot import.

As an example, if I edit groupbox.py:
```python
import itertools
from functools import partial
from typing import Any

from libqtile import hook
from libqtile.widget import base


import made_up_module
import this_doesnt_exist
import nope


class _GroupBase(base._TextBox, base.PaddingMixin, base.MarginMixin):
...
```

Running `qtile check` will output:
```
Checking Qtile config at: config/missing_deps.py
Checking if config is valid python...
Checking widget dependencies...
The following widgets have import errors:
 GroupBox: made_up_module, nope, this_doesnt_exist
Type checking config file...
```