### PR TITLE
ci: bump github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
                 python-version: ['3.12', '3.13', '3.14']
                 backend: ['x11', 'wayland']
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Set up python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Set up uv
-              uses: astral-sh/setup-uv@v6
+              uses: astral-sh/setup-uv@v7
               with:
                   enable-cache: true
                   cache-dependency-glob: "pyproject.toml"
@@ -37,7 +37,7 @@ jobs:
                 sudo apt install -y --no-install-recommends $(yq -r '.build.apt_packages | join(" ")' .readthedocs.yaml)
                 # Any Wayland-specific Ubuntu system dependencies should be installed from ./scripts/ubuntu_wayland_setup
             - name: Cache Wayland dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                 path: cache
                 key: ${{ runner.os }}-wayland-${{ hashFiles('scripts/ubuntu_wayland_setup') }}

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Create artifact
         run: tar czf ~/wayland.tar.gz -C ${HOME}/wayland/ .
       - name: Upload built libraries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wayland
           path: ~/wayland.tar.gz
@@ -206,7 +206,7 @@ jobs:
           name: wayland
       - name: Unpack wayland artifact
         run: tar xf wayland.tar.gz -C /
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set environment variables
         run: |
           PYTHON_ROOT=$(find /opt/python -name ${PYTHON_VERSION/./}-${PYTHON_VERSION/./})
@@ -222,7 +222,7 @@ jobs:
           auditwheel show dist/qtile-*.whl
           auditwheel repair --plat manylinux_2_34_x86_64 -w output_wheels dist/qtile-*.whl
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.python-version }}
           path: output_wheels/qtile*.whl
@@ -245,7 +245,7 @@ jobs:
         with:
           name: wheels-${{ matrix.manual-version }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install wheel
@@ -261,7 +261,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: dnf install -y cairo-devel libffi-devel
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set environment variables
         run: |
           PYTHON_ROOT=$(find /opt/python -name ${PYTHON_VERSION/./}-${PYTHON_VERSION/./})
@@ -274,7 +274,7 @@ jobs:
           python -m pip install build
           python -m build --sdist .
       - name: Upload source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: source
           path: dist/*.tar.gz


### PR DESCRIPTION
running on the nodejs treadmill:

    Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-python@v5, astral-sh/setup-uv@v6. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

    Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/