### PR TITLE
wayland: keep keybind layout constant in the C backend

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
     * bugfixes
+      - Wayland: keep keybindings consistent regardless of the active keyboard
+        layout. Fixes #4259.
 
 Qtile 0.36.0, released 2026-05-22:
     * features

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
     * bugfixes
+      - Wayland: keep keybindings consistent regardless of the active keyboard
+        layout. Fixes #4259.
 
 Qtile 0.37.0, released 2026-08-07:
     * features

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -134,6 +134,11 @@ PROTOS: list[Protocol] = [
     Protocol(
         f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
     ),
+    Protocol(
+        f"{QW_PROTO_IN_PATH}/virtual-keyboard-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -184,6 +189,16 @@ TEST_CLIENTS: list[TestClient] = [
             QW_PROTO_OUT_PATH / "tablet-v2-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="virtual-keyboard",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "virtual-keyboard.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "virtual-keyboard-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+        packages=["xkbcommon"],
     ),
 ]
 

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -134,6 +134,11 @@ PROTOS: list[Protocol] = [
     Protocol(
         f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
     ),
+    Protocol(
+        f"{QW_PROTO_IN_PATH}/virtual-keyboard-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -194,6 +199,16 @@ TEST_CLIENTS: list[TestClient] = [
             QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="virtual-keyboard",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "virtual-keyboard.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "virtual-keyboard-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+        packages=["xkbcommon"],
     ),
 ]
 

--- a/libqtile/backend/wayland/proto/virtual-keyboard-unstable-v1.xml
+++ b/libqtile/backend/wayland/proto/virtual-keyboard-unstable-v1.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="virtual_keyboard_unstable_v1">
+  <copyright>
+    Copyright © 2008-2011  Kristian Høgsberg
+    Copyright © 2010-2013  Intel Corporation
+    Copyright © 2012-2013  Collabora, Ltd.
+    Copyright © 2018       Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_virtual_keyboard_v1" version="1">
+    <description summary="virtual keyboard">
+      The virtual keyboard provides an application with requests which emulate
+      the behaviour of a physical keyboard.
+
+      This interface can be used by clients on its own to provide raw input
+      events, or it can accompany the input method protocol.
+    </description>
+
+    <request name="keymap">
+      <description summary="keyboard mapping">
+        Provide a file descriptor to the compositor which can be
+        memory-mapped to provide a keyboard mapping description.
+
+        Format carries a value from the keymap_format enumeration.
+      </description>
+      <arg name="format" type="uint" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </request>
+
+    <enum name="error">
+      <entry name="no_keymap" value="0" summary="No keymap was set"/>
+    </enum>
+
+    <request name="key">
+      <description summary="key event">
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond granularity, with an
+        undefined base. All requests regarding a single object must share the
+        same clock.
+
+        Keymap must be set before issuing this request.
+
+        State carries a value from the key_state enumeration.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" summary="physical state of the key"/>
+    </request>
+
+    <request name="modifiers">
+      <description summary="modifier and group state">
+        Notifies the compositor that the modifier and/or group state has
+        changed, and it should update state.
+
+        The client should use wl_keyboard.modifiers event to synchronize its
+        internal state with seat state.
+
+        Keymap must be set before issuing this request.
+      </description>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual keyboard keyboard object"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_virtual_keyboard_manager_v1" version="1">
+    <description summary="virtual keyboard manager">
+      A virtual keyboard manager allows an application to provide keyboard
+      input events as if they came from a physical keyboard.
+    </description>
+
+    <enum name="error">
+      <entry name="unauthorized" value="0" summary="client not authorized to use the interface"/>
+    </enum>
+
+    <request name="create_virtual_keyboard">
+      <description summary="Create a new virtual keyboard">
+        Creates a new virtual keyboard associated to a seat.
+
+        If the compositor enables a keyboard to perform arbitrary actions, it
+        should present an error when an untrusted client requests a new
+        keyboard.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="zwp_virtual_keyboard_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -73,12 +73,12 @@ static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
     // keycode offset by 8 as per evdev conventions
     uint32_t keycode = event->keycode + 8;
 
