### PR TITLE
Fix `qtile cmd-obj -f spawn` crash

### DIFF
--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -351,7 +351,10 @@ def lift_args(cmd, args, kwargs):
     converted_args = []
     converted_kwargs = dict()
 
-    params = typing.get_type_hints(cmd, globalns=globals())
+    # We use the globals from the command itself to ensure that all types are
+    # available. This means that structural types need to imported at run time
+    # and not just for typing.
+    params = typing.get_type_hints(cmd, globalns=cmd.__globals__)
 
     non_return_annotated_args = filter(lambda k: k != "return", params.keys())
     for param, arg in zip(non_return_annotated_args, args):


### PR DESCRIPTION
4c37efd introduced additional types that could be passed to `qtile.spawn`. This caused IPC to crash as it was unable to lift string arguments to this new type.

This PR adds better handling of argument types.

Fixes #5893