### PR TITLE
Remove redundant `group.layout_all()` calls

### DIFF
--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -485,7 +485,6 @@ class _SimpleLayoutBase(Layout):
 
     def swap(self, window1: Window, window2: Window) -> None:
         self.clients.swap(window1, window2)
-        self.group.layout_all()
         self.group.focus(window1)
 
     def next(self) -> None:

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -744,14 +744,12 @@ class MonadTall(_SimpleLayoutBase):
     def shuffle_up(self):
         """Shuffle the client up the stack"""
         self.clients.shuffle_up()
-        self.group.layout_all()
         self.group.focus(self.clients.current_client)
 
     @expose_command()
     def shuffle_down(self):
         """Shuffle the client down the stack"""
         self.clients.shuffle_down()
-        self.group.layout_all()
         self.group.focus(self.clients[self.focused])
 
     @expose_command()


### PR DESCRIPTION
In a couple of places there are calls to `group.layout_all` before `group.focus`. As `group.focus` calls `layout_all` at the end of the function, we can remove the unnecessary calls.