### PR TITLE
Fix Exec path for Qtile session

### DIFF
--- a/resources/qtile.desktop
+++ b/resources/qtile.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Qtile
 Comment=Qtile Session
-Exec=qtile start
+Exec=/usr/bin/qtile start
 Type=Application
 Keywords=wm;tiling


### PR DESCRIPTION
Sometimes GDM ignore sessions if exec path not full.
I change `Exec=qtile start` to `Exec=/usr/bin/qtile start`, because it fix this issue
