### PR TITLE
core: ensure there is at least one screen

### DIFF
--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -502,6 +502,10 @@ class Qtile(CommandObject):
             )
             new_screens.append(scr)
 
+        # There needs to be at least one screen.
+        if len(new_screens) == 0:
+            new_screens.append(Screen())
+
         for screen in self.screens:
             if screen not in new_screens:
                 screen.finalize_gaps()


### PR DESCRIPTION
If core.get_output_info() returns no screens (e.g. we are in the middle of a restart or reconfiguration due to randr events), we won't set up any current_screen, and can cause a crash.

Fixes #5995