### PR TITLE
Implement wp-cursor-shape-v1 protocol (now with working test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ uv.lock
 
 # dynamically built files for wayland backend build
 libconfig.mk
+
+# wayland-clients for testing
+test/wayland_clients/bin

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ exclude libqtile/backend/x11/_ffi*.py
 exclude libqtile/backend/wayland/_ffi*.*
 exclude libqtile/backend/wayland/_libinput*.*
 exclude libqtile/backend/wayland/qw/build/*.o
+exclude test/wayland_clients/bin/*
 exclude Makefile
 exclude .readthedocs.yaml
 exclude .git-blame-ignore-revs

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ lint: ## Check the source code
 
 .PHONY: clean
 clean: ## Clean generated files
-	-rm -rf dist qtile.egg-info docs/_build build/ .mypy_cache/ .pytest_cache/ .eggs/
+	-rm -rf dist qtile.egg-info docs/_build build/ .mypy_cache/ \
+	.pytest_cache/ .eggs/ libqtile/backend/wayland/cffi/.build/ \
+	libqtile/backend/wayland/qw/{build,proto}/ test/wayland_clients/bin/
 
 .PHONY: update-flake
 update-flake: ## Update the Nix flake.lock file, requires Nix installed with flake support, see: https://nixos.wiki/wiki/Flakes

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 from contextlib import chdir
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from cffi import FFI
@@ -28,6 +29,8 @@ if not WAYLAND_SCANNER:
         text=True,
         stdout=subprocess.PIPE,
     ).stdout.strip()
+if WAYLAND_SCANNER is None:
+    sys.exit("wayland-scanner not found. Exiting.")
 WAYLAND_PROTOCOLS = subprocess.run(
     [PKG_CONFIG, "--variable=pkgdatadir", "wayland-protocols"],
     text=True,
@@ -35,49 +38,129 @@ WAYLAND_PROTOCOLS = subprocess.run(
 ).stdout.strip()
 
 QW_PROTO_IN_PATH = (QW_PATH / ".." / "proto").resolve()
-
-PROTOS = [
-    [
-        "wlr-layer-shell-unstable-v1-protocol.h",
-        f"{QW_PROTO_IN_PATH}/wlr-layer-shell-unstable-v1.xml",
-    ],
-    [
-        "wlr-output-power-management-unstable-v1-protocol.h",
-        f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml",
-    ],
-    ["xdg-shell-protocol.h", f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml"],
-    [
-        "pointer-constraints-unstable-v1-protocol.h",
-        f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
-    ],
-    [
-        "cursor-shape-v1-protocol.h",
-        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
-    ],
-    [
-        "wlr-virtual-pointer-unstable-v1-protocol.h",
-        f"{QW_PROTO_IN_PATH}/wlr-virtual-pointer-unstable-v1.xml",
-    ],
-]
-
-CLIENT_PROTOS = [
-    ["xdg-shell-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml"],
-    [
-        "cursor-shape-v1-client-protocol",
-        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
-    ],
-    ["tablet-v2-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml"],
-]
-
 QW_PROTO_OUT_PATH = QW_PATH / "proto"
 QW_PROTO_OUT_PATH.mkdir(exist_ok=True)
 
+TEST_CLIENT_PATH = (
+    Path(__file__) / ".." / ".." / ".." / ".." / ".." / "test" / "wayland_clients"
+).resolve()
+TEST_CLIENT_IN_PATH = TEST_CLIENT_PATH / "src"
+TEST_CLIENT_OUT_PATH = TEST_CLIENT_PATH / "bin"
+TEST_CLIENT_OUT_PATH.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class Protocol:
+    xml_path: str
+    build_server: bool = True
+    build_client: bool = False
+
+    @property
+    def private_code(self) -> str:
+        """Derives the private code protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-protocol.c"
+
+    @property
+    def server_header(self) -> str:
+        """Derives the server header protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-protocol.h"
+
+    @property
+    def client_header(self) -> str:
+        """Derives the client header protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-client-protocol.h"
+
+    def _build(self, protocol_type: str, output: Path) -> None:
+        assert WAYLAND_SCANNER is not None
+        subprocess.run(
+            [WAYLAND_SCANNER, protocol_type, self.xml_path, output.resolve().as_posix()],
+            check=True,
+        )
+
+    def build(self) -> None:
+        if self.build_server:
+            self._build("server-header", QW_PROTO_OUT_PATH / self.server_header)
+
+        if self.build_client:
+            self._build("client-header", QW_PROTO_OUT_PATH / self.client_header)
+            self._build("private-code", QW_PROTO_OUT_PATH / self.private_code)
+
+
+@dataclass
+class TestClient:
+    name: str
+    sources: list[str | Path]
+    includes: list[str | Path] = field(default_factory=list)
+    packages: list[str] = field(default_factory=list)
+    extra_args: list[str] = field(default_factory=list)
+
+    def _to_string(self, value: str | Path) -> str:
+        if isinstance(value, Path):
+            return value.resolve().as_posix()
+        return value
+
+    @property
+    def all_packages(self) -> list[str]:
+        return ["wayland-client"] + self.packages
+
+    def build(self) -> None:
+        cflags = (
+            subprocess.check_output(["pkg-config", "--cflags", *self.all_packages])
+            .decode()
+            .split()
+        )
+
+        libs = (
+            subprocess.check_output(["pkg-config", "--libs", *self.all_packages]).decode().split()
+        )
+
+        cmd = [
+            "cc",
+            *cflags,
+            *(self._to_string(source) for source in self.sources),
+            *(arg for include in self.includes for arg in ("-I", self._to_string(include))),
+            *self.extra_args,
+            *libs,
+            "-o",
+            (TEST_CLIENT_OUT_PATH / self.name).resolve().as_posix(),
+        ]
+
+        subprocess.run(cmd, check=True)
+
+
+PROTOS = [
+    Protocol(f"{QW_PROTO_IN_PATH}/wlr-layer-shell-unstable-v1.xml"),
+    Protocol(f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml"),
+    Protocol(f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml", build_client=True),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
+    ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+        build_client=True,
+    ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
+    ),
+]
+
+
+TEST_CLIENTS = [
+    TestClient(
+        name="cursor-shape-v1",
+        sources=[
+            TEST_CLIENT_IN_PATH / "cursor-shape-v1.c",
+            QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
+            QW_PROTO_OUT_PATH / "cursor-shape-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "tablet-v2-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH],
+    )
+]
+
+
 for proto in PROTOS:
-    subprocess.run(
-        [WAYLAND_SCANNER, "server-header", proto[1], QW_PROTO_OUT_PATH / proto[0]],
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout.strip()
+    proto.build()
 
 
 # Helper to check whether wlroots has been compiled with xwayland support
@@ -85,19 +168,6 @@ def wlroots_has_xwayland():
     config = Path(WLROOTS_PATH) / "wlr" / "config.h"
     return "WLR_HAS_XWAYLAND 1" in config.read_text()
 
-
-for proto in CLIENT_PROTOS:
-    subprocess.run(
-        [WAYLAND_SCANNER, "client-header", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.h"],
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout.strip()
-
-    subprocess.run(
-        [WAYLAND_SCANNER, "private-code", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.c"],
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout.strip()
 
 CDEF = """
 // logging
@@ -302,41 +372,8 @@ def build_objects(debug: bool = False, asan: bool = False) -> None:
 
 
 def build_test_clients():
-    root = Path(__file__).parent.parent.parent.parent.parent
-    proto = QW_PROTO_OUT_PATH
-
-    (root / "test/wayland_clients/bin").mkdir(parents=True, exist_ok=True)
-
-    cmds = [
-        [
-            "cc",
-            str(root / "test/wayland_clients/src/cursor-shape-v1.c"),
-            str(proto / "xdg-shell-client-protocol.c"),
-            str(proto / "cursor-shape-v1-client-protocol.c"),
-            str(proto / "tablet-v2-client-protocol.c"),
-            "-I",
-            str(proto),
-            "-o",
-            str(root / "test/wayland_clients/bin/cursor-shape-v1"),
-        ],
-    ]
-
-    pkg = (
-        subprocess.check_output(
-            [
-                "pkg-config",
-                "--cflags",
-                "--libs",
-                "wayland-client",
-            ]
-        )
-        .decode()
-        .split()
-    )
-    for cmd in cmds:
-        cmd += pkg
-
-        subprocess.run(cmd, check=True)
+    for client in TEST_CLIENTS:
+        client.build()
 
 
 def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) -> None:

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -50,6 +50,23 @@ PROTOS = [
         "pointer-constraints-unstable-v1-protocol.h",
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
     ],
+    [
+        "cursor-shape-v1-protocol.h",
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+    ],
+    [
+        "wlr-virtual-pointer-unstable-v1-protocol.h",
+        f"{QW_PROTO_IN_PATH}/wlr-virtual-pointer-unstable-v1.xml",
+    ],
+]
+
+CLIENT_PROTOS = [
+    ["xdg-shell-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml"],
+    [
+        "cursor-shape-v1-client-protocol",
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+    ],
+    ["tablet-v2-client-protocol", f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml"],
 ]
 
 QW_PROTO_OUT_PATH = QW_PATH / "proto"
@@ -68,6 +85,19 @@ def wlroots_has_xwayland():
     config = Path(WLROOTS_PATH) / "wlr" / "config.h"
     return "WLR_HAS_XWAYLAND 1" in config.read_text()
 
+
+for proto in CLIENT_PROTOS:
+    subprocess.run(
+        [WAYLAND_SCANNER, "client-header", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.h"],
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+    subprocess.run(
+        [WAYLAND_SCANNER, "private-code", proto[1], QW_PROTO_OUT_PATH / f"{proto[0]}.c"],
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
 
 CDEF = """
 // logging
@@ -271,6 +301,44 @@ def build_objects(debug: bool = False, asan: bool = False) -> None:
         )
 
 
+def build_test_clients():
+    root = Path(__file__).parent.parent.parent.parent.parent
+    proto = QW_PROTO_OUT_PATH
+
+    (root / "test/wayland_clients/bin").mkdir(parents=True, exist_ok=True)
+
+    cmds = [
+        [
+            "cc",
+            str(root / "test/wayland_clients/src/cursor-shape-v1.c"),
+            str(proto / "xdg-shell-client-protocol.c"),
+            str(proto / "cursor-shape-v1-client-protocol.c"),
+            str(proto / "tablet-v2-client-protocol.c"),
+            "-I",
+            str(proto),
+            "-o",
+            str(root / "test/wayland_clients/bin/cursor-shape-v1"),
+        ],
+    ]
+
+    pkg = (
+        subprocess.check_output(
+            [
+                "pkg-config",
+                "--cflags",
+                "--libs",
+                "wayland-client",
+            ]
+        )
+        .decode()
+        .split()
+    )
+    for cmd in cmds:
+        cmd += pkg
+
+        subprocess.run(cmd, check=True)
+
+
 def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) -> None:
     # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
     # at libqtile/backend/wayland/_ffi.so.
@@ -308,6 +376,7 @@ def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) 
     ffi.compile(
         tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(), verbose=verbose
     )
+    build_test_clients()
 
 
 if __name__ == "__main__":

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -942,6 +942,9 @@ class Core(base.Core):
     def fake_click(self) -> None:
         lib.qw_cursor_fake_click(self.qw_cursor)
 
+    def add_dummy_input_devices(self) -> None:
+        lib.qw_server_add_dummy_input_devices(self.qw)
+
 
 class Painter:
     """

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -454,6 +454,18 @@ class Core(base.Core):
         else:
             return self.qtile.process_button_release(button, mask)
 
+    @expose_command
+    def get_cursor_shape_v1(self) -> str:
+        """
+        Get the current cursor shape name from cursor-shape-v1 protocol.
+
+        Returns None if the cursor has no shape name set.
+        """
+        cursor = self.qw_cursor
+        if cursor.current_shape_name == ffi.NULL:
+            return "default"
+        return ffi.string(cursor.current_shape_name).decode("utf-8")
+
     def handle_manage_view(self, view: ffi.CData) -> None:
         wid = self.new_wid()
         view.wid = wid

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -16,6 +16,7 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
     wl_list_remove(&cursor->motion_absolute.link);
     wl_list_remove(&cursor->frame.link);
     wl_list_remove(&cursor->button.link);
+    wl_list_remove(&cursor->request_set_cursor_shape.link);
 
     wlr_xcursor_manager_destroy(cursor->mgr);
 
@@ -392,6 +393,9 @@ static void qw_cursor_handle_frame(struct wl_listener *listener, void *data) {
     wlr_seat_pointer_notify_frame(cursor->server->seat);
 }
 
+// forward declaration
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
+
 struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     // Allocate memory for qw_cursor
     struct qw_cursor *cursor = calloc(1, sizeof(*cursor));
@@ -405,6 +409,7 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     cursor->cursor = wlr_cursor_create();
     wlr_cursor_attach_output_layout(cursor->cursor, server->output_layout);
     cursor->mgr = wlr_xcursor_manager_create(NULL, 24);
+    cursor->current_shape_name = NULL;
 
     // Setup listeners for various pointer events
     cursor->request_set.notify = qw_cursor_handle_seat_request_set;
@@ -424,6 +429,11 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
 
     cursor->button.notify = qw_cursor_handle_button;
     wl_signal_add(&cursor->cursor->events.button, &cursor->button);
+
+    cursor->cursor_shape_mgr = wlr_cursor_shape_manager_v1_create(server->display, 1);
+    cursor->request_set_cursor_shape.notify = qw_handle_request_set_cursor_shape;
+    wl_signal_add(&cursor->cursor_shape_mgr->events.request_set_shape,
+                  &cursor->request_set_cursor_shape);
 
     wl_list_init(&cursor->constraint_commit.link);
 
@@ -699,4 +709,19 @@ void qw_cursor_fake_click(struct qw_cursor *cursor) {
     // Simulate release
     event.state = WL_POINTER_BUTTON_STATE_RELEASED;
     qw_cursor_handle_button(&cursor->button, &event);
+}
+
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data) {
+    struct qw_cursor *cursor = wl_container_of(listener, cursor, request_set_cursor_shape);
+    struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
+
+    struct wlr_seat_client *focused_client = cursor->server->seat->pointer_state.focused_client;
+    if (focused_client != event->seat_client) {
+        return;
+    }
+
+    const char *name = wlr_cursor_shape_v1_name(event->shape);
+    cursor->current_shape_name = name;
+
+    wlr_cursor_set_xcursor(cursor->cursor, cursor->mgr, name);
 }

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -2,6 +2,7 @@
 #define CURSOR_H
 
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
@@ -18,6 +19,8 @@ struct qw_cursor {
     struct wlr_cursor *cursor;
     struct qw_view *view;
     struct qw_implicit_grab implicit_grab;
+    struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
+    const char *current_shape_name;
 
     // private data
     struct qw_server *server;
@@ -28,6 +31,7 @@ struct qw_cursor {
     struct wl_listener frame;
     struct wl_listener button;
     struct wl_listener constraint_commit;
+    struct wl_listener request_set_cursor_shape;
     struct wlr_xcursor_manager *mgr;
     struct wlr_xcursor_manager *xwayland_mgr;
     struct wlr_surface *saved_surface;

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/session.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
@@ -48,9 +51,18 @@ void qw_server_poll(struct qw_server *server) {
     wl_display_flush_clients(server->display);
 }
 
+static void qw_server_destroy_dummy_input_devices(struct qw_server *server) {
+    if (server->dummy_keyboard != NULL) {
+        wlr_keyboard_finish(server->dummy_keyboard);
+        free(server->dummy_keyboard);
+        server->dummy_keyboard = NULL;
+    }
+}
+
 // Cleanup routine to destroy the compositor and free resources.
 void qw_server_finalize(struct qw_server *server) {
     // TODO: what else to finalize?
+    qw_server_destroy_dummy_input_devices(server);
     wl_list_remove(&server->new_input.link);
     wl_list_remove(&server->new_output.link);
     wl_list_remove(&server->output_layout_change.link);
@@ -1179,4 +1191,37 @@ struct qw_view *qw_server_active_view(struct qw_server *server) {
 #endif
 
     return NULL;
+}
+
+static void qw_server_add_dummy_keyboard(struct qw_server *server) {
+    struct wlr_seat *seat = server->seat;
+    struct wlr_keyboard *kbd = calloc(1, sizeof(struct wlr_keyboard));
+    if (!kbd)
+        return;
+
+    // NULL impl is fine for a dummy — no real hardware to talk to
+    wlr_keyboard_init(kbd, NULL, "dummy-keyboard");
+
+    struct xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap = xkb_keymap_new_from_names(ctx, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    wlr_keyboard_set_keymap(kbd, keymap);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(ctx);
+
+    wlr_seat_set_keyboard(seat, kbd);
+
+    server->dummy_keyboard = kbd;
+}
+
+void qw_server_add_dummy_input_devices(struct qw_server *server) {
+    if (server->dummy_keyboard != NULL) {
+        return;
+    }
+
+    qw_server_add_dummy_keyboard(server);
+
+    // We don't create a dummy pointer but we pretend there is one available
+    uint32_t caps = WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD;
+    wlr_seat_set_capabilities(server->seat, caps);
 }

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -290,6 +290,7 @@ struct qw_server {
     struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
     struct wlr_pointer_constraints_v1 *pointer_constraints;
     struct wl_listener new_pointer_constraint;
+    struct wlr_keyboard *dummy_keyboard;
 };
 
 struct qw_drag_icon {
@@ -379,5 +380,7 @@ void qw_server_add_idle_timer(struct qw_server *server, int seconds);
 void qw_server_remove_idle_timer(struct qw_server *server, int seconds);
 
 struct qw_view *qw_server_active_view(struct qw_server *server);
+
+void qw_server_add_dummy_input_devices(struct qw_server *server);
 
 #endif /* SERVER_H */

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -58,7 +58,9 @@ class WaylandBackend(Backend):
     def create(self):
         """This is used to instantiate the Core"""
         os.environ.update(self.env)
-        return self.core(*self.args)
+        core = self.core(*self.args)
+        core.add_dummy_input_devices()
+        return core
 
     def configure(self, manager):
         """This backend needs to get WAYLAND_DISPLAY variable."""

--- a/test/backend/wayland/test_cursor.py
+++ b/test/backend/wayland/test_cursor.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+from test.helpers import Retry
+
+CLIENT_PATH = Path(__file__) / ".." / ".." / ".." / "wayland_clients" / "bin"
+CURSOR_CLIENT = CLIENT_PATH / "cursor-shape-v1"
+
+
+@pytest.mark.parametrize("shape", ["crosshair", "text", "wait", "help", "grab"])
+def test_cursor_shape_protocol(wmanager, shape):
+    """Test that the C client can successfully request shapes via the protocol."""
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_window():
+        assert len(wmanager.c.windows()) > 0
+
+    def cursor_name():
+        return wmanager.c.core.get_cursor_shape_v1()
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_cursor():
+        assert cursor_name() != "default"
+
+    wmanager.c.spawn(f"{CURSOR_CLIENT.resolve().as_posix()} -c {shape} -d")
+    wait_for_window()
+    wmanager.c.window.set_position_floating(150, 150)
+
+    # Cursor is outside window so should be default
+    wmanager.c.core.eval("self.warp_pointer(0, 0, motion=True)")
+    assert cursor_name() == "default"
+
+    # Move cursor inside test client window
+    wmanager.c.core.eval("self.warp_pointer(200, 200, motion=True)")
+    wmanager.c.core.eval("self.flush()")
+    wait_for_cursor()
+    cursor = cursor_name()
+
+    if shape == "wait":
+        assert cursor in ["wait", "watch"]
+    elif shape == "help":
+        assert cursor in ["help", "whats_this", "question_arrow"]
+    else:
+        assert cursor == shape

--- a/test/wayland_clients/src/cursor-shape-v1.c
+++ b/test/wayland_clients/src/cursor-shape-v1.c
@@ -1,0 +1,348 @@
+#include <errno.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+#include <wayland-client.h>
+
+#include "cursor-shape-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+#include <stdarg.h>
+
+static bool DEBUG = false;
+static FILE *log_file = NULL;
+
+// Logger - logs to file if -d option set
+static void log_msg(const char *fmt, ...) {
+    if (!DEBUG || log_file == NULL) {
+        return;
+    }
+
+    time_t now = time(NULL);
+    struct tm tm;
+    localtime_r(&now, &tm);
+
+    fprintf(log_file, "[%02d:%02d:%02d] ", tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(log_file, fmt, args);
+    va_end(args);
+
+    fputc('\n', log_file);
+    fflush(log_file);
+}
+/* ---------------- globals ---------------- */
+
+static struct wl_display *display;
+static struct wl_registry *registry;
+
+static struct wl_compositor *compositor;
+static struct xdg_wm_base *xdg_wm_base;
+static struct wl_shm *shm;
+
+static struct wl_surface *surface;
+static struct xdg_surface *xdg_surface;
+static struct xdg_toplevel *toplevel;
+
+static struct wl_pointer *pointer;
+static struct wp_cursor_shape_manager_v1 *cursor_manager;
+static struct wp_cursor_shape_device_v1 *cursor_device;
+
+/* ---------------- state ---------------- */
+
+static bool configured = false;
+static uint32_t configure_serial = 0;
+
+static uint32_t enter_serial = 0;
+
+static uint32_t requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+
+static bool pointer_entered = false;
+
+/* ---------------- shm ---------------- */
+
+static int create_shm_file(size_t size) {
+    char name[] = "/tmp/wl-shm-XXXXXX";
+    int fd = mkstemp(name);
+    unlink(name);
+
+    ftruncate(fd, size);
+    return fd;
+}
+
+static struct wl_buffer *create_buffer(int w, int h, void **data_out) {
+    int stride = w * 4;
+    int size = stride * h;
+
+    int fd = create_shm_file(size);
+
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
+
+    struct wl_buffer *buf =
+        wl_shm_pool_create_buffer(pool, 0, w, h, stride, WL_SHM_FORMAT_XRGB8888);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    *data_out = data;
+    return buf;
+}
+
+// Request a cursor shape
+static void set_shape(uint32_t serial, uint32_t shape) {
+    log_msg("[client] set_shape cursor_device=%p", cursor_device);
+    if (cursor_device == NULL)
+        return;
+
+    wp_cursor_shape_device_v1_set_shape(cursor_device, serial, shape);
+}
+
+static void pointer_enter(void *data, struct wl_pointer *p, uint32_t serial,
+                          struct wl_surface *surf, wl_fixed_t x, wl_fixed_t y) {
+    log_msg("[client] POINTER ENTER serial=%u surface=%p x=%f y=%f", serial, surf,
+            wl_fixed_to_double(x), wl_fixed_to_double(y));
+
+    enter_serial = serial;
+
+    if (cursor_device == NULL) {
+        log_msg("[client] WARNING: cursor_device is NULL at ENTER");
+    }
+
+    set_shape(serial, requested_shape);
+    pointer_entered = true;
+}
+
+static void pointer_leave(void *data, struct wl_pointer *p, uint32_t serial,
+                          struct wl_surface *surf) {
+    (void)data;
+    (void)p;
+    (void)serial;
+    (void)surf;
+}
+
+static void pointer_motion(void *data, struct wl_pointer *p, uint32_t time, wl_fixed_t x,
+                           wl_fixed_t y) {
+    (void)data;
+    (void)p;
+    (void)time;
+    (void)x;
+    (void)y;
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+    .enter = pointer_enter,
+    .leave = pointer_leave,
+    .motion = pointer_motion,
+};
+
+static void seat_capabilities(void *data, struct wl_seat *seat, uint32_t caps) {
+    log_msg("[client] SEAT CAPABILITIES: pointer=%d keyboard=%d",
+            !!(caps & WL_SEAT_CAPABILITY_POINTER), !!(caps & WL_SEAT_CAPABILITY_KEYBOARD));
+
+    if (caps & WL_SEAT_CAPABILITY_POINTER) {
+        pointer = wl_seat_get_pointer(seat);
+
+        log_msg("[client] wl_pointer created: %p", pointer);
+
+        wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+
+        cursor_device = wp_cursor_shape_manager_v1_get_pointer(cursor_manager, pointer);
+
+        log_msg("[client] cursor_device created: %p", cursor_device);
+    }
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_capabilities,
+};
+
+static void wm_ping(void *data, struct xdg_wm_base *wm, uint32_t serial) {
+    xdg_wm_base_pong(wm, serial);
+}
+
+static const struct xdg_wm_base_listener wm_listener = {
+    .ping = wm_ping,
+};
+
+static void xdg_surface_configure(void *data, struct xdg_surface *surf, uint32_t serial) {
+    xdg_surface_ack_configure(surf, serial);
+    wl_surface_commit(surface);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void toplevel_close(void *data, struct xdg_toplevel *t) { exit(0); }
+
+static void toplevel_configure(void *data, struct xdg_toplevel *t, int32_t w, int32_t h,
+                               struct wl_array *states) {
+    (void)data;
+    (void)t;
+    (void)w;
+    (void)h;
+    (void)states;
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+};
+
+/* ---------------- registry ---------------- */
+
+static void registry_global(void *data, struct wl_registry *reg, uint32_t name, const char *iface,
+                            uint32_t version) {
+    log_msg("[client] GLOBAL: %s (name=%u version=%u)", iface, name, version);
+
+    if (strcmp(iface, wl_compositor_interface.name) == 0) {
+        compositor = wl_registry_bind(reg, name, &wl_compositor_interface, 4);
+    }
+
+    if (strcmp(iface, xdg_wm_base_interface.name) == 0) {
+        xdg_wm_base = wl_registry_bind(reg, name, &xdg_wm_base_interface, 1);
+
+        xdg_wm_base_add_listener(xdg_wm_base, &wm_listener, NULL);
+    }
+
+    if (strcmp(iface, wl_shm_interface.name) == 0) {
+        shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+    }
+
+    if (strcmp(iface, wl_seat_interface.name) == 0) {
+        log_msg("[client] binding wl_seat");
+
+        struct wl_seat *seat = wl_registry_bind(reg, name, &wl_seat_interface, 1);
+
+        wl_seat_add_listener(seat, &seat_listener, NULL);
+    }
+
+    if (strcmp(iface, wp_cursor_shape_manager_v1_interface.name) == 0) {
+        log_msg("[client] binding cursor_shape_manager_v1");
+
+        cursor_manager = wl_registry_bind(reg, name, &wp_cursor_shape_manager_v1_interface, 1);
+    }
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+};
+
+int main(int argc, char *argv[]) {
+    int opt;
+
+    // Handle command line options
+    while ((opt = getopt(argc, argv, "c:hd")) != -1) {
+        switch (opt) {
+        case 'c':
+            if (strcmp(optarg, "text") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT;
+            else if (strcmp(optarg, "crosshair") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+            else if (strcmp(optarg, "wait") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_WAIT;
+            else if (strcmp(optarg, "help") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_HELP;
+            else if (strcmp(optarg, "pointer") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER;
+            else if (strcmp(optarg, "grab") == 0)
+                requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRAB;
+            break;
+
+        case 'h':
+            printf("Usage: %s [-c shape] [-d]\n", argv[0]);
+            printf("Shapes: text, crosshair, wait, help, pointer, move.\n");
+            printf("-d to enable debugging to /tmp/qtile_test_cursor_client.log.\n");
+            exit(EXIT_SUCCESS);
+
+        case 'd':
+            DEBUG = true;
+            break;
+
+        case '?':
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (DEBUG) {
+        log_file = fopen("/tmp/qtile_test_cursor_client.log", "a");
+        if (!log_file) {
+            perror("Error opening log file");
+            return 1;
+        }
+        setvbuf(log_file, NULL, _IOLBF, 0);
+    }
+
+    log_msg("=== START TEST ===");
+
+    // Connect to display
+    display = wl_display_connect(NULL);
+    if (!display) {
+        fprintf(stderr, "Cannot connect to display. Is compositor running?\n");
+        return 1;
+    }
+
+    registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, NULL);
+
+    // Bind globals
+    wl_display_roundtrip(display);
+
+    if (compositor == NULL || xdg_wm_base == NULL || shm == NULL || cursor_manager == NULL) {
+        fprintf(stderr, "Missing globals. Cannot continue.\n");
+        return 1;
+    }
+
+    // Create window
+    surface = wl_compositor_create_surface(compositor);
+
+    xdg_surface = xdg_wm_base_get_xdg_surface(xdg_wm_base, surface);
+    toplevel = xdg_surface_get_toplevel(xdg_surface);
+
+    xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, NULL);
+    xdg_toplevel_add_listener(toplevel, &toplevel_listener, NULL);
+
+    // Set fixed size so qtile will float window
+    xdg_toplevel_set_min_size(toplevel, 300, 300);
+    xdg_toplevel_set_max_size(toplevel, 300, 300);
+
+    wl_surface_commit(surface);
+    wl_display_roundtrip(display);
+
+    // Create contents of window
+    void *pixels;
+    struct wl_buffer *buffer = create_buffer(300, 300, &pixels);
+
+    memset(pixels, 0x80, 300 * 300 * 4);
+
+    wl_surface_attach(surface, buffer, 0, 0);
+    wl_surface_commit(surface);
+    wl_surface_attach(surface, buffer, 0, 0);
+    wl_display_roundtrip(display);
+
+    // Everything should be up and running now
+    log_msg("Running cursor-shape test window. Entering loop.\n");
+
+    while (wl_display_dispatch(display) != -1) {
+        wl_display_flush(display);
+    }
+
+    log_msg("=== END TEST ===\n");
+
+    if (log_file != NULL) {
+        fclose(log_file);
+        log_file = NULL;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Implement wp-cursor-shape-v1 protocol.

Also refactors some of `build.py` to be a bit neater in terms of building wayland protocols and test client scripts.

This replaces #5810 (I changed a lot, had to rebase multiple times and didn't want to force push to @Gurjaka branch.