### PR TITLE
Strip newline from Wttr widget

### DIFF
--- a/libqtile/widget/wttr.py
+++ b/libqtile/widget/wttr.py
@@ -96,5 +96,5 @@ class Wttr(GenPollUrl):
 
     def parse(self, response):
         for coord in self.location:
-            response = response.strip().replace(coord, self.location[coord])
-        return response
+            response = response.replace(coord, self.location[coord])
+        return response.strip()


### PR DESCRIPTION
Not quite sure why the existing code didn't work but moving the `strip()` call to the final return value seems to ensure that there's no trailing newline character.