### PR TITLE
build: upgrade wlroots 0.19 → 0.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ RUN dnf install -y \
     python3.12 python3.12-devel \
     python3.13 python3.13-devel \
     python3.14 python3.14-devel \
+    wayland-devel \
     wayland-protocols-devel \
-    wlroots0.19-devel \
+    wlroots \
+    wlroots-devel \
     xcb-util-cursor \
     xorg-x11-server-Xorg \
     xorg-x11-server-Xephyr \

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772542754,
-        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
         "type": "github"
       },
       "original": {

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -12,7 +12,7 @@ from setuptools import Distribution
 from setuptools.command.build_ext import build_ext
 
 QW_PATH = (Path(__file__).parent / ".." / "qw").resolve()
-WLROOTS_PATH = os.getenv("QTILE_WLROOTS_PATH", "/usr/include/wlroots-0.19")
+WLROOTS_PATH = os.getenv("QTILE_WLROOTS_PATH", "/usr/include/wlroots-0.20")
 
 PKG_CONFIG = os.environ.get("PKG_CONFIG", "pkg-config")
 WAYLAND_SCANNER = os.environ.get("QTILE_WAYLAND_SCANNER", shutil.which("wayland-scanner"))
@@ -230,7 +230,7 @@ INCLUDE_DIRS = [
     QW_PATH,
     QW_PROTO_OUT_PATH,
 ]
-LIBRARIES = ["wlroots-0.19", "wayland-server", "input", "cairo"]
+LIBRARIES = ["wlroots-0.20", "wayland-server", "input", "cairo"]
 
 # SOURCE_FILES loads all .c files...
 SOURCE_FILES = glob.glob(f"{QW_PATH}/*.c")

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -619,8 +619,8 @@ void qw_cursor_configure_xcursor(struct qw_cursor *cursor) {
             wlr_xcursor_manager_get_xcursor(cursor->xwayland_mgr, "default", 1);
         if (xcursor != NULL) {
             struct wlr_xcursor_image *image = xcursor->images[0];
-            wlr_xwayland_set_cursor(server->xwayland, image->buffer, image->width * 4, image->width,
-                                    image->height, image->hotspot_x, image->hotspot_y);
+            struct wlr_buffer *buffer = wlr_xcursor_image_get_buffer(image);
+            wlr_xwayland_set_cursor(server->xwayland, buffer, image->hotspot_x, image->hotspot_y);
         }
     }
 #endif

--- a/nix/build-config.nix
+++ b/nix/build-config.nix
@@ -48,8 +48,8 @@ let
     }
     {
       varname = "WLROOTS";
-      pkg = pkgs.wlroots_0_19;
-      header-dir = "wlroots-0.19";
+      pkg = pkgs.wlroots_0_20;
+      header-dir = "wlroots-0.20";
     }
   ];
 

--- a/nix/qtile.nix
+++ b/nix/qtile.nix
@@ -44,5 +44,5 @@ let
     };
 in
 (pkgs.python3Packages.qtile.overrideAttrs qtile-override-func).override {
-  wlroots = pkgs.wlroots_0_19;
+  wlroots = pkgs.wlroots_0_20;
 }


### PR DESCRIPTION
Update flake.lock nixpkgs revision to pull wlroots 0.20 and adjust all build references accordingly.

Changes:
- Bump WLROOTS_PATH and library link from 0.19 to 0.20
- Update cursor.c XWayland cursor handling to use new buffer-based API
- Replace direct buffer access (image->buffer, stride calculations) with wlr_xcursor_image_get_buffer()



Wlroots 0.20 release notes: https://gitlab.freedesktop.org/wlroots/wlroots/-/releases/0.20.0