### PR TITLE
*: drop some __future__ and TYPE_CHECKING imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ MOCK_MODULES = [
     "libqtile._ffi_pango",
     "libqtile.backend.wayland._ffi",
     "libqtile.backend.x11._ffi_xcursors",
+    "cairocffi",
     "cairocffi.ffi",
     "cairocffi.xcb",
     "cairocffi.pixbuf",

--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from libqtile.utils import QtileError
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from libqtile.backend.base import Core
 
 

--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -3,21 +3,18 @@ from __future__ import annotations
 import contextlib
 import typing
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
-from libqtile import hook
-from libqtile.command.base import CommandObject, expose_command
+from libqtile import config, hook
+from libqtile.backend.base.idle_inhibit import IdleInhibitorManager
+from libqtile.backend.base.idle_notify import IdleNotifier
+from libqtile.command.base import CommandObject, ItemT, expose_command
 from libqtile.config import Screen
+from libqtile.group import _Group
 
 if typing.TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile import config
     from libqtile.backend.base import Internal
-    from libqtile.backend.base.idle_inhibit import IdleInhibitorManager
-    from libqtile.backend.base.idle_notify import IdleNotifier
-    from libqtile.command.base import ItemT
     from libqtile.core.manager import Qtile
-    from libqtile.group import _Group
 
 
 class Core(CommandObject, metaclass=ABCMeta):

--- a/libqtile/backend/base/drawer.py
+++ b/libqtile/backend/base/drawer.py
@@ -8,10 +8,10 @@ import cairocffi
 
 from libqtile import pangocffi, utils
 from libqtile.log_utils import logger
+from libqtile.utils import ColorsType
 
 if typing.TYPE_CHECKING:
     from libqtile.backend.base import Internal
-    from libqtile.utils import ColorsType
 
 
 class Drawer:

--- a/libqtile/backend/base/idle_inhibit.py
+++ b/libqtile/backend/base/idle_inhibit.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from libqtile import hook
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
-
     from libqtile.backend.base.core import Core
     from libqtile.backend.base.window import Window
     from libqtile.core.manager import Qtile

--- a/libqtile/backend/base/idle_notify.py
+++ b/libqtile/backend/base/idle_notify.py
@@ -1,17 +1,10 @@
-from __future__ import annotations
-
 import asyncio
 import inspect
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING
 
 from libqtile.command import interface
 from libqtile.lazy import LazyCall
 from libqtile.utils import create_task, logger
-
-if TYPE_CHECKING:
-    pass
-
 
 IdleAction = Callable | Coroutine | LazyCall | None
 

--- a/libqtile/backend/base/window.py
+++ b/libqtile/backend/base/window.py
@@ -2,21 +2,18 @@ from __future__ import annotations
 
 import typing
 from abc import ABCMeta, abstractmethod
+from typing import Any
 
-from libqtile import hook
-from libqtile.command.base import CommandError, CommandObject, expose_command
+from libqtile import config, hook
+from libqtile.backend.base import Drawer
+from libqtile.command.base import CommandError, CommandObject, ItemT, expose_command
+from libqtile.group import _Group
 from libqtile.log_utils import logger
 from libqtile.scratchpad import ScratchPad
+from libqtile.utils import ColorsType
 
 if typing.TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile import config
-    from libqtile.backend.base import Drawer
-    from libqtile.command.base import ItemT
     from libqtile.core.manager import Qtile
-    from libqtile.group import _Group
-    from libqtile.utils import ColorsType
 
 
 class _Window(CommandObject, metaclass=ABCMeta):

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -34,8 +34,6 @@
 # Licensed under the MIT License.
 # See the LICENSE file in the root of this repository for details.
 
-from __future__ import annotations
-
 import asyncio
 import contextlib
 import functools
@@ -48,19 +46,19 @@ import time
 from collections import defaultdict
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from libqtile import hook
+from libqtile import config, hook
 from libqtile.backend import base
 from libqtile.backend.wayland import inputs
 from libqtile.backend.wayland.idle_inhibit import IdleInhibitorManager
 from libqtile.backend.wayland.idle_notify import IdleNotifier
 from libqtile.backend.wayland.window import Base, Internal, Static, Window
 from libqtile.command.base import allow_when_locked, expose_command
-from libqtile.config import Output, ScreenRect
+from libqtile.config import Output, Screen, ScreenRect
 from libqtile.images import Img
 from libqtile.log_utils import logger
-from libqtile.utils import QtileError, reap_zombies, rgb
+from libqtile.utils import ColorType, QtileError, reap_zombies, rgb
 
 try:
     from libqtile.backend.wayland._ffi import ffi, lib
@@ -69,11 +67,6 @@ except ModuleNotFoundError:
     print("Warning: Wayland backend not built. Backend will not run.")
 
     from libqtile.backend.wayland.ffi_stub import ffi, lib
-
-if TYPE_CHECKING:
-    from libqtile import config
-    from libqtile.config import Screen
-    from libqtile.utils import ColorType
 
 
 def translate_masks(modifiers: list[str]) -> int:

--- a/libqtile/backend/wayland/ffi_stub.py
+++ b/libqtile/backend/wayland/ffi_stub.py
@@ -6,20 +6,13 @@
 #     ^^^^^^^^^^^^^^
 # E   AttributeError: 'NoneType' object has no attribute 'def_extern'
 
-from __future__ import annotations
-
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    T = TypeVar("T")
+from typing import Any
 
 
 class FFIStub:
     @staticmethod
-    def def_extern() -> Callable[[T], T]:
+    def def_extern[T]() -> Callable[[T], T]:
         return lambda f: f
 
     def __getattr__(self, name: str) -> Any:

--- a/libqtile/backend/wayland/idle_inhibit.py
+++ b/libqtile/backend/wayland/idle_inhibit.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile.backend.base.idle_inhibit import IdleInhibitorManager as BaseIdleInhibitorManager
 from libqtile.backend.base.idle_inhibit import Inhibitor, InhibitorType
+from libqtile.backend.base.window import Window
+from libqtile.core.manager import Qtile
 
 try:
     from libqtile.backend.wayland._ffi import ffi, lib
 except ModuleNotFoundError:
     from libqtile.backend.wayland.ffi_stub import ffi, lib
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile.backend.base.window import Window
-    from libqtile.core.manager import Qtile
 
 
 class WaylandInhibitor(Inhibitor):

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -7,7 +7,7 @@ from libqtile import hook, utils
 from libqtile.backend.base import FloatStates
 from libqtile.backend.base.window import WindowType
 from libqtile.backend.wayland.drawer import Drawer
-from libqtile.command.base import CommandError, expose_command
+from libqtile.command.base import CommandError, CommandObject, ItemT, expose_command
 from libqtile.core.manager import Qtile
 from libqtile.group import _Group
 from libqtile.log_utils import logger
@@ -24,7 +24,6 @@ except ModuleNotFoundError:
 
 if typing.TYPE_CHECKING:
     from libqtile.backend.wayland.core import Core
-    from libqtile.command.base import CommandObject, ItemT
 
 
 class Base(base._Window):

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import asyncio
 import contextlib
 import os
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterator
 
 import xcffib
 import xcffib.randr
@@ -21,9 +19,6 @@ from libqtile.backend.x11.xkeysyms import keysyms
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import QtileError
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
 
 EVENT_TO_HANDLER = {
     xcffib.xproto.ButtonPressEvent: "handle_ButtonPress",

--- a/libqtile/backend/x11/window.py
+++ b/libqtile/backend/x11/window.py
@@ -1,11 +1,8 @@
-from __future__ import annotations
-
 import array
 import contextlib
 import inspect
 import traceback
 from itertools import islice
-from typing import TYPE_CHECKING
 
 import xcffib
 import xcffib.xproto
@@ -17,12 +14,9 @@ from libqtile.backend import base
 from libqtile.backend.base import FloatStates
 from libqtile.backend.x11 import xcbq
 from libqtile.backend.x11.drawer import Drawer
-from libqtile.command.base import CommandError, expose_command
+from libqtile.command.base import CommandError, ItemT, expose_command
 from libqtile.log_utils import logger
 from libqtile.scratchpad import ScratchPad
-
-if TYPE_CHECKING:
-    from libqtile.command.base import ItemT
 
 # ICCM Constants
 NoValue = 0x0000

--- a/libqtile/backend/x11/xcbq.py
+++ b/libqtile/backend/x11/xcbq.py
@@ -3,8 +3,6 @@ A minimal EWMH-aware OO layer over xcffib. This is NOT intended to be
 complete - it only implements the subset of functionalty needed by qtile.
 """
 
-from __future__ import annotations
-
 import contextlib
 import functools
 import operator

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import typing
 from collections import defaultdict
+from typing import Any
 
 from libqtile import configurable, hook
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.base import CommandObject, ItemT, expose_command
 from libqtile.log_utils import logger
-from libqtile.utils import has_transparency, is_valid_colors
+from libqtile.utils import ColorsType, has_transparency, is_valid_colors
 
 if typing.TYPE_CHECKING:
-    import asyncio
-    from typing import Any
-
     from libqtile.backend.base import Drawer, Internal, Window
-    from libqtile.command.base import ItemT
     from libqtile.config import Screen
     from libqtile.core.manager import Qtile
-    from libqtile.utils import ColorsType
     from libqtile.widget.base import _Widget
 
 NESW = ("top", "right", "bottom", "left")

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -9,17 +9,13 @@ import asyncio
 import inspect
 import sys
 import traceback
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
+from libqtile.command.graph import SelectorType
 from libqtile.log_utils import logger
 from libqtile.utils import create_task
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from libqtile.command.graph import SelectorType
-
-    ItemT = tuple[bool, list[str | int]] | None
+ItemT = tuple[bool, list[str | int]] | None
 
 
 def allow_when_locked(func: Callable) -> Callable:

--- a/libqtile/command/client.py
+++ b/libqtile/command/client.py
@@ -9,7 +9,7 @@ clients to do this interaction.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile.command.base import SelectError
 from libqtile.command.graph import (
@@ -17,15 +17,11 @@ from libqtile.command.graph import (
     CommandGraphNode,
     CommandGraphObject,
     CommandGraphRoot,
+    GraphType,
+    SelectorType,
 )
 from libqtile.command.interface import CommandInterface, IPCCommandInterface
 from libqtile.ipc import Client, find_sockfile
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile.command.graph import GraphType
-    from libqtile.command.interface import SelectorType
 
 
 class CommandClient:

--- a/libqtile/command/graph.py
+++ b/libqtile/command/graph.py
@@ -6,10 +6,8 @@ abstract command graph
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    SelectorType = tuple[str, str | int | None]
+SelectorType = tuple[str, str | int | None]
 
 
 class CommandGraphNode(metaclass=abc.ABCMeta):

--- a/libqtile/command/interface.py
+++ b/libqtile/command/interface.py
@@ -2,22 +2,17 @@
 The interface to execute commands on the command graph
 """
 
-from __future__ import annotations
-
 import traceback
 import types
 import typing
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin
+from typing import Any, Literal, Union, get_args, get_origin
 
 from libqtile import hook, ipc
 from libqtile.command.base import CommandError, CommandException, CommandObject, SelectError
-from libqtile.command.graph import CommandGraphCall, CommandGraphNode
+from libqtile.command.graph import CommandGraphCall, CommandGraphNode, SelectorType
 from libqtile.log_utils import logger
 from libqtile.utils import ColorsType, ColorType  # noqa: F401
-
-if TYPE_CHECKING:
-    from libqtile.command.graph import SelectorType
 
 SUCCESS = 0
 ERROR = 1

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -3,27 +3,23 @@ from __future__ import annotations
 import os.path
 import re
 import sys
+from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 from libqtile import configurable, hook, utils
-from libqtile.bar import Bar
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.bar import Bar, BarType
+from libqtile.command.base import CommandObject, ItemT, expose_command
+from libqtile.group import _Group
 from libqtile.log_utils import logger
+from libqtile.utils import ColorType
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-    from typing import Any, Literal
-
     from libqtile.backend import base
     from libqtile.backend.base.idle_notify import IdleAction
-    from libqtile.bar import BarType
-    from libqtile.command.base import ItemT
     from libqtile.core.manager import Qtile
-    from libqtile.group import _Group
     from libqtile.layout.base import Layout
     from libqtile.lazy import LazyCall
-    from libqtile.utils import ColorType
 
 
 class Key:

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -2,16 +2,13 @@ from __future__ import annotations
 
 import importlib
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from types import FunctionType
+from typing import Any, Literal
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from types import FunctionType
-    from typing import Any, Literal
-
-    from libqtile.config import Group, IdleInhibitor, IdleTimer, Key, Mouse, Output, Rule, Screen
-    from libqtile.layout.base import Layout
+from libqtile.config import Group, IdleInhibitor, IdleTimer, Key, Mouse, Output, Rule, Screen
+from libqtile.layout.base import Layout
 
 
 class ConfigError(Exception):

--- a/libqtile/core/loop.py
+++ b/libqtile/core/loop.py
@@ -1,14 +1,10 @@
-from __future__ import annotations
-
 import asyncio
 import contextlib
 import signal
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import Self
 
 from libqtile.log_utils import logger
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class LoopContext(contextlib.AbstractAsyncContextManager):
@@ -20,7 +16,7 @@ class LoopContext(contextlib.AbstractAsyncContextManager):
         self._signals = signals or {}
         self._stopped = False
 
-    async def __aenter__(self) -> LoopContext:
+    async def __aenter__(self) -> Self:
         self._stopped = False
         loop = asyncio.get_running_loop()
         loop.set_exception_handler(self._handle_exception)

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -13,15 +13,23 @@ import socket
 import tempfile
 import time
 from collections import defaultdict
+from collections.abc import Callable, Sequence
 from logging.handlers import RotatingFileHandler
+from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, Literal
 
 import libqtile
 from libqtile import bar, hook, ipc, utils
 from libqtile.backend import base
 from libqtile.command import interface
-from libqtile.command.base import CommandError, CommandException, CommandObject, expose_command
+from libqtile.command.base import (
+    CommandError,
+    CommandException,
+    CommandObject,
+    ItemT,
+    expose_command,
+)
 from libqtile.command.client import InteractiveCommandClient
 from libqtile.command.interface import IPCCommandServer, QtileCommandInterface
 from libqtile.config import (
@@ -37,6 +45,7 @@ from libqtile.config import (
     ScreenRect,
 )
 from libqtile.config import ScratchPad as ScratchPadConfig
+from libqtile.confreader import Config
 from libqtile.core.lifecycle import lifecycle
 from libqtile.core.loop import LoopContext
 from libqtile.core.state import QtileState
@@ -44,11 +53,13 @@ from libqtile.dgroups import DGroups
 from libqtile.extension.base import _Extension
 from libqtile.group import _Group
 from libqtile.interactive.repl import repl_server
+from libqtile.layout.base import Layout
 from libqtile.log_utils import logger
 from libqtile.resources.sleep import inhibitor
 from libqtile.scratchpad import ScratchPad
 from libqtile.scripts.main import VERSION
 from libqtile.utils import (
+    ColorType,
     create_task,
     get_cache_dir,
     lget,
@@ -56,16 +67,6 @@ from libqtile.utils import (
     send_notification,
 )
 from libqtile.widget.base import _Widget
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
-    from os import PathLike
-    from typing import Any, Literal
-
-    from libqtile.command.base import ItemT
-    from libqtile.confreader import Config
-    from libqtile.layout.base import Layout
-    from libqtile.utils import ColorType
 
 
 class Qtile(CommandObject):

--- a/libqtile/core/state.py
+++ b/libqtile/core/state.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from libqtile import hook
-from libqtile.backend.base import Window
+from libqtile.backend.base import Static, Window
 from libqtile.scratchpad import ScratchPad
 
 if TYPE_CHECKING:
-    from libqtile.backend.base import Static
     from libqtile.core.manager import Qtile
 
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -1,13 +1,6 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from libqtile import hook, utils
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.base import CommandObject, ItemT, expose_command
 from libqtile.log_utils import logger
-
-if TYPE_CHECKING:
-    from libqtile.command.base import ItemT
 
 
 class _Group(CommandObject):

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -1,18 +1,13 @@
-from __future__ import annotations
-
 import asyncio
 import contextlib
 import inspect
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from libqtile import backend, utils
 from libqtile.log_utils import logger
 from libqtile.resources.sleep import inhibitor
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    HookHandler = Callable[[Callable], Callable]
+HookHandler = Callable[[Callable], Callable]
 
 subscriptions = {}  # type: dict
 

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -5,8 +5,6 @@ run the same Python version, and that clients must be trusted (as
 un-marshalling untrusted data can result in arbitrary code execution).
 """
 
-from __future__ import annotations
-
 import asyncio
 import fcntl
 import json
@@ -14,7 +12,7 @@ import marshal
 import os.path
 import socket
 import struct
-from typing import Any
+from typing import Any, Self
 
 from libqtile import hook
 from libqtile.log_utils import logger
@@ -240,7 +238,7 @@ class Server:
             writer.close()
             await writer.wait_closed()
 
-    async def __aenter__(self) -> Server:
+    async def __aenter__(self) -> Self:
         """Start and return the server"""
         await self.start()
         return self

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -2,20 +2,15 @@ from __future__ import annotations
 
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, overload
+from collections.abc import Iterator, Sequence
+from typing import Any, Self, overload
 
 from libqtile import configurable
 from libqtile.backend.base import Window
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.base import CommandObject, ItemT, expose_command
 from libqtile.command.interface import CommandError
 from libqtile.config import ScreenRect
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
-    from typing import Any, Self
-
-    from libqtile.command.base import ItemT
-    from libqtile.group import _Group
+from libqtile.group import _Group
 
 
 class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Generator
+from typing import Any, Self
 
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import Layout
-
-if TYPE_CHECKING:
-    from collections.abc import Generator
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class _BspNode:

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -1,17 +1,11 @@
-from __future__ import annotations
+from typing import Any, Self
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import Layout, _ClientList
 from libqtile.log_utils import logger
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class _Column(_ClientList):

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -1,16 +1,9 @@
-from __future__ import annotations
+from typing import Any
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
-from libqtile.config import Match, _Match
+from libqtile.config import Match, ScreenRect, _Match
 from libqtile.layout.base import Layout
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
 
 
 class Floating(Layout):

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -1,17 +1,11 @@
-from __future__ import annotations
-
 import math
-from typing import TYPE_CHECKING
+from typing import Any, Self
 
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class Matrix(_SimpleLayoutBase):

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -1,13 +1,7 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
 
 
 class Max(_SimpleLayoutBase):

--- a/libqtile/layout/ratiotile.py
+++ b/libqtile/layout/ratiotile.py
@@ -1,16 +1,10 @@
-from __future__ import annotations
-
 import math
-from typing import TYPE_CHECKING
+from typing import Any, Self
 
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.group import _Group
 
 ROWCOL = 1  # do rows at a time left to right top down
 COLROW = 2  # do cols top to bottom, left to right

--- a/libqtile/layout/screensplit.py
+++ b/libqtile/layout/screensplit.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any
 
 from libqtile import hook
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
 from libqtile.config import ScreenRect, _Match
+from libqtile.group import _Group
 from libqtile.layout import Columns, Max
 from libqtile.layout.base import Layout
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
-
-    from libqtile.backend.base import Window
-    from libqtile.group import _Group
-
-    Rect = tuple[float, float, float, float]
+Rect = tuple[float, float, float, float]
 
 
 class Split:

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -2,21 +2,15 @@
 Slice layout. Serves as example of delegating layouts (or sublayouts)
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import Any, Self
 
 from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
 from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import Layout
 from libqtile.layout.max import Max
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Self
-
-    from libqtile.group import _Group
 
 
 class Single(Layout):

--- a/libqtile/layout/spiral.py
+++ b/libqtile/layout/spiral.py
@@ -1,18 +1,12 @@
-from __future__ import annotations
+from typing import Any, Self
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
 from libqtile.log_utils import logger
 
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.group import _Group
-
-    Rect = tuple[int, int, int, int]
+Rect = tuple[int, int, int, int]
 
 
 GOLDEN_RATIO = 1.618

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -1,16 +1,10 @@
-from __future__ import annotations
+from typing import Any, Self
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import Layout, _ClientList
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class _WinStack(_ClientList):

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -1,17 +1,10 @@
-from __future__ import annotations
+from typing import Any, Self
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
-from libqtile.config import _Match
+from libqtile.config import ScreenRect, _Match
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class Tile(_SimpleLayoutBase):

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -1,18 +1,12 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from collections.abc import Sequence
+from typing import Any, Self
 
 from libqtile import hook
+from libqtile.backend import base
 from libqtile.command.base import expose_command
 from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import Layout
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Self
-
-    from libqtile.backend import base
-    from libqtile.group import _Group
 
 to_superscript = dict(zip(map(ord, "0123456789"), map(ord, "⁰¹²³⁴⁵⁶⁷⁸⁹")))
 

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -1,15 +1,9 @@
-from __future__ import annotations
+from typing import Self
 
-from typing import TYPE_CHECKING
-
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from typing import Self
-
-    from libqtile.backend.base import Window
-    from libqtile.group import _Group
 
 
 class VerticalTile(_SimpleLayoutBase):

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -1,18 +1,12 @@
-from __future__ import annotations
-
 import math
 from collections import namedtuple
-from typing import TYPE_CHECKING
+from typing import Any, Self
 
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
+from libqtile.group import _Group
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from typing import Any, Self
-
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
-    from libqtile.group import _Group
 
 
 class MonadTall(_SimpleLayoutBase):

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -1,14 +1,8 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import libqtile
+from libqtile.backend.base import Window
 from libqtile.command.base import expose_command
+from libqtile.config import ScreenRect
 from libqtile.layout.base import _SimpleLayoutBase
-
-if TYPE_CHECKING:
-    from libqtile.backend.base import Window
-    from libqtile.config import ScreenRect
 
 
 class Zoomy(_SimpleLayoutBase):

--- a/libqtile/lazy.py
+++ b/libqtile/lazy.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterable
 
 from libqtile.command.client import InteractiveCommandClient
-from libqtile.command.graph import CommandGraphCall, CommandGraphNode
+from libqtile.command.graph import CommandGraphCall, CommandGraphNode, SelectorType
 from libqtile.command.interface import CommandInterface
+from libqtile.config import _Match
 from libqtile.log_utils import logger
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-
-    from libqtile.command.graph import SelectorType
-    from libqtile.config import _Match
 
 
 class LazyCall:

--- a/libqtile/log_utils.py
+++ b/libqtile/log_utils.py
@@ -1,15 +1,17 @@
-from __future__ import annotations
-
 import os
 import sys
-import typing
 import warnings
-from logging import WARNING, Formatter, StreamHandler, captureWarnings, getLogger
+from logging import (
+    WARNING,
+    Formatter,
+    Logger,
+    LogRecord,
+    StreamHandler,
+    captureWarnings,
+    getLogger,
+)
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-
-if typing.TYPE_CHECKING:
-    from logging import Logger, LogRecord
 
 logger = getLogger(__package__)
 

--- a/libqtile/popup.py
+++ b/libqtile/popup.py
@@ -1,15 +1,9 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from cairocffi import ImageSurface
 
 from libqtile import configurable, pangocffi
-
-if TYPE_CHECKING:
-    from cairocffi import ImageSurface
-
-    from libqtile.backend.base import Drawer, Internal
-    from libqtile.core.manager import Qtile
-    from libqtile.utils import ColorType
+from libqtile.backend.base import Drawer, Internal
+from libqtile.core.manager import Qtile
+from libqtile.utils import ColorType
 
 
 class Popup(configurable.Configurable):

--- a/libqtile/resources/sleep.py
+++ b/libqtile/resources/sleep.py
@@ -1,15 +1,10 @@
-from __future__ import annotations
-
 import fcntl
 import os
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile import hook
 from libqtile.log_utils import logger
 from libqtile.utils import create_task
-
-if TYPE_CHECKING:
-    from typing import Any
 
 try:
     from dbus_fast.aio import MessageBus
@@ -43,8 +38,7 @@ class Inhibitor:
         self.sleep = False
         self.resume = False
         self.fd: int = -1
-        if TYPE_CHECKING:
-            self.login: Any
+        self.login: Any = None
 
     def want_sleep(self) -> None:
         """

--- a/libqtile/scripts/cmd_obj.py
+++ b/libqtile/scripts/cmd_obj.py
@@ -4,8 +4,6 @@ Command-line tool to expose qtile.command functionality to shell.
 This can be used standalone or in other shell scripts.
 """
 
-from __future__ import annotations
-
 import argparse
 import itertools
 import json

--- a/libqtile/scripts/migrate.py
+++ b/libqtile/scripts/migrate.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import shutil
 import sys
+from collections.abc import Iterator
 from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -13,8 +14,6 @@ from libqtile.scripts.migrations import MIGRATIONS, load_migrations
 from libqtile.utils import get_config_file
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     import libcst
 
 BACKUP_SUFFIX = ".migrate.bak"

--- a/libqtile/scripts/migrations/_base.py
+++ b/libqtile/scripts/migrations/_base.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 import difflib
+from collections.abc import Collection
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import ClassVar
 
 import libcst
 import libcst.matchers as m
+from libcst.metadata.base_provider import ProviderT
 
 from libqtile.scripts.migrations import MIGRATIONS
-
-if TYPE_CHECKING:
-    from collections.abc import Collection
-    from typing import ClassVar
-
-    from libcst.metadata.base_provider import ProviderT
-
 
 # By default, libcst adds spaces around "=" so we should remove them
 EQUALS_NO_SPACE = libcst.AssignEqual(

--- a/libqtile/scripts/repl.py
+++ b/libqtile/scripts/repl.py
@@ -1,11 +1,8 @@
-from __future__ import annotations
-
 import codeop
 import re
 import socket
 import sys
 from time import sleep
-from typing import TYPE_CHECKING
 
 try:
     from prompt_toolkit import PromptSession
@@ -20,9 +17,6 @@ except (ImportError, ModuleNotFoundError):
 
 from libqtile.interactive.repl import COMPLETION_REQUEST, REPL_PORT, TERMINATOR
 from libqtile.scripts.cmd_obj import cmd_obj
-
-if TYPE_CHECKING:
-    pass
 
 HOST = "localhost"
 

--- a/libqtile/sh.py
+++ b/libqtile/sh.py
@@ -2,15 +2,13 @@
 A command shell for Qtile.
 """
 
-from __future__ import annotations
-
 import inspect
 import pprint
 import re
 import shutil
 import sys
 from importlib import import_module
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile.command.client import CommandClient
 from libqtile.command.interface import (
@@ -19,10 +17,6 @@ from libqtile.command.interface import (
     CommandInterface,
     format_selectors,
 )
-
-if TYPE_CHECKING:
-    from typing import Any
-
 
 # From: https://stackoverflow.com/a/64333329/3087339
 # Matches commas that are not enclosed in quote marks

--- a/libqtile/utils.py
+++ b/libqtile/utils.py
@@ -5,12 +5,12 @@ import glob
 import importlib
 import os
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Callable, Coroutine, Sequence
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from random import randint
 from shutil import which
-from typing import TYPE_CHECKING, cast
+from typing import Any, cast
 
 try:
     from dbus_fast import AuthError, Message, Variant
@@ -26,11 +26,6 @@ from libqtile.log_utils import logger
 
 ColorType = str | tuple[int, int, int] | tuple[int, int, int, float]
 ColorsType = ColorType | list[ColorType]
-if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine
-    from typing import Any, TypeVar
-
-    T = TypeVar("T")
 
 try:
     VERSION = distribution("qtile").version

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -5,19 +5,14 @@ import copy
 import inspect
 import math
 import subprocess
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile import bar, configurable, confreader, hook
 from libqtile.command import interface
-from libqtile.command.base import CommandObject, expose_command
+from libqtile.command.base import CommandObject, ItemT, expose_command
 from libqtile.lazy import LazyCall
 from libqtile.log_utils import logger
 from libqtile.utils import ColorType, create_task
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile.command.base import ItemT
 
 # Each widget class must define which bar orientation(s) it supports by setting
 # these bits in an 'orientations' class attribute. Simply having the attribute

--- a/libqtile/widget/battery.py
+++ b/libqtile/widget/battery.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import platform
 import re
@@ -7,19 +5,14 @@ from abc import ABC, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
-from typing import TYPE_CHECKING, NamedTuple
+from typing import Any, NamedTuple
 
 from libqtile import bar, configurable, images
 from libqtile.command.base import expose_command
 from libqtile.images import Img
 from libqtile.log_utils import logger
-from libqtile.utils import send_notification
+from libqtile.utils import ColorsType, send_notification
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import Any
-
-    from libqtile.utils import ColorsType
 
 
 @unique

--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 import time
 from datetime import UTC, datetime, timedelta, tzinfo

--- a/libqtile/widget/keyboardlayout.py
+++ b/libqtile/widget/keyboardlayout.py
@@ -1,18 +1,13 @@
-from __future__ import annotations
-
 import re
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from subprocess import CalledProcessError, check_output
-from typing import TYPE_CHECKING
 
 from libqtile.command.base import expose_command
 from libqtile.confreader import ConfigError
+from libqtile.core.manager import Qtile
 from libqtile.log_utils import logger
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from libqtile.core.manager import Qtile
 
 
 class _BaseLayoutBackend(metaclass=ABCMeta):

--- a/libqtile/widget/launchbar.py
+++ b/libqtile/widget/launchbar.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os.path
 
 import cairocffi

--- a/libqtile/widget/maildir.py
+++ b/libqtile/widget/maildir.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import mailbox
 import os.path
 

--- a/libqtile/widget/mpris2widget.py
+++ b/libqtile/widget/mpris2widget.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import asyncio
 import re
 import string
-from typing import TYPE_CHECKING
+from typing import Any
 
 from dbus_fast import Message, Variant
 from dbus_fast.aio import MessageBus
@@ -14,9 +12,6 @@ from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.utils import _send_dbus_message, add_signal_receiver, create_task
 from libqtile.widget import base
-
-if TYPE_CHECKING:
-    from typing import Any
 
 MPRIS_PATH = "/org/mpris/MediaPlayer2"
 MPRIS_OBJECT = "org.mpris.MediaPlayer2"

--- a/libqtile/widget/net.py
+++ b/libqtile/widget/net.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from math import log
 
 import psutil

--- a/libqtile/widget/prompt.py
+++ b/libqtile/widget/prompt.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import abc
 import glob
 import os

--- a/libqtile/widget/statusnotifier.py
+++ b/libqtile/widget/statusnotifier.py
@@ -1,11 +1,6 @@
-from typing import TYPE_CHECKING
-
 from libqtile import bar
 from libqtile.widget import base
-from libqtile.widget.helpers.status_notifier import has_xdg, host
-
-if TYPE_CHECKING:
-    from libqtile.widget.helpers.status_notifier import StatusNotifierItem
+from libqtile.widget.helpers.status_notifier import StatusNotifierItem, has_xdg, host
 
 
 class StatusNotifier(base._Widget):

--- a/libqtile/widget/systray.py
+++ b/libqtile/widget/systray.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import xcffib
 from xcffib.xproto import ClientMessageData, ClientMessageEvent, EventMask, SetMode
 

--- a/libqtile/widget/widgetbox.py
+++ b/libqtile/widget/widgetbox.py
@@ -1,14 +1,9 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import Any
 
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.pangocffi import markup_escape_text
 from libqtile.widget import Systray, base
-
-if TYPE_CHECKING:
-    from typing import Any
 
 
 class WidgetBox(base._TextBox):

--- a/libqtile/widget/window_count.py
+++ b/libqtile/widget/window_count.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from libqtile import bar, hook


### PR DESCRIPTION
Move imports out of `if TYPE_CHECKING:` blocks to real module-level imports where it doesn't cause circular imports, and drop the accompanying `from __future__ import annotations` where possible. Forward references to still-needed TYPE_CHECKING-only imports are preserved, and the few files that still require them (e.g. for self-referential annotations or known circular dependencies between backend, config, manager, etc.) keep both the guard and the future import.

We can remove all of these __future__ and imports and TYPE_CHECKING guards once our lowest supported python version is 3.14, which imports PEP 649, deferred evaluation of annotations: https://peps.python.org/pep-0649/

This gets rid of ~300 lines of boilerplate that I often find inscrutable: "when should I put this in TYPE_CHECKING? when should I not? why the difference?".