### PR TITLE
wayland: dispatch pointer enter/leave/motion to bar widgets

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -143,6 +143,7 @@ extern "Python" void manage_view_cb(struct qw_view *view, void *userdata);
 extern "Python" void unmanage_view_cb(struct qw_view *view, void *userdata);
 extern "Python" void cursor_motion_cb(void *userdata);
 extern "Python" int cursor_button_cb(int button, uint32_t mask, bool pressed, int x, int y, void *userdata);
+extern "Python" void pointer_internal_event_cb(int wid, int sx, int sy, int event_type, void *userdata);
 extern "Python" void on_screen_change_cb(void *userdata);
 extern "Python" void on_screen_reserve_space_cb(struct qw_output *output, void *userdata);
 extern "Python" void on_input_device_added_cb(void *userdata);

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -238,10 +238,6 @@ class Core(base.Core):
     def __init__(self) -> None:
         # this Internal window receives keyboard input, e.g. via the Prompt widget.
         self.focused_internal: base.Internal | None = None
-        # bar currently under the pointer and last bar-local cursor coords;
-        # used to dispatch widget hover events from handle_cursor_motion.
-        self._pointer_bar: Any = None
-        self._pointer_pos: tuple[int, int] = (0, 0)
 
         """Setup the Wayland core backend"""
         lib.qw_log_init(get_wlr_log_level(), lib.log_cb)
@@ -413,62 +409,9 @@ class Core(base.Core):
     def handle_cursor_motion(self) -> None:
         assert self.qtile is not None
         self._focus_pointer(motion=True)
-        cx = int(self.qw_cursor.cursor.x)
-        cy = int(self.qw_cursor.cursor.y)
-        self.qtile.process_button_motion(cx, cy)
-        self._dispatch_bar_pointer(cx, cy)
-
-    def _dispatch_bar_pointer(self, cx: int, cy: int) -> None:
-        """Hit-test the bars and dispatch pointer enter/leave/motion.
-
-        On X11 these are delivered via XCB EnterNotify/LeaveNotify/MotionNotify
-        which Internal-window event handlers forward to
-        ``Bar.process_pointer_{enter,leave,motion}`` (rewired in
-        ``Bar._configure``). On the Wayland side, wlroots gives the
-        compositor a single global cursor motion stream (``wlr_cursor``)
-        with no per-Internal-window enter/leave, so we hit-test the bar
-        rectangles ourselves and call the same entry points. Without
-        this, widget ``mouse_enter`` / ``mouse_leave`` callbacks (used
-        e.g. by qtile-extras' TooltipMixin) never fire on the Wayland
-        backend.
-        """
-        assert self.qtile is not None
-
-        new_bar = None
-        lx = ly = 0
-        live_bars = []
-        for screen in self.qtile.screens:
-            for bar in (screen.top, screen.bottom, screen.left, screen.right):
-                if bar is None:
-                    continue
-                live_bars.append(bar)
-                if bar.x <= cx < bar.x + bar.width and bar.y <= cy < bar.y + bar.height:
-                    new_bar = bar
-                    lx = cx - bar.x
-                    ly = cy - bar.y
-
-        prev = self._pointer_bar
-        # Drop the reference if the previous bar was finalized (e.g. on
-        # screen reconfigure). Calling process_pointer_leave on a dead bar
-        # would touch a torn-down drawer/window.
-        if prev is not None and prev not in live_bars:
-            prev = None
-            self._pointer_bar = None
-
-        if new_bar is prev:
-            if new_bar is not None:
-                new_bar.process_pointer_motion(lx, ly)
-                self._pointer_pos = (lx, ly)
-            return
-        if prev is not None:
-            # Pass the last known bar-local coords so widget.mouse_leave
-            # gets a sensible position, matching the X11 path which
-            # delivers the LeaveNotify event coordinates.
-            prev.process_pointer_leave(*self._pointer_pos)
-        if new_bar is not None:
-            new_bar.process_pointer_enter(lx, ly)
-        self._pointer_bar = new_bar
-        self._pointer_pos = (lx, ly)
+        self.qtile.process_button_motion(
+            int(self.qw_cursor.cursor.x), int(self.qw_cursor.cursor.y)
+        )
 
     def handle_cursor_button(self, button: int, mask: int, pressed: bool, x: int, y: int) -> bool:
         assert self.qtile is not None

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -238,6 +238,10 @@ class Core(base.Core):
     def __init__(self) -> None:
         # this Internal window receives keyboard input, e.g. via the Prompt widget.
         self.focused_internal: base.Internal | None = None
