### PR TITLE
Add pytest timeout with traceback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,3 +163,5 @@ filterwarnings = [
     "error:::test",
     "ignore:::dbus_next",
 ]
+faulthandler_timeout = 300
+faulthandler_exit_on_timeout = true


### PR DESCRIPTION
Dump the traceback of all threads and exit if a test takes longer than 5 minutes. Intended to provide diagnostic information, specifically in cases where a test has deadlocked