### PR TITLE
wayland: add system bell support

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -349,6 +349,7 @@ extern "Python" bool remove_idle_inhibitor_cb(void *userdata, void *inhibitor);
 extern "Python" bool check_inhibited_cb(void *userdata);
 extern "Python" struct qw_qtile_config *get_qtile_config_cb(void *userdata);
 extern "Python" void idle_state_change_cb(void *userdata, int seconds, bool is_idle);
+extern "Python" void on_system_bell_cb(void *userdata, void *view);
 
 extern "Python" int request_focus_cb(void *userdata);
 extern "Python" int request_close_cb(void *userdata);

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -134,6 +134,11 @@ PROTOS: list[Protocol] = [
     Protocol(
         f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
     ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/xdg-system-bell/xdg-system-bell-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -191,6 +196,16 @@ TEST_CLIENTS: list[TestClient] = [
             TEST_CLIENT_SRC_PATH / "layer-shell.c",
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "wlr-layer-shell-unstable-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="system-bell",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "system-bell.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "xdg-system-bell-v1-protocol.c",
             QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
@@ -349,6 +364,7 @@ extern "Python" bool remove_idle_inhibitor_cb(void *userdata, void *inhibitor);
 extern "Python" bool check_inhibited_cb(void *userdata);
 extern "Python" struct qw_qtile_config *get_qtile_config_cb(void *userdata);
 extern "Python" void idle_state_change_cb(void *userdata, int seconds, bool is_idle);
+extern "Python" void on_system_bell_cb(void *userdata, void *view);
 
 extern "Python" int request_focus_cb(void *userdata);
 extern "Python" int request_close_cb(void *userdata);

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -228,6 +228,17 @@ def idle_state_change_cb(userdata: ffi.CData, seconds: int, is_idle: bool) -> No
     core.handle_idle_state_change(seconds, is_idle)
 
 
+@ffi.def_extern()
+def on_system_bell_cb(userdata: ffi.CData, view: ffi.CData) -> None:
+    core = ffi.from_handle(userdata)
+    if view != ffi.NULL:
+        window = ffi.from_handle(view)
+        wid = window.wid
+    else:
+        wid = -1
+    core.handle_system_bell(wid)
+
+
 def get_wlr_log_level() -> int:
     if logger.level <= logging.DEBUG:
         return lib.WLR_DEBUG
@@ -280,6 +291,7 @@ class Core(base.Core):
         self.qw.check_inhibited_cb = lib.check_inhibited_cb
         self.qw.get_qtile_config_cb = lib.get_qtile_config_cb
         self.qw.idle_state_change_cb = lib.idle_state_change_cb
+        self.qw.on_system_bell_cb = lib.on_system_bell_cb
         lib.qw_server_start(self.qw)
         os.environ["WAYLAND_DISPLAY"] = self.display_name
         self.qw_cursor = lib.qw_server_get_cursor(self.qw)
@@ -955,6 +967,10 @@ class Core(base.Core):
     def test_destroy_output(self, index: int) -> None:
         """Destroy the nth output at runtime. Only available in an active test."""
         lib.qw_server_test_destroy_output(self.qw, index)
+
+    def handle_system_bell(self, wid: int) -> None:
+        window = self.qtile.windows_map.get(wid, None)
+        hook.fire("system_bell", window)
 
 
 class Painter:

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -228,6 +228,17 @@ def idle_state_change_cb(userdata: ffi.CData, seconds: int, is_idle: bool) -> No
     core.handle_idle_state_change(seconds, is_idle)
 
 
+@ffi.def_extern()
+def on_system_bell_cb(userdata: ffi.CData, view: ffi.CData) -> None:
+    core = ffi.from_handle(userdata)
+    if view != ffi.NULL:
+        window = ffi.from_handle(view)
+        wid = window.wid
+    else:
+        wid = -1
+    core.handle_system_bell(wid)
+
+
 def get_wlr_log_level() -> int:
     if logger.level <= logging.DEBUG:
         return lib.WLR_DEBUG
@@ -280,6 +291,7 @@ class Core(base.Core):
         self.qw.check_inhibited_cb = lib.check_inhibited_cb
         self.qw.get_qtile_config_cb = lib.get_qtile_config_cb
         self.qw.idle_state_change_cb = lib.idle_state_change_cb
+        self.qw.on_system_bell_cb = lib.on_system_bell_cb
         lib.qw_server_start(self.qw)
         os.environ["WAYLAND_DISPLAY"] = self.display_name
         self.qw_cursor = lib.qw_server_get_cursor(self.qw)
@@ -951,6 +963,10 @@ class Core(base.Core):
     def test_destroy_output(self, index: int) -> None:
         """Destroy the nth output at runtime. Only available in an active test."""
         lib.qw_server_test_destroy_output(self.qw, index)
+
+    def handle_system_bell(self, wid: int) -> None:
+        window = self.qtile.windows_map.get(wid, None)
+        hook.fire("system_bell", window)
 
 
 class Painter:

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -13,6 +13,7 @@
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
+#include <wlr/types/wlr_xdg_system_bell_v1.h>
 
 #include "cursor.h"
 #include "input-device.h"
@@ -84,6 +85,7 @@ void qw_server_finalize(struct qw_server *server) {
     wl_list_remove(&server->new_pointer_constraint.link);
     wl_list_remove(&server->new_idle_inhibitor.link);
     wl_list_remove(&server->set_output_power_mode.link);
+    wl_list_remove(&server->system_bell_ring.link);
 #if WLR_HAS_XWAYLAND
     wl_list_remove(&server->new_xwayland_surface.link);
     wl_list_remove(&server->xwayland_ready.link);
@@ -747,6 +749,26 @@ static void qw_server_handle_output_power_set_mode(struct wl_listener *listener,
     }
 }
 
+static void qw_server_handle_system_bell_ring(struct wl_listener *listener, void *data) {
+    struct qw_server *server = wl_container_of(listener, server, system_bell_ring);
+    struct wlr_xdg_system_bell_v1_ring_event *event = data;
+
+    struct qw_view *view;
+    void *view_data = NULL;
+
+    if (event->surface != NULL) {
+        bool is_layer_surface, is_session_lock_surface;
+        view =
+            qw_view_from_wlr_surface(event->surface, &is_layer_surface, &is_session_lock_surface);
+
+        if (view != NULL) {
+            view_data = view->cb_data;
+        }
+    }
+
+    server->on_system_bell_cb(server->cb_data, view_data);
+}
+
 // Create and initialize the server object with all components and listeners.
 struct qw_server *qw_server_create() {
     struct qw_server *server = calloc(1, sizeof(*server));
@@ -880,6 +902,11 @@ struct qw_server *qw_server_create() {
 
     // Initialize idle timers list
     wl_list_init(&server->idle_timers);
+
+    // System bell
+    server->system_bell = wlr_xdg_system_bell_v1_create(server->display, 1); // Revision 1
+    server->system_bell_ring.notify = qw_server_handle_system_bell_ring;
+    wl_signal_add(&server->system_bell->events.ring, &server->system_bell_ring);
 
 #if WLR_HAS_XWAYLAND
     server->xwayland = wlr_xwayland_create(server->display, server->compositor, true);

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -157,6 +157,8 @@ typedef struct qw_qtile_config *(*get_qtile_config_cb_t)(void *userdata);
 // Callback for idle state change
 typedef void (*idle_state_change_cb_t)(void *userdata, int seconds, bool is_idle);
 
+typedef void (*on_system_bell_cb_t)(void *userdata, void *view);
+
 enum {
     LAYER_BACKGROUND,   // background, layer shell
     LAYER_BOTTOM,       // bottom, layer shell
@@ -219,6 +221,7 @@ struct qw_server {
     check_inhibited_cb_t check_inhibited_cb;
     get_qtile_config_cb_t get_qtile_config_cb;
     idle_state_change_cb_t idle_state_change_cb;
+    on_system_bell_cb_t on_system_bell_cb;
     void *view_activation_cb_data;
     void *cb_data;
     struct qw_layer_view *exclusive_layer;
@@ -279,6 +282,8 @@ struct qw_server {
     struct wlr_output_power_manager_v1 *output_power_manager;
     struct wl_listener set_output_power_mode;
     struct wl_list idle_timers; // list of qw_idle_timer
+    struct wlr_xdg_system_bell_v1 *system_bell;
+    struct wl_listener system_bell_ring;
 #if WLR_HAS_XWAYLAND
     struct wlr_xwayland *xwayland;
     struct wl_listener xwayland_ready;

--- a/libqtile/hook.py
+++ b/libqtile/hook.py
@@ -1120,6 +1120,25 @@ hooks: list[Hook] = [
 
         """,
     ),
+    Hook(
+        "system_bell",
+        """
+        Called when the system bell is rung. Wayland only..
+
+        **Arguments**
+
+            ``window`` (Window | None):  Window ringing the bell
+
+        .. code::
+
+          from libqtile import hook
+
+          @hook.subscribe.system_bell
+          def on_system_bell(window):
+              window.urgent = True
+
+        """,
+    ),
 ]
 
 

--- a/test/backend/wayland/test_system_bell.py
+++ b/test/backend/wayland/test_system_bell.py
@@ -1,0 +1,50 @@
+import pytest
+
+from libqtile import hook, widget
+from libqtile.bar import Bar
+from libqtile.config import Screen
+from libqtile.confreader import Config
+from test.helpers import Retry
+
+
+class SystemBellConfig(Config):
+    bell_widget = widget.TextBox("", name="bell")
+
+    def update_widget(window):  # noqa: N805
+        if window is None:
+            SystemBellConfig.bell_widget.update("No window")
+        else:
+            SystemBellConfig.bell_widget.update(f"{window.wid}")
+
+    screens = [Screen(top=Bar([bell_widget], 20))]
+
+    hook.subscribe.system_bell(update_widget)
+
+
+pytestmark = [
+    pytest.mark.parametrize("test_client", ["system-bell"], indirect=True),
+    pytest.mark.parametrize("wmanager", [SystemBellConfig], indirect=True),
+]
+
+
+def test_system_bell_no_surface(wmanager, test_client):
+    """If system bell is rung with no surface attached, the hook will receive None."""
+    test_client.assert_ok("ring")
+    assert wmanager.c.widget["bell"].info()["text"] == "No window"
+
+
+def test_system_bell_with_window(wmanager, test_client):
+    """If system bell is rung with no surface attached, the hook will receive the relevant window."""
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_window():
+        assert len(wmanager.c.windows()) == 1
+
+    # Create a client window and get its ID
+    test_client.assert_ok("show")
+    wait_for_window()
+    wid = wmanager.c.windows()[0]["id"]
+
+    # Ring the bell and check that the widget receives the correct window
+    test_client.assert_ok("ring")
+    assert wmanager.c.widget["bell"].info()["text"] == f"{wid}"

--- a/test/wayland_clients/src/system-bell.c
+++ b/test/wayland_clients/src/system-bell.c
@@ -1,0 +1,119 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+#include "xdg-shell-client-protocol.h"
+#include "xdg-system-bell-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+
+    struct xdg_system_bell_v1 *system_bell;
+
+    struct xdg_wm_base *xdg_wm_base;
+    struct wl_surface *surface;
+    struct xdg_surface *xdg_surface;
+    struct xdg_toplevel *toplevel;
+    struct buffer *buffer;
+};
+
+static void xdg_surface_configure(void *data, struct xdg_surface *surf, uint32_t serial) {
+    struct test_state *state = data;
+    xdg_surface_ack_configure(surf, serial);
+    wl_surface_commit(state->surface);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, xdg_system_bell_v1_interface.name) == 0) {
+        uint32_t bind_version = (version < 1) ? version : 1;
+        state->system_bell =
+            wl_registry_bind(registry, name, &xdg_system_bell_v1_interface, bind_version);
+    } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        state->xdg_wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        // xdg_wm_base_add_listener(state->xdg_wm_base, &xdg_wm_listener, state);
+    }
+}
+
+static void cmd_ring(struct test_state *state) {
+    xdg_system_bell_v1_ring(state->system_bell, state->surface);
+    test_ok();
+}
+
+static void cmd_create_window(struct test_state *state) {
+    state->surface = wl_compositor_create_surface(state->base.compositor);
+
+    state->xdg_surface = xdg_wm_base_get_xdg_surface(state->xdg_wm_base, state->surface);
+    state->toplevel = xdg_surface_get_toplevel(state->xdg_surface);
+
+    xdg_surface_add_listener(state->xdg_surface, &xdg_surface_listener, state);
+
+    xdg_toplevel_set_min_size(state->toplevel, 300, 300);
+    xdg_toplevel_set_max_size(state->toplevel, 300, 300);
+
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    state->buffer = create_buffer(&state->base, 300, 300, 0xFF606060);
+
+    wl_surface_attach(state->surface, state->buffer->wl_buffer, 0, 0);
+    wl_surface_damage_buffer(state->surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    test_ok();
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "ring") == 0) {
+        cmd_ring(state);
+    } else if (strcmp(cmd, "show") == 0) {
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+    if (state->system_bell != NULL) {
+        xdg_system_bell_v1_destroy(state->system_bell);
+    }
+    if (state->buffer) {
+        wl_buffer_destroy(state->buffer->wl_buffer);
+        free(state->buffer);
+    }
+    if (state->toplevel) {
+        xdg_toplevel_destroy(state->toplevel);
+    }
+    if (state->xdg_surface) {
+        xdg_surface_destroy(state->xdg_surface);
+    }
+    if (state->surface) {
+        wl_surface_destroy(state->surface);
+    }
+    if (state->xdg_wm_base) {
+        xdg_wm_base_destroy(state->xdg_wm_base);
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}


### PR DESCRIPTION
Wayland clients ringing the system bell will trigger the `system_bell` hook which passes the window of the relevant client.