### PR TITLE
docs: update qtile-flake guide's url

### DIFF
--- a/docs/manual/install/nixos.rst
+++ b/docs/manual/install/nixos.rst
@@ -139,7 +139,7 @@ Gives you a script to run that runs Qemu to test your config. For this to work y
 
 .. seealso::
 
-   For a detailed walkthrough on setting up Qtile with flakes—from basic installation to package overrides, see `Gurjaka's Qtile Flake Guide <https://gurjaka.codeberg.page/blog.html?post=qtile-flake>`_.
+   For a detailed walkthrough on setting up Qtile with flakes—from basic installation to package overrides, see `Gurjaka's Qtile Flake Guide <https://gurjaka.dev/blog.html?post=qtile-flake>`_.
 
 To hack on Qtile with Nix, simply run `nix develop` in a checkout of the repo.
 In the development shell, there are a few useful things:


### PR DESCRIPTION
I have bought a custom domain, and also moved away from codeberg pages, the guide is no longer available at https://gurjaka.codeberg.page/blog.html?post=qtile-flake