### PR TITLE
tests: fix duplicate parametrization of 'outputs' under pytest 9

### DIFF
--- a/libqtile/pango_ffi.py
+++ b/libqtile/pango_ffi.py
@@ -57,6 +57,9 @@ pango_ffi.cdef(
     PangoLayout *pango_cairo_create_layout (cairo_t *cr);
     void g_object_unref(gpointer object);
 
+    typedef ... PangoCairoFontMap;
+    void pango_cairo_font_map_set_default (PangoCairoFontMap *fontmap);
+
     void
     pango_layout_set_font_description (PangoLayout *layout,
                                        const PangoFontDescription *desc);

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -11,6 +11,11 @@ def init_fontconfig():
     fontconfig.FcInit()
 
 
+def reset_font_map():
+    """Discard the process-global default Pango/cairo font map."""
+    pangocairo.pango_cairo_font_map_set_default(ffi.NULL)
+
+
 def create_layout(cairo_t):
     """Create a PangoLayout from a cairo context."""
     return PangoLayout(cairo_t._pointer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dev = [
     "pytest-cov",
     "pytest-asyncio>=1.1.0",
     "pytest-httpbin",
-    "pytest-timeout",
     "pre-commit",
     "PyGObject",
     "pycairo >= 1.25.1",
@@ -164,6 +163,5 @@ filterwarnings = [
     "error:::test",
     "ignore:::dbus_next",
 ]
-faulthandler_timeout = 360
+faulthandler_timeout = 300
 faulthandler_exit_on_timeout = true
-timeout = 300 # pytest-timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "coverage",
     "pytest-cov",
     "pytest-asyncio>=1.1.0",
+    "pytest-forked",
     "pytest-httpbin",
     "pre-commit",
     "PyGObject",

--- a/test/backend/wayland/test_drawer.py
+++ b/test/backend/wayland/test_drawer.py
@@ -8,6 +8,13 @@ from libqtile import images
 from libqtile.backend.wayland.drawer import Drawer
 from test.test_images import SVGS, png_img_24, rgba_pixel_data  # noqa: F401
 
+# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
+# spawns persistent glycin/GLib worker threads. Those threads would be inherited
+# by every qtile instance the suite later fork()s, deadlocking pango font loading
+# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
+# die with it and the main pytest process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 
 class FakeDrawer(Drawer):
     def __init__(self, image_surface, output_scale, monkeypatch):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,9 +33,9 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("backend_name", backends)
 
 
-@pytest.fixture(scope="session", params=[1])
+@pytest.fixture(scope="session")
 def outputs(request):
-    return request.param
+    return getattr(request, "param", 1)
 
 
 dualmonitor = pytest.mark.parametrize("outputs", [2], indirect=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -95,14 +95,6 @@ def manager(request, manager_nospawn):
 
 
 @pytest.fixture(scope="function")
-def manager_withlogs(request, manager_nospawn):
-    config = getattr(request, "param", BareConfig)
-
-    manager_nospawn.start(config, want_logs=True)
-    yield manager_nospawn
-
-
-@pytest.fixture(scope="function")
 def fake_window():
     """
     A fake window that can provide a fake drawer to test widgets.

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import multiprocessing
 import os
+import select
 import signal
 import subprocess
 import sys
@@ -190,6 +191,43 @@ class TestManager:
         # fiddling with the buffer size to grow it to whatever github allows.
         return os.read(self.logspipe, 64 * 1024).decode("utf-8")
 
+    def _drain_logs(self):
+        """Read everything currently buffered in qtile's log pipe without blocking.
+
+        qtile's logs are written to a pipe and are normally only read on demand
+        via ``get_log_buffer``. When something goes wrong (e.g. qtile fails to
+        start) nothing reads them, so they are lost. This reads whatever is
+        available so we can surface it for debugging.
+        """
+        if self.logspipe is None:
+            return ""
+        chunks = []
+        while True:
+            # poll with a zero timeout so we never block: if qtile has exited
+            # the write end is closed and we'll read EOF (b""); otherwise we
+            # just take whatever is buffered right now.
+            readable, _, _ = select.select([self.logspipe], [], [], 0)
+            if not readable:
+                break
+            try:
+                data = os.read(self.logspipe, 64 * 1024)
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+        return b"".join(chunks).decode("utf-8", "replace")
+
+    def _dump_logs(self, header):
+        """Print qtile's buffered log output to stderr, if there is any.
+
+        pytest captures stderr per-test and shows it when a test fails, so this
+        makes qtile's own logs visible when, for example, it failed to start.
+        """
+        logs = self._drain_logs()
+        if logs:
+            print(f"{header}\n{logs}", file=sys.stderr)
+
     def start(self, config_class, no_spawn=False, state=None):
         multiprocessing.set_start_method("fork", force=True)
         readlogs, writelogs = os.pipe()
@@ -198,20 +236,26 @@ class TestManager:
         def run_qtile():
             try:
                 rpipe.close()
+                os.close(readlogs)
                 os.environ.pop("DISPLAY", None)
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 init_log(self.log_level)
+                # Route qtile's logs into the pipe before doing any startup work
+                # (creating the backend, building the config, etc.) so that if
+                # qtile dies during startup the parent can still surface whatever
+                # it logged. Previously this was set up after backend.create(),
+                # so the most common failure -- not being able to connect to the
+                # display -- produced no captured logs at all.
+                formatter = logging.Formatter("%(levelname)s - %(message)s")
+                handler = logging.StreamHandler(os.fdopen(writelogs, "w"))
+                handler.setFormatter(formatter)
+                logger.addHandler(handler)
+
                 # Initialise fontconfig before starting qtile to prevent races
                 pangocffi.init_fontconfig()
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
                 from libqtile.core.lifecycle import lifecycle
-
-                os.close(readlogs)
-                formatter = logging.Formatter("%(levelname)s - %(message)s")
-                handler = logging.StreamHandler(os.fdopen(writelogs, "w"))
-                handler.setFormatter(formatter)
-                logger.addHandler(handler)
 
                 Qtile(
                     kore,
@@ -240,6 +284,10 @@ class TestManager:
                 self.c = command.client.InteractiveCommandClient(ipc_command)
                 self.backend.configure(self)
                 return
+            # qtile didn't come up: surface whatever it logged before dying so
+            # the failure is debuggable in CI rather than just "Error launching
+            # qtile".
+            self._dump_logs("qtile failed to start; captured log output:")
             if rpipe.poll(0.1):
                 error = rpipe.recv()
                 raise AssertionError(f"Error launching qtile, traceback:\n{error}")
@@ -287,6 +335,7 @@ class TestManager:
 
             if self.proc.exitcode:
                 print(f"qtile exited with exitcode: {self.proc.exitcode:d}", file=sys.stderr)
+                self._dump_logs("qtile log output before exit:")
 
             self.proc = None
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -243,6 +243,14 @@ class TestManager:
 
                 # Initialise fontconfig before starting qtile to prevent races
                 pangocffi.init_fontconfig()
+                # We've just fork()ed from the pytest process. If that process
+                # rendered any text (lots of the unit tests do), Pango spun up a
+                # "[pango] fontcon" helper thread to load fonts, and fork() did
+                # not copy it. Loading an as-yet-uncached font here would then
+                # block forever in g_cond_wait waiting on that missing thread --
+                # qtile would hang right after the compositor starts. Drop the
+                # inherited font map so this process builds its own.
+                pangocffi.reset_font_map()
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
                 from libqtile.core.lifecycle import lifecycle

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -156,20 +156,10 @@ class TestManager:
         self.testwindows = []
         self.logspipe = None
 
-    def timeout_handler(self, signum, frame):
-        os.kill(self.proc.pid, signal.SIGUSR2)
-        subprocess.run(["ps", "awfux"], stdout=sys.stderr)
-        old = self._old_sigalrm_handler
-        if callable(old):
-            old(signum, frame)
-
     def __enter__(self):
         """Set up resources"""
         faulthandler.enable(all_threads=True)
         faulthandler.register(signal.SIGUSR2, all_threads=True)
-        self._old_sigalrm_handler = signal.getsignal(signal.SIGALRM)
-        signal.signal(signal.SIGALRM, self.timeout_handler)
-        faulthandler.register(signal.SIGALRM, all_threads=True, chain=True)
         self._sockfile = tempfile.NamedTemporaryFile()
         self.sockfile = self._sockfile.name
         return self

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -14,6 +14,13 @@ import pytest
 
 from libqtile import images
 
+# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
+# spawns persistent glycin/GLib worker threads. Those threads would be inherited
+# by every qtile instance the suite later fork()s, deadlocking pango font loading
+# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
+# die with it and the main pytest process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 TEST_DIR = path.dirname(os.path.abspath(__file__))
 DATA_DIR = path.join(TEST_DIR, "data")
 PNGS = glob(path.join(DATA_DIR, "*", "*.png"))

--- a/test/test_images2.py
+++ b/test/test_images2.py
@@ -46,7 +46,15 @@ def should_skip():
     return actual_version < min_version
 
 
-pytestmark = pytest.mark.skipif(should_skip(), reason="recent version of imagemagick not found")
+# pytest.mark.forked: decoding images in-process (libqtile.images ->
+# cairocffi.pixbuf -> glycin) spawns persistent glycin/GLib worker threads that
+# would be inherited by every qtile instance the suite later fork()s, deadlocking
+# pango font loading in the child. Running each test in its own subprocess keeps
+# the main pytest process fork-safe.
+pytestmark = [
+    pytest.mark.skipif(should_skip(), reason="recent version of imagemagick not found"),
+    pytest.mark.forked,
+]
 
 TEST_DIR = path.dirname(path.abspath(__file__))
 DATA_DIR = path.join(TEST_DIR, "data")

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -217,6 +217,13 @@ def test_text_battery_error(monkeypatch):
     assert text == "Error: err"
 
 
+# setup_images() decodes images in-process (libqtile.images -> cairocffi.pixbuf
+# -> glycin), spawning persistent glycin/GLib worker threads that would be
+# inherited by later qtile fork()s and deadlock pango font loading in the child.
+# Run these in their own subprocess so the main pytest process stays fork-safe.
+# (Only these tests are marked, not the whole module, since the rest fork a qtile
+# and must not be nested inside another fork.)
+@pytest.mark.forked
 def test_images_fail():
     """Test BatteryIcon() with a bad theme_path
 
@@ -227,6 +234,7 @@ def test_images_fail():
         batt.setup_images()
 
 
+@pytest.mark.forked
 def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     """Test BatteryIcon() with a good theme_path
 
@@ -245,6 +253,7 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
         assert isinstance(img, images.Img)
 
 
+@pytest.mark.forked
 def test_images_default(fake_bar):
     """Test BatteryIcon() with the default theme_path
 

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -5,6 +5,14 @@ from libqtile import bar, images
 from libqtile.widget import Volume
 from test.widgets.conftest import TEST_DIR, FakeBar
 
+# Setting up the volume widget's images decodes them in-process (libqtile.images
+# -> cairocffi.pixbuf -> glycin), which spawns persistent glycin/GLib worker
+# threads. Those threads would be inherited by every qtile instance the suite
+# later fork()s, deadlocking pango font loading (g_cond_wait) in the child. Run
+# each test in its own subprocess so the threads die with it and the main pytest
+# process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 
 def test_images_fail():
     vol = Volume(theme_path=TEST_DIR)


### PR DESCRIPTION
pytest 9 rejects parametrizing an argname that is also a parametrized fixture. The `outputs` fixture declared `params=[1]`, which collided with the `dualmonitor`/`multimonitor` indirect `parametrize` marks and broke collection across the suite ("duplicate parametrization of 'outputs'"). Drop the fixture-level params and default to a single output via request.param; the indirect marks then parametrize cleanly.

==================================== ERRORS ==================================== _______________ ERROR collecting test/backend/x11/test_window.py _______________ test/backend/x11/test_window.py::test_urgent_hook_fire: duplicate parametrization of 'outputs' ______________________ ERROR collecting test/test_bar.py _______________________ test/test_bar.py::test_bar_hide_show_dual_screen: duplicate parametrization of 'outputs' ____________________ ERROR collecting test/test_command.py _____________________ test/test_command.py::test_items_qtile: duplicate parametrization of 'outputs' ______________________ ERROR collecting test/test_hook.py ______________________ test/test_hook.py::test_setgroup: duplicate parametrization of 'outputs' ____________________ ERROR collecting test/test_manager.py _____________________ test/test_manager.py::test_screen_dim: duplicate parametrization of 'outputs' _____________________ ERROR collecting test/test_window.py _____________________ test/test_window.py::test_center_window: duplicate parametrization of 'outputs' _____________ ERROR collecting test/widgets/test_currentscreen.py ______________ test/widgets/test_currentscreen.py::test_change_screen: duplicate parametrization of 'outputs'