### PR TITLE
Fix prompt hiding when window closes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
       - Initialise fontconfig before starting qtile
       - nix: add fontconfig to runtime library configuration
       - Only pass button presses to bar when press is inside bar
+      - Stop Prompt widget cancelling text entry when window closes
 
 Qtile 0.35.0, released 2026-03-20:
     !!! Breaking changes !!!

--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -116,6 +116,9 @@ class Gap:
         """
         return dict(position=self.position)
 
+    def has_keyboard(self) -> bool:
+        return False
+
 
 class Obj:
     def __init__(self, name: str) -> None:
@@ -790,6 +793,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
             else:
                 # Bar is not reserving screen space so let's keep above other windows
                 self.window.keep_above(enable=True)
+
+    def has_keyboard(self) -> bool:
+        return self._has_keyboard is not None
 
 
 BarType = Bar | Gap

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -1964,3 +1964,10 @@ class Qtile(CommandObject):
     def stop_repl_server(self) -> None:
         """Stop the REPL server."""
         create_task(repl_server.stop())
+
+    def widget_has_keyboard(self) -> bool:
+        for screen in self.screens:
+            for gap in screen.gaps:
+                if gap.has_keyboard():
+                    return True
+        return False

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -286,14 +286,16 @@ class _Group(CommandObject):
             if win in self.tiled_windows:
                 self.tiled_windows.remove(win)
 
+        widget_has_keyboard = self.qtile.widget_has_keyboard()
+
         # a notification may not have focus
-        if hadfocus:
+        if hadfocus and not widget_has_keyboard:
             self.focus(nextfocus, warp=True, force=force)
             # no next focus window means focus changed to nothing
             if not nextfocus:
                 hook.fire("focus_change")
         elif self.screen:
-            self.layout_all()
+            self.layout_all(focus=not widget_has_keyboard)
 
     def mark_floating(self, win, floating):
         if floating:


### PR DESCRIPTION
If a window closes when a user is using the Prompt widget, qtile will try to focus a different window. If there is a suitable target then the prompt widget will lose focus and the text entry will end. We need to check whether a widget is using the keyboard and, if so, prevent focus shifting to a new window.

Fixes #5894