### PR TITLE
widgets: move to zoneinfo for timezone manipulation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
+      - The Clock widget now uses the stdlib zoneinfo module for string
+        timezone lookup. pytz is no longer a (optional) dependency.
     * bugfixes
       - Fix timers on BackgrounPoll-based widgets not clearing on config reload
 

--- a/libqtile/widget/clock.py
+++ b/libqtile/widget/clock.py
@@ -1,20 +1,10 @@
-import sys
 import time
 from datetime import UTC, datetime, timedelta, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from libqtile.command.base import expose_command
 from libqtile.log_utils import logger
 from libqtile.widget import base
-
-try:
-    import pytz
-except ImportError:
-    pass
-
-try:
-    import dateutil.tz
-except ImportError:
-    pass
 
 
 class Clock(base.InLoopPollText):
@@ -26,11 +16,10 @@ class Clock(base.InLoopPollText):
         (
             "timezone",
             None,
-            "The timezone to use for this clock, either as"
-            ' string if pytz or dateutil is installed (e.g. "US/Central" or'
-            " anything in /usr/share/zoneinfo), or as tzinfo (e.g."
-            " datetime.timezone.utc). None means the system local timezone and is"
-            " the default.",
+            "The timezone to use for this clock, either as a string (e.g."
+            ' "US/Central" or anything in /usr/share/zoneinfo), or as a'
+            " datetime.tzinfo instance (e.g. datetime.timezone.utc). None"
+            " means the system local timezone and is the default.",
         ),
     ]
     DELTA = timedelta(seconds=0.5)
@@ -51,18 +40,10 @@ class Clock(base.InLoopPollText):
             if not timezone:
                 return None
 
