### PR TITLE
Only pass button presses to bar when press inside bar

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -526,13 +526,15 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
     def get_widget_in_position(self, x: int, y: int) -> _Widget | None:
         if self.horizontal:
-            for i in self.widgets:
-                if x < i.offsetx + i.length:
-                    return i
+            if self.border_width[3] <= y < self.size:
+                for i in self.widgets:
+                    if x < i.offsetx + i.length:
+                        return i
         else:
-            for i in self.widgets:
-                if y < i.offsety + i.length:
-                    return i
+            if self.border_width[0] <= x < self.size:
+                for i in self.widgets:
+                    if y < i.offsety + i.length:
+                        return i
         return None
 
     def process_button_click(self, x: int, y: int, button: int) -> None:


### PR DESCRIPTION
On wayland, the bar can still receive button press events, even when the mouse is not over the bar. This PR doesn't address that underlying issue but adds a check in `bar.py` to only forward button presses to widgets when the coordinates are inside the bar (the code previously only checked one axis).

Fixes #5892