### PR TITLE
wayland: add ext-data-control manager

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -774,6 +774,7 @@ struct qw_server *qw_server_create() {
     wlr_export_dmabuf_manager_v1_create(server->display);
     wlr_screencopy_manager_v1_create(server->display);
     wlr_data_control_manager_v1_create(server->display);
+    wlr_ext_data_control_manager_v1_create(server->display, 1);
     wlr_primary_selection_v1_device_manager_create(server->display);
     wlr_viewporter_create(server->display);
     wlr_single_pixel_buffer_manager_v1_create(server->display);

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -19,6 +19,7 @@
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
+#include <wlr/types/wlr_ext_data_control_v1.h>
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_gamma_control_v1.h>


### PR DESCRIPTION
Create the ext_data_control_manager_v1 alongside the existing wlr_data_control_manager_v1. ext_data_control is the replacement for wlr_data_control: the interface is identical and only the protocol name differs; wlr_data_control is expected to be deprecated. Exposing both keeps compatibility with current clipboard clients while supporting the new protocol.