### PR TITLE
wayland: Add node id to stacking_info output

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -815,6 +815,7 @@ class Core(base.Core):
 
             node = {
                 "name": ffi.string(info.name).decode(),
+                "id": node_id,
                 "enabled": bool(info.enabled),
                 "x": info.x,
                 "y": info.y,


### PR DESCRIPTION
Useful for identification if tracking changes to a node