### PR TITLE
Debounce screen change events

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -2,8 +2,6 @@ name: Nix Flake Check
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
+      - Add screen_change_debounce_timeout config option (default 1 second) to
+        debounce screen_change events on both backends
     * bugfixes
 
 Qtile 0.36.0, released 2026-05-22:

--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -149,6 +149,12 @@ configuration variables that control specific aspects of Qtile's behavior:
       - ``True``
       - Controls whether or not to automatically reconfigure screens when there
         are changes in randr output configuration.
+    * - ``screen_change_debounce_timeout``
+      - ``1``
+      - How long (in seconds) to wait after a screen change event before firing
+        the ``screen_change`` hook. Bursts of events arriving within this time
+        are coalesced into a single hook invocation. Set to ``0`` to fire the
+        hook immediately on every event.
     * - ``widget_defaults``
       - ``dict(font='sans', fontsize=12, padding=3)``
       - Default settings for bar widgets.

--- a/libqtile/backend/base/core.py
+++ b/libqtile/backend/base/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import typing
 from abc import ABCMeta, abstractmethod
@@ -23,6 +24,7 @@ class Core(CommandObject, metaclass=ABCMeta):
     qtile: Qtile
     idle_inhibitor_manager: IdleInhibitorManager[Any]
     idle_notifier: IdleNotifier
+    screen_change_timer: asyncio.TimerHandle | None = None
 
     @property
     @abstractmethod
@@ -105,6 +107,32 @@ class Core(CommandObject, metaclass=ABCMeta):
 
     def flush(self) -> None:
         """If needed, flush the backend's event queue."""
+
+    def fire_screen_change(self, event: Any = None) -> None:
+        if self.screen_change_timer is not None:
+            self.screen_change_timer.cancel()
+            self.screen_change_timer = None
+
+        # the wayland backend generates a screen change event when the initial
+        # output is created in Core.__init__(), before the Qtile instance is
+        # attached to the core; there is nothing to debounce yet, so fire the
+        # hook directly
+        qtile = getattr(self, "qtile", None)
+        if qtile is None:
+            hook.fire("screen_change", event)
+            return
+
+        timeout = qtile.config.screen_change_debounce_timeout
+        if timeout > 0:
+            self.screen_change_timer = qtile.call_later(
+                timeout, self.debounced_screen_change, event
+            )
+        else:
+            hook.fire("screen_change", event)
+
+    def debounced_screen_change(self, event: Any) -> None:
+        self.screen_change_timer = None
+        hook.fire("screen_change", event)
 
     def simulate_keypress(self, modifiers: list[str], key: str) -> None:
         """Simulate a keypress with given modifiers"""

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -372,7 +372,7 @@ class Core(base.Core):
         # TODO: Also configure devices when a new device is added
 
     def handle_screen_change(self) -> None:
-        hook.fire("screen_change", None)
+        self.fire_screen_change(None)
 
     def get_screen_for_output(self, output: ffi.CData) -> Screen:
         assert self.qtile is not None

--- a/libqtile/backend/x11/core.py
+++ b/libqtile/backend/x11/core.py
@@ -234,7 +234,7 @@ class Core(base.Core):
         # regardless of whether the screen had actually changed. so, we do
         # that here, since we had tests that enforced that behavior so
         # maybe someone depended on it.
-        hook.fire("screen_change", None)
+        self.fire_screen_change(None)
 
         if not initial:
             # We are just reloading config
@@ -829,7 +829,7 @@ class Core(base.Core):
             self.conn.fixup_focus()
 
     def handle_ScreenChangeNotify(self, event) -> None:  # noqa: N802
-        hook.fire("screen_change", event)
+        self.fire_screen_change(event)
 
     def _fake_input(self, input_type, detail, x=0, y=0) -> None:
         self._xtest.FakeInput(

--- a/libqtile/confreader.py
+++ b/libqtile/confreader.py
@@ -46,6 +46,7 @@ class Config:
     bring_front_click: bool | Literal["floating_only"]
     floats_kept_above: bool
     reconfigure_screens: bool
+    screen_change_debounce_timeout: int | float
     wmname: str
     auto_minimize: bool
     # Really we'd want to check this Any is libqtile.backend.wayland.ImportConfig, but

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -198,6 +198,10 @@ focus_on_window_activation = "smart"
 focus_previous_on_window_remove = False
 reconfigure_screens = True
 
+# How long (in seconds) to wait after a screen change event before firing the
+# screen_change hook, coalescing bursts of events into a single one.
+screen_change_debounce_timeout = 1
+
 # If things like steam games want to auto-minimize themselves when losing
 # focus, should we respect this or not?
 auto_minimize = True

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -214,6 +214,13 @@ class TestManager:
             print(f"{header}\n{logs}", file=sys.stderr)
 
     def start(self, config_class, no_spawn=False, state=None):
+        # the x server emits a real ScreenChangeNotify shortly after startup;
+        # debouncing it would fire the screen_change hook (and possibly
+        # reconfigure_screens()) at an arbitrary point mid-test, so configs
+        # that aren't explicitly testing the debounce opt out of it.
+        if not hasattr(config_class, "screen_change_debounce_timeout"):
+            config_class.screen_change_debounce_timeout = 0
+
         multiprocessing.set_start_method("fork", force=True)
         readlogs, writelogs = os.pipe()
         rpipe, wpipe = multiprocessing.Pipe()

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from multiprocessing import Value
 
 import pytest
@@ -665,6 +666,34 @@ def test_net_wm_icon_change(manager_nospawn, backend_name):
     manager_nospawn.start(ClientNewConfig)
     manager_nospawn.test_window("Test Client")
     assert_window(manager_nospawn, "Test Client")
+
+
+@pytest.mark.usefixtures("hook_fixture")
+def test_screen_change_debounce(manager_nospawn):
+    @Retry(ignore_exceptions=(AssertionError))
+    def assert_inc_calls(num: int):
+        assert manager_nospawn.screen_change_calls.value == num
+
+    def inc_screen_change_calls(event):
+        manager_nospawn.screen_change_calls.value += 1
+
+    manager_nospawn.screen_change_calls = Value("i", 0)
+    hook.subscribe.screen_change(inc_screen_change_calls)
+
+    class DebounceConfig(BareConfig):
+        screen_change_debounce_timeout = 0.5
+
+    manager_nospawn.start(DebounceConfig)
+    assert_inc_calls(1)
+
+    # a burst of screen change events is coalesced into a single hook firing
+    for _ in range(3):
+        manager_nospawn.c.eval("self.core.fire_screen_change(None)")
+    assert_inc_calls(2)
+
+    # and no further firings straggle in afterwards
+    time.sleep(2)
+    assert manager_nospawn.screen_change_calls.value == 2
 
 
 @pytest.mark.usefixtures("hook_fixture")


### PR DESCRIPTION
Here's a new config setting to allow for debouncing screen change events, since getting lots of them in a hurry is annoying.