### PR TITLE
Improve battery name getter for Linux in the battery widget

### DIFF
--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -230,7 +230,13 @@ class _LinuxBattery(_Battery, configurable.Configurable):
 
     def _get_battery_name(self):
         if os.path.isdir(self.BAT_DIR):
-            bats = [f for f in os.listdir(self.BAT_DIR) if f.startswith("BAT")]
+            bats = []
+            for f in os.listdir(self.BAT_DIR):
+                if f.startswith("BAT"):
+                    bats.append(f)
+                elif os.path.isdir(self.BAT_DIR + "/" + f):
+                    if "capacity" in os.listdir(self.BAT_DIR + "/" + f):
+                        bats.append(f)
             if bats:
                 return bats[0]
         return "BAT0"


### PR DESCRIPTION
Added support for non-standard ACPI names like 'axp288_fuel_gauge' found in some budget notebooks.