### PR TITLE
wayland: fix three use-after-free crashes in output/view lifecycle

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
     * bugfixes
+      - wayland: fix use-after-free crashes when a surface outlives its output.
+        Layer-shell surfaces that commit after their output is destroyed, session
+        lock surfaces on a destroyed output, and killed internal views no longer
+        dereference freed compositor state.
 
 Qtile 0.36.0, released 2026-05-22:
     * features

--- a/libqtile/backend/wayland/qw/session-lock.c
+++ b/libqtile/backend/wayland/qw/session-lock.c
@@ -109,6 +109,18 @@ void qw_session_lock_surface_handle_destroy(struct wl_listener *listener, void *
     struct qw_session_lock_surface *sls = wl_container_of(listener, sls, surface_destroy);
     struct qw_server *server = sls->server;
 
+    // Outputs keep a lock_surface back-pointer to this wlr_session_lock_surface_v1,
+    // which is freed after this handler. It is otherwise cleared only on explicit
+    // unlock in qw_session_lock_destroy, so an output-layout change after this
+    // surface dies (output destroyed on VT switch / display drop while locked)
+    // would dereference freed memory in qw_session_lock_output_change().
+    struct qw_output *o;
+    wl_list_for_each(o, &server->outputs, link) {
+        if (o->lock_surface == sls->lock_surface) {
+            o->lock_surface = NULL;
+        }
+    }
+
     if (server->lock != NULL && server->lock->lock != NULL &&
         !wl_list_empty(&server->lock->lock->surfaces)) {
         qw_session_lock_focus_first_lock_surface(server);

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -294,6 +294,12 @@ class Internal(Base, base.Internal):
 
     @property
     def surface(self) -> ffi.CData:
+        # qw_internal_view_kill() frees the C view struct, so once killed
+        # self._internal_ptr dangles and reading image_surface yields stale
+        # non-NULL garbage that crashes cairo_surface_reference in the drawer.
+        # Report no surface so callers' existing NULL guard skips drawing.
+        if self._killed:
+            return ffi.NULL
         return ffi.cast("void *", self._internal_ptr.image_surface)
 
     @property


### PR DESCRIPTION
This series fixes three distinct use-after-free segfaults in the Wayland backend, all hit on real hardware (external 5K display over Thunderbolt with occasional link drops, VT switches) and diagnosed from coredumps with full backtraces.

## 1. `qw_layer_view_handle_commit` dereferences a freed output (completes 1ec7a152)

1ec7a152 ("Fix segfault on screen unplug") nulls `layer_view->output` in `qw_output_handle_destroy` and guards the unmap handler, but the commit handler was missed: a layer-shell surface committing after its output was destroyed still dereferences the freed output in `qw_output_arrange_layers`. Captured live:

```
#0 qw_output_arrange_layers (output=0xae8be00) at output.c:72
     usable_area = { x=195442896, y=0, width=339585840, height=0 }   # freed memory
#1 qw_layer_view_handle_commit (listener=..., data=...) at layer-view.c:97
#2 wl_signal_emit_mutable
#3 surface_commit_state (wlr_compositor.c:567)
```

The fix mirrors the existing unmap-handler guard.

## 2. `output->lock_surface` left dangling after the lock surface is destroyed

`qw_session_lock_handle_new_surface` sets `output->lock_surface`, but it is only cleared on explicit unlock in `qw_session_lock_destroy`. If a lock surface dies any other way (its output disconnected while locked, lock client crash), the back-pointer dangles, and the next output-layout change crashes in `qw_session_lock_output_change`. Confirmed by re-symbolizing a coredump with the exact binary that crashed:

```
#6 qw_session_lock_output_change (output=0x416f6e50) at session-lock.c:73
     # qw_output itself alive and valid (full_area 2560x1440),
     # output->lock_surface = 0x4377a420 -> freed+reused heap,
     # lock_surface->surface = 0x1 -> fault at 0x349
#7 qw_server_handle_output_layout_change at server.c:201
#9 output_layout_reconfigure (wlr_output_layout.c:122)
#11 wlr_output_finish <- drm_connector_destroy_output <- libseat VT deactivate
```

The destroy handler now clears the back-pointer on every output that references the dying surface.

## 3. `Internal.surface` reads a freed C view struct after `kill()`

`qw_internal_view_kill()` frees the view struct, so `Internal._internal_ptr` dangles and the `surface` property returns stale non-NULL garbage; a subsequent bar redraw (observed trigger: a StatusNotifier D-Bus icon update racing a config reload) crashes in `cairo_surface_reference`:

```
asyncio callback -> cairocffi cdata_call -> ffi_call_unix64
-> cairo_surface_reference (libcairo) SIGSEGV
```

Returning `ffi.NULL` once `_killed` lets the drawer's existing NULL check skip drawing; the only consumer of this property is `drawer.py`.

All three are one-guard/one-invariant changes with no behavior change on the happy path. With these applied (plus 1ec7a152), the setup that previously crashed on display drops / VT switches has been stable.

## Testing

Includes a regression test for fix 1: a new layer-shell test client maps a surface on the second headless output, the output is destroyed at runtime via a new `PYTEST_CURRENT_TEST`-gated test hook (`qw_server_test_destroy_output`), and the client commits again — pre-fix this segfaults the compositor, with the fix it passes (`test/backend/wayland/test_output_lifecycle.py`). A CHANGELOG entry is included.

The `Internal.surface` fix has no test: under a non-ASAN build the freed struct reads back as zeros, so a test cannot distinguish fixed from unfixed (verified while developing). The full wayland test suite also ran clean under an ASan/UBSan build of the backend with these patches applied.
