### PR TITLE
Added substitution for constant path in desktop files for nix package.

### DIFF
--- a/nix/qtile.nix
+++ b/nix/qtile.nix
@@ -41,6 +41,18 @@ let
       postPatch = "";
 
       patches = [ ];
+    }
+    // {
+
+      # WARN: This is a temporary fix for the new path in the .desktop files.
+      # This should later be handled in nixpkgs, but for now it is simpler
+      # to put it here while we figure out what exactly we want to do there.
+      postInstall = (qtile-prev.postInstall or "") + ''
+        substituteInPlace $out/share/xsessions/qtile.desktop \
+          --replace-quiet /usr/bin/qtile $out/bin/qtile
+        substituteInPlace $out/share/wayland-sessions/qtile-wayland.desktop \
+          --replace-quiet /usr/bin/qtile $out/bin/qtile
+      '';
     };
 in
 (pkgs.python3Packages.qtile.overrideAttrs qtile-override-func).override {


### PR DESCRIPTION
Commit 0c38254 changed the path for the Qtile executable, but NixOS does not have the executable available at that path. This substitution is therefore required to make the `.desktop` files function correctly on NixOS.

**This is intended as a temporary solution!** Before the next update of Qtile in nixpkgs, changes similar to this should be made in nixpkgs. We are currently working on that solution, but it takes more time and consideration. Until then, this works well. 