### PR TITLE
Refactor Wayland View Management (hide, unhide, place)

### DIFF
--- a/libqtile/backend/wayland/qw/view.c
+++ b/libqtile/backend/wayland/qw/view.c
@@ -1,5 +1,6 @@
 #include "view.h"
 #include "cairo-buffer.h"
+#include "cursor.h"
 #include "server.h"
 #include "util.h"
 #include <stdlib.h>
@@ -175,6 +176,27 @@ void qw_view_move_down(struct qw_view *view) {
 
 bool qw_view_is_visible(struct qw_view *view) { return view->content_tree->node.enabled; }
 
+// Unhide the view by enabling its content_tree scene node if currently disabled
+void qw_view_unhide(void *self) {
+    struct qw_view *view = (struct qw_view *)self;
+    if (!view->content_tree->node.enabled) {
+        wlr_scene_node_set_enabled(&view->content_tree->node, true);
+    }
+}
+
+// Disable the content tree, deactivate, and clear keyboard
+// focus if this view's surface currently holds it. `activate` is the
+// backend-specific activate function (xdg or xwayland).
+void qw_view_disable_and_clear_focus(struct qw_view *view, struct wlr_surface *surface) {
+    wlr_scene_node_set_enabled(&view->content_tree->node, false);
+
+    if (surface == view->server->seat->keyboard_state.focused_surface) {
+        wlr_seat_keyboard_clear_focus(view->server->seat);
+    }
+
+    qw_cursor_update_pointer_focus(view->server->cursor);
+}
+
 // Creates and paints multiple border layers around the view content.
 // borders: array of qw_border for each border.
 // border_count: number of border layers to draw.
@@ -255,6 +277,37 @@ void qw_view_paint_borders(struct qw_view *view, const struct qw_border *borders
     }
 
     wlr_scene_node_raise_to_top(tree_node);
+}
+
+void qw_view_do_place(struct qw_view *view, struct qw_view_place_args args) {
+    bool geom_changed = args.geom_dst->x != args.geom_src.x ||
+                        args.geom_dst->y != args.geom_src.y ||
+                        args.geom_dst->width != args.geom_src.width ||
+                        args.geom_dst->height != args.geom_src.height;
+
+    *args.geom_dst = args.geom_src;
+    view->x = args.x;
+    view->y = args.y;
+    view->width = args.width;
+    view->height = args.height;
+
+    wlr_scene_node_set_position(&view->content_tree->node, args.x, args.y);
+
+    bool needs_repos = args.place_changed || geom_changed;
+
+    if (needs_repos) {
+        args.reconfigure(view, args.x, args.y, args.width, args.height);
+        args.clip(view);
+        qw_view_update_ftl_outputs(view, args.surface);
+    }
+
+    qw_view_paint_borders(view, args.borders, args.border_count);
+
+    if (args.above != 0) {
+        qw_view_raise_to_top(view);
+    }
+
+    qw_cursor_update_pointer_focus(view->server->cursor);
 }
 
 // Foreign toplevel manager requests

--- a/libqtile/backend/wayland/qw/view.h
+++ b/libqtile/backend/wayland/qw/view.h
@@ -139,6 +139,19 @@ struct qw_view {
     struct wl_list ftl_outputs;
 };
 
+struct qw_view_place_args {
+    int x, y, width, height;
+    const struct qw_border *borders;
+    int border_count;
+    int above;
+    bool place_changed;
+    struct wlr_box *geom_dst;
+    struct wlr_box geom_src;
+    struct wlr_surface *surface;
+    void (*reconfigure)(void *self, int x, int y, int width, int height);
+    void (*clip)(void *self);
+};
+
 void qw_view_reparent(struct qw_view *view, int layer);
 void qw_view_move_up(struct qw_view *view);
 void qw_view_move_down(struct qw_view *view);
@@ -146,6 +159,11 @@ void qw_view_raise_to_top(struct qw_view *view);
 void qw_view_lower_to_bottom(struct qw_view *view);
 
 bool qw_view_is_visible(struct qw_view *view);
+void qw_view_unhide(void *self);
+
+void qw_view_disable_and_clear_focus(struct qw_view *view, struct wlr_surface *surface);
+
+void qw_view_do_place(struct qw_view *view, struct qw_view_place_args args);
 
 // Free all border rectangles and clear border data
 void qw_view_cleanup_borders(struct qw_view *xdg_view);

