### PR TITLE
nix: add fontconfig to runtime library configuration

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -39,11 +39,11 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
 
     # Write library paths to file, if they are specified at build time via
     # --config-settings=PANGO_PATH=...
-    libs = ["PANGO", "PANGOCAIRO", "GOBJECT", "XCBCURSOR"]
+    libs = ["PANGO", "PANGOCAIRO", "GOBJECT", "XCBCURSOR", "FONTCONFIG"]
     if set(libs).intersection(config_settings.keys()):
         with open("libqtile/_build_config.py", "w") as f:
             f.write("# This file is generated at build time by builder.py\n")
-            for lib in ["PANGO", "PANGOCAIRO", "GOBJECT", "XCBCURSOR"]:
+            for lib in libs:
                 p = lib + "_PATH"
                 f.write(f"{p} = {config_settings.get(lib)!r}\n")
 

--- a/nix/build-config.nix
+++ b/nix/build-config.nix
@@ -22,6 +22,11 @@ let
       pkg = pkgs.libxcb-cursor;
       libname = "libxcb-cursor.so";
     }
+    {
+      varname = "FONTCONFIG";
+      pkg = pkgs.fontconfig;
+      libname = "libfontconfig.so";
+    }
   ];
 
   # header files provided through environment variables


### PR DESCRIPTION
Fixes fontconfig errors by adding FONTCONFIG to the list of libraries configurable via --config-setting, alongside PANGO, PANGOCAIRO, GOBJECT, and XCBCURSOR.