### PR TITLE
Fix window lost focus when dragged between screens

### DIFF
--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -828,8 +828,8 @@ class Window(Base, base.Window):
         screen = self.qtile.find_closest_screen(x + w // 2, y + h // 2)
         if self.group and screen is not None and screen != self.group.screen:
             self.group.remove(self, force=True)
-            screen.group.add(self, force=True)
             self.qtile.focus_screen(screen.index)
+            screen.group.add(self, force=True)
 
         self._reconfigure_floating(x, y, w, h)
 


### PR DESCRIPTION
Floating windows lose their focus border when dragged between screens. This is because the floating layout draws the border if client.has_focus is True. This is the case if the window is equal to qtile.current_window. qtile.current_window looks at the active group on the current screen. However, when dragging windows, we only change screen focus after the window has been added to the other group so qtile.current_window is looking at the old screen.

Fixes #5843