-            # A string timezone needs to be converted to a tzinfo object
-            if "pytz" in sys.modules:
-                return pytz.timezone(timezone)
-            elif "dateutil" in sys.modules:
-                return dateutil.tz.gettz(timezone)
-            else:
-                logger.warning(
-                    "Clock widget can not infer its timezone from a"
-                    " string without pytz or dateutil. Install one"
-                    " of these libraries, or give it a"
-                    " datetime.tzinfo instance."
-                )
+            try:
+                return ZoneInfo(timezone)
+            except ZoneInfoNotFoundError:
+                logger.warning("Invalid timezone %s.", timezone)
         elif timezone is None:
             pass
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ widgets = [
     "pulsectl",
     "pulsectl_asyncio",
     "python-mpd2",
-    "pytz",
     "pyxdg",
     "xmltodict",
     "aiohttp",

--- a/test/widgets/test_clock.py
+++ b/test/widgets/test_clock.py
@@ -1,278 +1,64 @@
 import datetime
-import sys
-from importlib import reload
+import time
 
 import pytest
 
-import libqtile.config
 from libqtile.widget import clock
-from test.widgets.conftest import FakeBar
 
 
-def no_op(*args, **kwargs):
-    pass
-
-
-# Mock Datetime object that returns a set datetime and also
-# has a simplified timezone method to check functionality of
-# the widget.
 class MockDatetime(datetime.datetime):
     @classmethod
-    def now(cls, *args, **kwargs):
-        return cls(2021, 1, 1, 10, 20, 30)
-
-    def astimezone(self, tzone=None):
-        if tzone is None:
-            return self
-        return self + tzone.utcoffset(None)
+    def now(cls, tz=None, *args, **kwargs):
+        return cls(2021, 1, 1, 10, 20, 30, tzinfo=tz)
 
 
 @pytest.fixture
 def patched_clock(monkeypatch):
-    # Stop system importing these modules in case they exist on environment
-    monkeypatch.setitem(sys.modules, "pytz", None)
-    monkeypatch.setitem(sys.modules, "dateutil", None)
-    monkeypatch.setitem(sys.modules, "dateutil.tz", None)
-
-    # Reload module to force ImportErrors
-    reload(clock)
-
-    # Override datetime.
-    # This is key for testing as we can fix time.
+    # Pretend the system timezone is UTC so .astimezone() with no arg behaves
+    # consistently across test machines.
+    monkeypatch.setenv("TZ", "UTC")
+    time.tzset()
     monkeypatch.setattr("libqtile.widget.clock.datetime", MockDatetime)
 
 
-def test_clock(fake_qtile, monkeypatch, fake_window):
+@pytest.mark.usefixtures("patched_clock")
+def test_clock_default():
     """test clock output with default settings"""
-    monkeypatch.setattr("libqtile.widget.clock.datetime", MockDatetime)
-    clk1 = clock.Clock()
-    fakebar = FakeBar([clk1], window=fake_window)
-    clk1._configure(fake_qtile, fakebar)
-    text = clk1.poll()
-    assert text == "10:20"
+    assert clock.Clock().poll() == "10:20"
 
 
 @pytest.mark.usefixtures("patched_clock")
-def test_clock_invalid_timezone(fake_qtile, monkeypatch, fake_window, caplog):
-    """test clock widget with invalid timezone (and no pytz or dateutil modules)"""
-
-    class FakeDateutilTZ:
-        @classmethod
-        def tz(cls):
-            return cls
-
-        @classmethod
-        def gettz(cls, val):
-            return None
-
-    # pytz and dateutil must not be in the sys.modules dict...
-    monkeypatch.delitem(sys.modules, "pytz")
-    monkeypatch.delitem(sys.modules, "dateutil")
-
-    # Set up references to pytz and dateutil so we know these aren't being used
-    # If they're called, the widget would try to run None(self.timezone) which
-    # would raise an exception
-    clock.pytz = None
-    clock.dateutil = FakeDateutilTZ
-
-    # Fake datetime module just adds the timezone value to the time
-    clk2 = clock.Clock(timezone="1")
-
-    fakebar = FakeBar([clk2], window=fake_window)
-    clk2._configure(fake_qtile, fakebar)
-
-    # An invalid timezone results in a log message
-    assert (
-        "Clock widget can not infer its timezone from a string without pytz or dateutil."
-        in caplog.text
-    )
+def test_clock_invalid_timezone(caplog):
+    """test clock widget with invalid timezone string"""
+    clock.Clock(timezone="Not/A/Real/Zone")
+    assert "Invalid timezone Not/A/Real/Zone." in caplog.text
 
 
 @pytest.mark.usefixtures("patched_clock")
-def test_clock_datetime_timezone(fake_qtile, monkeypatch, fake_window):
-    """test clock with datetime timezone"""
-
-    class FakeDateutilTZ:
-        class TZ:
-            @classmethod
-            def gettz(cls, val):
-                None
-
-        tz = TZ
-
-    # Set up references to pytz and dateutil so we know these aren't being used
-    # If they're called, the widget would try to run None(self.timezone) which
-    # would raise an exception
-    clock.pytz = None
-    clock.dateutil = FakeDateutilTZ
-
-    # Fake datetime module just adds the timezone value to the time
+def test_clock_datetime_timezone():
+    """test clock with a datetime.tzinfo timezone"""
     tz = datetime.timezone(datetime.timedelta(hours=1))
-    clk3 = clock.Clock(timezone=tz)
-
-    fakebar = FakeBar([clk3], window=fake_window)
-    clk3._configure(fake_qtile, fakebar)
-    text = clk3.poll()
-
-    # Default time is 10:20 and we add 1 hour for the timezone
-    assert text == "11:20"
+    assert clock.Clock(timezone=tz).poll() == "11:20"
 
 
 @pytest.mark.usefixtures("patched_clock")
-def test_clock_pytz_timezone(fake_qtile, monkeypatch, fake_window):
-    """test clock with pytz timezone"""
-
-    class FakeDateutilTZ:
-        class TZ:
-            @classmethod
-            def gettz(cls, val):
-                None
-
-        tz = TZ
-
-    class FakePytz:
-        # pytz timezone is a string so convert it to an int and add 1
-        # to show that this code is being run
-        @classmethod
-        def timezone(cls, value):
-            hours = int(value) + 1
-            return datetime.timezone(datetime.timedelta(hours=hours))
-
-    # We need pytz in the sys.modules dict
-    monkeypatch.setitem(sys.modules, "pytz", True)
-
-    # Set up references to pytz and dateutil so we know these aren't being used
-    # If they're called, the widget would try to run None(self.timezone) which
-    # would raise an exception
-    clock.pytz = FakePytz
-    clock.dateutil = FakeDateutilTZ
-
-    # Pytz timezone must be a string
-    clk4 = clock.Clock(timezone="1")
-
-    fakebar = FakeBar([clk4], window=fake_window)
-    clk4._configure(fake_qtile, fakebar)
-    text = clk4.poll()
-
-    # Default time is 10:20 and we add 1 hour for the timezone plus and extra
-    # 1 for the pytz function
-    assert text == "12:20"
+def test_clock_string_timezone():
+    """test clock with a zoneinfo string timezone"""
+    # Asia/Kolkata is UTC+5:30 year-round (no DST)
+    assert clock.Clock(timezone="Asia/Kolkata").poll() == "15:50"
 
 
 @pytest.mark.usefixtures("patched_clock")
-def test_clock_dateutil_timezone(fake_qtile, monkeypatch, fake_window):
-    """test clock with dateutil timezone"""
-
-    class FakeDateutilTZ:
-        class TZ:
-            @classmethod
-            def gettz(cls, val):
-                hours = int(val) + 2
-                return datetime.timezone(datetime.timedelta(hours=hours))
-
-        tz = TZ
-
-    # pytz must not be in the sys.modules dict...
-    monkeypatch.delitem(sys.modules, "pytz")
-
-    # ...but dateutil must be
-    monkeypatch.setitem(sys.modules, "dateutil", True)
-
-    # Set up references to pytz and dateutil so we know these aren't being used
-    # If they're called, the widget would try to run None(self.timezone) which
-    # would raise an exception
-    clock.pytz = None
-    clock.dateutil = FakeDateutilTZ
-
-    # Pytz timezone must be a string
-    clk5 = clock.Clock(timezone="1")
-
-    fakebar = FakeBar([clk5], window=fake_window)
-    clk5._configure(fake_qtile, fakebar)
-    text = clk5.poll()
-
-    # Default time is 10:20 and we add 1 hour for the timezone plus and extra
-    # 1 for the pytz function
-    assert text == "13:20"
-
-
-@pytest.mark.usefixtures("patched_clock")
-def test_clock_tick(manager_nospawn, minimal_conf_noscreen, monkeypatch):
-    """Test clock ticks"""
-
-    class FakeDateutilTZ:
-        class TZ:
-            @classmethod
-            def gettz(cls, val):
-                return int(val) + 2
-
-        tz = TZ
-
-    class TickingDateTime(datetime.datetime):
-        offset = 0
-
-        @classmethod
-        def now(cls, *args, **kwargs):
-            return cls(2021, 1, 1, 10, 20, 30)
-
-        # This will return 10:20 on first call and 10:21 on all
-        # subsequent calls
-        def astimezone(self, tzone=None):
-            extra = datetime.timedelta(minutes=TickingDateTime.offset)
-            if TickingDateTime.offset < 1:
-                TickingDateTime.offset += 1
-
-            if tzone is None:
-                return self + extra
-            return self + datetime.timedelta(hours=tzone) + extra
-
-    # pytz must not be in the sys.modules dict...
-    monkeypatch.delitem(sys.modules, "pytz")
-
-    # ...but dateutil must be
-    monkeypatch.setitem(sys.modules, "dateutil", True)
-
-    # Override datetime
-    monkeypatch.setattr("libqtile.widget.clock.datetime", TickingDateTime)
-
-    # Set up references to pytz and dateutil so we know these aren't being used
-    # If they're called, the widget would try to run None(self.timezone) which
-    # would raise an exception
-    clock.pytz = None
-    clock.dateutil = FakeDateutilTZ
-
-    # set a long update interval as we'll tick manually
-    clk6 = clock.Clock(update_interval=100)
-
-    config = minimal_conf_noscreen
-    config.screens = [libqtile.config.Screen(top=libqtile.bar.Bar([clk6], 10))]
-
-    manager_nospawn.start(config)
-
-    topbar = manager_nospawn.c.bar["top"]
-    manager_nospawn.c.widget["clock"].eval("self.tick()")
-    assert topbar.info()["widgets"][0]["text"] == "10:21"
-
-
-@pytest.mark.usefixtures("patched_clock")
-def test_clock_change_timezones(fake_qtile, monkeypatch, fake_window):
+def test_clock_change_timezones():
     """test commands to change timezones"""
-
     tz1 = datetime.timezone(datetime.timedelta(hours=1))
     tz2 = datetime.timezone(-datetime.timedelta(hours=1))
 
-    # Pytz timezone must be a string
-    clk4 = clock.Clock(timezone=tz1)
+    clk = clock.Clock(timezone=tz1)
+    assert clk.poll() == "11:20"
 
-    fakebar = FakeBar([clk4], window=fake_window)
-    clk4._configure(fake_qtile, fakebar)
-    text = clk4.poll()
-    assert text == "11:20"
+    clk.timezone = clk._lift_timezone(tz2)
+    assert clk.poll() == "09:20"
 
-    clk4.update_timezone(tz2)
-    text = clk4.poll()
-    assert text == "09:20"
-
-    clk4.use_system_timezone()
-    text = clk4.poll()
-    assert text == "10:20"
+    clk.timezone = clk._lift_timezone("")
+    assert clk.poll() == "10:20"

--- a/test/widgets/test_vertical_clock.py
+++ b/test/widgets/test_vertical_clock.py
@@ -1,6 +1,4 @@
 import datetime
-import sys
-from importlib import reload
 
 import pytest
 
@@ -25,14 +23,6 @@ class MockDatetime(datetime.datetime):
 
 @pytest.fixture
 def patched_clock(monkeypatch):
-    # Stop system importing these modules in case they exist on environment
-    monkeypatch.setitem(sys.modules, "pytz", None)
-    monkeypatch.setitem(sys.modules, "dateutil", None)
-    monkeypatch.setitem(sys.modules, "dateutil.tz", None)
-
-    # Reload module to force ImportErrors
-    reload(vertical_clock)
-
     # Override datetime.
     # This is key for testing as we can fix time.
     monkeypatch.setattr("libqtile.widget.vertical_clock.datetime", MockDatetime)


### PR DESCRIPTION
Now that we can use upstream zoneinfo to do lookup-by-string for timezone, switch to that so there's no longer an optional out of tree dependency required.

This also greatly simplifies the tests: we don't need any fake bar infrastructure, monkey patching of all the libraries, etc. We can just create the widget, set the timezone, and call poll() accordingly to see what time it renders.

Fixes #5798