### PR TITLE
Testing wayland protocol support (idle-notify, idle-inhibit, session-lock, foreign-toplevel-management, cursor-shape)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ uv.lock
 
 # dynamically built files for wayland backend build
 libconfig.mk
+
+# wayland-clients for testing
+test/wayland_clients/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y \
     ImageMagick \
     libnotify \
     pango \
+    procps \
     pulseaudio-libs \
     python3.12 python3.12-devel \
     python3.13 python3.13-devel \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -36,6 +36,7 @@ prune bin
 prune docs
 prune scripts
 prune rpm
+prune test/wayland_clients/bin
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ lint: ## Check the source code
 
 .PHONY: clean
 clean: ## Clean generated files
-	-rm -rf dist qtile.egg-info docs/_build build/ .mypy_cache/ .pytest_cache/ .eggs/
+	-rm -rf dist qtile.egg-info docs/_build build/ .mypy_cache/ \
+	.pytest_cache/ .eggs/ libqtile/backend/wayland/cffi/.build/ \
+	libqtile/backend/wayland/qw/{build,proto}/ test/wayland_clients/bin/
 
 .PHONY: update-flake
 update-flake: ## Update the Nix flake.lock file, requires Nix installed with flake support, see: https://nixos.wiki/wiki/Flakes

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -12,82 +12,83 @@ from cffi import FFI
 from setuptools import Distribution
 from setuptools.command.build_ext import build_ext
 
+# Path resolution
+
 QW_PATH = (Path(__file__).parent / ".." / "qw").resolve()
