### PR TITLE
[wayland] border colour fixes

### DIFF
--- a/libqtile/backend/wayland/qw/util.c
+++ b/libqtile/backend/wayland/qw/util.c
@@ -174,3 +174,12 @@ struct qw_view *qw_view_from_wlr_surface(struct wlr_surface *surface, bool *is_l
 
     return NULL;
 }
+
+void qw_util_premultiply_rgba(const float rgba[4], float opacity, float out[4]) {
+    float alpha = rgba[3] * opacity;
+
+    out[0] = rgba[0] * alpha;
+    out[1] = rgba[1] * alpha;
+    out[2] = rgba[2] * alpha;
+    out[3] = alpha;
+}

--- a/libqtile/backend/wayland/qw/util.h
+++ b/libqtile/backend/wayland/qw/util.h
@@ -38,4 +38,7 @@ bool qw_surfaces_on_same_output(struct wlr_surface *surface_a, struct wlr_surfac
 struct qw_view *qw_view_from_wlr_surface(struct wlr_surface *surface, bool *is_layer_surface,
                                          bool *is_session_lock_surface);
 
+// wlr scene rects expect pre-multiplied RGBA values
+void qw_util_premultiply_rgba(const float rgba[4], float opacity, float out[4]);
+
 #endif /* UTIL_H */

--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -223,8 +223,10 @@ void qw_view_paint_borders(struct qw_view *view, const struct qw_border *borders
 
         if (src->type == QW_BORDER_RECT) {
             for (int j = 0; j < 4; j++) {
+                float rect_color[4];
+                qw_util_premultiply_rgba(src->rect.color[j], view->opacity, rect_color);
                 struct wlr_scene_rect *rect = wlr_scene_rect_create(
-                    view->content_tree, sides[j].width, sides[j].height, src->rect.color[j]);
+                    view->content_tree, sides[j].width, sides[j].height, rect_color);
                 if (!rect) {
                     wlr_log(WLR_ERROR, "Failed to create scene_rect for border");
                     continue;
@@ -232,6 +234,8 @@ void qw_view_paint_borders(struct qw_view *view, const struct qw_border *borders
                 wlr_scene_node_set_position(&rect->node, sides[j].x, sides[j].y);
                 view->borders[i].rects[j] = rect;
             }
+            // Store the original colour in the border so we can update if window opacity changes
+            memcpy(view->borders[i].color, src->rect.color, sizeof(view->borders[i].color));
 
         } else if (src->type == QW_BORDER_BUFFER) {
             cairo_surface_t *surface = src->buffer.surface;
@@ -438,26 +442,40 @@ struct qw_output *qw_view_get_primary_output(struct qw_view *view) {
 void qw_view_grab_click(struct qw_view *view) { view->grabbed_click = true; }
 
 void qw_view_ungrab_click(struct qw_view *view) { view->grabbed_click = false; }
+
 static void qw_set_node_opacity(struct wlr_scene_node *node, float opacity) {
     if (node->type == WLR_SCENE_NODE_BUFFER) {
         struct wlr_scene_buffer *buf = wlr_scene_buffer_from_node(node);
         wlr_scene_buffer_set_opacity(buf, opacity);
-    } else if (node->type == WLR_SCENE_NODE_RECT) {
-        struct wlr_scene_rect *rect = wlr_scene_rect_from_node(node);
-        // RGBA
-        // A indicates opacity
-        float new_color[4] = {rect->color[0], rect->color[1], rect->color[2], opacity};
-        wlr_scene_rect_set_color(rect, new_color);
     } else if (node->type == WLR_SCENE_NODE_TREE) {
         struct wlr_scene_tree *tree = wlr_scene_tree_from_node(node);
         struct wlr_scene_node *child;
         wl_list_for_each(child, &tree->children, link) { qw_set_node_opacity(child, opacity); }
     }
 }
+
 void qw_view_set_opacity(struct qw_view *view, float opacity) {
     if (view->content_tree) {
         struct wlr_scene_node *node_ptr = &view->content_tree->node;
         qw_set_node_opacity(node_ptr, opacity);
         view->opacity = opacity;
+    }
+
+    // Update border opacity
+    for (int i = 0; i < view->border_count; i++) {
+        // Current border layer
+        typeof(*view->borders) *border = &view->borders[i];
+
+        for (int side = 0; side < 4; side++) {
+
+            if (border->type == QW_BORDER_RECT) {
+                float *color = border->color[side];
+                struct wlr_scene_rect *rect = border->rects[side];
+
+                float new_color[4];
+                qw_util_premultiply_rgba(color, view->opacity, new_color);
+                wlr_scene_rect_set_color(rect, new_color);
+            }
+        }
     }
 }

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -118,6 +118,7 @@ struct qw_view {
     struct {
         enum qw_border_type type;
         uint32_t width;
+        float color[4][4];
         union {
             struct wlr_scene_rect *rects[4];
             struct wlr_scene_buffer *scene_bufs[4];


### PR DESCRIPTION
Two issues being solved here:
1) scene rects require pre-multiplied RGBA values
2) changing the view opacity set the border opacity to the view opacity,
   overwriting any alpha value in the border.

Fixes #5942