### PR TITLE
start: detect the backend from the environment when -b is not given

### DIFF
--- a/libqtile/__init__.py
+++ b/libqtile/__init__.py
@@ -4,7 +4,7 @@ import enum
 
 
 class _UndefinedCore:
-    name = None
+    name: str | None = None
 
 
 class _UndefinedQtile:

--- a/libqtile/backend/__init__.py
+++ b/libqtile/backend/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import os
 from typing import TYPE_CHECKING, Any
 
 from libqtile.utils import QtileError
@@ -14,6 +15,15 @@ CORES = {
     "wayland": (),
     "x11": ("xcffib",),
 }
+
+
+def detect_backend() -> str:
+    session_type = os.environ.get("XDG_SESSION_TYPE")
+    if session_type in CORES:
+        return session_type
+    if "DISPLAY" in os.environ:
+        return "x11"
+    return "wayland"
 
 
 def has_deps(backend: str) -> list[str]:

--- a/libqtile/scripts/start.py
+++ b/libqtile/scripts/start.py
@@ -41,15 +41,16 @@ def get_default_config():
 
 
 def make_qtile(options) -> Qtile | None:
-    qtile.core.name = options.backend
-    if missing_deps := libqtile.backend.has_deps(options.backend):
-        print(f"Backend '{options.backend}' missing required Python dependencies:")
+    backend = options.backend or libqtile.backend.detect_backend()
+    qtile.core.name = backend
+    if missing_deps := libqtile.backend.has_deps(backend):
+        print(f"Backend '{backend}' missing required Python dependencies:")
         for dep in missing_deps:
             print("\t", dep)
 
         return None
 
-    kore = libqtile.backend.get_core(options.backend)
+    kore = libqtile.backend.get_core(backend)
 
     if not path.isfile(options.configfile):
         try:
@@ -148,7 +149,7 @@ def add_subcommand(subparsers, parents):
     parser.add_argument(
         "-b",
         "--backend",
-        default="x11",
+        default=None,
         dest="backend",
         choices=libqtile.backend.CORES.keys(),
         help="Use specified backend.",

--- a/test/backend/test_backend.py
+++ b/test/backend/test_backend.py
@@ -1,9 +1,29 @@
 import pytest
 
-from libqtile.backend import get_core
+from libqtile.backend import detect_backend, get_core
 from libqtile.utils import QtileError
 
 
 def test_get_core_bad():
     with pytest.raises(QtileError):
         get_core("NonBackend").finalize()
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        ({"XDG_SESSION_TYPE": "wayland"}, "wayland"),
+        ({"XDG_SESSION_TYPE": "x11"}, "x11"),
+        ({"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"}, "wayland"),
+        ({"DISPLAY": ":0"}, "x11"),
+        ({"XDG_SESSION_TYPE": "tty", "DISPLAY": ":0"}, "x11"),
+        ({}, "wayland"),
+        ({"WAYLAND_DISPLAY": "wayland-0"}, "wayland"),
+    ],
+)
+def test_detect_backend(monkeypatch, env, expected):
+    for var in ("XDG_SESSION_TYPE", "WAYLAND_DISPLAY", "DISPLAY"):
+        monkeypatch.delenv(var, raising=False)
+    for var, value in env.items():
+        monkeypatch.setenv(var, value)
+    assert detect_backend() == expected


### PR DESCRIPTION
This is a more sophisticated version of #5768 that looks at XDG_SESSION_TYPE first, before poking WAYLAND_DISPLAY and DISPLAY.

I believe I'm still right that display managers should set WAYLAND_DISPLAY in my comment in the above PR, viz.:

   loginctl session-status

which has (wayland) display info in it, in addition to the xdg desktop env var, etc.

So, let's use those to automatically decide which backend to start.