-WLROOTS_PATH = os.getenv("QTILE_WLROOTS_PATH", "/usr/include/wlroots-0.20")
-
-PKG_CONFIG = os.environ.get("PKG_CONFIG", "pkg-config")
-WAYLAND_SCANNER = os.environ.get("QTILE_WAYLAND_SCANNER", shutil.which("wayland-scanner"))
-if not WAYLAND_SCANNER:
-    print(
-        "Didn't find a wayland-scanner executable in $PATH, and "
-        "$QTILE_WAYLAND_SCANNER is not set. Trying to get the path to it from "
-        "pkg-config",
-        file=sys.stderr,
-    )
-    WAYLAND_SCANNER = subprocess.run(
-        [PKG_CONFIG, "--variable=wayland_scanner", "wayland-scanner"],
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout.strip()
-if WAYLAND_SCANNER is None:
-    sys.exit("wayland-scanner not found. Exiting.")
-WAYLAND_PROTOCOLS = subprocess.run(
-    [PKG_CONFIG, "--variable=pkgdatadir", "wayland-protocols"],
-    text=True,
-    stdout=subprocess.PIPE,
-).stdout.strip()
-
 QW_PROTO_IN_PATH = (QW_PATH / ".." / "proto").resolve()
 QW_PROTO_OUT_PATH = QW_PATH / "proto"
-QW_PROTO_OUT_PATH.mkdir(exist_ok=True)
 
 TEST_CLIENT_PATH = (
     Path(__file__) / ".." / ".." / ".." / ".." / ".." / "test" / "wayland_clients"
 ).resolve()
 TEST_CLIENT_SRC_PATH = TEST_CLIENT_PATH / "src"
 TEST_CLIENT_OUT_PATH = TEST_CLIENT_PATH / "bin"
-TEST_CLIENT_OUT_PATH.mkdir(parents=True, exist_ok=True)
 CLIENT_BASE = TEST_CLIENT_SRC_PATH / "client-base.c"
 
+# Tool resolution
 
-@dataclass
+PKG_CONFIG = os.environ.get("PKG_CONFIG", "pkg-config")
+
+
+def _resolve_wayland_scanner() -> str:
+    if explicit := os.environ.get("QTILE_WAYLAND_SCANNER"):
+        return explicit
+    if found := shutil.which("wayland-scanner"):
+        return found
+    print(
+        "wayland-scanner not found in $PATH or $QTILE_WAYLAND_SCANNER; "
+        "falling back to pkg-config",
+        file=sys.stderr,
+    )
+    result = subprocess.run(
+        [PKG_CONFIG, "--variable=wayland_scanner", "wayland-scanner"],
+        text=True,
+        stdout=subprocess.PIPE,
+    ).stdout.strip()
+
+    return result
+
+
+def _pkg_variable(package: str, variable: str) -> str:
+    return subprocess.run(
+        [PKG_CONFIG, f"--variable={variable}", package],
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout.strip()
+
+
+WAYLAND_SCANNER: str = _resolve_wayland_scanner()
+WAYLAND_PROTOCOLS: str = _pkg_variable("wayland-protocols", "pkgdatadir")
+WLROOTS_PATH: str = os.getenv("QTILE_WLROOTS_PATH", "/usr/include/wlroots-0.20")
+
+# Protocol and test-client declarations
+
+
+@dataclass(frozen=True)
 class Protocol:
     xml_path: str
     build_server: bool = True
     build_client: bool = False
 
     @property
+    def stem(self) -> str:
+        return Path(self.xml_path).stem
+
+    @property
     def private_code(self) -> str:
-        """Derives the private code protocol name from the XML filename."""
-        return f"{Path(self.xml_path).stem}-protocol.c"
+        return f"{self.stem}-protocol.c"
 
     @property
     def server_header(self) -> str:
-        """Derives the server header protocol name from the XML filename."""
-        return f"{Path(self.xml_path).stem}-protocol.h"
+        return f"{self.stem}-protocol.h"
 
     @property
     def client_header(self) -> str:
-        """Derives the client header protocol name from the XML filename."""
-        return f"{Path(self.xml_path).stem}-client-protocol.h"
-
-    def _build(self, protocol_type: str, output: Path) -> None:
-        assert WAYLAND_SCANNER is not None
-        subprocess.run(
-            [WAYLAND_SCANNER, protocol_type, self.xml_path, output.resolve().as_posix()],
-            check=True,
-        )
-
-    def build(self) -> None:
-        if self.build_server:
-            self._build("server-header", QW_PROTO_OUT_PATH / self.server_header)
-
-        if self.build_client:
-            self._build("client-header", QW_PROTO_OUT_PATH / self.client_header)
-            self._build("private-code", QW_PROTO_OUT_PATH / self.private_code)
+        return f"{self.stem}-client-protocol.h"
 
 
-@dataclass
+@dataclass(frozen=True)
 class TestClient:
     name: str
     sources: list[str | Path]
@@ -95,38 +96,9 @@ class TestClient:
     packages: list[str] = field(default_factory=list)
     extra_args: list[str] = field(default_factory=list)
 
-    def _to_string(self, value: str | Path) -> str:
-        if isinstance(value, Path):
-            return value.resolve().as_posix()
-        return value
-
     @property
     def all_packages(self) -> list[str]:
         return ["wayland-client"] + self.packages
-
-    def build(self) -> None:
-        cflags = (
-            subprocess.check_output(["pkg-config", "--cflags", *self.all_packages])
-            .decode()
-            .split()
-        )
-
-        libs = (
-            subprocess.check_output(["pkg-config", "--libs", *self.all_packages]).decode().split()
-        )
-
-        cmd = [
-            "cc",
-            *cflags,
-            *(self._to_string(source) for source in self.sources),
-            *(arg for include in self.includes for arg in ("-I", self._to_string(include))),
-            *self.extra_args,
-            *libs,
-            "-o",
-            (TEST_CLIENT_OUT_PATH / self.name).resolve().as_posix(),
-        ]
-
-        subprocess.run(cmd, check=True)
 
 
 PROTOS: list[Protocol] = [
@@ -154,7 +126,6 @@ PROTOS: list[Protocol] = [
     ),
 ]
 
-
 TEST_CLIENTS: list[TestClient] = [
     TestClient(
         name="idle-client",
@@ -177,18 +148,73 @@ TEST_CLIENTS: list[TestClient] = [
     ),
 ]
 
+# Build configuration
 
-for proto in PROTOS:
-    proto.build()
+CDEF_FILES = [
+    "log.h",
+    "session-lock.h",
+    "server.h",
+    "view.h",
+    "util.h",
+    "output.h",
+    "internal-view.h",
+    "cursor.h",
+    "input-device.h",
+    "keyboard.h",
+]
+XWAYLAND_ONLY_SOURCES = ["xwayland-view.c"]
 
 
-# Helper to check whether wlroots has been compiled with xwayland support
-def wlroots_has_xwayland():
+def wlroots_has_xwayland() -> bool:
     config = Path(WLROOTS_PATH) / "wlr" / "config.h"
     return "WLR_HAS_XWAYLAND 1" in config.read_text()
 
 
-CDEF = """
+@dataclass(frozen=True)
+class BuildConfig:
+    has_xwayland: bool
+    include_dirs: list[str]
+    libraries: list[str]
+    macros: list[tuple[str, str | None]]
+    source_files: list[str]
+
+    @classmethod
+    def from_environment(cls) -> "BuildConfig":
+        has_xwayland = wlroots_has_xwayland()
+        source_files = glob.glob(f"{QW_PATH}/*.c")
+        if not has_xwayland:
+            source_files = [
+                f for f in source_files if not any(x in f for x in XWAYLAND_ONLY_SOURCES)
+            ]
+        macros: list[tuple[str, str | None]] = [("WLR_USE_UNSTABLE", None)]
+        if not has_xwayland:
+            macros.append(("WLR_HAS_XWAYLAND", "0"))
+        return cls(
+            has_xwayland=has_xwayland,
+            include_dirs=[
+                os.getenv("QTILE_CAIRO_PATH", "/usr/include/cairo"),
+                os.getenv("QTILE_PIXMAN_PATH", "/usr/include/pixman-1"),
+                os.getenv("QTILE_LIBDRM_PATH", "/usr/include/libdrm"),
+                WLROOTS_PATH,
+                str(QW_PATH),
+                str(QW_PROTO_OUT_PATH),
+            ],
+            libraries=["wlroots-0.20", "wayland-server", "input", "cairo"],
+            source_files=source_files,
+            macros=macros,
+        )
+
+    @property
+    def objects(self) -> list[Path]:
+        return [
+            Path(src).parent / "build" / Path(src).with_suffix(".o").name
+            for src in self.source_files
+        ]
+
+
+# CDEF construction
+
+_CDEF_PREAMBLE = """
 // logging
 enum wlr_log_importance {
     WLR_SILENT,
@@ -284,154 +310,158 @@ extern "Python" void set_title_cb(char* title, void *userdata);
 extern "Python" void set_app_id_cb(char* app_id, void *userdata);
 """
 
-cdef_files = [
-    "log.h",
-    "session-lock.h",
-    "server.h",
-    "view.h",
-    "util.h",
-    "output.h",
-    "internal-view.h",
-    "cursor.h",
-    "input-device.h",
-    "keyboard.h",
-]
 
-XWAYLAND_ONLY_SOURCES = ["xwayland-view.c"]
-
-for file in cdef_files:
-    with open(QW_PATH / file) as f:
-        in_private_data = False
-        skip_no_xwayland_block = False
-        for line in f.readlines():
-            # cffi doesn't prepocess `#if` blocks so we need
-            # to strip out any xwayland blocks ourselves
-            stripped = line.strip()
-            if stripped.startswith("#if"):
-                if "WLR_HAS_XWAYLAND" in stripped and not wlroots_has_xwayland():
-                    skip_no_xwayland_block = True
-                continue
-            elif stripped.startswith("#else") and skip_no_xwayland_block:
-                skip_no_xwayland_block = False
-                continue
-            elif stripped.startswith("#endif") and skip_no_xwayland_block:
-                skip_no_xwayland_block = False
-                continue
-
-            if skip_no_xwayland_block:
-                continue
-
-            if line.startswith("#"):
-                continue
-            if line.strip().lower().startswith("// private data"):
-                in_private_data = True
-                CDEF += "    ...;\n"
-                continue
-            if line.startswith("};") and in_private_data:
-                in_private_data = False
-            if in_private_data:
-                continue
-            CDEF += line
-
-SOURCE = "\n".join(f'#include "{header}"' for header in cdef_files) + "\n"
+def _build_cdef(config: BuildConfig) -> str:
+    """Read QW headers and concatenate into a single CFFI cdef string."""
+    parts = [_CDEF_PREAMBLE]
+    for filename in CDEF_FILES:
+        parts.append(_read_header(QW_PATH / filename, config.has_xwayland))
+    return "".join(parts)
 
 
-def get_include_path(lib: str) -> str:
-    return subprocess.run(
-        ["pkg-config", "--variable=includedir", lib], text=True, stdout=subprocess.PIPE
-    ).stdout.strip()
+def _read_header(path: Path, has_xwayland: bool) -> str:
+    """
+    Read a single header, stripping preprocessor directives and
+    xwayland-only blocks when xwayland is not available.
+    """
+    lines: list[str] = []
+    in_private_data = False
+    skip_xwayland_block = False
+
+    for line in path.read_text().splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("#if"):
+            if "WLR_HAS_XWAYLAND" in stripped and not has_xwayland:
+                skip_xwayland_block = True
+            continue
+        if stripped.startswith("#else") and skip_xwayland_block:
+            skip_xwayland_block = False
+            continue
+        if stripped.startswith("#endif") and skip_xwayland_block:
+            skip_xwayland_block = False
+            continue
+        if skip_xwayland_block or line.startswith("#"):
+            continue
+        if stripped.lower().startswith("// private data"):
+            in_private_data = True
+            lines.append("    ...;\n")
+            continue
+        if line.startswith("};") and in_private_data:
+            in_private_data = False
+        if not in_private_data:
+            lines.append(line)
+
+    return "".join(lines)
 
 
-INCLUDE_DIRS = [
-    os.getenv("QTILE_CAIRO_PATH", "/usr/include/cairo"),
-    os.getenv("QTILE_PIXMAN_PATH", "/usr/include/pixman-1"),
-    os.getenv("QTILE_LIBDRM_PATH", "/usr/include/libdrm"),
-    WLROOTS_PATH,
-    QW_PATH,
-    QW_PROTO_OUT_PATH,
-]
-LIBRARIES = ["wlroots-0.20", "wayland-server", "input", "cairo"]
-
-# SOURCE_FILES loads all .c files...
-SOURCE_FILES = glob.glob(f"{QW_PATH}/*.c")
-
-# ...but we need to exclude any xwayland files
-if not wlroots_has_xwayland():
-    SOURCE_FILES = [f for f in SOURCE_FILES if not any(x in f for x in XWAYLAND_ONLY_SOURCES)]
-
-OBJECTS = [Path(src).parent / "build" / Path(src).with_suffix(".o").name for src in SOURCE_FILES]
+# Build steps
 
 
-MACROS: list[tuple[str, str | None]] = [("WLR_USE_UNSTABLE", None)]
-if not wlroots_has_xwayland():
-    MACROS.append(("WLR_HAS_XWAYLAND", "0"))
+def generate_protocols() -> None:
+    QW_PROTO_OUT_PATH.mkdir(exist_ok=True)
+    for proto in PROTOS:
+        _generate_protocol(proto)
 
 
-def build_objects(debug: bool = False, asan: bool = False) -> None:
-    # We have to use relative paths here for output_dir to work as expected
+def _generate_protocol(proto: Protocol) -> None:
+    if proto.build_server:
+        _run_scanner("server-header", proto.xml_path, QW_PROTO_OUT_PATH / proto.server_header)
+    if proto.build_client:
+        _run_scanner("client-header", proto.xml_path, QW_PROTO_OUT_PATH / proto.client_header)
+        _run_scanner("private-code", proto.xml_path, QW_PROTO_OUT_PATH / proto.private_code)
+
+
+def _run_scanner(mode: str, xml_path: str, output: Path) -> None:
+    subprocess.run([WAYLAND_SCANNER, mode, xml_path, output.resolve().as_posix()], check=True)
+
+
+def build_c_objects(config: BuildConfig, *, debug: bool = False, asan: bool = False) -> None:
     with chdir(QW_PATH):
         dist = Distribution()
         cmd = build_ext(dist)
         cmd.setup_shlib_compiler()
 
-        extra_preargs = []
-        if debug or asan:
-            extra_preargs = ["-g3", "-Og"]
-        else:
-            extra_preargs = ["-O2"]
-        extra_preargs.extend(["-fPIC", "-Wall", "-Wextra"])
+        preargs = ["-g3", "-Og"] if (debug or asan) else ["-O2"]
+        preargs += ["-fPIC", "-Wall", "-Wextra"]
 
         cmd.shlib_compiler.compile(
-            [os.path.basename(path) for path in SOURCE_FILES],
+            [os.path.basename(p) for p in config.source_files],
             output_dir="build",
-            macros=MACROS,
-            include_dirs=INCLUDE_DIRS,
-            extra_preargs=extra_preargs,
+            macros=config.macros,
+            include_dirs=config.include_dirs,
+            extra_preargs=preargs,
         )
 
 
-def build_test_clients():
+def build_test_clients() -> None:
+    TEST_CLIENT_OUT_PATH.mkdir(parents=True, exist_ok=True)
     for client in TEST_CLIENTS:
-        client.build()
+        _build_test_client(client)
 
 
-def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) -> None:
-    # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
-    # at libqtile/backend/wayland/_ffi.so.
-    # This is built at the path specified in tmpdir which is "." by default. So, if we're in a
-    # virtual environment, libqtile might be at .venv/lib/python3.13/site-packages/ but if we run
-    # the builder script, we'll get a new libqtile folder in th current directory that only has that
-    # tree shown above and the libtile library won't find the `_ffi` library.
-    # We therefore set the tmpdir to be the path to the folder containing libqtile so the library
-    # is always created in the correct folder.
-    # The compile command is nested in a function to ensure that the tmpdir value is not overwritten.
-    build_objects(debug=debug, asan=asan)
+def _build_test_client(client: TestClient) -> None:
+    def to_str(v: str | Path) -> str:
+        return v.resolve().as_posix() if isinstance(v, Path) else v
 
-    extra_compile_args = []
-    extra_link_args = []
+    cflags = (
+        subprocess.check_output(["pkg-config", "--cflags", *client.all_packages]).decode().split()
+    )
+    libs = (
+        subprocess.check_output(["pkg-config", "--libs", *client.all_packages]).decode().split()
+    )
+
+    cmd = [
+        "cc",
+        *cflags,
+        *(to_str(s) for s in client.sources),
+        *(arg for inc in client.includes for arg in ("-I", to_str(inc))),
+        *client.extra_args,
+        *libs,
+        "-o",
+        (TEST_CLIENT_OUT_PATH / client.name).resolve().as_posix(),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def compile_ffi(
+    config: BuildConfig, *, verbose: bool = False, debug: bool = False, asan: bool = False
+) -> None:
+    extra_compile_args: list[str] = []
+    extra_link_args: list[str] = []
     if debug or asan:
-        extra_compile_args.extend(["-g3", "-Og"])
+        extra_compile_args += ["-g3", "-Og"]
     if asan:
-        extra_compile_args.extend(
-            ["-fsanitize=address,leak,undefined", "-fno-omit-frame-pointer"]
-        )
-        extra_link_args.extend(["-fsanitize=address,undefined"])
+        extra_compile_args += ["-fsanitize=address,leak,undefined", "-fno-omit-frame-pointer"]
+        extra_link_args += ["-fsanitize=address,undefined"]
+
+    source = "\n".join(f'#include "{h}"' for h in CDEF_FILES) + "\n"
 
     ffi = FFI()
     ffi.set_source(
         "libqtile.backend.wayland._ffi",
-        SOURCE,
-        define_macros=MACROS,
-        include_dirs=INCLUDE_DIRS,
-        extra_objects=OBJECTS,
-        libraries=LIBRARIES,
+        source,
+        define_macros=config.macros,
+        include_dirs=config.include_dirs,
+        extra_objects=[str(o) for o in config.objects],
+        libraries=config.libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
     )
-    ffi.cdef(CDEF)
+    ffi.cdef(_build_cdef(config))
     ffi.compile(
-        tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(), verbose=verbose
+        tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(),
+        verbose=verbose,
     )
+
+
+# Top-level entry point
+
+
+def ffi_compile(*, verbose: bool = False, debug: bool = False, asan: bool = False) -> None:
+    config = BuildConfig.from_environment()
+    generate_protocols()
+    build_c_objects(config, debug=debug, asan=asan)
+    compile_ffi(config, verbose=verbose, debug=debug, asan=asan)
     build_test_clients()
 
 

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -110,7 +110,7 @@ PROTOS: list[Protocol] = [
     Protocol(
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
     ),
-    Protocol(f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml"),
+    Protocol(f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml", build_client=True),
     Protocol(
         f"{WAYLAND_PROTOCOLS}/staging/ext-idle-notify/ext-idle-notify-v1.xml",
         build_client=True,
@@ -130,6 +130,9 @@ PROTOS: list[Protocol] = [
         f"{QW_PROTO_IN_PATH}/wlr-foreign-toplevel-management-unstable-v1.xml",
         build_client=True,
         build_server=False,
+    ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
     ),
 ]
 
@@ -168,6 +171,17 @@ TEST_CLIENTS: list[TestClient] = [
             TEST_CLIENT_SRC_PATH / "ftl-manager.c",
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "wlr-foreign-toplevel-management-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="cursor-shape",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "cursor-shape.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "cursor-shape-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
+            QW_PROTO_OUT_PATH / "tablet-v2-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 from contextlib import chdir
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from cffi import FFI
@@ -28,6 +29,8 @@ if not WAYLAND_SCANNER:
         text=True,
         stdout=subprocess.PIPE,
     ).stdout.strip()
+if WAYLAND_SCANNER is None:
+    sys.exit("wayland-scanner not found. Exiting.")
 WAYLAND_PROTOCOLS = subprocess.run(
     [PKG_CONFIG, "--variable=pkgdatadir", "wayland-protocols"],
     text=True,
@@ -35,36 +38,113 @@ WAYLAND_PROTOCOLS = subprocess.run(
 ).stdout.strip()
 
 QW_PROTO_IN_PATH = (QW_PATH / ".." / "proto").resolve()
-
-PROTOS = [
-    [
-        "wlr-layer-shell-unstable-v1-protocol.h",
-        f"{QW_PROTO_IN_PATH}/wlr-layer-shell-unstable-v1.xml",
-    ],
-    [
-        "wlr-output-power-management-unstable-v1-protocol.h",
-        f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml",
-    ],
-    ["xdg-shell-protocol.h", f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml"],
-    [
-        "pointer-constraints-unstable-v1-protocol.h",
-        f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
-    ],
-    [
-        "cursor-shape-v1-protocol.h",
-        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
-    ],
-]
-
 QW_PROTO_OUT_PATH = QW_PATH / "proto"
 QW_PROTO_OUT_PATH.mkdir(exist_ok=True)
 
+TEST_CLIENT_PATH = (
+    Path(__file__) / ".." / ".." / ".." / ".." / ".." / "test" / "wayland_clients"
+).resolve()
+TEST_CLIENT_SRC_PATH = TEST_CLIENT_PATH / "src"
+TEST_CLIENT_OUT_PATH = TEST_CLIENT_PATH / "bin"
+TEST_CLIENT_OUT_PATH.mkdir(parents=True, exist_ok=True)
+CLIENT_BASE = TEST_CLIENT_SRC_PATH / "client-base.c"
+
+
+@dataclass
+class Protocol:
+    xml_path: str
+    build_server: bool = True
+    build_client: bool = False
+
+    @property
+    def private_code(self) -> str:
+        """Derives the private code protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-protocol.c"
+
+    @property
+    def server_header(self) -> str:
+        """Derives the server header protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-protocol.h"
+
+    @property
+    def client_header(self) -> str:
+        """Derives the client header protocol name from the XML filename."""
+        return f"{Path(self.xml_path).stem}-client-protocol.h"
+
+    def _build(self, protocol_type: str, output: Path) -> None:
+        assert WAYLAND_SCANNER is not None
+        subprocess.run(
+            [WAYLAND_SCANNER, protocol_type, self.xml_path, output.resolve().as_posix()],
+            check=True,
+        )
+
+    def build(self) -> None:
+        if self.build_server:
+            self._build("server-header", QW_PROTO_OUT_PATH / self.server_header)
+
+        if self.build_client:
+            self._build("client-header", QW_PROTO_OUT_PATH / self.client_header)
+            self._build("private-code", QW_PROTO_OUT_PATH / self.private_code)
+
+
+@dataclass
+class TestClient:
+    name: str
+    sources: list[str | Path]
+    includes: list[str | Path] = field(default_factory=list)
+    packages: list[str] = field(default_factory=list)
+    extra_args: list[str] = field(default_factory=list)
+
+    def _to_string(self, value: str | Path) -> str:
+        if isinstance(value, Path):
+            return value.resolve().as_posix()
+        return value
+
+    @property
+    def all_packages(self) -> list[str]:
+        return ["wayland-client"] + self.packages
+
+    def build(self) -> None:
+        cflags = (
+            subprocess.check_output(["pkg-config", "--cflags", *self.all_packages])
+            .decode()
+            .split()
+        )
+
+        libs = (
+            subprocess.check_output(["pkg-config", "--libs", *self.all_packages]).decode().split()
+        )
+
+        cmd = [
+            "cc",
+            *cflags,
+            *(self._to_string(source) for source in self.sources),
+            *(arg for include in self.includes for arg in ("-I", self._to_string(include))),
+            *self.extra_args,
+            *libs,
+            "-o",
+            (TEST_CLIENT_OUT_PATH / self.name).resolve().as_posix(),
+        ]
+
+        subprocess.run(cmd, check=True)
+
+
+PROTOS: list[Protocol] = [
+    Protocol(f"{QW_PROTO_IN_PATH}/wlr-layer-shell-unstable-v1.xml"),
+    Protocol(f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml"),
+    Protocol(f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml", build_client=True),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
+    ),
+    Protocol(f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml"),
+]
+
+
+TEST_CLIENTS: list[TestClient] = []
+
+
 for proto in PROTOS:
-    subprocess.run(
-        [WAYLAND_SCANNER, "server-header", proto[1], QW_PROTO_OUT_PATH / proto[0]],
-        text=True,
-        stdout=subprocess.PIPE,
-    ).stdout.strip()
+    proto.build()
 
 
 # Helper to check whether wlroots has been compiled with xwayland support
@@ -275,6 +355,11 @@ def build_objects(debug: bool = False, asan: bool = False) -> None:
         )
 
 
+def build_test_clients():
+    for client in TEST_CLIENTS:
+        client.build()
+
+
 def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) -> None:
     # The ffi source of "libqtile.backend.wayland._ffi" means that we'll compile the library file
     # at libqtile/backend/wayland/_ffi.so.
@@ -312,6 +397,7 @@ def ffi_compile(verbose: bool = False, debug: bool = False, asan: bool = False) 
     ffi.compile(
         tmpdir=Path(__file__).parent.parent.parent.parent.parent.as_posix(), verbose=verbose
     )
+    build_test_clients()
 
 
 if __name__ == "__main__":

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -147,6 +147,11 @@ PROTOS: list[Protocol] = [
         build_client=True,
         build_server=False,
     ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/ext-session-lock/ext-session-lock-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 
@@ -160,7 +165,16 @@ TEST_CLIENTS: list[TestClient] = [
             QW_PROTO_OUT_PATH / "idle-inhibit-unstable-v1-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
-    )
+    ),
+    TestClient(
+        name="session-lock",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "session-lock.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "ext-session-lock-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
 ]
 
 

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -103,7 +103,9 @@ class TestClient:
 
 PROTOS: list[Protocol] = [
     Protocol(f"{QW_PROTO_IN_PATH}/wlr-layer-shell-unstable-v1.xml"),
-    Protocol(f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml"),
+    Protocol(
+        f"{QW_PROTO_IN_PATH}/wlr-output-power-management-unstable-v1.xml", build_client=True
+    ),
     Protocol(f"{WAYLAND_PROTOCOLS}/stable/xdg-shell/xdg-shell.xml", build_client=True),
     Protocol(
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
@@ -143,6 +145,15 @@ TEST_CLIENTS: list[TestClient] = [
             TEST_CLIENT_SRC_PATH / "session-lock.c",
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "ext-session-lock-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="output-power-management",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "output-power-management.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "wlr-output-power-management-unstable-v1-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -137,10 +137,31 @@ PROTOS: list[Protocol] = [
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml"
     ),
     Protocol(f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml"),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/ext-idle-notify/ext-idle-notify-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 
-TEST_CLIENTS: list[TestClient] = []
+TEST_CLIENTS: list[TestClient] = [
+    TestClient(
+        name="idle-client",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "idle-client.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "ext-idle-notify-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "idle-inhibit-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    )
+]
 
 
 for proto in PROTOS:

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -126,6 +126,11 @@ PROTOS: list[Protocol] = [
         build_client=True,
         build_server=False,
     ),
+    Protocol(
+        f"{QW_PROTO_IN_PATH}/wlr-foreign-toplevel-management-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -154,6 +159,15 @@ TEST_CLIENTS: list[TestClient] = [
             TEST_CLIENT_SRC_PATH / "output-power-management.c",
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "wlr-output-power-management-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="ftl-manager",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "ftl-manager.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "wlr-foreign-toplevel-management-unstable-v1-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -722,6 +722,8 @@ class Core(base.Core):
     def _poll(self) -> None:
         lib.qw_server_poll(self.qw)
 
+    @expose_command()
+    @allow_when_locked
     def flush(self) -> None:
         self._poll()
 

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -944,6 +944,9 @@ class Core(base.Core):
     def fake_click(self) -> None:
         lib.qw_cursor_fake_click(self.qw_cursor)
 
+    def add_dummy_input_devices(self) -> None:
+        lib.qw_server_add_dummy_input_devices(self.qw)
+
 
 class Painter:
     """

--- a/libqtile/backend/wayland/proto/wlr-foreign-toplevel-management-unstable-v1.xml
+++ b/libqtile/backend/wayland/proto/wlr-foreign-toplevel-management-unstable-v1.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_foreign_toplevel_management_unstable_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_foreign_toplevel_manager_v1" version="3">
+    <description summary="list and control opened apps">
+      The purpose of this protocol is to enable the creation of taskbars
+      and docks by providing them with a list of opened applications and
+      letting them request certain actions on them, like maximizing, etc.
+
+      After a client binds the zwlr_foreign_toplevel_manager_v1, each opened
+      toplevel window will be sent via the toplevel event
+    </description>
+
+    <event name="toplevel">
+      <description summary="a toplevel has been created">
+        This event is emitted whenever a new toplevel window is created. It
+        is emitted for all toplevels, regardless of the app that has created
+        them.
+
+        All initial details of the toplevel(title, app_id, states, etc.) will
+        be sent immediately after this event via the corresponding events in
+        zwlr_foreign_toplevel_handle_v1.
+      </description>
+      <arg name="toplevel" type="new_id" interface="zwlr_foreign_toplevel_handle_v1"/>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new toplevels.
+        However the compositor may emit further toplevel_created events, until
+        the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished" type="destructor">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events to the
+        zwlr_foreign_toplevel_manager_v1. The server will destroy the object
+        immediately after sending this request, so it will become invalid and
+        the client should free any resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_foreign_toplevel_handle_v1" version="3">
+    <description summary="an opened toplevel">
+      A zwlr_foreign_toplevel_handle_v1 object represents an opened toplevel
+      window. Each app may have multiple opened toplevels.
+
+      Each toplevel has a list of outputs it is visible on, conveyed to the
+      client with the output_enter and output_leave events.
+    </description>
+
+    <event name="title">
+      <description summary="title change">
+        This event is emitted whenever the title of the toplevel changes.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id">
+      <description summary="app-id change">
+        This event is emitted whenever the app-id of the toplevel changes.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="toplevel entered an output">
+        This event is emitted whenever the toplevel becomes visible on
+        the given output. A toplevel may be visible on multiple outputs.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="toplevel left an output">
+        This event is emitted whenever the toplevel stops being visible on
+        the given output. It is guaranteed that an entered-output event
+        with the same output has been emitted before this event.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <request name="set_maximized">
+      <description summary="requests that the toplevel be maximized">
+        Requests that the toplevel be maximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="requests that the toplevel be unmaximized">
+        Requests that the toplevel be unmaximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="requests that the toplevel be minimized">
+        Requests that the toplevel be minimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_minimized">
+      <description summary="requests that the toplevel be unminimized">
+        Requests that the toplevel be unminimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the toplevel">
+        Request that this toplevel be activated on the given seat.
+        There is no guarantee the toplevel will be actually activated.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of states on the toplevel">
+        The different states that a toplevel can have. These have the same meaning
+        as the states with the same names defined in xdg-toplevel
+      </description>
+
+      <entry name="maximized"  value="0" summary="the toplevel is maximized"/>
+      <entry name="minimized"  value="1" summary="the toplevel is minimized"/>
+      <entry name="activated"  value="2" summary="the toplevel is active"/>
+      <entry name="fullscreen" value="3" summary="the toplevel is fullscreen" since="2"/>
+    </enum>
+
+    <event name="state">
+      <description summary="the toplevel state changed">
+        This event is emitted immediately after the zlw_foreign_toplevel_handle_v1
+        is created and each time the toplevel state changes, either because of a
+        compositor action or because of a request in this protocol.
+      </description>
+
+      <arg name="state" type="array"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have been
+        sent.
+
+        This allows changes to the zwlr_foreign_toplevel_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <request name="close">
+      <description summary="request that the toplevel be closed">
+        Send a request to the toplevel to close itself. The compositor would
+        typically use a shell-specific method to carry out this request, for
+        example by sending the xdg_toplevel.close event. However, this gives
+        no guarantees the toplevel will actually be destroyed. If and when
+        this happens, the zwlr_foreign_toplevel_handle_v1.closed event will
+        be emitted.
+      </description>
+    </request>
+
+    <request name="set_rectangle">
+      <description summary="the rectangle which represents the toplevel">
+        The rectangle of the surface specified in this request corresponds to
+        the place where the app using this protocol represents the given toplevel.
+        It can be used by the compositor as a hint for some operations, e.g
+        minimizing. The client is however not required to set this, in which
+        case the compositor is free to decide some default value.
+
+        If the client specifies more than one rectangle, only the last one is
+        considered.
+
+        The dimensions are given in surface-local coordinates.
+        Setting width=height=0 removes the already-set rectangle.
+      </description>
+
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <enum name="error">
+      <entry name="invalid_rectangle" value="0"
+        summary="the provided rectangle is invalid"/>
+    </enum>
+
+    <event name="closed">
+      <description summary="this toplevel has been destroyed">
+        This event means the toplevel has been destroyed. It is guaranteed there
+        won't be any more events for this zwlr_foreign_toplevel_handle_v1. The
+        toplevel itself becomes inert so any requests will be ignored except the
+        destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zwlr_foreign_toplevel_handle_v1 object">
+        Destroys the zwlr_foreign_toplevel_handle_v1 object.
+
+        This request should be called either when the client does not want to
+        use the toplevel anymore or after the closed event to finalize the
+        destruction of the object.
+      </description>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_fullscreen" since="2">
+      <description summary="request that the toplevel be fullscreened">
+        Requests that the toplevel be fullscreened on the given output. If the
+        fullscreen state and/or the outputs the toplevel is visible on actually
+        change, this will be indicated by the state and output_enter/leave
+        events.
+
+        The output parameter is only a hint to the compositor. Also, if output
+        is NULL, the compositor should decide which output the toplevel will be
+        fullscreened on, if at all.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen" since="2">
+      <description summary="request that the toplevel be unfullscreened">
+        Requests that the toplevel be unfullscreened. If the fullscreen state
+        actually changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <event name="parent" since="3">
+      <description summary="parent change">
+        This event is emitted whenever the parent of the toplevel changes.
+
+        No event is emitted when the parent handle is destroyed by the client.
+      </description>
+      <arg name="parent" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="true"/>
+    </event>
+  </interface>
+</protocol>

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/session.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/interfaces/wlr_pointer.h>
+#include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_relative_pointer_v1.h>
@@ -48,9 +51,18 @@ void qw_server_poll(struct qw_server *server) {
     wl_display_flush_clients(server->display);
 }
 
+static void qw_server_destroy_dummy_input_devices(struct qw_server *server) {
+    if (server->dummy_keyboard != NULL) {
+        wlr_keyboard_finish(server->dummy_keyboard);
+        free(server->dummy_keyboard);
+        server->dummy_keyboard = NULL;
+    }
+}
+
 // Cleanup routine to destroy the compositor and free resources.
 void qw_server_finalize(struct qw_server *server) {
     // TODO: what else to finalize?
+    qw_server_destroy_dummy_input_devices(server);
     wl_list_remove(&server->new_input.link);
     wl_list_remove(&server->new_output.link);
     wl_list_remove(&server->output_layout_change.link);
@@ -1178,4 +1190,37 @@ struct qw_view *qw_server_active_view(struct qw_server *server) {
 #endif
 
     return NULL;
+}
+
+static void qw_server_add_dummy_keyboard(struct qw_server *server) {
+    struct wlr_seat *seat = server->seat;
+    struct wlr_keyboard *kbd = calloc(1, sizeof(struct wlr_keyboard));
+    if (!kbd)
+        return;
+
+    // NULL impl is fine for a dummy — no real hardware to talk to
+    wlr_keyboard_init(kbd, NULL, "dummy-keyboard");
+
+    struct xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap = xkb_keymap_new_from_names(ctx, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    wlr_keyboard_set_keymap(kbd, keymap);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(ctx);
+
+    wlr_seat_set_keyboard(seat, kbd);
+
+    server->dummy_keyboard = kbd;
+}
+
+void qw_server_add_dummy_input_devices(struct qw_server *server) {
+    if (server->dummy_keyboard != NULL) {
+        return;
+    }
+
+    qw_server_add_dummy_keyboard(server);
+
+    // We don't create a dummy pointer but we pretend there is one available
+    uint32_t caps = WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD;
+    wlr_seat_set_capabilities(server->seat, caps);
 }

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -290,6 +290,7 @@ struct qw_server {
     struct wlr_relative_pointer_manager_v1 *relative_pointer_manager;
     struct wlr_pointer_constraints_v1 *pointer_constraints;
     struct wl_listener new_pointer_constraint;
+    struct wlr_keyboard *dummy_keyboard;
 };
 
 struct qw_drag_icon {
@@ -379,5 +380,7 @@ void qw_server_add_idle_timer(struct qw_server *server, int seconds);
 void qw_server_remove_idle_timer(struct qw_server *server, int seconds);
 
 struct qw_view *qw_server_active_view(struct qw_server *server);
+
+void qw_server_add_dummy_input_devices(struct qw_server *server);
 
 #endif /* SERVER_H */

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -222,6 +222,7 @@ struct qw_server {
     void *view_activation_cb_data;
     void *cb_data;
     struct qw_layer_view *exclusive_layer;
+    enum qw_session_lock_state lock_state;
 
     // Private data
     struct wl_event_loop *event_loop;
@@ -266,7 +267,6 @@ struct qw_server {
     struct wlr_session_lock_manager_v1 *lock_manager;
     struct qw_session_lock *lock;
     struct wlr_scene_tree *lock_tree;
-    enum qw_session_lock_state lock_state;
     struct wlr_foreign_toplevel_manager_v1 *ftl_mgr;
     struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard;
     struct wlr_virtual_pointer_manager_v1 *virtual_pointer;

--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -318,39 +318,11 @@ static void qw_handle_ftl_request_fullscreen(struct wl_listener *listener, void 
     }
 }
 
-static void qw_handle_ftl_output_enter(struct wl_listener *listener, void *data) {
-    struct qw_view *view = wl_container_of(listener, view, ftl_output_enter);
-    struct wlr_scene_output *output = data;
-    if (view->ftl_handle != NULL) {
-        wlr_foreign_toplevel_handle_v1_output_enter(view->ftl_handle, output->output);
-    }
-}
-
-static void qw_handle_ftl_output_leave(struct wl_listener *listener, void *data) {
-    struct qw_view *view = wl_container_of(listener, view, ftl_output_leave);
-    struct wlr_scene_output *output = data;
-    if (view->ftl_handle != NULL) {
-        wlr_foreign_toplevel_handle_v1_output_leave(view->ftl_handle, output->output);
-    }
-}
-
-static bool qw_handle_ftl_point_accepts_input(struct wlr_scene_buffer *buffer, double *x,
-                                              double *y) {
-    UNUSED(buffer);
-    UNUSED(x);
-    UNUSED(y);
-    return false;
-}
-
-void qw_view_resize_ftl_output_tracking_buffer(struct qw_view *view, int width, int height) {
-    if (view->ftl_output_tracking_buffer != NULL) {
-        wlr_scene_buffer_set_dest_size(view->ftl_output_tracking_buffer, width, height);
-    }
-}
-
 void qw_view_ftl_manager_handle_create(struct qw_view *view) {
     // Create a foreign toplevel handle and set up listeners
     view->ftl_handle = wlr_foreign_toplevel_handle_v1_create(view->server->ftl_mgr);
+
+    wl_list_init(&view->ftl_outputs);
 
     view->ftl_request_activate.notify = qw_handle_ftl_request_activate;
     wl_signal_add(&view->ftl_handle->events.request_activate, &view->ftl_request_activate);
@@ -366,19 +338,6 @@ void qw_view_ftl_manager_handle_create(struct qw_view *view) {
 
     view->ftl_request_fullscreen.notify = qw_handle_ftl_request_fullscreen;
     wl_signal_add(&view->ftl_handle->events.request_fullscreen, &view->ftl_request_fullscreen);
-
-    view->ftl_output_tracking_buffer = wlr_scene_buffer_create(view->content_tree, NULL);
-    if (view->ftl_output_tracking_buffer != NULL) {
-        view->ftl_output_enter.notify = qw_handle_ftl_output_enter;
-        wl_signal_add(&view->ftl_output_tracking_buffer->events.output_enter,
-                      &view->ftl_output_enter);
-        view->ftl_output_leave.notify = qw_handle_ftl_output_leave;
-        wl_signal_add(&view->ftl_output_tracking_buffer->events.output_leave,
-                      &view->ftl_output_leave);
-        view->ftl_output_tracking_buffer->point_accepts_input = qw_handle_ftl_point_accepts_input;
-    } else {
-        wlr_log(WLR_ERROR, "Failed to create a foreign toplevel tracking buffer.");
-    }
 }
 
 void qw_view_ftl_manager_handle_destroy(struct qw_view *view) {
@@ -393,12 +352,11 @@ void qw_view_ftl_manager_handle_destroy(struct qw_view *view) {
     wl_list_remove(&view->ftl_request_minimize.link);
     wl_list_remove(&view->ftl_request_fullscreen.link);
 
-    // Remove output tracking
-    if (view->ftl_output_tracking_buffer != NULL) {
-        wl_list_remove(&view->ftl_output_enter.link);
-        wl_list_remove(&view->ftl_output_leave.link);
-        wlr_scene_node_destroy(&view->ftl_output_tracking_buffer->node);
-        view->ftl_output_tracking_buffer = NULL;
+    // Remove the outputs
+    struct qw_view_output *vo, *tmp;
+    wl_list_for_each_safe(vo, tmp, &view->ftl_outputs, link) {
+        wl_list_remove(&vo->link);
+        free(vo);
     }
 
     // Destroy the handle
@@ -477,5 +435,64 @@ void qw_view_set_opacity(struct qw_view *view, float opacity) {
                 wlr_scene_rect_set_color(rect, new_color);
             }
         }
+    }
+}
+
+static bool qw_view_has_ftl_output(struct qw_view *view, struct wlr_output *output) {
+    struct qw_view_output *vo;
+
+    wl_list_for_each(vo, &view->ftl_outputs, link) {
+        if (vo->output == output) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void qw_view_update_ftl_outputs(struct qw_view *view, struct wlr_surface *surface) {
+    if (view->ftl_handle == NULL) {
+        return;
+    }
+
+    struct wlr_surface_output *so;
+
+    /* Enter new outputs */
+    wl_list_for_each(so, &surface->current_outputs, link) {
+        if (qw_view_has_ftl_output(view, so->output)) {
+            continue;
+        }
+
+        wlr_foreign_toplevel_handle_v1_output_enter(view->ftl_handle, so->output);
+
+        struct qw_view_output *vo = calloc(1, sizeof(*vo));
+        if (vo == NULL) {
+            continue;
+        }
+
+        vo->output = so->output;
+        wl_list_insert(&view->ftl_outputs, &vo->link);
+    }
+
+    /* Leave old outputs */
+    struct qw_view_output *vo, *tmp;
+    wl_list_for_each_safe(vo, tmp, &view->ftl_outputs, link) {
+        bool still_present = false;
+
+        wl_list_for_each(so, &surface->current_outputs, link) {
+            if (so->output == vo->output) {
+                still_present = true;
+                break;
+            }
+        }
+
+        if (still_present) {
+            continue;
+        }
+
+        wlr_foreign_toplevel_handle_v1_output_leave(view->ftl_handle, vo->output);
+
+        wl_list_remove(&vo->link);
+        free(vo);
     }
 }

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -48,6 +48,12 @@ enum qw_view_type {
     QW_VIEW_INTERNAL,
 };
 
+struct qw_view_output {
+    // Private data
+    struct wlr_output *output;
+    struct wl_list link;
+};
+
 enum qw_border_type {
     QW_BORDER_RECT,
     QW_BORDER_BUFFER,
@@ -130,9 +136,7 @@ struct qw_view {
     struct wl_listener ftl_request_minimize;
     struct wl_listener ftl_request_fullscreen;
     // ftl output tracking
-    struct wlr_scene_buffer *ftl_output_tracking_buffer;
-    struct wl_listener ftl_output_enter;
-    struct wl_listener ftl_output_leave;
+    struct wl_list ftl_outputs;
 };
 
 void qw_view_reparent(struct qw_view *view, int layer);
@@ -152,7 +156,6 @@ void qw_view_paint_borders(struct qw_view *view, const struct qw_border *borders
 // Create/destroy a foreign toplevel manager handle and listeners
 void qw_view_ftl_manager_handle_create(struct qw_view *view);
 void qw_view_ftl_manager_handle_destroy(struct qw_view *view);
-void qw_view_resize_ftl_output_tracking_buffer(struct qw_view *view, int width, int height);
 
 struct qw_output *qw_view_get_primary_output(struct qw_view *view);
 
@@ -160,4 +163,6 @@ int qw_view_get_layer(struct qw_view *view);
 void qw_view_grab_click(struct qw_view *view);
 void qw_view_ungrab_click(struct qw_view *view);
 void qw_view_set_opacity(struct qw_view *view, float opacity);
+
+void qw_view_update_ftl_outputs(struct qw_view *view, struct wlr_surface *surface);
 #endif /* VIEW_H */

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -204,6 +204,16 @@ static void qw_xdg_view_clip(struct qw_xdg_view *xdg_view) {
     wlr_scene_subsurface_tree_set_clip(&xdg_view->scene_tree->node, &clip);
 }
 
+void dump_surface_outputs(void *self) {
+    struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
+    struct wlr_surface *surface = xdg_view->xdg_toplevel->base->surface;
+    struct wlr_surface_output *so;
+
+    wl_list_for_each(so, &surface->current_outputs, link) {
+        wlr_log(WLR_ERROR, "current_output=%s", so->output->name);
+    }
+}
+
 // Place the xdg_view at given position and size with border and stacking info
 static void qw_xdg_view_place(void *self, int x, int y, int width, int height,
                               const struct qw_border *borders, int border_count, int above) {
@@ -237,8 +247,7 @@ static void qw_xdg_view_place(void *self, int x, int y, int width, int height,
         wlr_xdg_toplevel_set_size(xdg_view->xdg_toplevel, width, height);
         qw_xdg_view_clip(xdg_view);
 
-        // Resize the foreign toplevel output tracking buffer
-        qw_view_resize_ftl_output_tracking_buffer(&xdg_view->base, width, height);
+        qw_view_update_ftl_outputs(&xdg_view->base, xdg_view->xdg_toplevel->base->surface);
     }
 
     // Paint borders around the view with given border colors and width

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -340,8 +340,7 @@ static void qw_xwayland_view_place(void *self, int x, int y, int width, int heig
         wlr_xwayland_surface_configure(qw_xsurface, x, y, width, height);
         qw_xwayland_view_clip(xwayland_view);
 
-        // Resize the foreign toplevel output tracking buffer
-        qw_view_resize_ftl_output_tracking_buffer(&xwayland_view->base, width, height);
+        qw_view_update_ftl_outputs(&xwayland_view->base, xwayland_view->xwayland_surface->surface);
     }
 
     // Paint borders around the view with given border colors and width

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -705,14 +705,15 @@ class Window(Base, base.Window):
                 self.keep_above(enable=True)
         elif (not do_float) and self._float_state != FloatStates.NOT_FLOATING:
             self.reparent(lib.LAYER_LAYOUT)
-            self._update_fullscreen(False)
-            self._update_maximized(False)
-            self._update_minimized(False)
             if self._float_state == FloatStates.FLOATING:
                 # store last size
                 self._float_width = self.width
                 self._float_height = self.height
+            old_state = self._float_state
             self._float_state = FloatStates.NOT_FLOATING
+            self._update_fullscreen(False, old_state)
+            self._update_maximized(False, old_state)
+            self._update_minimized(False, old_state)
             if self.group:
                 self.group.mark_floating(self, False)
             hook.fire("float_change")
@@ -742,11 +743,12 @@ class Window(Base, base.Window):
         elif self._float_state == FloatStates.FULLSCREEN:
             self._restore_geometry()
             self.floating = False
-            self._update_fullscreen(False)
 
-    def _update_fullscreen(self, do_full: bool) -> None:
-        if do_full != (self._float_state == FloatStates.FULLSCREEN):
-            self._ptr.update_fullscreen(self._ptr, do_full)
+    def _update_fullscreen(self, do_full: bool, old_state: FloatStates) -> None:
+        if not (do_full or old_state == FloatStates.FULLSCREEN):
+            return
+
+        self._ptr.update_fullscreen(self._ptr, do_full)
 
         if self.group and self.group.screen:
             screen = self.group.screen
@@ -783,8 +785,8 @@ class Window(Base, base.Window):
                 self._restore_geometry()
                 self.floating = False
 
-    def _update_maximized(self, do_max: bool) -> None:
-        if do_max != (self._float_state == FloatStates.MAXIMIZED):
+    def _update_maximized(self, do_max: bool, old_state: FloatStates) -> None:
+        if do_max or old_state == FloatStates.MAXIMIZED:
             self._ptr.update_maximized(self._ptr, do_max)
 
     @property
@@ -800,8 +802,8 @@ class Window(Base, base.Window):
             if self._float_state == FloatStates.MINIMIZED:
                 self.floating = False
 
-    def _update_minimized(self, do_min: bool) -> None:
-        if do_min != (self._float_state == FloatStates.MINIMIZED):
+    def _update_minimized(self, do_min: bool, old_state: FloatStates) -> None:
+        if do_min or old_state == FloatStates.MINIMIZED:
             self._ptr.update_minimized(self._ptr, do_min)
 
     def _reconfigure_floating(
@@ -813,15 +815,16 @@ class Window(Base, base.Window):
         new_float_state: FloatStates = FloatStates.FLOATING,
     ) -> None:
         if self._float_state != new_float_state:
+            old_state = self._float_state
             self._float_state = new_float_state
             self.reparent(self.get_new_layer(new_float_state))
             if self.group:  # may be not, if it's called from hook
                 self.group.mark_floating(self, True)
-            self._update_fullscreen(new_float_state == FloatStates.FULLSCREEN)
+            self._update_fullscreen(new_float_state == FloatStates.FULLSCREEN, old_state)
+            self._update_maximized(new_float_state == FloatStates.MAXIMIZED, old_state)
+            self._update_minimized(new_float_state == FloatStates.MINIMIZED, old_state)
+
             hook.fire("float_change")
-        self._update_fullscreen(new_float_state == FloatStates.FULLSCREEN)
-        self._update_maximized(new_float_state == FloatStates.MAXIMIZED)
-        self._update_minimized(new_float_state == FloatStates.MINIMIZED)
         if new_float_state == FloatStates.MINIMIZED:
             self.hide()
         else:

--- a/libqtile/command/base.py
+++ b/libqtile/command/base.py
@@ -232,6 +232,7 @@ class CommandObject(metaclass=abc.ABCMeta):
         """
         return self._commands.get(name)
 
+    @allow_when_locked
     @expose_command()
     def commands(self) -> list[str]:
         """

--- a/libqtile/ipc.py
+++ b/libqtile/ipc.py
@@ -14,7 +14,6 @@ import socket
 import struct
 from typing import Any, Self
 
-from libqtile import hook
 from libqtile.log_utils import logger
 from libqtile.utils import get_cache_dir
 
@@ -186,11 +185,6 @@ class Server:
         self.handler = handler
         self.server = None  # type: asyncio.AbstractServer | None
 
-        # Use a flag to indicate if session is locked
-        self.locked = asyncio.Event()
-        hook.subscribe.locked(self.lock)
-        hook.subscribe.unlocked(self.unlock)
-
         if os.path.exists(socket_path):
             os.unlink(socket_path)
 
@@ -202,12 +196,6 @@ class Server:
             self.sock.bind(self.socket_path)
         finally:
             os.umask(old_umask)
-
-    def lock(self):
-        self.locked.set()
-
-    def unlock(self):
-        self.locked.clear()
 
     async def _server_callback(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -226,11 +214,7 @@ class Server:
         except IPCError:
             logger.warning("Invalid data received, closing connection")
         else:
-            # Don't handle requests when session is locked
-            if self.locked.is_set():
-                rep = (1, {"error": "Session locked."})
-            else:
-                rep = self.handler(req)
+            rep = self.handler(req)
 
             result = _IPC.pack(rep, is_json=is_json)
 

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -63,7 +63,9 @@ class WaylandBackend(Backend):
     def create(self):
         """This is used to instantiate the Core"""
         os.environ.update(self.env)
-        return self.core(*self.args)
+        core = self.core(*self.args)
+        core.add_dummy_input_devices()
+        return core
 
     def configure(self, manager):
         """This backend needs to get WAYLAND_DISPLAY variable."""

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -1,5 +1,10 @@
 import contextlib
+import fcntl
 import os
+import select
+import subprocess
+import time
+from pathlib import Path
 
 import pytest
 
@@ -101,3 +106,198 @@ def new_layer_client(wmanager, name="layer"):
     pid = wmanager.test_notification(name)
     wmanager.c.sync()
     return pid
+
+
+CLIENT_PATH = Path(__file__) / ".." / ".." / ".." / "wayland_clients" / "bin"
+
+
+def make_test_env(mgr):
+    """Generate environment variables to ensure client connects to test server."""
+    env = os.environ.copy()
+    env.pop("DISPLAY", None)
+    env.pop("WAYLAND_DISPLAY", None)
+    env.update(mgr.backend.env)
+    return env
+
+
+class ScriptError(Exception):
+    pass
+
+
+class ClientHandler:
+    def __init__(self, cmd, manager):
+        if Path(cmd).is_absolute():
+            cmd_path = Path(cmd)
+        else:
+            cmd_path = (CLIENT_PATH / cmd).resolve()
+
+        if not cmd_path.exists():
+            assert False, f"{cmd_path.as_posix()} not found."
+
+        self.cmd = cmd_path.as_posix()
+
+        self.process = None
+        self.manager = manager
+
+    def __enter__(self):
+        self._run()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+    def _run(self):
+        if self.cmd is None:
+            assert False, "No command defined."
+
+        if self.process is not None and self.process.poll() is None:
+            return
+
+        self.process = subprocess.Popen(
+            [self.cmd],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=make_test_env(self.manager),
+        )
+
+        fcntl.fcntl(self.process.stdout.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
+
+    def stop(self):
+        try:
+            if self.process and self.process.poll() is None:
+                self.process.stdin.write("quit\n")
+                self.process.stdin.flush()
+                self.process.wait(timeout=2)
+
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+
+        finally:
+            if self.process:
+                self.process.stdin.close()
+                self.process.stdout.close()
+                self.process.stderr.close()
+                self.process = None
+
+    def _send(self, command: str) -> None:
+        if self.process is None:
+            raise ScriptError("Process not started")
+
+        if self.process.poll() is not None:
+            raise ScriptError("Process has exited")
+        self.flush_manager()
+        self.process.stdin.write(command + "\n")
+        self.process.stdin.flush()
+        self.flush_manager()
+
+    def send(self, command: str) -> str:
+        """
+        Send a command and wait for one-line response.
+        Expected responses:
+            OK
+            ERROR: message
+        """
+        self._send(command)
+
+        while True:
+            response = self.process.stdout.readline()
+
+            if response == "":
+                if self.process.poll() is None:
+                    continue
+
+                stderr = self.process.stderr.read().strip()
+                raise ScriptError(f"Process closed stdout. stderr={stderr}")
+
+            break
+
+        return response.strip()
+
+    def assert_no_text(self, timeout_ms=200):
+        """
+        Verifies that no next is output by the client during a specified time period.
+
+        Useful if you want to demonstrate that no text is output by the clien
+        e.g. responding to a message from the compositor.
+        """
+        self.assert_line("", timeout_ms=timeout_ms, assert_timeout=True)
+
+    def assert_line(self, line, timeout_ms=1000, assert_timeout=False) -> None:
+        """
+        Waits for the client to output a specific line.
+        NB client only reads the first line available.
+        """
+        poll_obj = select.poll()
+        poll_obj.register(self.process.stdout, select.POLLIN)
+        poll_result = poll_obj.poll(timeout_ms)
+        if poll_result:
+            out = self.process.stdout.readline().strip()
+            assert out == line
+        else:
+            if assert_timeout:
+                assert True
+            else:
+                assert False, "No text received."
+
+    def assert_ok(self, command: str) -> None:
+        """Verify that the client outputs 'OK' after sending a command."""
+        assert self.send(command) == "OK"
+
+    def assert_error(self, command: str, error: str) -> None:
+        """Verify that the client outputs an error message."""
+        assert self.send(command) == f"ERROR: {error}"
+
+    def send_read_until(self, command, expected, timeout_ms=2000):
+        """
+        Send command and read stdout until `expected` is seen.
+
+        Returns all lines read (including the matching line).
+
+        Raises TimeoutError if the line is not received before the timeout.
+        """
+        self._send(command)
+
+        poll_obj = select.poll()
+        poll_obj.register(self.process.stdout, select.POLLIN)
+
+        deadline = time.monotonic() + timeout_ms / 1000
+        lines = []
+
+        while True:
+            remaining = max(0, int((deadline - time.monotonic()) * 1000))
+
+            if remaining == 0:
+                assert False, f"Timed out waiting for {expected!r}. Received: {lines!r}"
+
+            if not poll_obj.poll(remaining):
+                assert False, f"Timed out waiting for {expected!r}. Received: {lines!r}"
+
+            data = self.process.stdout.read()
+            if not data:  # EOF
+                raise EOFError(f"Process exited before {expected!r}. Received: {lines!r}")
+
+            raw_lines = [l.strip() for l in data.split("\n") if l]
+            lines.extend(raw_lines)
+
+            if expected in lines:
+                return lines
+
+    def restart(self):
+        self._run()
+
+    def flush_manager(self):
+        self.manager.c.core.flush()
+
+
+@pytest.fixture
+def test_client(wmanager, request):
+    script = getattr(request, "param", None)
+
+    if script is None:
+        raise ValueError("The test_client fixture must be parameterised.")
+
+    with ClientHandler(script, wmanager) as client:
+        yield client

--- a/test/backend/wayland/test_cursor_shape.py
+++ b/test/backend/wayland/test_cursor_shape.py
@@ -1,0 +1,42 @@
+import pytest
+
+from test.helpers import Retry
+
+pytestmark = pytest.mark.parametrize("test_client", ["cursor-shape"], indirect=True)
+
+
+@pytest.mark.parametrize("shape", ["crosshair", "text", "wait", "help", "grab"])
+def test_cursor_shape_protocol(test_client, wmanager, shape):
+    """Test that the C client can successfully request shapes via the protocol."""
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_window():
+        assert len(wmanager.c.windows()) > 0
+
+    def cursor_name():
+        return wmanager.c.core.get_cursor_shape_v1()
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_cursor():
+        assert cursor_name() != "default"
+
+    test_client.assert_ok(shape)
+    wait_for_window()
+    wmanager.c.window.set_position_floating(150, 150)
+
+    # Cursor is outside window so should be default
+    wmanager.c.core.eval("self.warp_pointer(0, 0, motion=True)")
+    assert cursor_name() == "default"
+
+    # Move cursor inside test client window
+    wmanager.c.core.eval("self.warp_pointer(200, 200, motion=True)")
+    wmanager.c.core.flush()
+    wait_for_cursor()
+    cursor = cursor_name()
+
+    if shape == "wait":
+        assert cursor in ["wait", "watch"]
+    elif shape == "help":
+        assert cursor in ["help", "whats_this", "question_arrow"]
+    else:
+        assert cursor == shape

--- a/test/backend/wayland/test_foreign_toplevel_management.py
+++ b/test/backend/wayland/test_foreign_toplevel_management.py
@@ -1,0 +1,132 @@
+import pytest
+
+from test.conftest import dualmonitor
+
+pytestmark = pytest.mark.parametrize("test_client", ["ftl-manager"], indirect=True)
+
+
+def make_line(title, activated=False, fullscreen=False, maximized=False, minimized=False):
+    def yn(value):
+        return "Y" if value else "N"
+
+    return (
+        f"title:{title} app_id:TestWindow activated:{yn(activated)} "
+        f"fullscreen:{yn(fullscreen)} maximized:{yn(maximized)} "
+        f"minimized:{yn(minimized)}"
+    )
+
+
+def get_window(title, wmanager):
+    wins = wmanager.c.windows()
+    for w in wins:
+        if w["name"] == title:
+            return wmanager.c.window[w["id"]]
+
+    assert False
+
+
+def test_ftl_state(wmanager, test_client):
+    """Test that client is notified about client state."""
+    wmanager.test_window("window1")
+    win1 = get_window("window1", wmanager)
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+
+    # Test maximize
+    win1.toggle_maximize()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True, maximized=True) in lines
+    win1.toggle_maximize()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+
+    # Test minimize (NB window is not focused when minimized)
+    win1.toggle_minimize()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=False, minimized=True) in lines
+    win1.toggle_minimize()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+
+    # Test fullscreen
+    win1.toggle_fullscreen()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True, fullscreen=True) in lines
+    win1.toggle_fullscreen()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+
+
+def test_focus_state(wmanager, test_client):
+    wmanager.test_window("window1")
+    wmanager.test_window("window2")
+    win1 = get_window("window1", wmanager)
+    win2 = get_window("window2", wmanager)
+
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1") in lines
+    assert make_line("window2", activated=True) in lines
+
+    win1.focus()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+    assert make_line("window2") in lines
+
+    win2.focus()
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1") in lines
+    assert make_line("window2", activated=True) in lines
+
+
+def test_client_set_state(wmanager, test_client):
+    wmanager.test_window("window1")
+    win1 = get_window("window1", wmanager)
+    lines = test_client.send_read_until("list", "OK")
+    assert make_line("window1", activated=True) in lines
+
+    test_client.assert_ok("fullscreen window1")
+    assert win1.info()["fullscreen"]
+    test_client.assert_ok("fullscreen window1")
+    assert not win1.info()["fullscreen"]
+
+    test_client.assert_ok("maximize window1")
+    assert win1.info()["maximized"]
+    test_client.assert_ok("maximize window1")
+    assert not win1.info()["maximized"]
+
+    test_client.assert_ok("minimize window1")
+    assert win1.info()["minimized"]
+    test_client.assert_ok("minimize window1")
+    assert not win1.info()["minimized"]
+
+
+def test_client_focus(wmanager, test_client):
+    def assert_focused(name):
+        assert wmanager.c.window.info()["name"] == name
+
+    wmanager.test_window("window1")
+    wmanager.test_window("window2")
+
+    assert_focused("window2")
+
+    test_client.assert_ok("activate window1")
+    assert_focused("window1")
+
+    test_client.assert_ok("activate window2")
+    assert_focused("window2")
+
+
+@dualmonitor
+def test_output_enter_leave(wmanager, test_client):
+    wmanager.test_window("window1")
+    win1 = get_window("window1", wmanager)
+
+    test_client.assert_ok("output_reset window1")
+    win1.set_size_floating(200, 200)
+    win1.set_position_floating(700, 100)
+    lines = test_client.send_read_until("output_enter window1", "OK")
+    assert "output_enter: HEADLESS-1" in lines
+    test_client.assert_error("output_leave window1", "output_leave message not received")
+    win1.set_position(900, 100)
+    lines = test_client.send_read_until("output_leave window1", "OK")
+    assert "output_leave: HEADLESS-2" in lines

--- a/test/backend/wayland/test_idle.py
+++ b/test/backend/wayland/test_idle.py
@@ -1,0 +1,81 @@
+import pytest
+
+from libqtile import hook, widget
+from libqtile.bar import Bar
+from libqtile.config import Screen
+from libqtile.confreader import Config
+
+
+class IdleConfig(Config):
+    idle_widget = widget.TextBox("False", name="idle")
+
+    def update_widget(inhibited):  # noqa: N805
+        IdleConfig.idle_widget.update(f"{inhibited}")
+
+    screens = [Screen(top=Bar([idle_widget], 20))]
+
+    hook.subscribe.idle_inhibitor_change(update_widget)
+
+
+idle_config = pytest.mark.parametrize("wmanager", [IdleConfig], indirect=True)
+pytestmark = pytest.mark.parametrize("test_client", ["idle-client"], indirect=True)
+
+
+def test_idle_notify(wmanager, test_client):
+    """Test idle messages sent by compositor to clients."""
+    # Request idle notification timer
+    test_client.assert_ok("watch 100")
+
+    # Confirm client receives idle message
+    test_client.assert_line("idled")
+
+    # Trigger activity and verify resumed message
+    wmanager.c.core.idle_notify_activity()
+    wmanager.c.core.flush()
+    test_client.assert_line("resumed")
+
+    # Unsubscribe notification timer
+    test_client.assert_ok("unwatch")
+
+    # Idle notify timeout was 100ms so we wait for 200ms and confirm
+    # there's no IDLED event
+    test_client.assert_no_text()
+
+
+def test_idle_inhibit_client(wmanager, test_client):
+    """Test idle messages not sent by compositor to clients when inhibited."""
+    # Request an inhibitor before idle notification timer
+    test_client.assert_ok("inhibit")
+    test_client.assert_ok("watch 100")
+
+    # Inhibited so no messages
+    test_client.assert_no_text()
+
+    # Remove inhibitor and verify we now get idle messages
+    test_client.assert_ok("uninhibit")
+    test_client.assert_line("idled")
+
+
+def test_idle_inhibit_qtile(wmanager, test_client):
+    """
+    Test idle messages not sent by compositor to clients when using internal inhibitor.
+    """
+    # Request an inhibitor before idle notification timer
+    wmanager.c.core.set_idle_inhibitor()
+    test_client.assert_ok("watch 100")
+
+    # Inhibited so no messages
+    test_client.assert_no_text()
+
+    # Remove inhibitor and verify we now get idle messages
+    wmanager.c.core.remove_idle_inhibitor()
+    test_client.assert_line("idled")
+
+
+@idle_config
+def test_idle_inhibit_hooks(wmanager, test_client):
+    assert wmanager.c.widget["idle"].info()["text"] == "False"
+    test_client.assert_ok("inhibit")
+    assert wmanager.c.widget["idle"].info()["text"] == "True"
+    test_client.assert_ok("uninhibit")
+    assert wmanager.c.widget["idle"].info()["text"] == "False"

--- a/test/backend/wayland/test_output_power.py
+++ b/test/backend/wayland/test_output_power.py
@@ -1,0 +1,70 @@
+import pytest
+
+from test.conftest import dualmonitor
+from test.helpers import Retry
+
+
+@Retry(ignore_exceptions=(AssertionError,))
+def wait_for_outputs(client, num=1):
+    client.assert_ok(f"outputs {num}")
+
+
+pytestmark = pytest.mark.parametrize("test_client", ["output-power-management"], indirect=True)
+
+
+def test_opm(wmanager, test_client):
+    """Test that client is notified about client state."""
+    wait_for_outputs(test_client)
+    test_client.assert_ok("count_on 1")
+    test_client.assert_ok("power_off")
+    test_client.assert_ok("count_on 0")
+    test_client.assert_ok("power_on")
+    test_client.assert_ok("count_on 1")
+
+
+def test_opm_window_persistence(wmanager, test_client):
+    """Check that client window is unaffected by power state."""
+    wait_for_outputs(test_client)
+    wmanager.test_window("opm")
+    wmanager.c.window.set_size_floating(300, 200)
+    wmanager.c.window.set_position_floating(100, 100)
+    test_client.assert_ok("power_off")
+    test_client.assert_ok("count_on 0")
+    test_client.assert_ok("power_on")
+    info = wmanager.c.window.info()
+    assert info
+    assert info["name"] == "opm"
+    assert info["x"] == 100
+    assert info["y"] == 100
+    assert info["width"] == 300
+    assert info["height"] == 200
+
+
+@dualmonitor
+def test_opm_dual_monitor(wmanager, test_client):
+    """Check each output can be powered individually."""
+
+    def get_output_state():
+        return test_client.send_read_until("identify", "OK")
+
+    # Check client is notified about two outputs
+    wait_for_outputs(test_client, 2)
+
+    outputs = get_output_state()
+    assert "Output: HEADLESS-1 (Power: ON)" in outputs
+    assert "Output: HEADLESS-2 (Power: ON)" in outputs
+
+    test_client.assert_ok("power_off")
+    outputs = get_output_state()
+    assert "Output: HEADLESS-1 (Power: OFF)" in outputs
+    assert "Output: HEADLESS-2 (Power: OFF)" in outputs
+
+    test_client.assert_ok("power_on HEADLESS-1")
+    outputs = get_output_state()
+    assert "Output: HEADLESS-1 (Power: ON)" in outputs
+    assert "Output: HEADLESS-2 (Power: OFF)" in outputs
+
+    test_client.assert_ok("power_on HEADLESS-2")
+    outputs = get_output_state()
+    assert "Output: HEADLESS-1 (Power: ON)" in outputs
+    assert "Output: HEADLESS-2 (Power: ON)" in outputs

--- a/test/backend/wayland/test_session_lock.py
+++ b/test/backend/wayland/test_session_lock.py
@@ -1,0 +1,289 @@
+from types import MethodType
+
+import pytest
+
+from libqtile.backend.wayland._ffi import lib
+from libqtile.command.base import CommandError
+from test.conftest import dualmonitor
+
+
+class LockState:
+    """Maps server lock status flags."""
+
+    LOCKED = lib.QW_SESSION_LOCK_LOCKED
+    UNLOCKED = lib.QW_SESSION_LOCK_UNLOCKED
+    CRASHED = lib.QW_SESSION_LOCK_CRASHED
+
+
+# Functions for finding/navigating LAYER_LOCK
+
+
+def find_layer_lock(stacking_info):
+    """Recursively search the nested stacking tree for the LAYER_LOCK node."""
+    if not isinstance(stacking_info, dict):
+        return None
+
+    # Check current node
+    if stacking_info.get("name") == "LAYER_LOCK":
+        return stacking_info
+
+    # Recurse through children
+    for child in stacking_info.get("children", []):
+        result = find_layer_lock(child)
+        if result is not None:
+            return result
+
+    return None
+
+
+def find_node_at_position(node, node_type, x, y, parent_x=0, parent_y=0):
+    """
+    Looks for a node at given position but, as tree nodes are relative,
+    we need to track absolute position of child node.
+    """
+    if not isinstance(node, dict):
+        return False
+
+    abs_x = parent_x + node["x"]
+    abs_y = parent_y + node["y"]
+
+    if node["type"] == node_type:
+        return abs_x == x and abs_y == y
+
+    for child in node.get("children", []):
+        result = find_node_at_position(
+            child,
+            node_type,
+            x,
+            y,
+            abs_x,
+            abs_y,
+        )
+        if result:
+            return True
+
+    return False
+
+
+def count_node_types(node, counts=None):
+    """Returns dict of the number of each node type in a given node."""
+    if counts is None:
+        counts = {}
+
+    if not isinstance(node, dict):
+        return counts
+
+    # Count current node type
+    node_type = node.get("type")
+    if node_type:
+        counts[node_type] = counts.get(node_type, 0) + 1
+
+    # Recurse through children
+    for child in node.get("children", []):
+        count_node_types(child, counts)
+
+    return counts
+
+
+@pytest.fixture
+def ipc_enable(request):
+    """Convenience fixture to enable IPC when locked."""
+    yield getattr(request, "param", False)
+
+
+enable_ipc = pytest.mark.parametrize("ipc_enable", [True], indirect=True)
+
+
+@pytest.fixture
+def lock_manager(wmanager, ipc_enable):
+    """Modified manager instance with additional methods to test session lock."""
+
+    def remove_hooks(self) -> None:
+        self.c.eval("del hook.subscriptions['qtile']['locked']")
+        self.c.eval("del hook.subscriptions['qtile']['unlocked']")
+
+    def _lock_state(self) -> int:
+        return int(self.c.core.eval("self.qw.lock_state"))
+
+    def assert_locked(self) -> None:
+        assert self._lock_state() == LockState.LOCKED
+
+    def assert_unlocked(self) -> None:
+        assert self._lock_state() == LockState.UNLOCKED
+
+    def assert_crashed(self) -> None:
+        assert self._lock_state() == LockState.CRASHED
+
+    def _get_layer_lock(self) -> dict:
+        info = self.c.core.stacking_info()
+        layer = find_layer_lock(info)
+        assert layer
+        return layer
+
+    def assert_layer_lock_enabled(self, enabled):
+        assert self._get_layer_lock()["enabled"] == enabled
+
+    def assert_rect_at_position(self, x, y):
+        layer = self._get_layer_lock()
+        assert find_node_at_position(layer, "rect", x, y)
+
+    def assert_buffer_at_position(self, x, y):
+        layer = self._get_layer_lock()
+        assert find_node_at_position(layer, "buffer", x, y)
+
+    def assert_rect_count(self, num):
+        layer = self._get_layer_lock()
+        counts = count_node_types(layer)
+        assert counts.get("rect", 0) == num
+
+    def assert_buffer_count(self, num):
+        layer = self._get_layer_lock()
+        counts = count_node_types(layer)
+        assert counts.get("buffer", 0) == num
+
+    # bind methods to our manager instance
+    for f in [
+        remove_hooks,
+        _lock_state,
+        assert_locked,
+        assert_unlocked,
+        assert_crashed,
+        _get_layer_lock,
+        assert_layer_lock_enabled,
+        assert_rect_at_position,
+        assert_buffer_at_position,
+        assert_rect_count,
+        assert_buffer_count,
+    ]:
+        setattr(wmanager, f.__name__, MethodType(f, wmanager))
+
+    # When the session is locked, IPC is disabled by default.
+    # However, for testing, we need access to the internals so we
+    # re-enable IPC by removing the hooks in the server.
+    if ipc_enable:
+        wmanager.remove_hooks()
+
+    yield wmanager
+
+
+# Parameterise every test with the session-lock client
+pytestmark = pytest.mark.parametrize("test_client", ["session-lock"], indirect=True)
+
+
+@enable_ipc
+def test_session_lock_server(lock_manager, test_client):
+    """Basic test of locked state."""
+    # Session is unlocked so layer lock is disabled
+    lock_manager.assert_layer_lock_enabled(False)
+
+    # Lock then client and verify lock state and layer_lock state
+    test_client.assert_ok("lock")
+    lock_manager.assert_locked()
+    lock_manager.assert_layer_lock_enabled(True)
+
+    # Check state is reset after unlock
+    test_client.assert_ok("unlock")
+    lock_manager.assert_unlocked()
+    lock_manager.assert_layer_lock_enabled(False)
+
+
+def test_session_lock_client(lock_manager, test_client):
+    """Check that correct messages are sent to clients."""
+    test_client.assert_ok("lock")
+    test_client.assert_ok("check_locked")
+
+    test_client.assert_ok("unlock")
+    test_client.assert_ok("check_unlocked")
+
+
+def test_ipc_disabled(lock_manager, test_client):
+    """
+    Confirm IPC is unavailable when locked and re-enabled when lock is removed.
+    """
+    test_client.assert_ok("lock")
+    with pytest.raises(CommandError):
+        lock_manager.assert_locked()
+
+    # Unlocking should re-enable IPC
+    test_client.assert_ok("unlock")
+    lock_manager.assert_unlocked()
+
+
+@enable_ipc
+def test_crashed(lock_manager, test_client):
+    """Confirm crashed state is still locked."""
+    test_client.assert_ok("lock")
+    lock_manager.assert_layer_lock_enabled(True)
+
+    test_client.assert_ok("crash")
+    lock_manager.assert_crashed()
+    lock_manager.assert_layer_lock_enabled(True)
+
+    test_client.restart()
+    test_client.assert_error("lock", "compositor rejected lock")
+    test_client.assert_error("unlock", "no active lock")
+
+
+def test_crashed_ipc_disabled(lock_manager, test_client):
+    """Confirm IPC is still locked when in crashed state."""
+    test_client.assert_ok("lock")
+    test_client.assert_ok("crash")
+    with pytest.raises(CommandError):
+        lock_manager.assert_crashed()
+
+
+@enable_ipc
+def test_multiple_lock_requests(lock_manager, test_client):
+    """Multiple requests for a lock should be rejected."""
+    test_client.assert_ok("lock")
+    lock_manager.assert_locked()
+
+    test_client.assert_error("lock", "already holding a lock object")
+    lock_manager.assert_locked()
+
+    test_client.assert_ok("unlock")
+    lock_manager.assert_unlocked()
+
+
+@enable_ipc
+def test_lock_surface_single(lock_manager, test_client):
+    """Check that lock surface is added to LAYER_LOCK."""
+    lock_manager.assert_rect_count(1)
+    lock_manager.assert_rect_at_position(0, 0)
+
+    lock_manager.assert_buffer_count(0)
+
+    test_client.assert_ok("lock")
+    test_client.assert_ok("create_surface")
+    test_client.assert_ok("check_surface_count 1")
+
+    lock_manager.assert_buffer_count(1)
+    lock_manager.assert_buffer_at_position(0, 0)
+
+    test_client.assert_ok("unlock")
+    lock_manager.assert_buffer_count(0)
+
+
+@dualmonitor
+@enable_ipc
+def test_lock_surface_dualmonito(lock_manager, test_client):
+    """
+    Check that lock surfaces are added to LAYER_LOCK and
+    positioned correctly on multiple monitors.
+    """
+    lock_manager.assert_rect_count(2)
+    lock_manager.assert_rect_at_position(0, 0)
+    lock_manager.assert_rect_at_position(800, 0)
+
+    lock_manager.assert_buffer_count(0)
+
+    test_client.assert_ok("lock")
+    test_client.assert_ok("create_surface")
+    test_client.assert_ok("check_surface_count 2")
+
+    lock_manager.assert_buffer_count(2)
+    lock_manager.assert_buffer_at_position(0, 0)
+    lock_manager.assert_buffer_at_position(800, 0)
+
+    test_client.assert_ok("unlock")
+    lock_manager.assert_buffer_count(0)

--- a/test/wayland_clients/src/client-base.c
+++ b/test/wayland_clients/src/client-base.c
@@ -108,19 +108,19 @@ static bool dispatch_line(struct client_state *state, char *line) {
 
 static void client_state_cleanup(struct client_state *state) {
     if (state->seat) {
-        wl_seat_destroy(state.seat);
+        wl_seat_destroy(state->seat);
     }
 
     if (state->compositor) {
-        wl_compositor_destroy(state.compositor);
+        wl_compositor_destroy(state->compositor);
     }
 
     if (state->registry) {
-        wl_registry_destroy(state.registry);
+        wl_registry_destroy(state->registry);
     }
 
     if (state->display) {
-        wl_display_disconnect(state.display);
+        wl_display_disconnect(state->display);
     }
 }
 

--- a/test/wayland_clients/src/client-base.c
+++ b/test/wayland_clients/src/client-base.c
@@ -1,0 +1,301 @@
+/* client-base.c */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "client-base.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static const struct client_ops *ops_ptr;
+
+void test_ok(void) {
+    puts("OK");
+    fflush(stdout);
+}
+
+void test_error(const char *fmt, ...) {
+    printf("ERROR: ");
+
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    va_end(args);
+
+    printf("\n");
+    fflush(stdout);
+}
+
+void test_message(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vprintf(fmt, args);
+    va_end(args);
+
+    printf("\n");
+    fflush(stdout);
+}
+
+void do_roundtrip(struct client_state *state) { wl_display_roundtrip(state->display); }
+
+static void registry_global(void *data, struct wl_registry *registry, uint32_t name,
+                            const char *interface, uint32_t version) {
+    struct client_state *state = data;
+
+    /* Common globals */
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        state->compositor =
+            wl_registry_bind(registry, name, &wl_compositor_interface, version < 4 ? version : 4);
+
+    } else if (strcmp(interface, wl_seat_interface.name) == 0) {
+        state->seat =
+            wl_registry_bind(registry, name, &wl_seat_interface, version < 7 ? version : 7);
+
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        state->shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+    }
+
+    if (ops_ptr->registry_global) {
+        ops_ptr->registry_global(state, registry, name, interface, version);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *registry, uint32_t name) {
+    if (ops_ptr->registry_global_remove) {
+        ops_ptr->registry_global_remove(data, registry, name);
+    }
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+static bool dispatch_line(struct client_state *state, char *line) {
+    size_t len = strlen(line);
+
+    while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+        line[--len] = '\0';
+    }
+
+    if (len == 0) {
+        return true;
+    }
+
+    char *verb = line;
+    char *arg = NULL;
+
+    char *sp = strchr(line, ' ');
+    if (sp) {
+        *sp = '\0';
+        arg = sp + 1;
+    }
+
+    if (strcmp(verb, "quit") == 0) {
+        return false;
+    }
+
+    if (ops_ptr->dispatch_command != NULL) {
+        return ops_ptr->dispatch_command(state, verb, arg);
+    }
+}
+
+static void client_state_cleanup(struct client_state *state) {
+    if (state->seat) {
+        wl_seat_destroy(state.seat);
+    }
+
+    if (state->compositor) {
+        wl_compositor_destroy(state.compositor);
+    }
+
+    if (state->registry) {
+        wl_registry_destroy(state.registry);
+    }
+
+    if (state->display) {
+        wl_display_disconnect(state.display);
+    }
+}
+
+int client_run(struct client_state *state, const struct client_ops *ops) {
+    ops_ptr = ops;
+
+    state->display = wl_display_connect(NULL);
+    if (!state->display) {
+        fprintf(stderr, "ERROR: failed to connect to display: %s\n", strerror(errno));
+        return 1;
+    }
+
+    if (ops->setup != NULL) {
+        ops->setup(state);
+    }
+
+    state->registry = wl_display_get_registry(state->display);
+
+    wl_registry_add_listener(state->registry, &registry_listener, state);
+
+    wl_display_roundtrip(state->display);
+
+    int stdin_flags = fcntl(STDIN_FILENO, F_GETFL, 0);
+
+    fcntl(STDIN_FILENO, F_SETFL, stdin_flags | O_NONBLOCK);
+
+    fprintf(stderr, "ready\n");
+    fflush(stderr);
+
+    char line[256];
+    size_t pos = 0;
+
+    struct pollfd fds[2] = {
+        {
+            .fd = STDIN_FILENO,
+            .events = POLLIN,
+        },
+        {
+            .fd = wl_display_get_fd(state->display),
+            .events = POLLIN,
+        },
+    };
+
+    bool running = true;
+
+    while (running) {
+        wl_display_flush(state->display);
+
+        int ret = poll(fds, 2, -1);
+
+        if (ret < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+
+            perror("poll");
+            break;
+        }
+
+        if (fds[1].revents & POLLIN) {
+            wl_display_dispatch(state->display);
+        }
+
+        if (fds[0].revents & POLLIN) {
+            ssize_t n = read(STDIN_FILENO, line + pos, sizeof(line) - pos - 1);
+
+            if (n <= 0) {
+                if (n == 0) {
+                    break;
+                }
+
+                if (errno == EAGAIN) {
+                    continue;
+                }
+
+                perror("read");
+                break;
+            }
+
+            pos += (size_t)n;
+            line[pos] = '\0';
+
+            char *start = line;
+            char *nl;
+
+            while ((nl = strchr(start, '\n')) != NULL) {
+                *nl = '\0';
+
+                running = dispatch_line(state, start);
+
+                if (!running) {
+                    break;
+                }
+
+                start = nl + 1;
+            }
+
+            size_t remaining = (size_t)((line + pos) - start);
+
+            memmove(line, start, remaining);
+
+            pos = remaining;
+        }
+    }
+
+    if (ops->cleanup != NULL) {
+        ops->cleanup(state);
+    }
+
+    client_state_cleanup(state);
+
+    return 0;
+}
+
+/*
+Common SHM buffer code
+*/
+
+static int create_shm_file(size_t size) {
+    char template[] = "/tmp/wayland-test-shm-XXXXXX";
+    int fd = mkstemp(template);
+    if (fd < 0) {
+        return -1;
+    }
+
+    unlink(template);
+
+    if (ftruncate(fd, (off_t)size) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+struct buffer *create_buffer(struct client_state *state, uint32_t width, uint32_t height,
+                             uint32_t colour) {
+    const uint32_t stride = width * 4;
+    const uint32_t size = stride * height;
+
+    int fd = create_shm_file(size);
+    if (fd < 0) {
+        return NULL;
+    }
+
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+    if (data == MAP_FAILED) {
+        close(fd);
+        return NULL;
+    }
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(state->shm, fd, size);
+
+    struct wl_buffer *buffer =
+        wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_XRGB8888);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    if (buffer == NULL) {
+        munmap(data, size);
+        return NULL;
+    }
+
+    /* Fill with given colour */
+    uint32_t *pixels = data;
+    for (uint32_t i = 0; i < width * height; i++) {
+        pixels[i] = colour;
+    }
+
+    struct buffer *buf = calloc(1, sizeof(*buf));
+    buf->wl_buffer = buffer;
+    buf->data = data;
+    buf->size = size;
+
+    return buf;
+}

--- a/test/wayland_clients/src/client-base.h
+++ b/test/wayland_clients/src/client-base.h
@@ -1,0 +1,46 @@
+#ifndef CLIENT_BASE_H
+#define CLIENT_BASE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <wayland-client.h>
+
+struct buffer {
+    struct wl_buffer *wl_buffer;
+    void *data;
+    size_t size;
+};
+struct client_state {
+    struct wl_display *display;
+    struct wl_registry *registry;
+    struct wl_compositor *compositor;
+    struct wl_seat *seat;
+    struct wl_shm *shm;
+};
+
+struct client_ops {
+    void (*setup)(struct client_state *state);
+
+    void (*registry_global)(struct client_state *state, struct wl_registry *registry, uint32_t name,
+                            const char *interface, uint32_t version);
+
+    void (*registry_global_remove)(struct client_state *state, struct wl_registry *registry,
+                                   uint32_t name);
+
+    bool (*dispatch_command)(struct client_state *state, const char *command, const char *arg);
+
+    void (*cleanup)(struct client_state *state);
+};
+
+void do_roundtrip(struct client_state *state);
+
+int client_run(struct client_state *state, const struct client_ops *ops);
+
+void test_ok(void);
+void test_error(const char *fmt, ...);
+void test_message(const char *fmt, ...);
+
+struct buffer *create_buffer(struct client_state *state, uint32_t width, uint32_t height,
+                             uint32_t colour);
+
+#endif /* CLIENT_BASE_H */

--- a/test/wayland_clients/src/client-template.c
+++ b/test/wayland_clients/src/client-template.c
@@ -1,0 +1,146 @@
+/*
+This file shows a skeleton for building clients to test client interaction
+with the qtile wayland compositor.
+
+In addition to creating a new test client, you must add the necessary information
+to build.py to build the client. This includes building the necessary client protocol
+files and the client itself.
+
+Example:
+
+PROTOS: list[Protocol] = [
+    ...,
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/ext-idle-notify/ext-idle-notify-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
+]
+
+TEST_CLIENTS: list[TestClient] = [
+    TestClient(
+        name="idle-client",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "idle-client.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "ext-idle-notify-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "idle-inhibit-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    )
+]
+
+In the TestClient sources, CLIENT_BASE is the path to 'client-base.c'. This must be included if your
+client is based off this template.
+
+The pytest fixture for the client expects successful commands to print "OK" to stdout (use
+'test_ok') or "ERROR: <error message>" (use 'test_error').
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+
+/*
+Add required extension includes
+*/
+
+struct test_state {
+    struct client_state base;
+
+    /*
+    Custom state properties for test
+
+    for example:
+    struct ext_idle_notifier_v1 *idle_notifier;
+    struct ext_idle_notification_v1 *notification;
+    */
+};
+
+/*
+Binding registry globals specific to the test client. The display, compositor etc. are bound before
+this function is called.
+*/
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    /*
+    if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
+        state->idle_notifier = wl_registry_bind(registry, name, &ext_idle_notifier_v1_interface, 1);
+
+    } else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+        state->idle_inhibit_manager =
+        wl_registry_bind(registry, name, &zwp_idle_inhibit_manager_v1_interface, 1);
+    }
+    */
+}
+
+/*
+Function to handle removal of global items. Only necessary if this benhaviour is expected or
+being tested.
+*/
+static void registry_global_remove(void *data, struct wl_registry *registry, uint32_t name) {
+    struct client_state *state = data;
+    (void)registry;
+    (void)name;
+}
+
+/*
+Function for parsing commands received via stdin. Function receives the command name
+(first word of stdin) and an arg (anything after the command name).
+
+Function should return true to remain in the main loop, returning false will cause the script
+to exit.
+*/
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    /*
+    if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    */
+    return true;
+}
+
+/*
+Called just before the main loop starts.
+
+Function to handle initalising any variables (e.g. lists). The global registry binding has not
+happened at this stage.
+*/
+void setup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+
+/*
+Called when the main loop exits.
+
+Function to handle tidying up of any items. Display, compositor etc.
+will be destroyed after this function.
+*/
+void cleanup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+
+/*
+main function MUST initialise state and bind cliet operations.
+
+"client_run" will start the loop, listening to STDIN as well as the
+wayland socket.
+*/
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .registry_global_remove = registry_global_remove,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/cursor-shape.c
+++ b/test/wayland_clients/src/cursor-shape.c
@@ -1,0 +1,285 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+
+#include "cursor-shape-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct xdg_wm_base *xdg_wm_base;
+    struct wl_surface *surface;
+    struct xdg_surface *xdg_surface;
+    struct xdg_toplevel *toplevel;
+    struct wl_pointer *pointer;
+    struct wp_cursor_shape_manager_v1 *cursor_manager;
+    struct wp_cursor_shape_device_v1 *cursor_device;
+    uint32_t requested_shape;
+    uint32_t enter_serial;
+    uint32_t configure_serial;
+    struct buffer *buffer;
+};
+
+static void toplevel_close(void *data, struct xdg_toplevel *t) { exit(0); }
+
+static void toplevel_configure(void *data, struct xdg_toplevel *t, int32_t w, int32_t h,
+                               struct wl_array *states) {
+    (void)data;
+    (void)t;
+    (void)w;
+    (void)h;
+    (void)states;
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+};
+
+static void xdg_surface_configure(void *data, struct xdg_surface *surf, uint32_t serial) {
+    struct test_state *state = data;
+    xdg_surface_ack_configure(surf, serial);
+    wl_surface_commit(state->surface);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void set_shape(struct test_state *state, uint32_t serial, uint32_t shape) {
+    if (state->cursor_device == NULL)
+        return;
+
+    wp_cursor_shape_device_v1_set_shape(state->cursor_device, serial, shape);
+}
+
+static void pointer_enter(void *data, struct wl_pointer *p, uint32_t serial,
+                          struct wl_surface *surf, wl_fixed_t x, wl_fixed_t y) {
+    struct test_state *state = data;
+    state->enter_serial = serial;
+
+    if (state->cursor_device == NULL) {
+        test_error("cursor_device is NULL at enter");
+        return;
+    }
+
+    set_shape(state, serial, state->requested_shape);
+    // pointer_entered = true;
+}
+
+static void pointer_leave(void *data, struct wl_pointer *p, uint32_t serial,
+                          struct wl_surface *surf) {
+    (void)data;
+    (void)p;
+    (void)serial;
+    (void)surf;
+}
+
+static void pointer_motion(void *data, struct wl_pointer *p, uint32_t time, wl_fixed_t x,
+                           wl_fixed_t y) {
+    (void)data;
+    (void)p;
+    (void)time;
+    (void)x;
+    (void)y;
+}
+
+static void pointer_button(void *data, struct wl_pointer *pointer, uint32_t serial, uint32_t time,
+                           uint32_t button, uint32_t state) {
+    (void)data;
+    (void)pointer;
+    (void)serial;
+    (void)time;
+    (void)button;
+    (void)state;
+}
+
+static void pointer_axis(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis,
+                         wl_fixed_t value) {
+    (void)data;
+    (void)pointer;
+    (void)time;
+    (void)axis;
+    (void)value;
+}
+
+static void pointer_frame(void *data, struct wl_pointer *pointer) {
+    (void)data;
+    (void)pointer;
+}
+
+static void pointer_axis_source(void *data, struct wl_pointer *pointer, uint32_t axis_source) {
+    (void)data;
+    (void)pointer;
+    (void)axis_source;
+}
+
+static void pointer_axis_stop(void *data, struct wl_pointer *pointer, uint32_t time,
+                              uint32_t axis) {
+    (void)data;
+    (void)pointer;
+    (void)time;
+    (void)axis;
+}
+
+static void pointer_axis_discrete(void *data, struct wl_pointer *pointer, uint32_t axis,
+                                  int32_t discrete) {
+    (void)data;
+    (void)pointer;
+    (void)axis;
+    (void)discrete;
+}
+
+static void pointer_axis_value120(void *data, struct wl_pointer *pointer, uint32_t axis,
+                                  int32_t value120) {
+    (void)data;
+    (void)pointer;
+    (void)axis;
+    (void)value120;
+}
+
+static void pointer_axis_relative_direction(void *data, struct wl_pointer *pointer, uint32_t axis,
+                                            uint32_t direction) {
+    (void)data;
+    (void)pointer;
+    (void)axis;
+    (void)direction;
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+    .enter = pointer_enter,
+    .leave = pointer_leave,
+    .motion = pointer_motion,
+    .button = pointer_button,
+    .axis = pointer_axis,
+    .frame = pointer_frame,
+    .axis_source = pointer_axis_source,
+    .axis_stop = pointer_axis_stop,
+    .axis_discrete = pointer_axis_discrete,
+    .axis_value120 = pointer_axis_value120,
+    .axis_relative_direction = pointer_axis_relative_direction,
+};
+
+static void seat_capabilities(void *data, struct wl_seat *seat, uint32_t caps) {
+    struct test_state *state = data;
+    if (caps & WL_SEAT_CAPABILITY_POINTER) {
+        state->pointer = wl_seat_get_pointer(state->base.seat);
+
+        wl_pointer_add_listener(state->pointer, &pointer_listener, state);
+        state->cursor_device =
+            wp_cursor_shape_manager_v1_get_pointer(state->cursor_manager, state->pointer);
+    }
+}
+
+static void seat_name(void *data, struct wl_seat *seat, const char *name) {
+    (void)data;
+    (void)seat;
+    (void)name;
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_capabilities,
+    .name = seat_name,
+};
+
+static void wm_ping(void *data, struct xdg_wm_base *wm, uint32_t serial) {
+    xdg_wm_base_pong(wm, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_listener = {
+    .ping = wm_ping,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        state->xdg_wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(state->xdg_wm_base, &xdg_wm_listener, state);
+
+    } else if (strcmp(interface, wp_cursor_shape_manager_v1_interface.name) == 0) {
+        state->cursor_manager =
+            wl_registry_bind(registry, name, &wp_cursor_shape_manager_v1_interface, 1);
+
+    } else if (strcmp(interface, wl_seat_interface.name) == 0) {
+        wl_seat_add_listener(state->base.seat, &seat_listener, state);
+    }
+}
+
+void cmd_create_window(struct test_state *state) {
+    state->surface = wl_compositor_create_surface(state->base.compositor);
+
+    state->xdg_surface = xdg_wm_base_get_xdg_surface(state->xdg_wm_base, state->surface);
+    state->toplevel = xdg_surface_get_toplevel(state->xdg_surface);
+
+    xdg_surface_add_listener(state->xdg_surface, &xdg_surface_listener, state);
+    xdg_toplevel_add_listener(state->toplevel, &xdg_toplevel_listener, state);
+
+    // Set fixed size so qtile will float window
+    xdg_toplevel_set_min_size(state->toplevel, 300, 300);
+    xdg_toplevel_set_max_size(state->toplevel, 300, 300);
+
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    // Create contents of window
+    state->buffer = create_buffer(&state->base, 300, 300, 0xFF606060);
+
+    wl_surface_attach(state->surface, state->buffer->wl_buffer, 0, 0);
+    wl_surface_damage_buffer(state->surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    test_ok();
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "crosshair") == 0) {
+        state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "text") == 0) {
+        state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT;
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "wait") == 0) {
+        state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_WAIT;
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "help") == 0) {
+        state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_HELP;
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "grab") == 0) {
+        state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_GRAB;
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    return true;
+}
+
+void setup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+    state->requested_shape = WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR;
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+    if (state->surface) {
+        wl_surface_destroy(state->surface);
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/ftl-manager.c
+++ b/test/wayland_clients/src/ftl-manager.c
@@ -1,0 +1,457 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+
+#include "wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct zwlr_foreign_toplevel_manager_v1 *ftl_manager;
+
+    struct wl_list toplevels; // toplevel_entry
+    struct wl_list outputs;   // output_entry
+
+    bool pending_close;
+};
+
+enum {
+    STATE_MAXIMIZED = 1 << 0,
+    STATE_MINIMIZED = 1 << 1,
+    STATE_ACTIVATED = 1 << 2,
+    STATE_FULLSCREEN = 1 << 3,
+};
+
+enum {
+    OUTPUT_RESET,
+    OUTPUT_ENTER,
+    OUTPUT_LEAVE,
+};
+
+struct output_entry {
+    struct wl_output *wl_output;
+    char *name;
+    struct wl_list link;
+};
+
+struct toplevel_entry {
+    struct test_state *test_state;
+    struct zwlr_foreign_toplevel_handle_v1 *ftl_handle;
+    char *title;
+    char *app_id;
+    uint32_t toplevel_state;
+    struct wl_list link;
+    char *output_enter;
+    char *output_leave;
+};
+
+static char *find_output_name(struct test_state *state, struct wl_output *wl_output) {
+    struct output_entry *oe;
+    wl_list_for_each(oe, &state->outputs, link) {
+        if (oe->wl_output == wl_output) {
+            return oe->name;
+        }
+    }
+    return NULL;
+}
+
+static void toplevel_title(void *data,
+                           struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                           const char *title) {
+    (void)zwlr_foreign_toplevel_handle_v1;
+    struct toplevel_entry *te = data;
+    free(te->title);
+    te->title = strdup(title);
+}
+
+static void toplevel_app_id(void *data,
+                            struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                            const char *app_id) {
+    (void)zwlr_foreign_toplevel_handle_v1;
+    struct toplevel_entry *te = data;
+    free(te->app_id);
+    te->app_id = strdup(app_id);
+}
+
+static void
+toplevel_output_enter(void *data,
+                      struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                      struct wl_output *wl_output) {
+    (void)zwlr_foreign_toplevel_handle_v1;
+    struct toplevel_entry *te = data;
+    free(te->output_enter);
+    te->output_enter = strdup(find_output_name(te->test_state, wl_output));
+}
+
+static void
+toplevel_output_leave(void *data,
+                      struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                      struct wl_output *wl_output) {
+    (void)zwlr_foreign_toplevel_handle_v1;
+    struct toplevel_entry *te = data;
+    free(te->output_leave);
+    te->output_leave = strdup(find_output_name(te->test_state, wl_output));
+}
+
+static void toplevel_state(void *data,
+                           struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                           struct wl_array *state) {
+    struct toplevel_entry *te = data;
+    uint32_t flags = 0;
+    uint32_t *s;
+
+    wl_array_for_each(s, state) {
+        switch (*s) {
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED:
+            flags |= STATE_MAXIMIZED;
+            break;
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MINIMIZED:
+            flags |= STATE_MINIMIZED;
+            break;
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED:
+            flags |= STATE_ACTIVATED;
+            break;
+        case ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_FULLSCREEN:
+            flags |= STATE_FULLSCREEN;
+            break;
+        }
+    }
+    te->toplevel_state = flags;
+}
+
+static void toplevel_done(void *data,
+                          struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1) {
+    (void)data;
+    (void)zwlr_foreign_toplevel_handle_v1;
+}
+
+static void
+toplevel_closed(void *data,
+                struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1) {
+    struct toplevel_entry *te = data;
+    zwlr_foreign_toplevel_handle_v1_destroy(zwlr_foreign_toplevel_handle_v1);
+
+    wl_list_remove(&te->link);
+    te->test_state->pending_close = false;
+    free(te);
+}
+
+static void toplevel_parent(void *data,
+                            struct zwlr_foreign_toplevel_handle_v1 *zwlr_foreign_toplevel_handle_v1,
+                            struct zwlr_foreign_toplevel_handle_v1 *parent) {
+    (void)data;
+    (void)zwlr_foreign_toplevel_handle_v1;
+    (void)parent;
+}
+
+static const struct zwlr_foreign_toplevel_handle_v1_listener toplevel_listener = {
+    .title = toplevel_title,
+    .app_id = toplevel_app_id,
+    .output_enter = toplevel_output_enter,
+    .output_leave = toplevel_output_leave,
+    .state = toplevel_state,
+    .done = toplevel_done,
+    .closed = toplevel_closed,
+    .parent = toplevel_parent,
+};
+
+static void
+ftl_finished(void *data,
+             struct zwlr_foreign_toplevel_manager_v1 *zwlr_foreign_toplevel_manager_v1) {
+    (void)data;
+    (void)zwlr_foreign_toplevel_manager_v1;
+}
+
+static void ftl_toplevel(void *data,
+                         struct zwlr_foreign_toplevel_manager_v1 *zwlr_foreign_toplevel_manager_v1,
+                         struct zwlr_foreign_toplevel_handle_v1 *toplevel) {
+
+    (void)zwlr_foreign_toplevel_manager_v1;
+    struct test_state *state = data;
+    struct toplevel_entry *te = calloc(1, sizeof(*te));
+    te->ftl_handle = toplevel;
+    te->test_state = state;
+    zwlr_foreign_toplevel_handle_v1_add_listener(te->ftl_handle, &toplevel_listener, te);
+    wl_list_insert(&state->toplevels, &te->link);
+}
+
+static const struct zwlr_foreign_toplevel_manager_v1_listener ftl_listener = {
+    .toplevel = ftl_toplevel,
+    .finished = ftl_finished,
+};
+
+static void output_geometry(void *data, struct wl_output *wl_output, int32_t x, int32_t y,
+                            int32_t physical_width, int32_t physical_height, int32_t subpixel,
+                            const char *make, const char *model, int32_t transform) {
+
+    (void)data;
+    (void)wl_output;
+    (void)x;
+    (void)y;
+    (void)physical_width;
+    (void)physical_height;
+    (void)subpixel;
+    (void)make;
+    (void)model;
+    (void)transform;
+}
+
+static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags, int32_t width,
+                        int32_t height, int32_t refresh) {
+
+    (void)data;
+    (void)wl_output;
+    (void)flags;
+    (void)width;
+    (void)height;
+    (void)refresh;
+}
+
+static void output_done(void *data, struct wl_output *wl_output) {
+    (void)data;
+    (void)wl_output;
+}
+
+static void output_scale(void *data, struct wl_output *wl_output, int32_t factor) {
+    (void)data;
+    (void)wl_output;
+    (void)factor;
+}
+
+static void output_name(void *data, struct wl_output *wl_output, const char *name) {
+    (void)wl_output;
+    struct output_entry *oe = data;
+    oe->name = strdup(name);
+}
+
+static void output_description(void *data, struct wl_output *wl_output, const char *desc) {
+    (void)data;
+    (void)wl_output;
+    (void)desc;
+}
+
+static const struct wl_output_listener output_listener = {
+    .geometry = output_geometry,
+    .mode = output_mode,
+    .done = output_done,
+    .scale = output_scale,
+    .name = output_name,
+    .description = output_description,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, zwlr_foreign_toplevel_manager_v1_interface.name) == 0) {
+        state->ftl_manager =
+            wl_registry_bind(registry, name, &zwlr_foreign_toplevel_manager_v1_interface, 3);
+        zwlr_foreign_toplevel_manager_v1_add_listener(state->ftl_manager, &ftl_listener, state);
+    } else if (strcmp(interface, wl_output_interface.name) == 0) {
+        // wlroots only sends output_enter/leave events if the outputs are also bound by the client
+        struct output_entry *oe = calloc(1, sizeof(*oe));
+        oe->wl_output = wl_registry_bind(registry, name, &wl_output_interface, 4);
+        oe->name = NULL;
+        wl_output_add_listener(oe->wl_output, &output_listener, oe);
+        wl_list_insert(&state->outputs, &oe->link);
+    }
+}
+
+char *format_state(uint32_t toplevel_state, uint32_t reference) {
+    if (toplevel_state & reference) {
+        return "Y";
+    }
+    return "N";
+}
+
+/*
+List toplevel view "title (app_id) state:"
+*/
+static void cmd_list_toplevels(struct test_state *state) {
+    struct toplevel_entry *te;
+    wl_list_for_each(te, &state->toplevels, link) {
+        test_message("title:%s app_id:%s activated:%s fullscreen:%s maximized:%s minimized:%s",
+                     te->title, te->app_id, format_state(te->toplevel_state, STATE_ACTIVATED),
+                     format_state(te->toplevel_state, STATE_FULLSCREEN),
+                     format_state(te->toplevel_state, STATE_MAXIMIZED),
+                     format_state(te->toplevel_state, STATE_MINIMIZED));
+    }
+    test_ok();
+}
+
+/*
+Close toplevel window and verify close message received from server.
+*/
+static void cmd_close(struct test_state *state, const char *title) {
+    test_message("close requested");
+    struct toplevel_entry *te;
+    bool found = false;
+    wl_list_for_each(te, &state->toplevels, link) {
+        if (strcmp(te->title, title) == 0) {
+            zwlr_foreign_toplevel_handle_v1_close(te->ftl_handle);
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        test_error("toplevel not found");
+        return;
+    }
+
+    do_roundtrip(&state->base);
+    if (state->pending_close) {
+        test_error("close message not received");
+    } else {
+        test_ok();
+    }
+}
+
+static void cmd_check_state(struct test_state *state, const char *title, uint32_t toplevel_state) {
+    struct toplevel_entry *te;
+    wl_list_for_each(te, &state->toplevels, link) {
+        if (strcmp(te->title, title) == 0) {
+            if (te->toplevel_state & toplevel_state) {
+                test_ok();
+            } else {
+                test_error("state does not match");
+            }
+            return;
+        }
+    }
+    test_error("toplevel not found");
+}
+
+static void cmd_toggle_state(struct test_state *state, const char *title, uint32_t toplevel_state) {
+    struct toplevel_entry *te;
+    bool found = false;
+    bool expected;
+    wl_list_for_each(te, &state->toplevels, link) {
+        if (strcmp(te->title, title) == 0) {
+            expected = !(te->toplevel_state & toplevel_state);
+            if (toplevel_state & STATE_FULLSCREEN) {
+                if (te->toplevel_state & STATE_FULLSCREEN) {
+                    zwlr_foreign_toplevel_handle_v1_unset_fullscreen(te->ftl_handle);
+                } else {
+                    zwlr_foreign_toplevel_handle_v1_set_fullscreen(te->ftl_handle, NULL);
+                }
+            } else if (toplevel_state & STATE_MAXIMIZED) {
+                if (te->toplevel_state & STATE_MAXIMIZED) {
+                    zwlr_foreign_toplevel_handle_v1_unset_maximized(te->ftl_handle);
+                } else {
+                    zwlr_foreign_toplevel_handle_v1_set_maximized(te->ftl_handle);
+                }
+            } else if (toplevel_state & STATE_MINIMIZED) {
+                if (te->toplevel_state & STATE_MINIMIZED) {
+                    zwlr_foreign_toplevel_handle_v1_unset_minimized(te->ftl_handle);
+                } else {
+                    zwlr_foreign_toplevel_handle_v1_set_minimized(te->ftl_handle);
+                }
+
+            } else if (toplevel_state & STATE_ACTIVATED) {
+                if (!(te->toplevel_state & STATE_ACTIVATED)) {
+                    zwlr_foreign_toplevel_handle_v1_activate(te->ftl_handle, state->base.seat);
+                }
+            }
+            break;
+        }
+    }
+
+    do_roundtrip(&state->base);
+    bool actual = te->toplevel_state & toplevel_state;
+    if (actual == expected) {
+        test_ok();
+    } else {
+        test_error("state not changed");
+    }
+}
+
+static void cmd_output(struct test_state *state, const char *title, int output_mode) {
+    struct toplevel_entry *te;
+    bool expected;
+    wl_list_for_each(te, &state->toplevels, link) {
+        if (strcmp(te->title, title) == 0) {
+            if (output_mode == OUTPUT_RESET) {
+                free(te->output_enter);
+                free(te->output_leave);
+                te->output_enter = NULL;
+                te->output_leave = NULL;
+                test_ok();
+            } else if (output_mode == OUTPUT_ENTER) {
+                if (te->output_enter) {
+                    test_message("output_enter: %s", te->output_enter);
+                    test_ok();
+                } else {
+                    test_error("output_enter message not received");
+                }
+            } else if (output_mode == OUTPUT_LEAVE) {
+                if (te->output_leave) {
+                    test_message("output_leave: %s", te->output_leave);
+                    test_ok();
+                } else {
+                    test_error("output_leave message not received");
+                }
+            }
+            return;
+        }
+    }
+    test_error("toplevel not found");
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "list") == 0)
+        cmd_list_toplevels(state);
+    else if (strcmp(cmd, "close") == 0)
+        cmd_close(state, arg);
+    else if (strcmp(cmd, "check_activated") == 0)
+        cmd_check_state(state, arg, STATE_ACTIVATED);
+    else if (strcmp(cmd, "check_maximized") == 0)
+        cmd_check_state(state, arg, STATE_MAXIMIZED);
+    else if (strcmp(cmd, "check_maximized") == 0)
+        cmd_check_state(state, arg, STATE_MINIMIZED);
+    else if (strcmp(cmd, "check_fullscreen") == 0)
+        cmd_check_state(state, arg, STATE_FULLSCREEN);
+    else if (strcmp(cmd, "fullscreen") == 0)
+        cmd_toggle_state(state, arg, STATE_FULLSCREEN);
+    else if (strcmp(cmd, "maximize") == 0)
+        cmd_toggle_state(state, arg, STATE_MAXIMIZED);
+    else if (strcmp(cmd, "minimize") == 0)
+        cmd_toggle_state(state, arg, STATE_MINIMIZED);
+    else if (strcmp(cmd, "activate") == 0)
+        cmd_toggle_state(state, arg, STATE_ACTIVATED);
+    else if (strcmp(cmd, "output_reset") == 0)
+        cmd_output(state, arg, OUTPUT_RESET);
+    else if (strcmp(cmd, "output_enter") == 0)
+        cmd_output(state, arg, OUTPUT_ENTER);
+    else if (strcmp(cmd, "output_leave") == 0)
+        cmd_output(state, arg, OUTPUT_LEAVE);
+    else if (strcmp(cmd, "quit") == 0) {
+        test_ok();
+        return false;
+    }
+    return true;
+}
+
+void cleanup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+
+void setup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    wl_list_init(&state->toplevels);
+    wl_list_init(&state->outputs);
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/idle-client.c
+++ b/test/wayland_clients/src/idle-client.c
@@ -1,0 +1,186 @@
+#include "client-base.h"
+
+struct idle_state {
+    struct client_state base;
+
+    struct ext_idle_notifier_v1 *idle_notifier;
+    struct ext_idle_notification_v1 *notification;
+    bool subscribed;
+
+    struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager;
+    struct zwp_idle_inhibitor_v1 *inhibitor;
+    bool inhibited;
+
+    struct wl_surface *surface;
+};
+
+static void create_watch(struct client_state *base, uint32_t timeout_ms) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (!state.idle_notifier) {
+        fprintf(stderr, "No ext_idle_notifier_v1\n");
+        return;
+    }
+
+    if (!state.seat) {
+        fprintf(stderr, "No wl_seat\n");
+        return;
+    }
+
+    if (state.notification) {
+        ext_idle_notification_v1_destroy(state.notification);
+        state.notification = NULL;
+    }
+
+    state.notification =
+        ext_idle_notifier_v1_get_idle_notification(state.idle_notifier, timeout_ms, state.seat);
+
+    ext_idle_notification_v1_add_listener(state.notification, &idle_notification_listener, &state);
+
+    wl_display_roundtrip(state.display);
+
+    puts("OK");
+    fflush(stdout);
+}
+
+static void destroy_watch(struct client_state *base) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (!state.notification) {
+        puts("No notification");
+        return;
+    }
+
+    ext_idle_notification_v1_destroy(state.notification);
+
+    state.notification = NULL;
+
+    puts("OK");
+    fflush(stdout);
+}
+
+static void create_inhibitor(struct client_state *base) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (!state.idle_inhibit_manager) {
+        fprintf(stderr, "No zwp_idle_inhibit_manager_v1\n");
+        return;
+    }
+
+    if (!state.compositor) {
+        fprintf(stderr, "No wl_compositor\n");
+        return;
+    }
+
+    if (state.inhibitor) {
+        return;
+    }
+
+    if (!state.surface) {
+        state.surface = wl_compositor_create_surface(state.compositor);
+
+        wl_surface_commit(state.surface);
+    }
+
+    state.inhibitor =
+        zwp_idle_inhibit_manager_v1_create_inhibitor(state.idle_inhibit_manager, state.surface);
+
+    wl_display_roundtrip(state.display);
+
+    puts("OK");
+    fflush(stdout);
+}
+
+static void destroy_inhibitor(struct client_state *base) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (!state.inhibitor) {
+        return;
+    }
+
+    zwp_idle_inhibitor_v1_destroy(state.inhibitor);
+
+    state.inhibitor = NULL;
+
+    puts("OK");
+    fflush(stdout);
+}
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
+
+        state->idle_notifier = wl_registry_bind(registry, name, &ext_idle_notifier_v1_interface, 1);
+
+    } else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+
+        state->idle_inhibit_manager =
+            wl_registry_bind(registry, name, &zwp_idle_inhibit_manager_v1_interface, 1);
+    }
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    if (strcmp(cmd, "watch") == 0) {
+        if (!arg) {
+            fprintf(stderr, "watch requires timeout\n");
+            return;
+        }
+
+        create_watch(state, atoi(arg));
+
+    } else if (strcmp(cmd, "unwatch") == 0) {
+        destroy_watch(state);
+
+    } else if (strcmp(cmd, "inhibit") == 0) {
+        create_inhibitor(state);
+
+    } else if (strcmp(cmd, "uninhibit") == 0) {
+        destroy_inhibitor(state);
+
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    return true;
+}
+
+void do_cleanup(struct client_state *base) {
+    struct idle_state *state = (struct idle_state *)base;
+
+    static void cleanup(struct client_state * base) {
+        struct idle_state *state = (struct idle_state *)base;
+
+        if (state->subscribed) {
+            destroy_watch(state);
+        }
+
+        if (state->inhibited) {
+            destroy_inhibitor(state);
+        }
+
+        if (state.surface) {
+            wl_surface_destroy(state.surface);
+        }
+
+        if (state.idle_inhibit_manager) {
+            zwp_idle_inhibit_manager_v1_destroy(state.idle_inhibit_manager);
+        }
+
+        if (state.idle_notifier) {
+            ext_idle_notifier_v1_destroy(state.idle_notifier);
+        }
+    }
+}
+
+int main(void) {
+    struct idle_state state = {0};
+
+    const struct client_ops ops = {.registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/idle-client.c
+++ b/test/wayland_clients/src/idle-client.c
@@ -1,6 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "client-base.h"
 
-struct idle_state {
+#include "ext-idle-notify-v1-client-protocol.h"
+#include "idle-inhibit-unstable-v1-client-protocol.h"
+
+struct test_state {
     struct client_state base;
 
     struct ext_idle_notifier_v1 *idle_notifier;
@@ -14,101 +21,116 @@ struct idle_state {
     struct wl_surface *surface;
 };
 
-static void create_watch(struct client_state *base, uint32_t timeout_ms) {
-    struct idle_state *state = (struct idle_state *)base;
+static void handle_idled(void *data, struct ext_idle_notification_v1 *notification) {
+    (void)data;
+    (void)notification;
 
-    if (!state.idle_notifier) {
+    test_message("idled");
+}
+
+static void handle_resumed(void *data, struct ext_idle_notification_v1 *notification) {
+    (void)data;
+    (void)notification;
+
+    test_message("resumed");
+}
+
+static const struct ext_idle_notification_v1_listener idle_notification_listener = {
+    .idled = handle_idled,
+    .resumed = handle_resumed,
+};
+
+static void create_watch(struct test_state *state, uint32_t timeout_ms) {
+
+    if (!state->idle_notifier) {
         fprintf(stderr, "No ext_idle_notifier_v1\n");
         return;
     }
 
-    if (!state.seat) {
+    if (!state->base.seat) {
         fprintf(stderr, "No wl_seat\n");
         return;
     }
 
-    if (state.notification) {
-        ext_idle_notification_v1_destroy(state.notification);
-        state.notification = NULL;
+    if (state->notification) {
+        ext_idle_notification_v1_destroy(state->notification);
+        state->notification = NULL;
     }
 
-    state.notification =
-        ext_idle_notifier_v1_get_idle_notification(state.idle_notifier, timeout_ms, state.seat);
+    state->notification = ext_idle_notifier_v1_get_idle_notification(state->idle_notifier,
+                                                                     timeout_ms, state->base.seat);
 
-    ext_idle_notification_v1_add_listener(state.notification, &idle_notification_listener, &state);
+    ext_idle_notification_v1_add_listener(state->notification, &idle_notification_listener, state);
+    state->subscribed = true;
 
-    wl_display_roundtrip(state.display);
+    wl_display_roundtrip(state->base.display);
 
-    puts("OK");
-    fflush(stdout);
+    test_ok();
 }
 
-static void destroy_watch(struct client_state *base) {
-    struct idle_state *state = (struct idle_state *)base;
+static void destroy_watch(struct test_state *state) {
 
-    if (!state.notification) {
-        puts("No notification");
+    if (!state->notification) {
+        test_message("No notification");
         return;
     }
 
-    ext_idle_notification_v1_destroy(state.notification);
+    ext_idle_notification_v1_destroy(state->notification);
 
-    state.notification = NULL;
+    state->notification = NULL;
+    state->subscribed = false;
 
-    puts("OK");
-    fflush(stdout);
+    test_ok();
 }
 
-static void create_inhibitor(struct client_state *base) {
-    struct idle_state *state = (struct idle_state *)base;
+static void create_inhibitor(struct test_state *state) {
 
-    if (!state.idle_inhibit_manager) {
-        fprintf(stderr, "No zwp_idle_inhibit_manager_v1\n");
-        return;
-    }
-
-    if (!state.compositor) {
+    if (!state->base.compositor) {
         fprintf(stderr, "No wl_compositor\n");
         return;
     }
 
-    if (state.inhibitor) {
+    if (!state->idle_inhibit_manager) {
+        test_error("No zwp_idle_inhibit_manager_v1.");
         return;
     }
 
-    if (!state.surface) {
-        state.surface = wl_compositor_create_surface(state.compositor);
-
-        wl_surface_commit(state.surface);
+    if (state->inhibitor) {
+        return;
     }
 
-    state.inhibitor =
-        zwp_idle_inhibit_manager_v1_create_inhibitor(state.idle_inhibit_manager, state.surface);
+    if (!state->surface) {
+        state->surface = wl_compositor_create_surface(state->base.compositor);
+        wl_surface_commit(state->surface);
+    }
 
-    wl_display_roundtrip(state.display);
+    state->inhibitor =
+        zwp_idle_inhibit_manager_v1_create_inhibitor(state->idle_inhibit_manager, state->surface);
 
-    puts("OK");
-    fflush(stdout);
+    state->inhibited = true;
+
+    wl_display_roundtrip(state->base.display);
+
+    test_ok();
 }
 
-static void destroy_inhibitor(struct client_state *base) {
-    struct idle_state *state = (struct idle_state *)base;
+static void destroy_inhibitor(struct test_state *state) {
 
-    if (!state.inhibitor) {
+    if (!state->inhibitor) {
         return;
     }
 
-    zwp_idle_inhibitor_v1_destroy(state.inhibitor);
+    zwp_idle_inhibitor_v1_destroy(state->inhibitor);
 
-    state.inhibitor = NULL;
+    state->inhibitor = NULL;
+    state->inhibited = false;
 
-    puts("OK");
-    fflush(stdout);
+    test_ok();
 }
 
 static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
                              const char *interface, uint32_t version) {
-    struct idle_state *state = (struct idle_state *)base;
+    struct test_state *state = (struct test_state *)base;
 
     if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
 
@@ -122,12 +144,12 @@ static void registry_handler(struct client_state *base, struct wl_registry *regi
 }
 
 static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
-    struct idle_state *state = (struct idle_state *)base;
+    struct test_state *state = (struct test_state *)base;
 
     if (strcmp(cmd, "watch") == 0) {
         if (!arg) {
             fprintf(stderr, "watch requires timeout\n");
-            return;
+            return true;
         }
 
         create_watch(state, atoi(arg));
@@ -147,36 +169,32 @@ static bool dispatch_command(struct client_state *base, const char *cmd, const c
     return true;
 }
 
-void do_cleanup(struct client_state *base) {
-    struct idle_state *state = (struct idle_state *)base;
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
 
-    static void cleanup(struct client_state * base) {
-        struct idle_state *state = (struct idle_state *)base;
+    if (state->subscribed) {
+        destroy_watch(state);
+    }
 
-        if (state->subscribed) {
-            destroy_watch(state);
-        }
+    if (state->inhibited) {
+        destroy_inhibitor(state);
+    }
 
-        if (state->inhibited) {
-            destroy_inhibitor(state);
-        }
+    if (state->surface) {
+        wl_surface_destroy(state->surface);
+    }
 
-        if (state.surface) {
-            wl_surface_destroy(state.surface);
-        }
+    if (state->idle_inhibit_manager) {
+        zwp_idle_inhibit_manager_v1_destroy(state->idle_inhibit_manager);
+    }
 
-        if (state.idle_inhibit_manager) {
-            zwp_idle_inhibit_manager_v1_destroy(state.idle_inhibit_manager);
-        }
-
-        if (state.idle_notifier) {
-            ext_idle_notifier_v1_destroy(state.idle_notifier);
-        }
+    if (state->idle_notifier) {
+        ext_idle_notifier_v1_destroy(state->idle_notifier);
     }
 }
 
 int main(void) {
-    struct idle_state state = {0};
+    struct test_state state = {0};
 
     const struct client_ops ops = {.registry_global = registry_handler,
                                    .dispatch_command = dispatch_command,

--- a/test/wayland_clients/src/output-power-management.c
+++ b/test/wayland_clients/src/output-power-management.c
@@ -1,0 +1,235 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+
+#include "wlr-output-power-management-unstable-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct zwlr_output_power_manager_v1 *power_manager;
+
+    struct wl_list outputs; // output_entry
+};
+
+struct output_entry {
+    struct wl_output *wl_output;
+    struct zwlr_output_power_v1 *power;
+    enum zwlr_output_power_v1_mode mode;
+    char *name;
+    bool failed;
+    struct wl_list link;
+};
+
+static void handle_output_power_mode(void *data, struct zwlr_output_power_v1 *zwlr_output_power_v1,
+                                     uint32_t mode) {
+    (void)zwlr_output_power_v1;
+    struct output_entry *oe = data;
+    oe->mode = (enum zwlr_output_power_v1_mode)mode;
+}
+
+static void handle_output_power_failed(void *data,
+                                       struct zwlr_output_power_v1 *zwlr_output_power_v1) {
+
+    (void)zwlr_output_power_v1;
+    struct output_entry *oe = data;
+    oe->failed = true;
+}
+
+static const struct zwlr_output_power_v1_listener output_power_listener = {
+    .mode = handle_output_power_mode, .failed = handle_output_power_failed};
+
+static void output_geometry(void *data, struct wl_output *wl_output, int32_t x, int32_t y,
+                            int32_t physical_width, int32_t physical_height, int32_t subpixel,
+                            const char *make, const char *model, int32_t transform) {
+
+    (void)data;
+    (void)wl_output;
+    (void)x;
+    (void)y;
+    (void)physical_width;
+    (void)physical_height;
+    (void)subpixel;
+    (void)make;
+    (void)model;
+    (void)transform;
+}
+
+static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags, int32_t width,
+                        int32_t height, int32_t refresh) {
+
+    (void)data;
+    (void)wl_output;
+    (void)flags;
+    (void)width;
+    (void)height;
+    (void)refresh;
+}
+
+static void output_done(void *data, struct wl_output *wl_output) {
+    (void)data;
+    (void)wl_output;
+}
+
+static void output_scale(void *data, struct wl_output *wl_output, int32_t factor) {
+    (void)data;
+    (void)wl_output;
+    (void)factor;
+}
+
+static void output_name(void *data, struct wl_output *wl_output, const char *name) {
+    (void)wl_output;
+    struct output_entry *oe = data;
+    oe->name = strdup(name);
+}
+
+static void output_description(void *data, struct wl_output *wl_output, const char *desc) {
+    (void)data;
+    (void)wl_output;
+    (void)desc;
+}
+
+static const struct wl_output_listener output_listener = {
+    .geometry = output_geometry,
+    .mode = output_mode,
+    .done = output_done,
+    .scale = output_scale,
+    .name = output_name,
+    .description = output_description,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, zwlr_output_power_manager_v1_interface.name) == 0) {
+        state->power_manager =
+            wl_registry_bind(registry, name, &zwlr_output_power_manager_v1_interface, 1);
+
+    } else if (strcmp(interface, wl_output_interface.name) == 0) {
+        struct output_entry *oe = calloc(1, sizeof(*oe));
+        oe->wl_output = wl_registry_bind(registry, name, &wl_output_interface, 4);
+        oe->name = NULL;
+        wl_output_add_listener(oe->wl_output, &output_listener, oe);
+        oe->power =
+            zwlr_output_power_manager_v1_get_output_power(state->power_manager, oe->wl_output);
+        zwlr_output_power_v1_add_listener(oe->power, &output_power_listener, oe);
+        wl_list_insert(&state->outputs, &oe->link);
+    }
+}
+
+// Count number of outputs with given power state
+static void cmd_count_power_mode(struct test_state *state, const char *arg,
+                                 enum zwlr_output_power_v1_mode mode) {
+    struct output_entry *oe;
+    int target = atoi(arg);
+    int count = 0;
+
+    wl_list_for_each(oe, &state->outputs, link) {
+        if (oe->mode == mode) {
+            count++;
+        }
+    }
+    if (target == count) {
+        test_ok();
+    } else {
+        test_error("expected %d got %d", target, count);
+    }
+}
+
+/*
+Set power state. Can pass an output name to set individual output or
+NULL to change all outputs.
+*/
+static void cmd_set_power(struct test_state *state, const char *name,
+                          enum zwlr_output_power_v1_mode mode) {
+    struct output_entry *oe;
+    bool success = true;
+
+    wl_list_for_each(oe, &state->outputs, link) {
+        if (name == NULL || strcmp(name, oe->name) == 0) {
+            if (oe->mode != mode) {
+                zwlr_output_power_v1_set_mode(oe->power, mode);
+                do_roundtrip(&state->base);
+                if (oe->mode != mode) {
+                    success = false;
+                }
+            }
+        }
+    }
+
+    if (success) {
+        test_ok();
+    } else {
+        test_error("could not set power mode");
+    }
+}
+
+// Output name of outputs and power state
+static void cmd_identify(struct test_state *state) {
+    struct output_entry *oe;
+
+    wl_list_for_each(oe, &state->outputs, link) {
+        char *power = (oe->mode == ZWLR_OUTPUT_POWER_V1_MODE_ON) ? "ON" : "OFF";
+        test_message("Output: %s (Power: %s)", oe->name, power);
+    }
+
+    test_ok();
+}
+
+// Verify number of outputs presented by compositor
+static void cmd_outputs(struct test_state *state, const char *arg) {
+    int target = atoi(arg);
+    int count = 0;
+    struct output_entry *oe;
+    wl_list_for_each(oe, &state->outputs, link) { count++; }
+
+    if (count == target) {
+        test_ok();
+    } else {
+        test_error("expected %d got %d", target, count);
+    }
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "count_on") == 0)
+        cmd_count_power_mode(state, arg, ZWLR_OUTPUT_POWER_V1_MODE_ON);
+    else if (strcmp(cmd, "count_off") == 0)
+        cmd_count_power_mode(state, arg, ZWLR_OUTPUT_POWER_V1_MODE_OFF);
+    else if (strcmp(cmd, "power_on") == 0)
+        cmd_set_power(state, arg, ZWLR_OUTPUT_POWER_V1_MODE_ON);
+    else if (strcmp(cmd, "power_off") == 0)
+        cmd_set_power(state, arg, ZWLR_OUTPUT_POWER_V1_MODE_OFF);
+    else if (strcmp(cmd, "identify") == 0)
+        cmd_identify(state);
+    else if (strcmp(cmd, "outputs") == 0)
+        cmd_outputs(state, arg);
+    else if (strcmp(cmd, "quit") == 0) {
+        test_ok();
+        return false;
+    }
+    return true;
+}
+
+void cleanup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+
+void setup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    wl_list_init(&state->outputs);
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/session-lock.c
+++ b/test/wayland_clients/src/session-lock.c
@@ -1,0 +1,378 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+
+#include "ext-session-lock-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct ext_session_lock_manager_v1 *lock_manager;
+
+    struct wl_list outputs;  // output_entry
+    struct wl_list surfaces; // surface_entry
+
+    struct ext_session_lock_v1 *lock;
+    bool got_locked;
+    bool lock_finished;
+
+    bool do_crash;
+};
+
+struct output_entry {
+    struct wl_output *wl_output;
+    int32_t x, y, width, height; /* logical geometry */
+    struct wl_list link;
+};
+
+struct surface_entry {
+    struct ext_session_lock_surface_v1 *lock_surface;
+    struct wl_surface *wl_surface;
+    struct output_entry *output;
+    struct buffer *buffer;
+    uint32_t width;
+    uint32_t height;
+    bool configured;
+    struct wl_list link;
+    struct test_state *state;
+};
+
+static void surface_configure(void *data, struct ext_session_lock_surface_v1 *lock_surface,
+                              uint32_t serial, uint32_t width, uint32_t height) {
+    struct surface_entry *se = data;
+
+    se->configured = true;
+    se->width = width;
+    se->height = height;
+
+    ext_session_lock_surface_v1_ack_configure(lock_surface, serial);
+
+    if (se->buffer == NULL) {
+        se->buffer = create_buffer(&se->state->base, width, height, 0xFF606060);
+
+        if (se->buffer == NULL) {
+            fprintf(stderr, "failed to create buffer\n");
+            return;
+        }
+    }
+
+    wl_surface_attach(se->wl_surface, se->buffer->wl_buffer, 0, 0);
+    wl_surface_damage_buffer(se->wl_surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(se->wl_surface);
+}
+
+static const struct ext_session_lock_surface_v1_listener surface_listener = {
+    .configure = surface_configure,
+};
+
+static void lock_locked(void *data, struct ext_session_lock_v1 *lock) {
+    (void)lock;
+    struct test_state *state = data;
+    state->got_locked = true;
+}
+
+static void lock_finished(void *data, struct ext_session_lock_v1 *lock) {
+    /*
+     * "finished" is sent when:
+     *   (a) the compositor rejects the lock (already locked / crashed), or
+     *   (b) another compositor-side event invalidates this lock.
+     * In either case the client MUST destroy the lock object.
+     */
+    struct test_state *state = data;
+    state->lock_finished = true;
+    ext_session_lock_v1_destroy(lock);
+    state->lock = NULL;
+}
+
+static const struct ext_session_lock_v1_listener lock_listener = {
+    .locked = lock_locked,
+    .finished = lock_finished,
+};
+
+static void output_geometry(void *data, struct wl_output *wl_output, int32_t x, int32_t y,
+                            int32_t physical_width, int32_t physical_height, int32_t subpixel,
+                            const char *make, const char *model, int32_t transform) {
+    struct output_entry *oe = data;
+    oe->x = x;
+    oe->y = y;
+    (void)wl_output;
+    (void)physical_width;
+    (void)physical_height;
+    (void)subpixel;
+    (void)make;
+    (void)model;
+    (void)transform;
+}
+
+static void output_mode(void *data, struct wl_output *wl_output, uint32_t flags, int32_t width,
+                        int32_t height, int32_t refresh) {
+    struct output_entry *oe = data;
+    if (flags & WL_OUTPUT_MODE_CURRENT) {
+        oe->width = width;
+        oe->height = height;
+    }
+    (void)wl_output;
+    (void)refresh;
+}
+
+static void output_done(void *data, struct wl_output *wl_output) {
+    (void)data;
+    (void)wl_output;
+}
+static void output_scale(void *data, struct wl_output *wl_output, int32_t factor) {
+    (void)data;
+    (void)wl_output;
+    (void)factor;
+}
+static void output_name(void *data, struct wl_output *wl_output, const char *name) {
+    (void)data;
+    (void)wl_output;
+    (void)name;
+}
+static void output_description(void *data, struct wl_output *wl_output, const char *desc) {
+    (void)data;
+    (void)wl_output;
+    (void)desc;
+}
+
+static const struct wl_output_listener output_listener = {
+    .geometry = output_geometry,
+    .mode = output_mode,
+    .done = output_done,
+    .scale = output_scale,
+    .name = output_name,
+    .description = output_description,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, ext_session_lock_manager_v1_interface.name) == 0) {
+        state->lock_manager =
+            wl_registry_bind(registry, name, &ext_session_lock_manager_v1_interface, 1);
+
+    } else if (strcmp(interface, wl_output_interface.name) == 0) {
+        struct output_entry *oe = calloc(1, sizeof(*oe));
+        oe->wl_output = wl_registry_bind(registry, name, &wl_output_interface, 4);
+        wl_output_add_listener(oe->wl_output, &output_listener, oe);
+        wl_list_insert(&state->outputs, &oe->link);
+    }
+}
+
+static void cmd_lock(struct test_state *state) {
+    if (state->lock_manager == NULL) {
+        test_error("ext_session_lock_manager_v1 not advertised by compositor");
+        return;
+    }
+    if (state->lock != NULL) {
+        test_error("already holding a lock object");
+        return;
+    }
+
+    state->got_locked = false;
+    state->lock_finished = false;
+
+    state->lock = ext_session_lock_manager_v1_lock(state->lock_manager);
+    ext_session_lock_v1_add_listener(state->lock, &lock_listener, state);
+
+    /* Give the compositor a chance to reply */
+    do_roundtrip(&state->base);
+
+    if (state->got_locked) {
+        test_ok();
+    } else if (state->lock_finished) {
+        test_error("compositor rejected lock");
+    } else {
+        test_error("neither locked nor finished received after roundtrip");
+    }
+}
+
+static void cmd_unlock(struct test_state *state) {
+    if (state->lock == NULL) {
+        test_error("no active lock");
+        return;
+    }
+    if (!state->got_locked) {
+        test_error("lock was never confirmed (no locked event)");
+        return;
+    }
+
+    ext_session_lock_v1_unlock_and_destroy(state->lock);
+    state->lock = NULL;
+    state->got_locked = false;
+
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static void cmd_create_surface(struct test_state *state) {
+    if (state->lock == NULL || !state->got_locked) {
+        test_error("not locked");
+        return;
+    }
+    if (state->base.compositor == NULL) {
+        test_error("wl_compositor not available");
+        return;
+    }
+
+    int created = 0;
+    struct output_entry *oe;
+    wl_list_for_each(oe, &state->outputs, link) {
+        struct surface_entry *se = calloc(1, sizeof(*se));
+        se->state = state;
+        se->output = oe;
+        se->wl_surface = wl_compositor_create_surface(state->base.compositor);
+
+        se->lock_surface =
+            ext_session_lock_v1_get_lock_surface(state->lock, se->wl_surface, oe->wl_output);
+        ext_session_lock_surface_v1_add_listener(se->lock_surface, &surface_listener, se);
+
+        wl_list_insert(&state->surfaces, &se->link);
+        created++;
+    }
+
+    if (created == 0) {
+        test_error("no outputs found");
+        return;
+    }
+
+    /* Roundtrip: compositor should send configure events */
+    do_roundtrip(&state->base);
+
+    /* Check all surfaces received configure */
+    bool all_configured = true;
+    struct surface_entry *se;
+    wl_list_for_each(se, &state->surfaces, link) {
+        if (!se->configured) {
+            all_configured = false;
+            break;
+        }
+    }
+
+    if (all_configured) {
+        test_ok();
+    } else {
+        test_error("one or more lock surfaces did not receive configure event");
+    }
+}
+
+static void cmd_destroy_surface(struct test_state *state) {
+    if (wl_list_empty(&state->surfaces)) {
+        test_error("no surfaces to destroy");
+        return;
+    }
+
+    struct surface_entry *se, *tmp;
+    wl_list_for_each_safe(se, tmp, &state->surfaces, link) {
+        ext_session_lock_surface_v1_destroy(se->lock_surface);
+        wl_surface_destroy(se->wl_surface);
+        wl_list_remove(&se->link);
+        free(se);
+    }
+
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+/*
+ * check_locked
+ * Verify we have received the "locked" event (synchronous check).
+ */
+static void cmd_check_locked(struct test_state *state) {
+    do_roundtrip(&state->base);
+    if (state->lock != NULL && state->got_locked) {
+        test_ok();
+    } else {
+        test_error("not in locked state");
+    }
+}
+
+static void cmd_check_unlocked(struct test_state *state) {
+    do_roundtrip(&state->base);
+    if (state->lock == NULL && !state->got_locked) {
+        test_ok();
+    } else {
+        test_error("still in locked state");
+    }
+}
+
+static void cmd_check_surface_count(struct test_state *state, const char *arg) {
+    if (arg == NULL) {
+        test_error("usage: check_surface_count <N>");
+        return;
+    }
+    int expected = atoi(arg);
+    int actual = 0;
+    struct surface_entry *se;
+    wl_list_for_each(se, &state->surfaces, link) { actual++; }
+    if (actual == expected) {
+        test_ok();
+    } else {
+        printf("ERROR: expected %d surfaces, got %d\n", expected, actual);
+    }
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "lock") == 0)
+        cmd_lock(state);
+    else if (strcmp(cmd, "unlock") == 0)
+        cmd_unlock(state);
+    else if (strcmp(cmd, "create_surface") == 0)
+        cmd_create_surface(state);
+    else if (strcmp(cmd, "destroy_surface") == 0)
+        cmd_destroy_surface(state);
+    else if (strcmp(cmd, "check_locked") == 0)
+        cmd_check_locked(state);
+    else if (strcmp(cmd, "check_unlocked") == 0)
+        cmd_check_unlocked(state);
+    else if (strcmp(cmd, "check_surface_count") == 0)
+        cmd_check_surface_count(state, arg);
+    else if (strcmp(cmd, "crash") == 0) {
+        state->do_crash = true;
+        test_ok();
+        return false;
+    } else if (strcmp(cmd, "quit") == 0) {
+        test_ok();
+        return false;
+    }
+    return true;
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (!state->do_crash) {
+        struct surface_entry *se, *stmp;
+        wl_list_for_each_safe(se, stmp, &state->surfaces, link) {
+            ext_session_lock_surface_v1_destroy(se->lock_surface);
+            wl_surface_destroy(se->wl_surface);
+            free(se);
+        }
+        if (state->lock) {
+            ext_session_lock_v1_destroy(state->lock);
+        }
+    }
+}
+
+void setup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    wl_list_init(&state->outputs);
+    wl_list_init(&state->surfaces);
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}


### PR DESCRIPTION
To help test wayland protocol support, it's useful to build interactive clients. This PR adds the building blocks for creating these clients:
 - common code (`client-base.{h,c}`)
 - template client (`client-template.c`)
 - Simplified building of protocols (including client protocols)
 - Building of test clients
 - Pytest fixtures to run and interact with clients

Using these building blocks, I have built clients and tests for `idle-notify`, `idle-inhibit` (same client/test) and `session-lock`.

Assuming this is ok, I'll rewrite the cursor shape client and test based on the template.