### PR TITLE
wayland: implement wp-cursor-shape-v1 protocol

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -50,6 +50,10 @@ PROTOS = [
         "pointer-constraints-unstable-v1-protocol.h",
         f"{WAYLAND_PROTOCOLS}/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
     ],
+    [
+        "cursor-shape-v1-protocol.h",
+        f"{WAYLAND_PROTOCOLS}/staging/cursor-shape/cursor-shape-v1.xml",
+    ],
 ]
 
 QW_PROTO_OUT_PATH = QW_PATH / "proto"

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -454,6 +454,18 @@ class Core(base.Core):
         else:
             return self.qtile.process_button_release(button, mask)
 
+    @expose_command
+    def get_cursor_shape_v1(self) -> str:
+        """
+        Get the current cursor shape name from cursor-shape-v1 protocol.
+
+        Returns None if the cursor has no shape name set.
+        """
+        cursor = self.qw_cursor
+        if cursor.current_shape_name == ffi.NULL:
+            return "default"
+        return ffi.string(cursor.current_shape_name).decode("utf-8")
+
     def handle_manage_view(self, view: ffi.CData) -> None:
         wid = self.new_wid()
         view.wid = wid

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -16,6 +16,7 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
     wl_list_remove(&cursor->motion_absolute.link);
     wl_list_remove(&cursor->frame.link);
     wl_list_remove(&cursor->button.link);
+    wl_list_remove(&cursor->request_set_cursor_shape.link);
 
     wlr_xcursor_manager_destroy(cursor->mgr);
 
@@ -392,6 +393,9 @@ static void qw_cursor_handle_frame(struct wl_listener *listener, void *data) {
     wlr_seat_pointer_notify_frame(cursor->server->seat);
 }
 
+// forward declaration
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data);
+
 struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     // Allocate memory for qw_cursor
     struct qw_cursor *cursor = calloc(1, sizeof(*cursor));
@@ -405,6 +409,7 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
     cursor->cursor = wlr_cursor_create();
     wlr_cursor_attach_output_layout(cursor->cursor, server->output_layout);
     cursor->mgr = wlr_xcursor_manager_create(NULL, 24);
+    cursor->current_shape_name = NULL;
 
     // Setup listeners for various pointer events
     cursor->request_set.notify = qw_cursor_handle_seat_request_set;
@@ -424,6 +429,11 @@ struct qw_cursor *qw_server_cursor_create(struct qw_server *server) {
 
     cursor->button.notify = qw_cursor_handle_button;
     wl_signal_add(&cursor->cursor->events.button, &cursor->button);
+
+    cursor->cursor_shape_mgr = wlr_cursor_shape_manager_v1_create(server->display, 1);
+    cursor->request_set_cursor_shape.notify = qw_handle_request_set_cursor_shape;
+    wl_signal_add(&cursor->cursor_shape_mgr->events.request_set_shape,
+                  &cursor->request_set_cursor_shape);
 
     wl_list_init(&cursor->constraint_commit.link);
 
@@ -699,4 +709,19 @@ void qw_cursor_fake_click(struct qw_cursor *cursor) {
     // Simulate release
     event.state = WL_POINTER_BUTTON_STATE_RELEASED;
     qw_cursor_handle_button(&cursor->button, &event);
+}
+
+static void qw_handle_request_set_cursor_shape(struct wl_listener *listener, void *data) {
+    struct qw_cursor *cursor = wl_container_of(listener, cursor, request_set_cursor_shape);
+    struct wlr_cursor_shape_manager_v1_request_set_shape_event *event = data;
+
+    struct wlr_seat_client *focused_client = cursor->server->seat->pointer_state.focused_client;
+    if (focused_client != event->seat_client) {
+        return;
+    }
+
+    const char *name = wlr_cursor_shape_v1_name(event->shape);
+    cursor->current_shape_name = name;
+
+    wlr_cursor_set_xcursor(cursor->cursor, cursor->mgr, name);
 }

--- a/libqtile/backend/wayland/qw/cursor.h
+++ b/libqtile/backend/wayland/qw/cursor.h
@@ -2,6 +2,7 @@
 #define CURSOR_H
 
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 
@@ -18,6 +19,8 @@ struct qw_cursor {
     struct wlr_cursor *cursor;
     struct qw_view *view;
     struct qw_implicit_grab implicit_grab;
+    struct wlr_cursor_shape_manager_v1 *cursor_shape_mgr;
+    const char *current_shape_name;
 
     // private data
     struct qw_server *server;
@@ -28,6 +31,7 @@ struct qw_cursor {
     struct wl_listener frame;
     struct wl_listener button;
     struct wl_listener constraint_commit;
+    struct wl_listener request_set_cursor_shape;
     struct wlr_xcursor_manager *mgr;
     struct wlr_xcursor_manager *xwayland_mgr;
     struct wlr_surface *saved_surface;


### PR DESCRIPTION
Add support for the staging cursor-shape-v1 protocol. This allows clients to request standard cursor shapes by enum (e.g., pointer, text, crosshair) rather than providing their own pixel buffers.

The test will be added separately as part of #5967 