-    int layout_index = xkb_state_key_get_layout(keyboard->wlr_keyboard->xkb_state, keycode);
-
-    // Get the symbols for this key in the current layout and level 0
+    // Resolve keysyms against the first layout (index 0) instead of the active
+    // one, so keybindings stay constant regardless of the selected keyboard
+    // layout (mirrors X11 grabbing on the initial layout). Fixes qtile #4259.
     const xkb_keysym_t *syms;
     int nsyms = xkb_keymap_key_get_syms_by_level(keyboard->wlr_keyboard->keymap, keycode,
-                                                 layout_index, 0, &syms);
+                                                 0, 0, &syms);
 
     bool handled = false;
     // Get current keyboard modifiers (shift, ctrl, alt, etc.)

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -77,8 +77,8 @@ static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
     // one, so keybindings stay constant regardless of the selected keyboard
     // layout (mirrors X11 grabbing on the initial layout). Fixes qtile #4259.
     const xkb_keysym_t *syms;
-    int nsyms = xkb_keymap_key_get_syms_by_level(keyboard->wlr_keyboard->keymap, keycode,
-                                                 0, 0, &syms);
+    int nsyms =
+        xkb_keymap_key_get_syms_by_level(keyboard->wlr_keyboard->keymap, keycode, 0, 0, &syms);
 
     bool handled = false;
     // Get current keyboard modifiers (shift, ctrl, alt, etc.)

--- a/test/backend/wayland/test_keybind_layout.py
+++ b/test/backend/wayland/test_keybind_layout.py
@@ -1,0 +1,66 @@
+"""
+Regression test for keybinding keysym resolution in the Wayland C backend.
+
+With multiple keyboard layouts configured (e.g. "us,ru") and a non-primary
+layout active, a binding declared against the primary-layout keysym must still
+fire when the corresponding physical key is pressed. The C backend resolves
+keybinding keysyms against layout index 0 rather than the active layout
+(qw/keyboard.c, qw_keyboard_handle_key); before that fix, pressing the physical
+"r" key while the Russian layout was active yielded Cyrillic_ka and the binding
+declared as ``Key([], "r", ...)`` stopped firing.
+
+The test uses the virtual-keyboard protocol to attach a client-provided "us,ru"
+keymap, switch the active layout to Russian, and inject a physical "r" press.
+"""
+
+import time
+
+import pytest
+
+from libqtile.config import Key
+from libqtile.lazy import lazy
+from test.helpers import BareConfig
+
+# evdev keycode for the physical "r" key (linux/input-event-codes.h KEY_R).
+KEY_R = 19
+
+
+class KeybindLayoutConfig(BareConfig):
+    keys = [
+        Key([], "r", lazy.group["b"].toscreen()),
+    ]
+
+
+keybind_layout_config = pytest.mark.parametrize("wmanager", [KeybindLayoutConfig], indirect=True)
+pytestmark = pytest.mark.parametrize("test_client", ["virtual-keyboard"], indirect=True)
+
+
+def wait_for_group(wmanager, name, timeout=5.0):
+    """Poll the current group name until it matches or the timeout elapses."""
+    deadline = time.monotonic() + timeout
+    current = None
+    while time.monotonic() < deadline:
+        current = wmanager.c.group.info()["name"]
+        if current == name:
+            return current
+        time.sleep(0.05)
+    return current
+
+
+@keybind_layout_config
+def test_keybinding_fires_with_nonprimary_layout_active(wmanager, test_client):
+    # Sanity check: we start on the first group.
+    assert wmanager.c.group.info()["name"] == "a"
+
+    # Attach a us,ru keymap to the virtual keyboard and make Russian (layout
+    # index 1) the active layout.
+    test_client.assert_ok("keymap us,ru")
+    test_client.assert_ok("group 1")
+
+    # Press the physical "r" key. Resolved against layout 0 this is keysym "r",
+    # which matches the configured binding; against the active Russian layout it
+    # would be Cyrillic_ka and would not match.
+    test_client.assert_ok(f"press {KEY_R}")
+    test_client.assert_ok(f"release {KEY_R}")
+
+    assert wait_for_group(wmanager, "b") == "b"

