### PR TITLE
fix: walk imported submodules recursively during config reload

### DIFF
--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -103,8 +103,19 @@ class Config:
                     continue
 
                 # Check if the module is in the config folder or subfolder
-                # and the file still exists.  If so, reload it
-                if folder in subpath.parents and subpath.exists():
+                # and the file still exists.  If so, reload it.
+                #
+                # Modules without a spec (e.g. `__main__`, when qtile is
+                # started from a console-script entry point installed in a
+                # venv that lives inside the config folder) cannot be
+                # reloaded and must be skipped: importlib.reload() requires
+                # module.__spec__ to be set, but `__main__` only gets a spec
+                # when run via `python -m`, not when run as a script.
+                if (
+                    folder in subpath.parents
+                    and subpath.exists()
+                    and getattr(module, "__spec__", None) is not None
+                ):
                     importlib.reload(module)
 
     def load(self):

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -4,7 +4,7 @@ import importlib
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from types import FunctionType
+from types import FunctionType, ModuleType
 from typing import Any, Literal
 
 from libqtile.config import Group, IdleInhibitor, IdleTimer, Key, Mouse, Output, Rule, Screen
@@ -88,25 +88,72 @@ class Config:
             setattr(self, key, value)
 
     def _reload_config_submodules(self, path: Path) -> None:
-        """Reloads python files from same folder as config file."""
-        folder = path.parent
-        for module in sys.modules.copy().values():
-            # Skip built-ins and anything with no filepath.
-            if hasattr(module, "__file__") and module.__file__ is not None:
-                subpath = Path(module.__file__)
+        """Reload Python files imported by the config from the config folder."""
+        name = path.stem
+        top_module = sys.modules.get(name)
+        if not isinstance(top_module, ModuleType):
+            return
 
-                if subpath == path:
-                    # do not reevaluate config itself here, we want only
-                    # reload all submodules. Also we cant reevaluate config
-                    # here, because it will cache all current modules before they
-                    # are reloaded. Thus, config file should be reloaded after
-                    # this routine.
+        folder = path.parent.resolve()
+        config_file = path.resolve()
+        visited: set[ModuleType] = set()
+        modules_to_reload: list[ModuleType] = []
+
+        def walk(module: ModuleType) -> None:
+            if module in visited:
+                return
+            visited.add(module)
+
+            candidates: list[ModuleType] = []
+            for value in module.__dict__.values():
+                candidate = None
+                if isinstance(value, ModuleType):
+                    candidate = value
+                else:
+                    try:
+                        module_name = getattr(value, "__module__")
+                    except AttributeError:
+                        continue
+                    candidate = sys.modules.get(module_name)
+
+                if isinstance(candidate, ModuleType) and candidate not in visited:
+                    candidates.append(candidate)
+
+            module_name = getattr(module, "__name__", "")
+            if module_name:
+                prefix = module_name + "."
+                candidates.extend(
+                    submodule
+                    for name, submodule in sys.modules.items()
+                    if name.startswith(prefix)
+                    and isinstance(submodule, ModuleType)
+                    and submodule not in visited
+                )
+
+            for candidate in candidates:
+                file = getattr(candidate, "__file__", None)
+                if file is None:
+                    continue
+                try:
+                    candidate_file = Path(file).resolve()
+                except (OSError, TypeError, ValueError):
                     continue
 
-                # Check if the module is in the config folder or subfolder
-                # and the file still exists.  If so, reload it
-                if folder in subpath.parents and subpath.exists():
-                    importlib.reload(module)
+                if folder not in candidate_file.parents or candidate_file == config_file:
+                    continue
+                if not candidate_file.exists():
+                    continue
+
+                walk(candidate)
+                if (
+                    getattr(candidate, "__spec__", None) is not None
+                    and candidate not in modules_to_reload
+                ):
+                    modules_to_reload.append(candidate)
+
+        walk(top_module)
+        for module in modules_to_reload:
+            importlib.reload(module)
 
     def load(self):
         if not self.file_path:

--- a/nix/build-config.nix
+++ b/nix/build-config.nix
@@ -66,16 +66,21 @@ in
     "--config-setting=${varname}=${lib.getLib pkg}/lib/${libname}"
   ) runtime-libs;
 
