### PR TITLE
fix(bar): stop drawing finalized widgets and bars

### DIFF
--- a/libqtile/bar.py
+++ b/libqtile/bar.py
@@ -630,6 +630,9 @@ class Bar(Gap, configurable.Configurable, CommandObject):
     def draw(self) -> None:
         assert self.qtile is not None
 
+        if not hasattr(self, "drawer"):
+            # The bar has been finalized (the drawer is deleted) or not yet configured
+            return
         if not self.widgets:
             return  # calling self._actual_draw in this case would cause a NameError.
         if not self._draw_queued:
@@ -640,6 +643,8 @@ class Bar(Gap, configurable.Configurable, CommandObject):
 
     def _actual_draw(self) -> None:
         self._draw_queued = False
+        if not hasattr(self, "drawer"):
+            return
         self._resize(self.length, self.widgets)
         # We draw the border before the widgets
         if any(self.border_width):
@@ -689,6 +694,10 @@ class Bar(Gap, configurable.Configurable, CommandObject):
                 )
 
         for i in self.widgets:
+            # Widgets are finalized before bars so a queued draw can run while
+            # the bar is alive but its widgets are already dead
+            if i.finalized:
+                continue
             try:
                 i.draw()
             except Exception:

--- a/libqtile/widget/base.py
+++ b/libqtile/widget/base.py
@@ -149,6 +149,10 @@ class _Widget(CommandObject, configurable.Configurable):
 
     @property
     def length(self):
+        if self.finalized:
+            # The drawer and layout have been destroyed (e.g. during
+            # reload_config/restart) so a length can no longer be calculated.
+            return 0
         if self.length_type == bar.CALCULATED:
             try:
                 return int(self.calculate_length())


### PR DESCRIPTION
## Summary

Fixes #5960 (general case of #5886 and #5774).

Hi! First qtile contribution here. I am a certified qtile noob, so if anything in this PR looks odd, it probably is. Tell me and I will happily fix it.

## The crime scene

On reload_config/restart, `Qtile._finalize_configurables()` finalizes every widget before the bars. A `Bar._actual_draw()` that was queued on the event loop before that point then wakes up, finds all its widgets dead (`drawer.ctx` and `layout` are `None`), and tries to draw them anyway. The widgets object loudly, and the log fills up with "error when calculating widget ... length" and "Widget failed to draw" tracebacks on every restart.

## The fix

Teach the bar to stop drawing dead widgets, using the `finalized` state that already exists instead of patching `Drawer`:

- `_Widget.length` returns 0 once the widget is finalized
- `Bar` tracks a `_finalized` flag, set in `finalize()` and cleared in `_configure()` (mirroring the widget base class), and `draw()` / `_actual_draw()` return early when it is set or the drawer is gone
- `Bar._actual_draw()` skips finalized widgets, covering the window where the widgets are already dead but the bar has not gotten the news yet

## Tests

Adds backend-free regression tests (`test/widgets/test_finalize_guards.py`) covering:

- finalized widget reports zero length without logging
- re-configured widget reports a real length again (screen re-add path)
- `Bar._actual_draw()` does not touch finalized widgets (widgets-finalized-before-bar ordering)
- `Bar.draw()` does not queue a draw after the bar is finalized
- a queued `Bar._actual_draw()` is a no-op after the bar is finalized

All five were verified red against current master before the fix and green after. No widgets were harmed in the making of this PR. They were already finalized.
