### PR TITLE
ipc: bind socket with 0o600 permissions

### DIFF
--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -197,7 +197,11 @@ class Server:
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
         flags = fcntl.fcntl(self.sock.fileno(), fcntl.F_GETFD)
         fcntl.fcntl(self.sock.fileno(), fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
-        self.sock.bind(self.socket_path)
+        old_umask = os.umask(0o177)
+        try:
+            self.sock.bind(self.socket_path)
+        finally:
+            os.umask(old_umask)
 
     def lock(self):
         self.locked.set()


### PR DESCRIPTION
Set umask to 0o177 around the bind so the qtile IPC socket is created with owner-only rw permissions, preventing other users on the system from connecting to it.