### PR TITLE
tests: pass full env to x11_identify_output test

### DIFF
--- a/test/backend/x11/test_x11_identify_output.py
+++ b/test/backend/x11/test_x11_identify_output.py
@@ -4,14 +4,11 @@ import subprocess
 import sys
 
 
-def run_identify_output(env=None):
+def run_identify_output(env):
     cmd = os.path.join(
         os.path.dirname(__file__), "..", "..", "..", "libqtile", "scripts", "main.py"
     )
     argv = [sys.executable, cmd, "x11-identify-output"]
-
-    if env is None:
-        env = os.environ.copy()
 
     proc = subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     stdout, stderr = proc.communicate()
@@ -32,6 +29,8 @@ def check_identify_output(stdout, resolution):
 
 def test_identify_output(xmanager_nospawn):
     backend = xmanager_nospawn.backend
-    stdout, _ = run_identify_output(env=backend.env)
+    env = os.environ.copy()
+    env.update(backend.env)
+    stdout, _ = run_identify_output(env)
     resolution = "800x600"
     check_identify_output(stdout, resolution)


### PR DESCRIPTION
If we only pass the backend's env, we'll only get $DISPLAY but not $PYTHONPATH. This means that we won't be able to find qtile's libs, and the test will fail.