### PR TITLE
Initialise fontconfig before starting qtile

### DIFF
--- a/libqtile/__init__.py
+++ b/libqtile/__init__.py
@@ -25,6 +25,7 @@ class DynamicLibraries(enum.Enum):
     PANGO = "pango-1.0"
     PANGOCAIRO = "pangocairo-1.0"
     XCBCURSOR = "xcb-cursor"
+    FONTCONFIG = "fontconfig"
 
 
 def find_library(key: DynamicLibraries) -> str | None:

--- a/libqtile/pango_ffi.py
+++ b/libqtile/pango_ffi.py
@@ -37,6 +37,9 @@ pango_ffi.cdef(
     typedef ... GError;
     typedef int gint;
 
+    int
+    FcInit(void);
+
     void
     pango_cairo_show_layout (cairo_t *cr,
                              PangoLayout *layout);

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -4,6 +4,11 @@ from libqtile.pango_ffi import pango_ffi as ffi
 gobject = ffi.dlopen(find_library(DynamicLibraries.GOBJECT))  # type: ignore
 pango = ffi.dlopen(find_library(DynamicLibraries.PANGO))  # type: ignore
 pangocairo = ffi.dlopen(find_library(DynamicLibraries.PANGOCAIRO))  # type: ignore
+fontconfig = ffi.dlopen(find_library(DynamicLibraries.FONTCONFIG))  # type: ignore
+
+
+def init_fontconfig():
+    fontconfig.FcInit()
 
 
 def create_layout(cairo_t):

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -7,7 +7,7 @@ from sys import exit
 from typing import TYPE_CHECKING
 
 import libqtile.backend
-from libqtile import confreader, qtile
+from libqtile import confreader, pangocffi, qtile
 from libqtile.log_utils import logger
 from libqtile.utils import VERSION, get_config_file
 
@@ -84,6 +84,9 @@ def start(options):
         locale.setlocale(locale.LC_ALL, "")
     except locale.Error:
         pass
+
+    # Initialise fontconfig before starting qtile to prevent races
+    pangocffi.init_fontconfig()
 
     libpath = (LIBQTILE_PATH / "..").resolve()
     logger.warning(f"Starting Qtile {VERSION} from {libpath}")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -19,7 +19,7 @@ import traceback
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 
-from libqtile import command, config, ipc, layout
+from libqtile import command, config, ipc, layout, pangocffi
 from libqtile.confreader import Config
 from libqtile.core.manager import Qtile
 from libqtile.lazy import lazy
@@ -191,6 +191,8 @@ class TestManager:
                 os.environ.pop("DISPLAY", None)
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 init_log(self.log_level)
+                # Initialise fontconfig before starting qtile to prevent races
+                pangocffi.init_fontconfig()
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
                 from libqtile.core.lifecycle import lifecycle


### PR DESCRIPTION
Prevent unsynchronised initialisation calls by initialising before main qtile code

Attempting to fix #5896

An experiment - have had some success on my local branch

AI says because it is called with subprocess it runs in a separate process and the only benefit is it may warm up the cache

Ideally then, we should try calling FcInit directly, which would require a cffi reference to libfontconfig