### PR TITLE
wayland: Disable client focus when exclusive_layer held

### DIFF
--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -51,6 +51,10 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
         return;
     }
 
+    if (server->exclusive_layer != NULL) {
+        return;
+    }
+
     if (prev_surface == surface) {
         return;
     }

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -36,6 +36,10 @@ static void qw_xwayland_view_do_focus(struct qw_xwayland_view *xwayland_view,
         return;
     }
 
+    if (server->exclusive_layer != NULL) {
+        return;
+    }
+
     if (prev_surface == surface) {
         return;
     }


### PR DESCRIPTION
Fixes #5901