### PR TITLE
wayland: Fix floating kept above behaviour

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -423,10 +423,10 @@ class Core(base.Core):
     def handle_cursor_button(self, button: int, mask: int, pressed: bool, x: int, y: int) -> bool:
         assert self.qtile is not None
         if pressed:
-            if not self.qw_cursor.implicit_grab.live:
-                self._focus_by_click()
-
             handled = self.qtile.process_button_click(int(button), int(mask), x, y)
+
+            if not handled and not self.qw_cursor.implicit_grab.live:
+                self._focus_by_click()
 
             if isinstance(self.qtile.hovered_window, Internal):
                 self.qtile.hovered_window.process_button_click(
@@ -501,14 +501,28 @@ class Core(base.Core):
         # TODO logic imcomplete
         win._ptr.focus(win._ptr, False)  # What is the second argument?
 
+    def _grab_click_on_current_window(self) -> None:
+        """Grab button events on the current window.
+
+        Called before switching screens to ensure clicks on the now-unfocused
+        window will be intercepted to refocus it.
+        """
+        win = self.qtile.current_window
+        if win:
+            # In wayland backend, current_window is always an wayland Window
+            assert isinstance(win, Window)
+            win._grab_click()
+
     def _focus_by_click(self) -> ffi.CData:
         assert self.qtile is not None
         view = self.qw_cursor.view
 
         if view != ffi.NULL:
             win = self.qtile.windows_map.get(view.wid)
+            if win is None:
+                return
 
-            if win is not None and self.qtile.config.bring_front_click is True:
+            if self.qtile.config.bring_front_click is True:
                 win.bring_to_front()
             elif self.qtile.config.bring_front_click == "floating_only":
                 if isinstance(win, base.Window) and win.floating:
@@ -518,16 +532,17 @@ class Core(base.Core):
                 if win.screen is not self.qtile.current_screen:
                     self.qtile.focus_screen(win.screen.index, warp=False)
                 win.focus(False)
-            elif isinstance(win, base.Window):
+            elif isinstance(win, Window):
                 if win.group and win.group.screen is not self.qtile.current_screen:
                     self.qtile.focus_screen(win.group.screen.index, warp=False)
                 self.qtile.current_group.focus(win, False)
-
+                win._ungrab_click()
         else:
             screen = self.qtile.find_screen(
                 int(self.qw_cursor.cursor.x), int(self.qw_cursor.cursor.y)
             )
             if screen:
+                self._grab_click_on_current_window()
                 self.qtile.focus_screen(screen.index, warp=False)
 
         return view

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -522,6 +522,8 @@ class Core(base.Core):
             if win is None:
                 return
 
+            hook.fire("client_focus_by_click", win)
+
             if self.qtile.config.bring_front_click is True:
                 win.bring_to_front()
             elif self.qtile.config.bring_front_click == "floating_only":
@@ -907,6 +909,9 @@ class Core(base.Core):
     @expose_command
     def idle_notify_activity(self) -> None:
         lib.qw_server_idle_notify_activity(self.qw)
+
+    def fake_click(self) -> None:
+        lib.qw_cursor_fake_click(self.qw_cursor)
 
 
 class Painter:

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -226,17 +226,22 @@ static void qw_cursor_create_implicit_grab(struct qw_cursor *cursor, uint32_t ti
 }
 
 static bool qw_cursor_process_button(struct qw_cursor *cursor, int button, bool pressed) {
+    if (cursor->server->lock_state != QW_SESSION_LOCK_UNLOCKED) {
+        return false;
+    }
+
     // Get current keyboard modifiers (shift, ctrl, etc)
     struct wlr_keyboard *kb = wlr_seat_get_keyboard(cursor->server->seat);
     uint32_t modifiers = kb ? wlr_keyboard_get_modifiers(kb) : 0;
 
-    // Call server's button callback with button info and modifiers
-    if (cursor->server->lock_state == QW_SESSION_LOCK_UNLOCKED) {
-        return cursor->server->cursor_button_cb(button, modifiers, pressed, (int)cursor->cursor->x,
-                                                (int)cursor->cursor->y,
-                                                cursor->server->cb_data) != 0;
+    // TODO: Callback should only fire for bound modifier + button combos
+    if (cursor->view != NULL && !cursor->view->grabbed_click && modifiers == 0) {
+        return false;
     }
-    return false;
+
+    // Call server's button callback with button info and modifiers
+    return cursor->server->cursor_button_cb(button, modifiers, pressed, (int)cursor->cursor->x,
+                                            (int)cursor->cursor->y, cursor->server->cb_data) != 0;
 }
 
 static void qw_cursor_handle_button(struct wl_listener *listener, void *data) {

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -651,3 +651,18 @@ void qw_cursor_configure_xcursor(struct qw_cursor *cursor) {
         wlr_cursor_warp(cursor->cursor, NULL, cursor->cursor->x, cursor->cursor->y);
     }
 }
+
+void qw_cursor_fake_click(struct qw_cursor *cursor) {
+    struct wlr_pointer_button_event event = {
+        .button = 0x110, // BTN_LEFT (0x110 from linux/input-event-codes.h)
+        .state = WL_POINTER_BUTTON_STATE_PRESSED,
+        .time_msec = 0,
+    };
+
+    // Simulate press
+    qw_cursor_handle_button(&cursor->button, &event);
+
+    // Simulate release
+    event.state = WL_POINTER_BUTTON_STATE_RELEASED;
+    qw_cursor_handle_button(&cursor->button, &event);
+}

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -71,4 +71,6 @@ void qw_cursor_configure_xcursor(struct qw_cursor *cursor);
 void qw_cursor_constrain_cursor(struct qw_cursor *cursor,
                                 struct wlr_pointer_constraint_v1 *constraint);
 
+void qw_cursor_fake_click(struct qw_cursor *cursor);
+
 #endif /* CURSOR_H */

--- a/libqtile/backend/wayland/qw/internal-view.c
+++ b/libqtile/backend/wayland/qw/internal-view.c
@@ -77,7 +77,7 @@ static void qw_internal_view_place(void *self, int x, int y, int width, int heig
 
     struct qw_internal_view *view = (struct qw_internal_view *)self;
     if (above != 0) {
-        qw_view_reparent(&view->base, LAYER_BRINGTOFRONT);
+        qw_view_raise_to_top(&view->base);
     }
     view->base.x = x;
     view->base.y = y;
@@ -149,7 +149,6 @@ struct qw_internal_view *qw_server_internal_view_new(struct qw_server *server, i
     // Initialize the base qw_view with provided geometry and callbacks
     struct qw_view base = {
         .server = server,
-        .layer = LAYER_LAYOUT,
         .x = x,
         .y = y,
         .width = width,

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -1154,3 +1154,26 @@ bool qw_server_inhibitor_surface_visible(struct qw_idle_inhibitor *inhibitor,
 
     return false;
 }
+
+struct qw_view *qw_server_active_view(struct qw_server *server) {
+    struct wlr_surface *focused = server->seat->keyboard_state.focused_surface;
+    if (focused == NULL) {
+        return NULL;
+    }
+
+    struct wlr_xdg_toplevel *xdg_toplevel = wlr_xdg_toplevel_try_from_wlr_surface(focused);
+    if (xdg_toplevel != NULL) {
+
+        return xdg_toplevel->base->data;
+    }
+
+#if WLR_HAS_XWAYLAND
+    struct wlr_xwayland_surface *xwayland_surface =
+        wlr_xwayland_surface_try_from_wlr_surface(focused);
+    if (xwayland_surface != NULL) {
+        return xwayland_surface->data;
+    }
+#endif
+
+    return NULL;
+}

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -368,4 +368,6 @@ bool qw_server_inhibitor_surface_visible(struct qw_idle_inhibitor *inhibitor,
 void qw_server_add_idle_timer(struct qw_server *server, int seconds);
 void qw_server_remove_idle_timer(struct qw_server *server, int seconds);
 
+struct qw_view *qw_server_active_view(struct qw_server *server);
+
 #endif /* SERVER_H */

--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -1,4 +1,5 @@
 #include "util.h"
+#include "server.h"
 #include "xdg-view.h"
 #include <string.h>
 #include <wlr/config.h>
@@ -89,6 +90,7 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
         if (xdg_view->base.ftl_handle != NULL) {
             wlr_foreign_toplevel_handle_v1_set_activated(xdg_view->base.ftl_handle, false);
         }
+
         return;
     }
 
@@ -103,6 +105,7 @@ void qw_util_deactivate_surface(struct wlr_surface *surface) {
         if (xwayland_view->base.ftl_handle != NULL) {
             wlr_foreign_toplevel_handle_v1_set_activated(xwayland_view->base.ftl_handle, false);
         }
+
         return;
     }
 #endif

--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -433,3 +433,7 @@ struct qw_output *qw_view_get_primary_output(struct qw_view *view) {
 
     return primary_output->data;
 }
+
+void qw_view_grab_click(struct qw_view *view) { view->grabbed_click = true; }
+
+void qw_view_ungrab_click(struct qw_view *view) { view->grabbed_click = false; }

--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -75,9 +75,20 @@ static struct wlr_surface *qw_view_get_surface_from_tree(struct wlr_scene_node *
     }
 }
 
+int qw_view_get_layer(struct qw_view *view) {
+    struct wlr_scene_node *layer_node = &view->content_tree->node.parent->node;
+
+    for (int i = 0; i < LAYER_END; i++) {
+        if (&view->server->scene_windows_layers[i]->node == layer_node) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
 void qw_view_reparent(struct qw_view *view, int layer) {
     wlr_scene_node_reparent(&view->content_tree->node, view->server->scene_windows_layers[layer]);
-    view->layer = layer;
 }
 
 void qw_view_raise_to_top(struct qw_view *view) {
@@ -102,7 +113,8 @@ void qw_view_move_up(struct qw_view *view) {
         return;
     }
 
-    wl_list_for_each(child, &view->server->scene_windows_layers[view->layer]->children, link) {
+    int layer = qw_view_get_layer(view);
+    wl_list_for_each(child, &view->server->scene_windows_layers[layer]->children, link) {
         if (child == &view->content_tree->node) {
             found_child = true;
         } else if (found_child) {
@@ -139,7 +151,8 @@ void qw_view_move_down(struct qw_view *view) {
         return;
     }
 
-    wl_list_for_each(child, &view->server->scene_windows_layers[view->layer]->children, link) {
+    int layer = qw_view_get_layer(view);
+    wl_list_for_each(child, &view->server->scene_windows_layers[layer]->children, link) {
         struct wlr_surface *other_surface = qw_view_get_surface_from_tree(child);
         if (other_surface == NULL) {
             continue;

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -70,7 +70,6 @@ struct qw_border {
 
 struct qw_view {
     struct qw_server *server;
-    int layer;
     int x;
     int y;
     int width;
@@ -154,5 +153,7 @@ void qw_view_ftl_manager_handle_destroy(struct qw_view *view);
 void qw_view_resize_ftl_output_tracking_buffer(struct qw_view *view, int width, int height);
 
 struct qw_output *qw_view_get_primary_output(struct qw_view *view);
+
+int qw_view_get_layer(struct qw_view *view);
 
 #endif /* VIEW_H */

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -87,6 +87,7 @@ struct qw_view {
     bool skip_taskbar;
     struct wlr_scene_tree *content_tree; // Scene tree holding the view's content
     struct wlr_foreign_toplevel_handle_v1 *ftl_handle;
+    bool grabbed_click;
 
     request_focus_cb_t request_focus_cb;
     request_close_cb_t request_close_cb;
@@ -155,5 +156,8 @@ void qw_view_resize_ftl_output_tracking_buffer(struct qw_view *view, int width, 
 struct qw_output *qw_view_get_primary_output(struct qw_view *view);
 
 int qw_view_get_layer(struct qw_view *view);
+
+void qw_view_grab_click(struct qw_view *view);
+void qw_view_ungrab_click(struct qw_view *view);
 
 #endif /* VIEW_H */

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -237,9 +237,9 @@ static void qw_xdg_view_place(void *self, int x, int y, int width, int height,
     // Paint borders around the view with given border colors and width
     qw_view_paint_borders((struct qw_view *)xdg_view, borders, border_count);
 
-    // Raise view to front if requested
+    // Raise view if requested
     if (above != 0) {
-        qw_view_reparent(&xdg_view->base, LAYER_BRINGTOFRONT);
+        qw_view_raise_to_top(&xdg_view->base);
     }
 
     // View under the cursor may have changed
@@ -660,7 +660,6 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
     // Create a scene tree node for this view inside the main layout tree
     xdg_view->base.content_tree = wlr_scene_tree_create(server->scene_windows_layers[LAYER_LAYOUT]);
     xdg_view->base.content_tree->node.data = xdg_view;
-    xdg_view->base.layer = LAYER_LAYOUT;
 
     // If the protocol version supports WM capabilities, set maximize/fullscreen/minimize
     if (wl_resource_get_version(xdg_view->xdg_toplevel->resource) >=

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -269,12 +269,6 @@ static struct wlr_scene_node *qw_xwayland_view_get_tree_node(void *self) {
     return &xwayland_view->scene_tree->node;
 }
 
-// Bring the xwayland_view's content scene node to the front
-static void qw_xwayland_view_bring_to_front(void *self) {
-    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
-    wlr_scene_node_raise_to_top(&xwayland_view->base.content_tree->node);
-}
-
 // Clip the xwayland_view's scene tree if needed
 static void qw_xwayland_view_clip(struct qw_xwayland_view *xwayland_view) {
     // Only clip if scene_tree exists, node is disabled, and node is linked
@@ -349,9 +343,9 @@ static void qw_xwayland_view_place(void *self, int x, int y, int width, int heig
     // Paint borders around the view with given border colors and width
     qw_view_paint_borders((struct qw_view *)xwayland_view, borders, border_count);
 
-    // Raise view to front if requested
+    // Raise view if requested
     if (above != 0) {
-        qw_xwayland_view_bring_to_front(self);
+        qw_view_raise_to_top(&xwayland_view->base);
     }
 
     // View under the cursor may have changed
@@ -913,7 +907,6 @@ void qw_server_xwayland_view_new(struct qw_server *server,
     xwayland_view->base.content_tree =
         wlr_scene_tree_create(server->scene_windows_layers[LAYER_LAYOUT]);
     xwayland_view->base.content_tree->node.data = xwayland_view;
-    xwayland_view->base.layer = LAYER_LAYOUT;
     xwayland_view->initial_commit = true;
 
     wl_signal_add(&xwayland_surface->events.destroy, &xwayland_view->destroy);

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -46,17 +46,17 @@ class Base(base._Window):
         self.core: Core = typing.cast("Core", qtile.core)
 
     def reparent(self, layer: int) -> None:
-        if self.layer == layer:
+        if self.layer() == layer:
             return
         lib.qw_view_reparent(self._ptr, layer)
 
-    @property
+    @expose_command()
     def layer(self) -> int:
-        return self._ptr.layer
+        return lib.qw_view_get_layer(self._ptr)
 
     @expose_command()
     def keep_above(self, enable: bool | None = None) -> None:
-        is_enabled = self.layer == lib.LAYER_KEEPABOVE
+        is_enabled = self.layer() == lib.LAYER_KEEPABOVE
         if enable is None:
             enable = not is_enabled
 
@@ -67,7 +67,7 @@ class Base(base._Window):
 
     @expose_command()
     def keep_below(self, enable: bool | None = None) -> None:
-        is_enabled = self.layer == lib.LAYER_KEEPBELOW
+        is_enabled = self.layer() == lib.LAYER_KEEPBELOW
         if enable is None:
             enable = not is_enabled
         if enable:
@@ -604,14 +604,14 @@ class Window(Base, base.Window):
 
     @expose_command()
     def move_up(self, force: bool = False) -> None:
-        if force and self.layer == lib.LAYER_KEEPBELOW:
+        if force and self.layer() == lib.LAYER_KEEPBELOW:
             new_layer = self.get_new_layer(self._float_state)
             self.reparent(new_layer)
         lib.qw_view_move_up(self._ptr)
 
     @expose_command()
     def move_down(self, force: bool = False) -> None:
-        if force and self.layer == lib.LAYER_KEEPAOVE:
+        if force and self.layer() == lib.LAYER_KEEPABOVE:
             new_layer = self.get_new_layer(self._float_state)
             self.reparent(new_layer)
         lib.qw_view_move_down(self._ptr)
@@ -665,7 +665,7 @@ class Window(Base, base.Window):
             else:
                 # if we are setting floating early, e.g. from a hook, we don't have a screen yet
                 self._float_state = FloatStates.FLOATING
-            if self.layer != lib.LAYER_KEEPABOVE and self.qtile.config.floats_kept_above:
+            if self.layer() != lib.LAYER_KEEPABOVE and self.qtile.config.floats_kept_above:
                 self.keep_above(enable=True)
         elif (not do_float) and self._float_state != FloatStates.NOT_FLOATING:
             self.reparent(lib.LAYER_LAYOUT)

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -45,6 +45,12 @@ class Base(base._Window):
         self.group: _Group | None = None
         self.core: Core = typing.cast("Core", qtile.core)
 
+    def _grab_click(self) -> None:
+        lib.qw_view_grab_click(self._ptr)
+
+    def _ungrab_click(self) -> None:
+        lib.qw_view_ungrab_click(self._ptr)
+
     def reparent(self, layer: int) -> None:
         if self.layer() == layer:
             return
@@ -236,6 +242,14 @@ class Base(base._Window):
 
     @expose_command()
     def focus(self, warp: bool = True) -> None:
+        # re-grab button events on the previously focused window,
+        # but only un-grab them on focus by click
+        old = lib.qw_server_active_view(self.core.qw)
+        if old != ffi.NULL and old.wid != ffi.NULL and old.wid in self.qtile.windows_map:
+            old_win = self.qtile.windows_map[old.wid]
+            if isinstance(old_win, Window):
+                old_win._grab_click()
+
         self.core.focus_window(self)
 
         if warp and self.qtile.config.cursor_warp:
@@ -260,6 +274,7 @@ class Internal(Base, base.Internal):
         ptr.base.wid = wid
         self._internal_ptr = ptr
         self._killed = False
+        self._grab_click()
 
     @property
     def surface(self) -> ffi.CData:
@@ -375,6 +390,7 @@ class Window(Base, base.Window):
         ptr.request_fullscreen_cb = lib.request_fullscreen_cb
         ptr.set_title_cb = lib.set_title_cb
         ptr.set_app_id_cb = lib.set_app_id_cb
+        self._grab_click()
 
     def handle_request_focus(self) -> bool:
         logger.debug("Focusing window from external request")
@@ -662,6 +678,9 @@ class Window(Base, base.Window):
                     self._float_width,
                     self._float_height,
                 )
+
+                # Make sure floating window is placed above other LAYOUT windows
+                self.move_to_top()
             else:
                 # if we are setting floating early, e.g. from a hook, we don't have a screen yet
                 self._float_state = FloatStates.FLOATING
@@ -790,7 +809,7 @@ class Window(Base, base.Window):
             self.hide()
         else:
             self.place(
-                x, y, w, h, self.borderwidth, self.bordercolor, above=True, respect_hints=True
+                x, y, w, h, self.borderwidth, self.bordercolor, above=False, respect_hints=True
             )
 
     def _tweak_float(

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -914,6 +914,7 @@ class Core(base.Core):
                 if window.group.screen is not qtile.current_screen:
                     qtile.focus_screen(window.group.screen.index, warp=False)
                 qtile.current_group.focus(window, warp=False)
+                window._ungrab_click()
             except AttributeError:
                 # probably clicked an internal window
                 screen = qtile.find_screen(e.root_x, e.root_y)

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -902,6 +902,8 @@ class Core(base.Core):
         assert qtile is not None
 
         if window:
+            hook.fire("client_focus_by_click", window)
+
             if qtile.config.bring_front_click and (
                 qtile.config.bring_front_click != "floating_only"
                 or getattr(window, "floating", False)

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1317,7 +1317,8 @@ class _Window:
 
         self.window.set_property("_NET_WM_STATE", state)
 
-        # re-grab button events on the previously focussed window
+        # re-grab button events on the previously focussed window,
+        # but only un-grab them on focus by click
         old = self.qtile.core._root.get_property("_NET_ACTIVE_WINDOW", "WINDOW", unpack=int)
         if old and old[0] in self.qtile.windows_map:
             old_win = self.qtile.windows_map[old[0]]
@@ -1328,7 +1329,6 @@ class _Window:
                     state.remove(state_focused)
                     old_win.window.set_property("_NET_WM_STATE", state)
         self.qtile.core._root.set_property("_NET_ACTIVE_WINDOW", self.window.wid)
-        self._ungrab_click()
 
         # Check if we need to restack a previously focused fullscreen window
         self.qtile.core.check_stacking(self)

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -658,6 +658,28 @@ hooks: list[Hook] = [
         """,
     ),
     Hook(
+        "client_focus_by_click",
+        """
+        Called when a mouse button is clicked on an inactive client
+
+        **Arguments**
+
+            * ``Window`` of window clicked
+
+        Example:
+
+        .. code:: python
+
+            from libqtile import hook
+            from libqtile.utils import send_notification
+
+            @hook.subscribe.client_focus_by_click
+            def client_focus_by_click(client):
+                send_notification("qtile", f"Mouse was clicked on {client.name}")
+
+        """,
+    ),
+    Hook(
         "client_name_updated",
         """
         Called when the client name changes

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -72,9 +72,8 @@ class WaylandBackend(Backend):
 
     def fake_click(self, x, y):
         """Click at the specified coordinates"""
-        # Currently only restacks windows, and does not trigger bindings
         self.fake_motion(x, y)
-        self.manager.c.eval("self.core._focus_by_click()")
+        self.manager.c.eval("self.core.fake_click()")
 
     def get_all_windows(self):
         """Get a list of all windows in ascending order of Z position"""

--- a/test/backend/wayland/test_window.py
+++ b/test/backend/wayland/test_window.py
@@ -1,7 +1,11 @@
 import pytest
 
+import libqtile.layout
+from libqtile.backend.wayland._ffi import lib
 from test.backend.wayland.conftest import new_layer_client, new_xdg_client
 from test.conftest import BareConfig
+from test.helpers import window_by_name
+from test.layouts.test_common import AllLayoutsConfig
 
 try:
     # Check to see if we should skip layer shell tests
@@ -15,11 +19,23 @@ try:
 except (ImportError, ValueError):
     has_layer_shell = False
 
-pytestmark = pytest.mark.skipif(not has_layer_shell, reason="GtkLayerShell not available")
+
+class LayersConfig(BareConfig):
+    layouts = [
+        libqtile.layout.stack.Stack(num_stacks=2),
+        libqtile.layout.max.Max(),
+    ]
+    floats_kept_above = False
+
 
 bare_config = pytest.mark.parametrize("wmanager", [BareConfig], indirect=True)
+layers_config = pytest.mark.parametrize("wmanager", [LayersConfig], indirect=True)
+each_layout_config = pytest.mark.parametrize(
+    "wmanager", AllLayoutsConfig.generate(), indirect=True
+)
 
 
+@pytest.mark.skipif(not has_layer_shell, reason="GtkLayerShell not available")
 @bare_config
 def test_info(wmanager):
     """
@@ -40,3 +56,46 @@ def test_info(wmanager):
     wid = wmanager.c.windows()[0]["id"]
     assert wmanager.c.window[wid].info()["shell"] == "layer"
     wmanager.kill_window(pid)
+
+
+class FloatsKeptAboveConfig(LayersConfig):
+    floats_kept_above = True
+
+
+@pytest.fixture
+def floats_kept_above(request):
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "wmanager, floats_kept_above",
+    [(LayersConfig, False), (FloatsKeptAboveConfig, True)],
+    indirect=True,
+)
+def test_layer_floats_kept_above(wmanager, floats_kept_above):
+    """Use keep above layer to keep floating windows above tiled"""
+
+    wmanager.test_window("one", floating=True)
+    if floats_kept_above:
+        assert window_by_name(wmanager.c, "one").layer() == lib.LAYER_KEEPABOVE
+    else:
+        assert window_by_name(wmanager.c, "one").layer() == lib.LAYER_LAYOUT
+
+    window_by_name(wmanager.c, "one").toggle_floating()
+    assert window_by_name(wmanager.c, "one").layer() == lib.LAYER_LAYOUT
+
+
+@layers_config
+def test_layer_bring_to_front(wmanager):
+    """Move windows to bring to front layer"""
+    # TODO: This test should be extended to also test mechanisms for returning
+    # windows from bring to front layer
+
+    wmanager.test_window("one")
+    assert window_by_name(wmanager.c, "one").layer() == lib.LAYER_LAYOUT
+
+    wmanager.c.window.bring_to_front()
+    assert window_by_name(wmanager.c, "one").layer() == lib.LAYER_BRINGTOFRONT
+
+
+# TODO: Add test for bring_front_click

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -483,9 +483,11 @@ def test_group_window_remove(manager_nospawn):
 class CallWindow:
     def __init__(self):
         self.window = ""
+        self.count = 0
 
     def __call__(self, window):
         self.window = window.name
+        self.count += 1
 
 
 @Retry(ignore_exceptions=(AssertionError))
@@ -557,6 +559,25 @@ def test_client_mouse_enter(manager_nospawn):
     manager_nospawn.test_window("Test Client")
     manager_nospawn.backend.fake_click(0, 0)
     assert_window(manager_nospawn, "Test Client")
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_client_focus_by_click(manager_nospawn):
+    class ClientMouseClickConfig(BareConfig):
+        test = CallWindow()
+        hook.subscribe.client_focus_by_click(test)
+
+    manager_nospawn.start(ClientMouseClickConfig)
+    manager_nospawn.test_window("Test Client")
+
+    manager_nospawn.backend.fake_click(0, 0)
+    assert manager_nospawn.c.eval("self.config.test.window") == "Test Client"
+    assert manager_nospawn.c.eval("self.config.test.count") == "1"
+
+    # Clicking on the window again will not fire the hook
+    manager_nospawn.backend.fake_click(0, 0)
+    assert manager_nospawn.c.eval("self.config.test.window") == "Test Client"
+    assert manager_nospawn.c.eval("self.config.test.count") == "1"
 
 
 @pytest.mark.usefixtures("hook_fixture")

--- a/test/test_window.py
+++ b/test/test_window.py
@@ -164,6 +164,9 @@ def bring_front_click(request):
     indirect=True,
 )
 def test_bring_front_click(manager, bring_front_click):
+    if manager.backend.name == "wayland":
+        pytest.skip("Temporarily moved to backend/wayland/test_window.py")
+
     manager.c.group.setlayout("tile")
     # this is a tiled window.
     manager.test_window("one")


### PR DESCRIPTION
The idea is to have sensible defaults with the ability to easily
customize other behaviours

`floats_kept_above` moves floating windows to the KEEPABOVE layer
Fixes floating windows going behind tiled windows when
`floats_kept_above = True`

~~`bring_front_click` moves clicked window to the top of its layer~~

~~`bring_to_front()` moves window to the BRINGTOFRONT layer
When a window returns from BRINGTOFRONT, it returns to its natural/base
layer~~

Added `client_focus_by_click` hook, which can be used for custom behaviour like:
```python
follow_mouse_focus = True 
bring_front_click = False
floats_kept_above = True

@hook.subscribe.client_focus_by_click
def client_focus_by_click(client):
    client.move_to_top() 
```

TODO:

- [x] Add tests (wayland) verifying correct movement between layers