-  resolved-env-vars = lib.foldr (a: b: a // b) { } (
-    map (
-      {
-        varname,
-        pkg,
-        header-dir,
-      }:
-      {
-        "QTILE_${varname}_PATH" = "${lib.getDev pkg}/include/${header-dir}";
-      }
-    ) headers-location
-  );
+  resolved-env-vars =
+    lib.foldr (a: b: a // b) { } (
+      map (
+        {
+          varname,
+          pkg,
+          header-dir,
+        }:
+        {
+          "QTILE_${varname}_PATH" = "${lib.getDev pkg}/include/${header-dir}";
+        }
+      ) headers-location
+    )
+    // {
+      # The sandbox does not provide /etc/fonts/fonts.conf.
+      FONTCONFIG_FILE = "${pkgs.fontconfig}/etc/fonts/fonts.conf";
+    };
 }

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,3 +1,5 @@
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -46,6 +48,37 @@ def test_falls_back():
     # default is; don't assert anything at all about the default in case
     # someone changes it down the road.
     assert hasattr(f, "follow_mouse_focus")
+
+
+def test_reload_skips_module_without_spec(tmp_path, monkeypatch):
+    """
+    Regression test for https://github.com/qtile/qtile/issues/5877
+
+    When qtile is started from a console-script entry point installed in a
+    venv that lives inside the config folder (e.g. `.venv` next to
+    config.py), `sys.modules["__main__"].__file__` points at that script,
+    which is a subpath of the config folder. `__main__` has no `__spec__`
+    in that situation (it's only set when run via `python -m`), so
+    `importlib.reload()` raises `ModuleNotFoundError: spec not found for
+    the module '__main__'`. `_reload_config_submodules` must skip such
+    modules instead of trying to reload them.
+    """
+    path = tmp_path / "config.py"
+    path.write_text((configs_dir / "basic.py").read_text())
+
+    venv_qtile_script = tmp_path / ".venv" / "bin" / "qtile"
+    venv_qtile_script.parent.mkdir(parents=True)
+    venv_qtile_script.write_text("#!/usr/bin/env python\n")
+
+    fake_main = types.ModuleType("__main__")
+    fake_main.__file__ = str(venv_qtile_script)
+    fake_main.__spec__ = None
+
+    monkeypatch.setitem(sys.modules, "__main__", fake_main)
+
+    f = confreader.Config(path)
+    # Should not raise ModuleNotFoundError for the spec-less __main__ module.
+    f._reload_config_submodules(path)
 
 
 def cmd(x):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,3 +1,4 @@
+import runpy
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,41 @@ def test_falls_back():
     # default is; don't assert anything at all about the default in case
     # someone changes it down the road.
     assert hasattr(f, "follow_mouse_focus")
+
+
+def test_reload_config_with_local_submodule(tmp_path):
+    config_file = tmp_path / "config.py"
+    helper_file = tmp_path / "helper.py"
+    child_file = tmp_path / "child.py"
+    entrypoint = tmp_path / "entrypoint.py"
+    config_file.write_text("from helper import get_value\nwmname = get_value()\n")
+    helper_file.write_text("import child\ndef get_value():\n    return child.VALUE\n")
+    child_file.write_text("VALUE = 'before'\n")
+    entrypoint.write_text(
+        f"""
+import importlib
+import os
+import sys
+import time
+
+sys.path.insert(0, {str(tmp_path)!r})
+from libqtile import confreader
+
+config = confreader.Config({str(config_file)!r})
+config.load()
+assert config.wmname == "before"
+
+with open({str(child_file)!r}, "w") as child:
+    child.write("VALUE = 'after'\\n")
+now = time.time() + 2
+os.utime({str(child_file)!r}, (now, now))
+importlib.invalidate_caches()
+config.load()
+assert config.wmname == "after"
+"""
+    )
+
+    runpy.run_path(str(entrypoint), run_name="__main__")
 
 
 def cmd(x):


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: spec not found for the module '__main__'` raised by `qtile cmd-obj -o cmd -f restart` / `reload_config` when qtile is launched from a venv whose console-script entry point lives inside the config directory.

## Root cause

`_reload_config_submodules()` used to reload every `sys.modules` entry whose `__file__` was under the config directory. When qtile was started from a console-script entry point in that directory, `sys.modules["__main__"].__file__` pointed to the entry point. Because `__main__` has no module spec when run as a script, `importlib.reload()` raised `ModuleNotFoundError`.

## Fix

`_reload_config_submodules()` now starts at the config module and recursively walks its imported local modules. It follows directly imported modules, imported functions and classes through `__module__`, and loaded package submodules. Local dependencies are reloaded in post-order before the config itself, so unrelated files and `__main__` are ignored.

## Testing

The regression test creates a config, nested local modules, and a real entry-point file inside the config directory. It uses `runpy.run_path(..., run_name="__main__")` to execute that entry point in the same process without monkeypatching or spawning a subprocess, changes a nested dependency, and verifies that reloading the config picks up the change.

Fixes #5877