--- a/test/backend/wayland/test_keybind_layout.py
+++ b/test/backend/wayland/test_keybind_layout.py
@@ -13,13 +13,11 @@ The test uses the virtual-keyboard protocol to attach a client-provided "us,ru"
 keymap, switch the active layout to Russian, and inject a physical "r" press.
 """
 
-import time
-
 import pytest
 
 from libqtile.config import Key
 from libqtile.lazy import lazy
-from test.helpers import BareConfig
+from test.helpers import BareConfig, Retry
 
 # evdev keycodes (linux/input-event-codes.h).
 KEY_R = 19
@@ -43,16 +41,9 @@ keybind_layout_config = pytest.mark.parametrize("wmanager", [KeybindLayoutConfig
 pytestmark = pytest.mark.parametrize("test_client", ["virtual-keyboard"], indirect=True)
 
 
-def wait_for_group(wmanager, name, timeout=5.0):
-    """Poll the current group name until it matches or the timeout elapses."""
-    deadline = time.monotonic() + timeout
-    current = None
-    while time.monotonic() < deadline:
-        current = wmanager.c.group.info()["name"]
-        if current == name:
-            return current
-        time.sleep(0.05)
-    return current
+@Retry(ignore_exceptions=(AssertionError,))
+def wait_for_group(wmanager, name):
+    assert wmanager.c.group.info()["name"] == name
 
 
 @keybind_layout_config
@@ -71,7 +62,7 @@ def test_keybinding_fires_with_nonprimary_layout_active(wmanager, test_client):
     test_client.assert_ok(f"press {KEY_R}")
     test_client.assert_ok(f"release {KEY_R}")
 
-    assert wait_for_group(wmanager, "b") == "b"
+    wait_for_group(wmanager, "b")
 
 
 @keybind_layout_config
@@ -91,4 +82,4 @@ def test_keycode_binding_fires_with_nonprimary_layout_active(wmanager, test_clie
     test_client.assert_ok(f"press {KEY_T}")
     test_client.assert_ok(f"release {KEY_T}")
 
-    assert wait_for_group(wmanager, "c") == "c"
+    wait_for_group(wmanager, "c")

--- a/test/backend/wayland/test_keybind_layout.py
+++ b/test/backend/wayland/test_keybind_layout.py
@@ -21,13 +21,21 @@ from libqtile.config import Key
 from libqtile.lazy import lazy
 from test.helpers import BareConfig
 
-# evdev keycode for the physical "r" key (linux/input-event-codes.h KEY_R).
+# evdev keycodes (linux/input-event-codes.h).
 KEY_R = 19
+KEY_T = 20
+
+# Keycode bindings use XKB keycodes (evdev + 8).
+XKB_KEY_T = KEY_T + 8
 
 
 class KeybindLayoutConfig(BareConfig):
     keys = [
         Key([], "r", lazy.group["b"].toscreen()),
+        # Same scenario for a binding declared by raw keycode: it is converted
+        # to a keysym at grab time (qw_server_get_sym_from_code, i.e. "t" under
+        # the default layout), so runtime matching is keysym-based as well.
+        Key([], XKB_KEY_T, lazy.group["c"].toscreen()),
     ]
 
 
@@ -64,3 +72,23 @@ def test_keybinding_fires_with_nonprimary_layout_active(wmanager, test_client):
     test_client.assert_ok(f"release {KEY_R}")
 
     assert wait_for_group(wmanager, "b") == "b"
+
+
+@keybind_layout_config
+def test_keycode_binding_fires_with_nonprimary_layout_active(wmanager, test_client):
+    """
+    Bindings declared by raw keycode go through the same keysym matching: the
+    keycode is resolved to a keysym once at grab time, and key presses must
+    resolve to that same keysym regardless of the active layout. Before the
+    layout-0 fix, pressing the physical "t" key with Russian active yielded
+    Cyrillic_ie and the ``Key([], 28, ...)`` binding stopped firing too.
+    """
+    assert wmanager.c.group.info()["name"] == "a"
+
+    test_client.assert_ok("keymap us,ru")
+    test_client.assert_ok("group 1")
+
+    test_client.assert_ok(f"press {KEY_T}")
+    test_client.assert_ok(f"release {KEY_T}")
+
+    assert wait_for_group(wmanager, "c") == "c"

--- a/test/wayland_clients/src/virtual-keyboard.c
+++ b/test/wayland_clients/src/virtual-keyboard.c
@@ -14,7 +14,7 @@
  *   release <evdev>    send a key release for the given evdev keycode
  */
 
-#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
 
 #include <fcntl.h>
 #include <stdio.h>
@@ -45,12 +45,10 @@ static uint32_t next_time(struct test_state *state) {
 }
 
 static int write_keymap_fd(const char *keymap, size_t size) {
-    char template[] = "/tmp/qtile-vkbd-keymap-XXXXXX";
-    int fd = mkstemp(template);
+    int fd = memfd_create("qtile-vkbd-keymap", MFD_CLOEXEC);
     if (fd < 0) {
         return -1;
     }
-    unlink(template);
 
     if (ftruncate(fd, (off_t)size) < 0) {
         close(fd);

--- a/test/wayland_clients/src/virtual-keyboard.c
+++ b/test/wayland_clients/src/virtual-keyboard.c
@@ -1,0 +1,213 @@
+/*
+ * virtual-keyboard.c
+ *
+ * Test client for the zwp_virtual_keyboard_v1 protocol. It ships a
+ * client-provided xkb keymap (e.g. layouts "us,ru") to the compositor, lets the
+ * test select the active layout group, and injects raw evdev key presses. This
+ * exercises the C backend's keybinding keysym resolution
+ * (qw_keyboard_handle_key) under a non-primary active layout.
+ *
+ * Line protocol commands:
+ *   keymap <layouts>   build "us,ru"-style keymap and attach it to the keyboard
+ *   group <n>          make layout index <n> the active group (modifiers request)
+ *   press <evdev>      send a key press for the given evdev keycode (KEY_R = 19)
+ *   release <evdev>    send a key release for the given evdev keycode
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <xkbcommon/xkbcommon.h>
+
+#include "client-base.h"
+
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct zwp_virtual_keyboard_manager_v1 *vkbd_manager;
+    struct zwp_virtual_keyboard_v1 *vkbd;
+    bool has_keymap;
+    uint32_t time_msec;
+};
+
+static uint32_t next_time(struct test_state *state) {
+    /* wlroots only requires monotonically increasing event timestamps. */
+    return ++state->time_msec;
+}
+
+static int write_keymap_fd(const char *keymap, size_t size) {
+    char template[] = "/tmp/qtile-vkbd-keymap-XXXXXX";
+    int fd = mkstemp(template);
+    if (fd < 0) {
+        return -1;
+    }
+    unlink(template);
+
+    if (ftruncate(fd, (off_t)size) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        close(fd);
+        return -1;
+    }
+
+    memcpy(data, keymap, size);
+    munmap(data, size);
+
+    return fd;
+}
+
+static void cmd_keymap(struct test_state *state, const char *arg) {
+    if (state->vkbd_manager == NULL) {
+        test_error("zwp_virtual_keyboard_manager_v1 not advertised by compositor");
+        return;
+    }
+    if (state->base.seat == NULL) {
+        test_error("wl_seat not available");
+        return;
+    }
+    if (arg == NULL) {
+        test_error("usage: keymap <layouts>");
+        return;
+    }
+
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (context == NULL) {
+        test_error("failed to create xkb context");
+        return;
+    }
+
+    struct xkb_rule_names names = {.layout = arg};
+    struct xkb_keymap *keymap =
+        xkb_keymap_new_from_names(context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    if (keymap == NULL) {
+        xkb_context_unref(context);
+        test_error("failed to compile keymap for layouts '%s'", arg);
+        return;
+    }
+
+    char *keymap_str = xkb_keymap_get_as_string(keymap, XKB_KEYMAP_FORMAT_TEXT_V1);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+
+    if (keymap_str == NULL) {
+        test_error("failed to serialize keymap");
+        return;
+    }
+
+    size_t size = strlen(keymap_str) + 1;
+    int fd = write_keymap_fd(keymap_str, size);
+    free(keymap_str);
+
+    if (fd < 0) {
+        test_error("failed to create keymap fd");
+        return;
+    }
+
+    if (state->vkbd == NULL) {
+        state->vkbd = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(state->vkbd_manager,
+                                                                              state->base.seat);
+    }
+
+    zwp_virtual_keyboard_v1_keymap(state->vkbd, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, fd,
+                                   (uint32_t)size);
+    close(fd);
+
+    do_roundtrip(&state->base);
+    state->has_keymap = true;
+    test_ok();
+}
+
+static void cmd_group(struct test_state *state, const char *arg) {
+    if (state->vkbd == NULL || !state->has_keymap) {
+        test_error("keymap not set");
+        return;
+    }
+    if (arg == NULL) {
+        test_error("usage: group <n>");
+        return;
+    }
+
+    uint32_t group = (uint32_t)atoi(arg);
+    zwp_virtual_keyboard_v1_modifiers(state->vkbd, 0, 0, 0, group);
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static void cmd_key(struct test_state *state, const char *arg, uint32_t key_state) {
+    if (state->vkbd == NULL || !state->has_keymap) {
+        test_error("keymap not set");
+        return;
+    }
+    if (arg == NULL) {
+        test_error("usage: press/release <evdev-keycode>");
+        return;
+    }
+
+    uint32_t keycode = (uint32_t)atoi(arg);
+    zwp_virtual_keyboard_v1_key(state->vkbd, next_time(state), keycode, key_state);
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, zwp_virtual_keyboard_manager_v1_interface.name) == 0) {
+        state->vkbd_manager = wl_registry_bind(
+            registry, name, &zwp_virtual_keyboard_manager_v1_interface, version < 1 ? version : 1);
+    }
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "keymap") == 0)
+        cmd_keymap(state, arg);
+    else if (strcmp(cmd, "group") == 0)
+        cmd_group(state, arg);
+    else if (strcmp(cmd, "press") == 0)
+        cmd_key(state, arg, WL_KEYBOARD_KEY_STATE_PRESSED);
+    else if (strcmp(cmd, "release") == 0)
+        cmd_key(state, arg, WL_KEYBOARD_KEY_STATE_RELEASED);
+    else
+        test_error("unknown command '%s'", cmd);
+
+    return true;
+}
+
+static void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (state->vkbd) {
+        zwp_virtual_keyboard_v1_destroy(state->vkbd);
+    }
+    if (state->vkbd_manager) {
+        zwp_virtual_keyboard_manager_v1_destroy(state->vkbd_manager);
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {
+        .registry_global = registry_handler,
+        .dispatch_command = dispatch_command,
+        .cleanup = cleanup,
+    };
+
+    return client_run(&state.base, &ops);
+}


### PR DESCRIPTION
The Wayland backend resolves a pressed key to keysyms using the *active* keyboard layout (`xkb_state_key_get_layout`) before calling `xkb_keymap_key_get_syms_by_level()` in `qw/keyboard.c`. With multiple layouts configured (e.g. `kb_layout="us,ru"`), switching to a non-primary layout makes the physical keys produce that layout's keysyms, so configured keybindings — matched against the primary-layout keysym — stop firing.

Resolve keysyms against layout index 0 instead, mirroring the X11 backend which grabs on the initial layout.

This restores the behaviour fixed in #4259, whose original fix (in `libqtile/backend/wayland/inputs.py`) regressed when keyboard handling moved to C in the new `qw` backend.

Fixes #4259

Testing note: the original #4259 fix included a unit test that monkeypatched `lib.xkb_keymap_key_get_syms_by_level`, which no longer maps to the C implementation. Happy to add an integration test if you can point me at the preferred pattern for the new backend.