### PR TITLE
pre-commit: bump versions of things

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,18 @@
 exclude: "test/configs/syntaxerr.py"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.15.7
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.17.1
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies: ["types-python-dateutil", "types-pytz"]
         files: "^libqtile\/.*"
-  - repo: https://github.com/jendrikseipp/vulture
-    rev: v2.14
-    hooks:
-      - id: vulture
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.8
+    rev: v22.1.1
     hooks:
     - id: clang-format

--- a/libqtile/backend/base/idle_inhibit.py
+++ b/libqtile/backend/base/idle_inhibit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 from libqtile import hook
 from libqtile.log_utils import logger
@@ -85,10 +85,7 @@ class Inhibitor:
         return f"<window={name} type={mode} status={active}>"
 
 
-TInhibitor = TypeVar("TInhibitor", bound=Inhibitor)
-
-
-class IdleInhibitorManager(Generic[TInhibitor]):
+class IdleInhibitorManager[TInhibitor: Inhibitor]:
     def __init__(self, core: Core) -> None:
         self.core = core
         self.inhibitors: list[TInhibitor] = []

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -67,7 +67,7 @@ class QtileError(Exception):
     pass
 
 
-def lget(o: list[T], v: int) -> T | None:
+def lget[T](o: list[T], v: int) -> T | None:
     try:
         return o[v]
     except (IndexError, TypeError):


### PR DESCRIPTION
The most notable thing here is to drop vulture, which gives a bogus result:

    libqtile/backend/x11/window.py:2125: unreachable code after 'while' (100% confidence)

...that code is definitely reachable, otherwise we would have an infinite loop :)

But there are some other typing fixes as well:

    UP046 Generic class `IdleInhibitorManager` uses `Generic` subclass instead of type parameters
      --> libqtile/backend/base/idle_inhibit.py:91:28
       |
    91 | class IdleInhibitorManager(Generic[TInhibitor]):
       |                            ^^^^^^^^^^^^^^^^^^^
    92 |     def __init__(self, core: Core) -> None:
    93 |         self.core = core
       |
    help: Use type parameters

and

    UP047 Generic function `lget` should use type parameters
      --> libqtile/utils.py:70:5
       |
    70 | def lget(o: list[T], v: int) -> T | None:
       |     ^^^^^^^^^^^^^^^^^^^^^^^^
    71 |     try:
    72 |         return o[v]
       |
    help: Use type parameters