### PR TITLE
DF Widget: Floating Point Values and Used Space

### DIFF
--- a/libqtile/widget/df.py
+++ b/libqtile/widget/df.py
@@ -18,7 +18,7 @@ class DF(base.InLoopPollText):
         (
             "format",
             "{p} ({uf:.0f}{m}|{r:.0f}%)",
-            "String format (p: partition, s: size, "
+            "String format (p: partition, s: size, u: used space, "
             "f: free space, uf: user free space, m: measure, r: ratio (uf/s))",
         ),
         ("update_interval", 60, "The update interval."),
@@ -46,6 +46,7 @@ class DF(base.InLoopPollText):
         size = statvfs.f_frsize * statvfs.f_blocks / self.calc
         free = statvfs.f_frsize * statvfs.f_bfree / self.calc
         self.user_free = statvfs.f_frsize * statvfs.f_bavail / self.calc
+        used = size - free
 
         if self.visible_on_warn and self.user_free >= self.warn_space:
             text = ""
@@ -54,6 +55,7 @@ class DF(base.InLoopPollText):
                 p=self.partition,
                 s=size,
                 f=free,
+                u=used,
                 uf=self.user_free,
                 m=self.measure,
                 r=(size - self.user_free) / size * 100,

--- a/libqtile/widget/df.py
+++ b/libqtile/widget/df.py
@@ -17,7 +17,7 @@ class DF(base.InLoopPollText):
         ("measure", "G", "Measurement (G, M, B)"),
         (
             "format",
-            "{p} ({uf}{m}|{r:.0f}%)",
+            "{p} ({uf:.0f}{m}|{r:.0f}%)",
             "String format (p: partition, s: size, "
             "f: free space, uf: user free space, m: measure, r: ratio (uf/s))",
         ),
@@ -43,9 +43,9 @@ class DF(base.InLoopPollText):
     def poll(self):
         statvfs = os.statvfs(self.partition)
 
-        size = statvfs.f_frsize * statvfs.f_blocks // self.calc
-        free = statvfs.f_frsize * statvfs.f_bfree // self.calc
-        self.user_free = statvfs.f_frsize * statvfs.f_bavail // self.calc
+        size = statvfs.f_frsize * statvfs.f_blocks / self.calc
+        free = statvfs.f_frsize * statvfs.f_bfree / self.calc
+        self.user_free = statvfs.f_frsize * statvfs.f_bavail / self.calc
 
         if self.visible_on_warn and self.user_free >= self.warn_space:
             text = ""


### PR DESCRIPTION
I noticed that the DF widget used integer division when converting from bytes to kilo-, mega- or gigabytes. This way, when trying to display the free space in GiB to two decimals with `{f:.2f}` in the format parameter of the widget, the digits after the dot would always be zero.

I was also missing a used space option, something that I would want to add to my widget. I checked using `df -h /` and the value is the same as what is calculated here.

*I recognize that this change affects existing configs,* as it might produce long unwanted decimals if `:.0f`is not added after the parameter in the format string.

I would like to hear your input on this change!