+        # bar currently under the pointer and last bar-local cursor coords;
+        # used to dispatch widget hover events from handle_cursor_motion.
+        self._pointer_bar: Any = None
+        self._pointer_pos: tuple[int, int] = (0, 0)
 
         """Setup the Wayland core backend"""
         lib.qw_log_init(get_wlr_log_level(), lib.log_cb)
@@ -409,9 +413,62 @@ class Core(base.Core):
     def handle_cursor_motion(self) -> None:
         assert self.qtile is not None
         self._focus_pointer(motion=True)
-        self.qtile.process_button_motion(
-            int(self.qw_cursor.cursor.x), int(self.qw_cursor.cursor.y)
-        )
+        cx = int(self.qw_cursor.cursor.x)
+        cy = int(self.qw_cursor.cursor.y)
+        self.qtile.process_button_motion(cx, cy)
+        self._dispatch_bar_pointer(cx, cy)
+
+    def _dispatch_bar_pointer(self, cx: int, cy: int) -> None:
+        """Hit-test the bars and dispatch pointer enter/leave/motion.
+
+        On X11 these are delivered via XCB EnterNotify/LeaveNotify/MotionNotify
+        which Internal-window event handlers forward to
+        ``Bar.process_pointer_{enter,leave,motion}`` (rewired in
+        ``Bar._configure``). On the Wayland side, wlroots gives the
+        compositor a single global cursor motion stream (``wlr_cursor``)
+        with no per-Internal-window enter/leave, so we hit-test the bar
+        rectangles ourselves and call the same entry points. Without
+        this, widget ``mouse_enter`` / ``mouse_leave`` callbacks (used
+        e.g. by qtile-extras' TooltipMixin) never fire on the Wayland
+        backend.
+        """
+        assert self.qtile is not None
+
+        new_bar = None
+        lx = ly = 0
+        live_bars = []
+        for screen in self.qtile.screens:
+            for bar in (screen.top, screen.bottom, screen.left, screen.right):
+                if bar is None:
+                    continue
+                live_bars.append(bar)
+                if bar.x <= cx < bar.x + bar.width and bar.y <= cy < bar.y + bar.height:
+                    new_bar = bar
+                    lx = cx - bar.x
+                    ly = cy - bar.y
+
+        prev = self._pointer_bar
+        # Drop the reference if the previous bar was finalized (e.g. on
+        # screen reconfigure). Calling process_pointer_leave on a dead bar
+        # would touch a torn-down drawer/window.
+        if prev is not None and prev not in live_bars:
+            prev = None
+            self._pointer_bar = None
+
+        if new_bar is prev:
+            if new_bar is not None:
+                new_bar.process_pointer_motion(lx, ly)
+                self._pointer_pos = (lx, ly)
+            return
+        if prev is not None:
+            # Pass the last known bar-local coords so widget.mouse_leave
+            # gets a sensible position, matching the X11 path which
+            # delivers the LeaveNotify event coordinates.
+            prev.process_pointer_leave(*self._pointer_pos)
+        if new_bar is not None:
+            new_bar.process_pointer_enter(lx, ly)
+        self._pointer_bar = new_bar
+        self._pointer_pos = (lx, ly)
 
     def handle_cursor_button(self, button: int, mask: int, pressed: bool, x: int, y: int) -> bool:
         assert self.qtile is not None

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -137,6 +137,14 @@ def cursor_button_cb(
 
 
 @ffi.def_extern()
+def pointer_internal_event_cb(
+    wid: int, sx: int, sy: int, event_type: int, userdata: ffi.CData
+) -> None:
+    core = ffi.from_handle(userdata)
+    core.handle_pointer_internal_event(wid, sx, sy, event_type)
+
+
+@ffi.def_extern()
 def on_screen_change_cb(userdata: ffi.CData) -> None:
     core = ffi.from_handle(userdata)
     core.handle_screen_change()
@@ -258,6 +266,7 @@ class Core(base.Core):
         self.qw.unmanage_view_cb = lib.unmanage_view_cb
         self.qw.cursor_motion_cb = lib.cursor_motion_cb
         self.qw.cursor_button_cb = lib.cursor_button_cb
+        self.qw.pointer_internal_event_cb = lib.pointer_internal_event_cb
         self.qw.on_screen_change_cb = lib.on_screen_change_cb
         self.qw.on_screen_reserve_space_cb = lib.on_screen_reserve_space_cb
         self.qw.view_activation_cb = lib.view_activation_cb
@@ -412,6 +421,19 @@ class Core(base.Core):
         self.qtile.process_button_motion(
             int(self.qw_cursor.cursor.x), int(self.qw_cursor.cursor.y)
         )
+
+    def handle_pointer_internal_event(self, wid: int, sx: int, sy: int, event_type: int) -> None:
+        """Forward a pointer enter/leave/motion event on an Internal view."""
+        assert self.qtile is not None
+        win = self.qtile.windows_map.get(wid)
+        if not isinstance(win, base.Internal):
+            return
+        if event_type == lib.QW_POINTER_INTERNAL_ENTER:
+            win.process_pointer_enter(sx, sy)
+        elif event_type == lib.QW_POINTER_INTERNAL_LEAVE:
+            win.process_pointer_leave(sx, sy)
+        elif event_type == lib.QW_POINTER_INTERNAL_MOTION:
+            win.process_pointer_motion(sx, sy)
 
     def handle_cursor_button(self, button: int, mask: int, pressed: bool, x: int, y: int) -> bool:
         assert self.qtile is not None

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -6,6 +6,7 @@
 #include "output.h"
 #include "server.h"
 #include "util.h"
+#include "view.h"
 #include "wayland-util.h"
 
 void qw_cursor_destroy(struct qw_cursor *cursor) {
@@ -20,6 +21,9 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
 
     free(cursor);
 }
+
+// Forward declaration: dispatch Internal-view enter/leave/motion to compositor.
+static void qw_cursor_dispatch_internal_pointer(struct qw_cursor *cursor, double sx, double sy);
 
 // Pointer focus helper function
 static void update_pointer_focus(struct qw_cursor *cursor, struct wlr_surface *surface, double sx,
@@ -37,6 +41,35 @@ static void update_pointer_focus(struct qw_cursor *cursor, struct wlr_surface *s
         if (surface != prev_surface) {
             wlr_seat_pointer_notify_enter(seat, surface, sx, sy);
         }
+    }
+    qw_cursor_dispatch_internal_pointer(cursor, sx, sy);
+}
+
+// Notify the compositor about pointer enter/leave/motion on Internal views.
+static void qw_cursor_dispatch_internal_pointer(struct qw_cursor *cursor, double sx, double sy) {
+    if (!cursor->server->pointer_internal_event_cb) {
+        return;
+    }
+
+    int new_wid = -1;
+    if (cursor->view != NULL && cursor->view->view_type == QW_VIEW_INTERNAL) {
+        new_wid = cursor->view->wid;
+    }
+
+    int prev_wid = cursor->prev_internal_wid;
+    if (new_wid != prev_wid) {
+        if (prev_wid != -1) {
+            cursor->server->pointer_internal_event_cb(prev_wid, 0, 0, QW_POINTER_INTERNAL_LEAVE,
+                                                      cursor->server->cb_data);
+        }
+        if (new_wid != -1) {
+            cursor->server->pointer_internal_event_cb(
+                new_wid, (int)sx, (int)sy, QW_POINTER_INTERNAL_ENTER, cursor->server->cb_data);
+        }
+        cursor->prev_internal_wid = new_wid;
+    } else if (new_wid != -1) {
+        cursor->server->pointer_internal_event_cb(
+            new_wid, (int)sx, (int)sy, QW_POINTER_INTERNAL_MOTION, cursor->server->cb_data);
     }
 }
 
@@ -368,6 +401,7 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     }
 
     cursor->server = server;
