### PR TITLE
[wayland] Fix segfault if window dies while Prompt open

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -618,8 +618,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
         """
         Removes keyboard focus from the widget.
         """
-        if self._saved_focus is not None:
+        assert self.qtile is not None
+        if self._saved_focus is not None and self._saved_focus.wid in self.qtile.windows_map:
             self._saved_focus.focus(False)
+        self._saved_focus = None
         self._has_keyboard = None
 
     def draw(self) -> None:


### PR DESCRIPTION
When the prompt widget is open, it saves a reference to the current window. When the widget releases the keyboard, it tries to focus the previously focused window. If that window has been closed then the wayland backend tries to focus a view object that has already been freed in the backend, resulting in a segfault.

The fix is to check whether qtile is still managing the window before trying to focus it.