### PR TITLE
Fix test_net.py

### DIFF
--- a/test/widgets/test_net.py
+++ b/test/widgets/test_net.py
@@ -34,6 +34,8 @@ class MockPsutil(ModuleType):
 @pytest.fixture
 def patch_net(fake_qtile, monkeypatch, fake_window):
     def build_widget(**kwargs):
+        MockPsutil.up = 0
+        MockPsutil.down = 0
         monkeypatch.setitem(sys.modules, "psutil", MockPsutil("psutil"))
         from libqtile.widget import net
 
@@ -62,15 +64,15 @@ def test_net_defaults(patch_net):
 def test_net_single_interface(patch_net):
     """Display single named interface"""
     net2 = patch_net(interface="wlp58s0")
-    assert net2.poll() == "wlp58s0: U 40.0kB 160.0kB D 1.2MB 4.8MB T 1.24MB 4.96MB"
+    assert net2.poll() == "wlp58s0: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
 
 
 def test_net_list_interface(patch_net):
     """Display multiple named interfaces"""
     net2 = patch_net(interface=["wlp58s0", "lo"])
     assert net2.poll() == (
-        "wlp58s0: U 40.0kB 240.0kB D 1.2MB 7.2MB T 1.24MB 7.44MB lo: U 40.0kB "
-        "240.0kB D 1.2MB 7.2MB T 1.24MB 7.44MB"
+        "wlp58s0: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB "
+        "lo: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
     )
 
 
@@ -83,7 +85,7 @@ def test_net_invalid_interface(patch_net):
 def test_net_use_bits(patch_net):
     """Display all interfaces in bits rather than bytes"""
     net4 = patch_net(use_bits=True)
-    assert net4.poll() == "all: U 320.0kb 2.56Mb D 9.6Mb 76.8Mb T 9.92Mb 79.36Mb"
+    assert net4.poll() == "all: U 320.0kb 640.0kb D 9.6Mb 19.2Mb T 9.92Mb 19.84Mb"
 
 
 def test_net_convert_zero_b(patch_net):
@@ -95,7 +97,7 @@ def test_net_convert_zero_b(patch_net):
 def test_net_use_prefix(patch_net):
     """Tests `prefix` configurable option"""
     net6 = patch_net(prefix="M")
-    assert net6.poll() == "all: U 0.04MB 440.0kB D 1.2MB 13.2MB T 1.24MB 13.64MB"
+    assert net6.poll() == "all: U 0.04MB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
 
 
 def test_net_missing_interface(patch_net):


### PR DESCRIPTION
The test uses a fake psutil module to get net statistics. However, values are increased between tests and so will fail if tests are run in a different order. We fix this by resetting stats between tests.