### PR TITLE
widget: make ThermalSensor threaded again

### DIFF
--- a/libqtile/widget/sensors.py
+++ b/libqtile/widget/sensors.py
@@ -3,7 +3,7 @@ import psutil
 from libqtile.widget import base
 
 
-class ThermalSensor(base.InLoopPollText):
+class ThermalSensor(base.BackgroundPoll):
     """Widget to display temperature sensor information
 
     For using the thermal sensor widget you need to have lm-sensors installed.
@@ -37,7 +37,7 @@ class ThermalSensor(base.InLoopPollText):
     ]
 
     def __init__(self, **config):
-        base.InLoopPollText.__init__(self, **config)
+        base.BackgroundPoll.__init__(self, **config)
         self.add_defaults(ThermalSensor.defaults)
         temp_values = self.get_temp_sensors()
 
@@ -52,7 +52,7 @@ class ThermalSensor(base.InLoopPollText):
 
     def _configure(self, qtile, bar):
         self.unit = "°C" if self.metric else "°F"
-        base.InLoopPollText._configure(self, qtile, bar)
+        base.BackgroundPoll._configure(self, qtile, bar)
         self.foreground_normal = self.foreground
 
     def get_temp_sensors(self):


### PR DESCRIPTION
It seems that some sysfs reads for these sensors do actually block, and so we should keep this as threaded. Hopefully someone will implement an asyncio-based psutil (that's real, I looked at aiopsutil, but it just spawns threads itself), and then we can use `async def apoll` and not need the thread at all...

Fixes #5912