### PR TITLE
fix: qtile shell on/for python 3.14

### DIFF
--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -4,13 +4,11 @@ A command shell for Qtile.
 
 from __future__ import annotations
 
-import fcntl
 import inspect
 import pprint
 import re
-import struct
+import shutil
 import sys
-import termios
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -51,14 +49,11 @@ def tidy_str(text):
     return text.strip(""" "'\t\r\n""")
 
 
-def terminal_width():
-    width = None
+def terminal_width() -> int:
     try:
-        cr = struct.unpack("hh", fcntl.ioctl(0, termios.TIOCGWINSZ, "1234"))
-        width = int(cr[1])
-    except (OSError, ImportError):
-        pass
-    return width or 80
+        return shutil.get_terminal_size(fallback=(80, 24)).columns
+    except (AttributeError, ValueError):
+        return 80
 
 
 class QSh:


### PR DESCRIPTION
the way `fcntl` is used in `terminal_width` no longer works on python 3.14

```py
Python 3.13.11 (main, Jan 14 2026, 19:38:04) [Clang 21.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import termios
>>> import fcntl
>>> fcntl.ioctl(0, termios.TIOCGWINSZ, "1234")
b'\x16\x00b\x00'
>>>
```

```py
Python 3.14.4 (main, Apr  8 2026, 17:48:49) [GCC 15.2.1 20260209] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import termios
>>> import fcntl
>>> fcntl.ioctl(0, termios.TIOCGWINSZ, "1234")
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    fcntl.ioctl(0, termios.TIOCGWINSZ, "1234")
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SystemError: buffer overflow
>>>
```

see https://github.com/python/cpython/issues/132915 for details