### PR TITLE
doc: add installation instructions for Void Linux

### DIFF
--- a/docs/manual/install/index.rst
+++ b/docs/manual/install/index.rst
@@ -18,6 +18,7 @@ running something else, please see `Installing From Source`_.
     Slackware <slackware>
     FreeBSD <freebsd>
     NixOS <nixos>
+    Void <void>
     Without DM <without-dm>
 
 .. _installing-from-source:

--- a/docs/manual/install/void.rst
+++ b/docs/manual/install/void.rst
@@ -1,0 +1,9 @@
+========================
+Installing on Void Linux
+========================
+
+Qtile is available in the Void Linux repositories. To install Qtile, run:
+
+.. code-block:: bash
+
+    sudo xbps-install -S qtile


### PR DESCRIPTION
This PR adds installation instructions for Void Linux to the Qtile documentation.