### PR TITLE
wayland: Fix cursor_warp focus loop

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -640,9 +640,9 @@ class Core(base.Core):
     def grab_button(self, mouse: config.Mouse) -> int:
         return translate_masks(mouse.modifiers)
 
-    def warp_pointer(self, x: int, y: int) -> None:
+    def warp_pointer(self, x: int, y: int, motion: bool = False) -> None:
         """Warp the pointer to the coordinates in relative to the output layout"""
-        lib.qw_cursor_warp_cursor(self.qw_cursor, x, y)
+        lib.qw_cursor_warp_cursor(self.qw_cursor, x, y, motion)
 
     @contextlib.contextmanager
     def masked(self) -> Generator:

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -170,9 +170,12 @@ static void qw_cursor_handle_motion_absolute(struct wl_listener *listener, void 
     }
 }
 
-void qw_cursor_warp_cursor(struct qw_cursor *cursor, double x, double y) {
+void qw_cursor_warp_cursor(struct qw_cursor *cursor, double x, double y, bool motion) {
     wlr_cursor_warp_closest(cursor->cursor, NULL, x, y);
-    qw_cursor_process_motion(cursor, 0, NULL, 0, 0, 0, 0);
+    qw_cursor_update_pointer_focus(cursor);
+    if (motion) {
+        cursor->server->cursor_motion_cb(cursor->server->cb_data);
+    }
 }
 
 static void qw_cursor_handle_seat_request_set(struct wl_listener *listener, void *data) {

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -53,7 +53,7 @@ void qw_cursor_destroy(struct qw_cursor *cursor);
 // Create and initialize a new cursor associated with the server
 struct qw_cursor *qw_server_cursor_create(struct qw_server *cursor);
 
-void qw_cursor_warp_cursor(struct qw_cursor *cursor, double x, double y);
+void qw_cursor_warp_cursor(struct qw_cursor *cursor, double x, double y, bool motion);
 
 void qw_cursor_update_pointer_focus(struct qw_cursor *cursor);
 

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -68,7 +68,7 @@ class WaylandBackend(Backend):
 
     def fake_motion(self, x, y):
         """Move pointer to the specified coordinates"""
-        self.manager.c.eval(f"self.core.warp_pointer({x}, {y})")
+        self.manager.c.eval(f"self.core.warp_pointer({x}, {y}, motion=True)")
 
     def fake_click(self, x, y):
         """Click at the specified coordinates"""


### PR DESCRIPTION
In certain circumstances, appears to be a loop between: focus warp
cursor -> process_motion cursor_motion_cb -> _focus_pointer calling
focus -> focus warp cursor

Break the loop by updating pointer focus after warp without processing
motion

Add a warp with motion option for fake_motion()

Fixes #5841