### PR TITLE
Restore solid background for systray widgets

### DIFF
--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -100,7 +100,9 @@ class Core(CommandObject, metaclass=ABCMeta):
         """A context manager to suppress window events while operating on many windows."""
         yield
 
-    def create_internal(self, x: int, y: int, width: int, height: int) -> Internal:
+    def create_internal(
+        self, x: int, y: int, width: int, height: int, depth: int = 32
+    ) -> Internal:
         """Create an internal window controlled by Qtile."""
         raise NotImplementedError  # Only error when called, not when instantiating class
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -577,7 +577,9 @@ class Core(base.Core):
     def display_name(self) -> str:
         return ffi.string(self.qw.socket).decode()
 
-    def create_internal(self, x: int, y: int, width: int, height: int) -> base.Internal:
+    def create_internal(
+        self, x: int, y: int, width: int, height: int, depth: int = 32
+    ) -> base.Internal:
         ptr = lib.qw_server_internal_view_new(self.qw, x, y, width, height)
         if not ptr:
             raise RuntimeError("failed creating internal view")

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -622,6 +622,7 @@ class Core(base.Core):
         y: int,
         width: int,
         height: int,
+        depth: int = 32,
     ) -> base.Internal:
         assert self.qtile is not None
 
@@ -629,8 +630,8 @@ class Core(base.Core):
         # backgrounds. If the Screen doesn't support 32-bit visuals, the code
         # in create_window() -> _get_depth_and_visual() will fall back to an
         # appropriate depth.
-        win = self.conn.create_window(x, y, width, height, desired_depth=32)
-        internal = window.Internal(win, self.qtile, desired_depth=32)
+        win = self.conn.create_window(x, y, width, height, desired_depth=depth)
+        internal = window.Internal(win, self.qtile, desired_depth=depth)
 
         internal.place(x, y, width, height, 0, None)
         self.qtile.manage(internal)

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from libqtile import configurable, hook
 from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
-from libqtile.utils import is_valid_colors
+from libqtile.utils import has_transparency, is_valid_colors
 
 if typing.TYPE_CHECKING:
     import asyncio
@@ -266,7 +266,15 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             # Whereas we won't have a window if we're startup up for the first time or
             # the window has been killed by us no longer using the bar's screen
 
-            self.window = qtile.core.create_internal(self.x, self.y, width, height)
+            if qtile.core.name == "x11":
+                if has_transparency(self.background):
+                    depth = 32
+                else:
+                    depth = qtile.core.conn.default_screen.root_depth  # type: ignore[attr-defined]
+            else:
+                depth = 32  # This could be anything as it's not needed for wayland.
+
+            self.window = qtile.core.create_internal(self.x, self.y, width, height, depth)
 
             self.window.opacity = self.opacity
             self.window.unhide()


### PR DESCRIPTION
eab276e forced all windows to be 32-bit depth if the monitor supports this. However, we need 24-bit depth to set the background colour (I've no idea why but I could never get it to work - this is why we have that warning in the docs about transparent bars).

This PR restores 24 bit depth for bars that do not request a (semi-)transparent background colour.

Fixes #5856

Before:
<img width="102" height="23" alt="20260328_073529" src="https://github.com/user-attachments/assets/bfebc54e-2730-4ec6-9fd4-2a487ed73a89" />

After:
<img width="96" height="22" alt="20260328_073440" src="https://github.com/user-attachments/assets/0e5af5f2-c3cc-4e5a-b211-c4aadc74487f" />
