### PR TITLE
widget: add return type annotations to BackgroundPoll.poll and apoll

### DIFF
--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -839,11 +839,11 @@ class BackgroundPoll(_TextBox):
     def timer_setup(self):
         create_task(self.do_tick())
 
-    def poll(self):
+    def poll(self) -> str | None:
         """An optional non-async-based method for polling. Will be run as an
         async future."""
 
-    async def apoll(self):
+    async def apoll(self) -> str | None:
         """An optional async-based method for polling."""
 
     async def do_tick(self, requeue=True):


### PR DESCRIPTION
## Problem

`BackgroundPoll.poll` and `BackgroundPoll.apoll` are stub methods designed to be overridden by subclasses. The contract is documented in the class docstring and enforced at runtime in `do_tick` — the return value is passed to `self.update()` (expects `str`) or used as a stop-polling signal if `None`:

https://github.com/qtile/qtile/blob/67dcd07f08fc1231ac663a452f7e80820e7264a9/libqtile/widget/base.py#L849-L866

However, the stubs themselves had no return type annotations:

https://github.com/qtile/qtile/blob/67dcd07f08fc1231ac663a452f7e80820e7264a9/libqtile/widget/base.py#L842-L847

So type checkers (e.g. Pyright) inferred `-> None` for both, causing false-positive `reportIncompatibleMethodOverride` errors in any subclass that correctly returns `str`.

## Fix

Annotate both stubs as `-> str | None`, matching the documented and enforced contract.