### PR TITLE
[docs] Fix GenPollUrl widget screenshots

### DIFF
--- a/test/widgets/docs_screenshots/conftest.py
+++ b/test/widgets/docs_screenshots/conftest.py
@@ -83,7 +83,14 @@ def target():
 
 
 @pytest.fixture
-def screenshot_manager(widget, request, manager_nospawn, minimal_conf_noscreen, target, vertical):
+def widget_name():
+    yield ""
+
+
+@pytest.fixture
+def screenshot_manager(
+    widget, widget_name, request, manager_nospawn, minimal_conf_noscreen, target, vertical
+):
     """
     Create a manager instance for the screenshots. Individual "tests" should only call
     `screenshot_manager.take_screenshot()` but the destination path is also available in
@@ -107,7 +114,7 @@ def screenshot_manager(widget, request, manager_nospawn, minimal_conf_noscreen, 
         def __init__(self, *args, **kwargs):
             widget_class.__init__(self, *args, **kwargs)
             # We need the widget's name to be the name of the inherited class
-            self.name = widget_class.__name__.lower()
+            self.name = (widget_name or widget_class.__name__).lower()
 
         def _configure(self, bar, screen):
             widget_class._configure(self, bar, screen)
@@ -196,6 +203,7 @@ def screenshot_manager(widget, request, manager_nospawn, minimal_conf_noscreen, 
     # Add some convenience attributes for taking screenshots
     manager_nospawn.target = filename
     ss_widget = manager_nospawn.c.widget[name]
+    manager_nospawn.widget = ss_widget
     manager_nospawn.take_screenshot = lambda f=filename: ss_widget.take_screenshot(f())
 
     yield manager_nospawn

--- a/test/widgets/docs_screenshots/ss_caps_lock_indicator.py
+++ b/test/widgets/docs_screenshots/ss_caps_lock_indicator.py
@@ -5,7 +5,12 @@ from libqtile.widget.textbox import TextBox
 
 @pytest.fixture
 def widget():
-    return TextBox
+    yield TextBox
+
+
+@pytest.fixture
+def widget_name():
+    return "CapsNumLockIndicator"
 
 
 @pytest.mark.parametrize(
@@ -16,5 +21,5 @@ def widget():
     indirect=True,
 )
 def ss_caps_num_lock_indicator(screenshot_manager):
-    screenshot_manager.c.widget["textbox"].update("Caps on Num on")
+    screenshot_manager.widget.update("Caps on Num on")
     screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_genpollurl.py
+++ b/test/widgets/docs_screenshots/ss_genpollurl.py
@@ -8,6 +8,11 @@ def widget():
     yield TextBox
 
 
+@pytest.fixture
+def widget_name():
+    return "GenPollUrl"
+
+
 def ss_genpollurl(screenshot_manager):
-    screenshot_manager.c.widget["textbox"].update("Text from URL")
+    screenshot_manager.widget.update("Text from URL")
     screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_openweather.py
+++ b/test/widgets/docs_screenshots/ss_openweather.py
@@ -8,6 +8,11 @@ def widget():
     yield TextBox
 
 
+@pytest.fixture
+def widget_name():
+    return "OpenWeather"
+
+
 @pytest.mark.parametrize(
     "screenshot_manager,expected",
     [
@@ -19,5 +24,5 @@ def widget():
     indirect=["screenshot_manager"],
 )
 def ss_openweather(screenshot_manager, expected):
-    screenshot_manager.c.widget["textbox"].update(expected)
+    screenshot_manager.widget.update(expected)
     screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_stock_ticker.py
+++ b/test/widgets/docs_screenshots/ss_stock_ticker.py
@@ -8,7 +8,12 @@ def widget():
     yield TextBox
 
 
+@pytest.fixture
+def widget_name():
+    return "StockTicker"
+
+
 @pytest.mark.parametrize("screenshot_manager", [{}], indirect=True)
 def ss_stock_ticker(screenshot_manager):
-    screenshot_manager.c.widget["textbox"].update("QTIL: $140.98")
+    screenshot_manager.widget.update("QTIL: $140.98")
     screenshot_manager.take_screenshot()

--- a/test/widgets/docs_screenshots/ss_textbox.py
+++ b/test/widgets/docs_screenshots/ss_textbox.py
@@ -7,7 +7,7 @@ from libqtile.widget import TextBox
 
 @pytest.fixture
 def widget():
-    yield partial(TextBox, "Testing Text Box")
+    yield partial(TextBox, text="Testing Text Box")
 
 
 @pytest.mark.parametrize("screenshot_manager", [{}, {"foreground": "2980b9"}], indirect=True)

--- a/test/widgets/docs_screenshots/ss_wttr.py
+++ b/test/widgets/docs_screenshots/ss_wttr.py
@@ -8,7 +8,12 @@ def widget():
     yield TextBox
 
 
+@pytest.fixture
+def widget_name():
+    return "Wttr"
+
+
 @pytest.mark.parametrize("screenshot_manager", [{}], indirect=True)
 def ss_wttr(screenshot_manager):
-    screenshot_manager.c.widget["textbox"].update("Home: +17°C")
+    screenshot_manager.widget.update("Home: +17°C")
     screenshot_manager.take_screenshot()


### PR DESCRIPTION
f2b68125a1801b4dfe748d851e4a75335f97cc34 changed certain widget screenshots to just use a TextBox. However, the docs use the widget name to display the screenshots next to the correct widget text. So, as a result of the change, screenshots for certain widgets were diplayed next to the `TextBox` widget.