--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -30,7 +30,8 @@ static void qw_xdg_view_handle_decoration_destroy(struct wl_listener *listener, 
 }
 
 // Change xdg surface activate state
-static void qw_xdg_view_activate(struct qw_xdg_view *xdg_view, bool activate) {
+static void qw_xdg_view_activate(void *self, bool activate) {
+    struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_xdg_toplevel_set_activated(xdg_view->xdg_toplevel, activate);
     if (xdg_view->base.ftl_handle != NULL) {
         wlr_foreign_toplevel_handle_v1_set_activated(xdg_view->base.ftl_handle, activate);
@@ -84,17 +85,8 @@ static void qw_xdg_view_do_focus(struct qw_xdg_view *xdg_view, struct wlr_surfac
 // Hide the xdg_view (disable scene node and clear keyboard focus if needed)
 static void qw_xdg_view_hide(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
-    wlr_scene_node_set_enabled(&xdg_view->base.content_tree->node, false);
     qw_xdg_view_activate(xdg_view, false);
-
-    // Clear keyboard focus if this view was focused
-    if (xdg_view->xdg_toplevel->base->surface ==
-        xdg_view->base.server->seat->keyboard_state.focused_surface) {
-        wlr_seat_keyboard_clear_focus(xdg_view->base.server->seat);
-    }
-
-    // View under the cursor may have changed
-    qw_cursor_update_pointer_focus(xdg_view->base.server->cursor);
+    qw_view_disable_and_clear_focus(&xdg_view->base, xdg_view->xdg_toplevel->base->surface);
 }
 
 // Handle the unmap event for the xdg_view (when it's hidden/unmapped)
@@ -214,66 +206,44 @@ void dump_surface_outputs(void *self) {
     }
 }
 
+static void qw_xdg_view_reconfigure(void *self, int x, int y, int width, int height) {
+    UNUSED(x);
+    UNUSED(y);
+    struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
+    wlr_xdg_toplevel_set_size(xdg_view->xdg_toplevel, width, height);
+}
+
 // Place the xdg_view at given position and size with border and stacking info
 static void qw_xdg_view_place(void *self, int x, int y, int width, int height,
                               const struct qw_border *borders, int border_count, int above) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
-    struct wlr_xdg_surface *surface = xdg_view->xdg_toplevel->base;
     struct wlr_xdg_toplevel_state state = xdg_view->xdg_toplevel->current;
 
-    // Check if placement or geometry changed
     bool place_changed = xdg_view->base.x != x || xdg_view->base.y != y ||
                          xdg_view->base.width != width || xdg_view->base.height != height ||
                          state.width != width || state.height != height;
 
-    struct wlr_box geom = surface->geometry;
-    bool geom_changed = xdg_view->geom.x != geom.x || xdg_view->geom.y != geom.y ||
-                        xdg_view->geom.width != geom.width || xdg_view->geom.height != geom.height;
+    struct wlr_box geom = xdg_view->xdg_toplevel->base->geometry;
+    struct qw_view_place_args args = {.x = x,
+                                      .y = y,
+                                      .width = width,
+                                      .height = height,
+                                      .borders = borders,
+                                      .border_count = border_count,
+                                      .above = above,
+                                      .place_changed = place_changed,
+                                      .geom_dst = &xdg_view->geom,
+                                      .geom_src = geom,
+                                      .surface = xdg_view->xdg_toplevel->base->surface,
+                                      .reconfigure = qw_xdg_view_reconfigure,
+                                      .clip = (void (*)(void *))qw_xdg_view_clip};
 
-    bool needs_repos = place_changed || geom_changed;
-
-    // Update stored geometry and base view rectangle
-    xdg_view->geom = geom;
-    xdg_view->base.x = x;
-    xdg_view->base.y = y;
-    xdg_view->base.width = width;
-    xdg_view->base.height = height;
-
-    // Set position of the content scene node
-    wlr_scene_node_set_position(&xdg_view->base.content_tree->node, x, y);
-
-    if (needs_repos) {
-        // Resize the toplevel surface and apply clipping if needed
-        wlr_xdg_toplevel_set_size(xdg_view->xdg_toplevel, width, height);
-        qw_xdg_view_clip(xdg_view);
-
-        qw_view_update_ftl_outputs(&xdg_view->base, xdg_view->xdg_toplevel->base->surface);
-    }
-
-    // Paint borders around the view with given border colors and width
-    qw_view_paint_borders((struct qw_view *)xdg_view, borders, border_count);
-
-    // Raise view if requested
-    if (above != 0) {
-        qw_view_raise_to_top(&xdg_view->base);
-    }
-
-    // View under the cursor may have changed
-    qw_cursor_update_pointer_focus(xdg_view->base.server->cursor);
+    qw_view_do_place(&xdg_view->base, args);
 }
-
 // Send close event to the xdg_toplevel surface (kill the view)
 static void qw_xdg_view_kill(void *self) {
     struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
     wlr_xdg_toplevel_send_close(xdg_view->xdg_toplevel);
-}
-
-// Unhide the xdg_view by enabling its content_tree scene node if currently disabled
-static void qw_xdg_view_unhide(void *self) {
-    struct qw_xdg_view *xdg_view = (struct qw_xdg_view *)self;
-    if (!xdg_view->base.content_tree->node.enabled) {
-        wlr_scene_node_set_enabled(&xdg_view->base.content_tree->node, true);
-    }
 }
 
 // Focus the xdg_view if it is mapped (visible), calling internal focus helper
@@ -708,7 +678,7 @@ void qw_server_xdg_view_new(struct qw_server *server, struct wlr_xdg_toplevel *x
     xdg_view->base.get_parent = qw_xdg_view_get_parent;
     xdg_view->base.kill = qw_xdg_view_kill;
     xdg_view->base.hide = qw_xdg_view_hide;
-    xdg_view->base.unhide = qw_xdg_view_unhide;
+    xdg_view->base.unhide = qw_view_unhide;
     xdg_view->base.has_fixed_size = qw_xdg_view_has_fixed_size;
 
     // Add listeners for surface lifecycle events (map, unmap, commit)

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -15,7 +15,8 @@
 #include <xcb/xcb_icccm.h>
 
 // Change xwayland surface activate state
-static void qw_xwayland_view_activate(struct qw_xwayland_view *xwayland_view, bool activate) {
+static void qw_xwayland_view_activate(void *self, bool activate) {
+    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
     wlr_xwayland_surface_activate(xwayland_view->xwayland_surface, activate);
     if (xwayland_view->base.ftl_handle != NULL) {
         wlr_foreign_toplevel_handle_v1_set_activated(xwayland_view->base.ftl_handle, activate);
@@ -298,63 +299,45 @@ static void qw_xwayland_view_clip(struct qw_xwayland_view *xwayland_view) {
     wlr_scene_subsurface_tree_set_clip(&xwayland_view->scene_tree->node, &clip);
 }
 
+static void qw_xwayland_view_reconfigure(void *self, int x, int y, int width, int height) {
+    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
+    wlr_xwayland_surface_configure(xwayland_view->xwayland_surface, x, y, width, height);
+}
+
 // Place the xwayland_view at given position and size with border and stacking info
 static void qw_xwayland_view_place(void *self, int x, int y, int width, int height,
                                    const struct qw_border *borders, int border_count, int above) {
     struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
     struct wlr_xwayland_surface *qw_xsurface = xwayland_view->xwayland_surface;
 
-    // Check if placement or geometry changed
     bool place_changed = xwayland_view->base.x != x || xwayland_view->base.y != y ||
                          xwayland_view->base.width != width || xwayland_view->base.height != height;
 
-    // For XWayland, we need to check the surface geometry differently
     // clang-format off
     struct wlr_box geom = {
-        .x = qw_xsurface->x, 
-        .y = qw_xsurface->y, 
-        .width = qw_xsurface->width, 
+        .x = qw_xsurface->x,
+        .y = qw_xsurface->y,
+        .width = qw_xsurface->width,
         .height = qw_xsurface->height
     };
     // clang-format on
 
-    bool geom_changed = xwayland_view->geom.x != geom.x || xwayland_view->geom.y != geom.y ||
-                        xwayland_view->geom.width != geom.width ||
-                        xwayland_view->geom.height != geom.height;
+    struct qw_view_place_args args = {.x = x,
+                                      .y = y,
+                                      .width = width,
+                                      .height = height,
+                                      .borders = borders,
+                                      .border_count = border_count,
+                                      .above = above,
+                                      .place_changed = place_changed,
+                                      .geom_dst = &xwayland_view->geom,
+                                      .geom_src = geom,
+                                      .surface = qw_xsurface->surface,
+                                      .reconfigure = qw_xwayland_view_reconfigure,
+                                      .clip = (void (*)(void *))qw_xwayland_view_clip};
 
-    bool needs_repos = place_changed || geom_changed;
-
-    // Update stored geometry and base view rectangle
-    xwayland_view->geom = geom;
-    xwayland_view->base.x = x;
-    xwayland_view->base.y = y;
-    xwayland_view->base.width = width;
-    xwayland_view->base.height = height;
-
-    // Set position of the content scene node
-    wlr_scene_node_set_position(&xwayland_view->base.content_tree->node, x, y);
-
-    // TODO: don't force repo
-    if (needs_repos) {
-        // For XWayland, we configure the surface position and size
-        wlr_xwayland_surface_configure(qw_xsurface, x, y, width, height);
-        qw_xwayland_view_clip(xwayland_view);
-
-        qw_view_update_ftl_outputs(&xwayland_view->base, xwayland_view->xwayland_surface->surface);
-    }
-
-    // Paint borders around the view with given border colors and width
-    qw_view_paint_borders((struct qw_view *)xwayland_view, borders, border_count);
-
-    // Raise view if requested
-    if (above != 0) {
-        qw_view_raise_to_top(&xwayland_view->base);
-    }
-
-    // View under the cursor may have changed
-    qw_cursor_update_pointer_focus(xwayland_view->base.server->cursor);
+    qw_view_do_place(&xwayland_view->base, args);
 }
-
 // Send close event to the xwayland surface (kill the view)
 static void qw_xwayland_view_kill(void *self) {
     struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
@@ -364,25 +347,8 @@ static void qw_xwayland_view_kill(void *self) {
 // Hide the xwayland_view (disable scene node and clear keyboard focus if needed)
 static void qw_xwayland_view_hide(void *self) {
     struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
-    wlr_scene_node_set_enabled(&xwayland_view->base.content_tree->node, false);
     qw_xwayland_view_activate(xwayland_view, false);
-
-    // Clear keyboard focus if this view was focused
-    if (xwayland_view->xwayland_surface->surface ==
-        xwayland_view->base.server->seat->keyboard_state.focused_surface) {
-        wlr_seat_keyboard_clear_focus(xwayland_view->base.server->seat);
-    }
-
-    // View under the cursor may have changed
-    qw_cursor_update_pointer_focus(xwayland_view->base.server->cursor);
-}
-
-// Unhide the xwayland_view by enabling its content_tree scene node if currently disabled
-static void qw_xwayland_view_unhide(void *self) {
-    struct qw_xwayland_view *xwayland_view = (struct qw_xwayland_view *)self;
-    if (!xwayland_view->base.content_tree->node.enabled) {
-        wlr_scene_node_set_enabled(&xwayland_view->base.content_tree->node, true);
-    }
+    qw_view_disable_and_clear_focus(&xwayland_view->base, xwayland_view->xwayland_surface->surface);
 }
 
 // Retrieve the PID of the client owning this xwayland_view
@@ -950,7 +916,7 @@ void qw_server_xwayland_view_new(struct qw_server *server,
     xwayland_view->base.focus = qw_xwayland_view_focus;
     xwayland_view->base.kill = qw_xwayland_view_kill;
     xwayland_view->base.hide = qw_xwayland_view_hide;
-    xwayland_view->base.unhide = qw_xwayland_view_unhide;
+    xwayland_view->base.unhide = qw_view_unhide;
     xwayland_view->base.get_pid = qw_xwayland_view_get_pid;
     xwayland_view->base.get_wm_type = qw_xwayland_view_get_window_type;
     xwayland_view->base.get_parent = qw_xwayland_get_parent;


### PR DESCRIPTION
This PR refactors shared view lifecycle and placement routines between XDG Shell (`qw_xdg_view`) and XWayland (`qw_xwayland_view`) into generic `qw_view` functions. It removes ~100 lines of duplicated logic while standardizing surface state updates, geometry tracking, scene node translations, and pointer focus updates across backends.

### changes: 
* **Shared Unhide (`qw_view_unhide`)**: Consolidated identical 3-line scene node enable calls from XDG and XWayland view handlers into a single `qw_view_unhide` function in `view.c`.
* **Shared Hide (`qw_view_hide_generic`)**: Extracted common view hiding behavior—disabling content tree scene nodes, deactivating surfaces, clearing seat keyboard focus when active, and updating cursor focus—into a generic helper accepting a surface and backend-specific `activate` callback.
* **Unified Placement (`qw_view_do_place`)**: Unified surface geometry comparison, base view coordinate assignments, scene node positioning, conditional surface reconfiguration/clipping, border painting, window raising, and pointer focus tracking via a new `struct qw_view_place_args`.