### PR TITLE
Try pytest-timeout to catch deadlocked tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pytest-cov",
     "pytest-asyncio>=1.1.0",
     "pytest-httpbin",
+    "pytest-timeout",
     "pre-commit",
     "PyGObject",
     "pycairo >= 1.25.1",
@@ -163,5 +164,6 @@ filterwarnings = [
     "error:::test",
     "ignore:::dbus_next",
 ]
-faulthandler_timeout = 300
+faulthandler_timeout = 360
 faulthandler_exit_on_timeout = true
+timeout = 300 # pytest-timeout

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -155,10 +155,20 @@ class TestManager:
         self.testwindows = []
         self.logspipe = None
 
+    def timeout_handler(self, signum, frame):
+        os.kill(self.proc.pid, signal.SIGUSR2)
+        subprocess.run(["ps", "awfux"], stdout=sys.stderr)
+        old = self._old_sigalrm_handler
+        if callable(old):
+            old(signum, frame)
+
     def __enter__(self):
         """Set up resources"""
         faulthandler.enable(all_threads=True)
         faulthandler.register(signal.SIGUSR2, all_threads=True)
+        self._old_sigalrm_handler = signal.getsignal(signal.SIGALRM)
+        signal.signal(signal.SIGALRM, self.timeout_handler)
+        faulthandler.register(signal.SIGALRM, all_threads=True, chain=True)
         self._sockfile = tempfile.NamedTemporaryFile()
         self.sockfile = self._sockfile.name
         return self


### PR DESCRIPTION
If this works, we can use a custom handler to output more helpful diagnostic information than just the traceback provided by faulthandler_timeout