+    cursor->prev_internal_wid = -1;
     cursor->cursor = wlr_cursor_create();
     wlr_cursor_attach_output_layout(cursor->cursor, server->output_layout);
     cursor->mgr = wlr_xcursor_manager_create(NULL, 24);

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -37,6 +37,8 @@ struct qw_cursor {
     struct wlr_pointer_constraint_v1 *active_constraint;
     bool active_confine_requires_warp;
     pixman_region32_t confine;
+    // Wid of the Internal view currently under the pointer (-1 if none).
+    int prev_internal_wid;
 };
 
 struct qw_pointer_constraint {

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -99,6 +99,15 @@ typedef void (*cursor_motion_cb_t)(void *userdata);
 typedef int (*cursor_button_cb_t)(int button, uint32_t mask, bool pressed, int x, int y,
                                   void *userdata);
 
+// Pointer enter/leave/motion event on an Internal view (e.g. a bar).
+enum qw_pointer_internal_event_type {
+    QW_POINTER_INTERNAL_ENTER = 0,
+    QW_POINTER_INTERNAL_LEAVE = 1,
+    QW_POINTER_INTERNAL_MOTION = 2,
+};
+typedef void (*pointer_internal_event_cb_t)(int wid, int sx, int sy, int event_type,
+                                            void *userdata);
+
 // Forward declaration for wlr_output
 struct wlr_output;
 
@@ -197,6 +206,7 @@ struct qw_server {
     unmanage_view_cb_t unmanage_view_cb;
     cursor_motion_cb_t cursor_motion_cb;
     cursor_button_cb_t cursor_button_cb;
+    pointer_internal_event_cb_t pointer_internal_event_cb;
     on_screen_change_cb_t on_screen_change_cb;
     on_screen_reserve_space_cb_t on_screen_reserve_space_cb;
     view_activation_cb_t view_activation_cb;

--- a/test/backend/wayland/test_bar_pointer.py
+++ b/test/backend/wayland/test_bar_pointer.py
@@ -1,0 +1,66 @@
+import pytest
+
+import libqtile.bar
+import libqtile.config
+import libqtile.widget
+from test.conftest import BareConfig
+
+
+class HoverCounter(libqtile.widget.TextBox):
+    """TextBox that counts mouse_enter / mouse_leave calls."""
+
+    def __init__(self, **kwargs):
+        libqtile.widget.TextBox.__init__(self, **kwargs)
+        self.enter_count = 0
+        self.leave_count = 0
+
+    def mouse_enter(self, x, y):
+        self.enter_count += 1
+
+    def mouse_leave(self, x, y):
+        self.leave_count += 1
+
+
+class HoverConfig(BareConfig):
+    screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [HoverCounter(text="hov", name="hov")],
+                30,
+            ),
+        ),
+    ]
+
+
+hover_config = pytest.mark.parametrize("wmanager", [HoverConfig], indirect=True)
+
+
+@hover_config
+def test_bar_widget_pointer_events(wmanager):
+    """Cursor crossing a bar widget fires mouse_enter / mouse_leave."""
+    enter = 'self.widgets_map["hov"].enter_count'
+    leave = 'self.widgets_map["hov"].leave_count'
+
+    # Cursor outside the bar — no events.
+    wmanager.backend.fake_motion(400, 400)
+    wmanager.c.sync()
+    assert int(wmanager.c.eval(enter)) == 0
+    assert int(wmanager.c.eval(leave)) == 0
+
+    # Move into the top bar over the widget.
+    wmanager.backend.fake_motion(10, 10)
+    wmanager.c.sync()
+    assert int(wmanager.c.eval(enter)) == 1
+    assert int(wmanager.c.eval(leave)) == 0
+
+    # Move back out.
+    wmanager.backend.fake_motion(400, 400)
+    wmanager.c.sync()
+    assert int(wmanager.c.eval(enter)) == 1
+    assert int(wmanager.c.eval(leave)) == 1
+
+    # Re-entering increments enter_count again.
+    wmanager.backend.fake_motion(10, 10)
+    wmanager.c.sync()
+    assert int(wmanager.c.eval(enter)) == 2
+    assert int(wmanager.c.eval(leave)) == 1


### PR DESCRIPTION
Like x11, bar widgets need mouse_enter / mouse_leave to drive things like tooltips. On x11 the EnterNotify / LeaveNotify / MotionNotify path already feeds Bar.process_pointer_* on each bar window. On wayland nothing was firing those, so hover callbacks (e.g. qtile-extras' TooltipMixin) never ran.

The qw_view returned by qw_server_view_at is already enough — when it points to an Internal view, fire pointer_internal_event_cb after the existing focus update. Track the previous wid in qw_cursor so each transition produces one ENTER / LEAVE / MOTION event. The python side just forwards into win.process_pointer_*, which is the same dispatch x11 uses.

No extra hit-testing on the hot path: the scene graph lookup was already running for ordinary pointer focus.