### PR TITLE
[wayland] check modifiers on all keyboard devices

### DIFF
--- a/libqtile/backend/wayland/qw/input-device.c
+++ b/libqtile/backend/wayland/qw/input-device.c
@@ -68,8 +68,14 @@ struct libinput_device *qw_input_device_get_libinput_handle(struct qw_input_devi
 }
 
 struct qw_keyboard *qw_input_device_get_keyboard(struct qw_input_device *input_device) {
-    struct qw_keyboard *keyboard = (struct qw_keyboard *)(input_device->device->data);
-    return keyboard;
+    struct qw_server *server = input_device->server;
+    struct qw_keyboard *kbd;
+    wl_list_for_each(kbd, &server->keyboards, link) {
+        if (kbd->wlr_keyboard == wlr_keyboard_from_input_device(input_device->device)) {
+            return kbd;
+        }
+    }
+    return NULL;
 }
 
 bool qw_input_device_is_touchpad(struct qw_input_device *input_device) {

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -82,7 +82,12 @@ static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
 
     bool handled = false;
     // Get current keyboard modifiers (shift, ctrl, alt, etc.)
-    uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->wlr_keyboard);
+    // check all keyboard devices in certain keys are represented as a separate device
+    uint32_t modifiers = 0;
+    struct qw_keyboard *kbd;
+    wl_list_for_each(kbd, &server->keyboards, link) {
+        modifiers |= wlr_keyboard_get_modifiers(kbd->wlr_keyboard);
+    }
 
     // If key is pressed...
     if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -3,148 +3,78 @@
 #include "util.h"
 #include <stdlib.h>
 #include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
-// Called when the keyboard device is destroyed
-static void qw_keyboard_handle_destroy(struct wl_listener *listener, void *data) {
-    UNUSED(data);
-
-    struct qw_keyboard *keyboard = wl_container_of(listener, keyboard, destroy);
-
-    wl_list_remove(&keyboard->modifiers.link);
-    wl_list_remove(&keyboard->key.link);
-    wl_list_remove(&keyboard->destroy.link);
-    wl_list_remove(&keyboard->link);
-
-    // There appears to be a delay between when a keyboard is destroyed and when
-    // wlroots updates the seat's active keyboard. It is possible to miss a focus
-    // event during this delay (issue #5927)
-    // We can work around this by updating the active keyboard here
-    if (keyboard->wlr_keyboard == wlr_seat_get_keyboard(keyboard->server->seat)) {
-        struct qw_keyboard *new_keyboard = NULL;
-        wl_list_for_each(new_keyboard, &keyboard->server->keyboards, link) {
-            wlr_seat_set_keyboard(keyboard->server->seat, new_keyboard->wlr_keyboard);
-            break;
-        }
-        if (new_keyboard == NULL) {
-            wlr_log(WLR_DEBUG, "No keyboards remaining, seat has no active keyboard");
-            wlr_seat_set_keyboard(keyboard->server->seat, NULL);
-        }
-    }
-
-    free(keyboard);
-}
-
-// Called via a timer when key is held
-static int qw_keyboard_do_repeat(void *data) {
-    struct qw_keyboard *keyboard = data;
-    struct qw_server *server = keyboard->server;
-
-    // If key has been released, do nothing.
-    if (!keyboard->key_pressed) {
-        return 0;
-    }
-
-    // Repeat handled key: send callback
-    uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->wlr_keyboard);
-    server->keyboard_key_cb(keyboard->repeat_keysym, modifiers, server->cb_data);
-
-    // Schedule next repeat according to repeat rate
-    struct wlr_keyboard *wlr_kbd = keyboard->wlr_keyboard;
-    int rate = wlr_kbd->repeat_info.rate;
-    if (rate > 0 && keyboard->repeat_source) {
-        int next = 1000 / rate;
-        wl_event_source_timer_update(keyboard->repeat_source, next);
-    }
-
-    return 0;
-}
-
-// Called on each key event (press/release)
-static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
-    struct qw_keyboard *keyboard = wl_container_of(listener, keyboard, key);
-    struct qw_server *server = keyboard->server;
+void qw_keyboard_group_handle_key(struct wl_listener *listener, void *data) {
+    struct qw_server *server = wl_container_of(listener, server, keyboard_group_key);
     struct wlr_keyboard_key_event *event = data;
+    struct wlr_keyboard *wlr_keyboard = &server->keyboard_group->keyboard;
     struct wlr_seat *seat = server->seat;
 
     qw_server_idle_notify_activity(server);
 
-    // keycode offset by 8 as per evdev conventions
     uint32_t keycode = event->keycode + 8;
+    int layout_index = xkb_state_key_get_layout(wlr_keyboard->xkb_state, keycode);
 
-    int layout_index = xkb_state_key_get_layout(keyboard->wlr_keyboard->xkb_state, keycode);
-
-    // Get the symbols for this key in the current layout and level 0
     const xkb_keysym_t *syms;
-    int nsyms = xkb_keymap_key_get_syms_by_level(keyboard->wlr_keyboard->keymap, keycode,
-                                                 layout_index, 0, &syms);
+    int nsyms =
+        xkb_keymap_key_get_syms_by_level(wlr_keyboard->keymap, keycode, layout_index, 0, &syms);
+
+    uint32_t modifiers = wlr_keyboard_get_modifiers(wlr_keyboard);
+
+    wlr_log(WLR_ERROR, "[DEBUG] KEY EVENT: keycode=%u, state=%s, nsyms=%d, mods=0x%x",
+            event->keycode, event->state == WL_KEYBOARD_KEY_STATE_PRESSED ? "PRESSED" : "RELEASED",
+            nsyms, modifiers);
 
     bool handled = false;
-    // Get current keyboard modifiers (shift, ctrl, alt, etc.)
-    uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->wlr_keyboard);
 
-    // If key is pressed...
     if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-        // Track key for repeat
-        keyboard->key_pressed = true;
-
-        // Don't handle presses if an exclusive layer has focus
-        if (server->exclusive_layer == NULL) {
-            // Call user callback for each symbol to check if handled
+        if (server->exclusive_layer == NULL && server->keyboard_key_cb != NULL) {
             for (int i = 0; i < nsyms; ++i) {
-                // TODO: for efficiency maybe let c take control of the key list?
-                // If callback returns 1, event is handled; no further processing needed
                 if (server->keyboard_key_cb(syms[i], modifiers, server->cb_data) == 1) {
                     handled = true;
-                    keyboard->repeat_keysym = syms[i];
                     break;
                 }
             }
         }
 
-        if (handled) {
-            // Set up timer to repeat key press
-            if (keyboard->repeat_source == NULL) {
-                keyboard->repeat_source =
-                    wl_event_loop_add_timer(server->event_loop, qw_keyboard_do_repeat, keyboard);
-            }
-
-            // Schedule the repeat timer
-            if (keyboard->repeat_source != NULL) {
-                struct wlr_keyboard *wlr_kbd = keyboard->wlr_keyboard;
-                int delay = wlr_kbd->repeat_info.delay;
-                if (delay <= 0)
-                    delay = 600;
-                wl_event_source_timer_update(keyboard->repeat_source, delay);
-            }
-        } else {
-            // If not handled, forward the key event to the seat for default processing
-            wlr_seat_set_keyboard(seat, keyboard->wlr_keyboard);
+        if (!handled) {
+            wlr_seat_set_keyboard(seat, wlr_keyboard);
             wlr_seat_keyboard_notify_key(seat, event->time_msec, event->keycode, event->state);
         }
-
-        // Remove the timer if key is released
     } else if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-        keyboard->key_pressed = false;
-        if (keyboard->repeat_source != NULL) {
-            wl_event_source_remove(keyboard->repeat_source);
-            keyboard->repeat_source = NULL;
-        }
-
         // Forward release to seat (handled or not — release must always be sent)
-        wlr_seat_set_keyboard(seat, keyboard->wlr_keyboard);
+        wlr_seat_set_keyboard(seat, wlr_keyboard);
         wlr_seat_keyboard_notify_key(seat, event->time_msec, event->keycode, event->state);
     }
 }
 
 // Called when keyboard modifiers change (shift, ctrl, etc.)
-static void keyboard_handle_modifiers(struct wl_listener *listener, void *data) {
+void qw_keyboard_group_handle_modifiers(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_server *server = wl_container_of(listener, server, keyboard_group_modifiers);
+    struct wlr_keyboard *wlr_keyboard = &server->keyboard_group->keyboard;
+
+    wlr_seat_set_keyboard(server->seat, wlr_keyboard);
+    wlr_seat_keyboard_notify_modifiers(server->seat, &wlr_keyboard->modifiers);
+}
+
+static void qw_keyboard_handle_destroy(struct wl_listener *listener, void *data) {
     UNUSED(data);
 
-    struct qw_keyboard *keyboard = wl_container_of(listener, keyboard, modifiers);
-    wlr_seat_set_keyboard(keyboard->server->seat, keyboard->wlr_keyboard);
-    wlr_seat_keyboard_notify_modifiers(keyboard->server->seat, &keyboard->wlr_keyboard->modifiers);
+    struct qw_keyboard *keyboard = wl_container_of(listener, keyboard, destroy);
+
+    if (keyboard->server->keyboard_group != NULL) {
+        wlr_keyboard_group_remove_keyboard(keyboard->server->keyboard_group,
+                                           keyboard->wlr_keyboard);
+    }
+
+    wl_list_remove(&keyboard->destroy.link);
+    wl_list_remove(&keyboard->link);
+
+    free(keyboard);
 }
 
 void qw_keyboard_set_keymap(struct qw_keyboard *keyboard, const char *layout, const char *options,
@@ -179,32 +109,28 @@ void qw_server_keyboard_new(struct qw_server *server, struct wlr_input_device *d
     keyboard->server = server;
     keyboard->wlr_keyboard = wlr_keyboard;
 
-    // Give keyboard input devices a reference to qw_keyboard
-    device->data = keyboard;
+    // Match the device keymap to the group keymap before adding it.
+    // If the group already has a keymap, apply it to the physical keyboard.
+    if (server->keyboard_group->keyboard.keymap != NULL) {
+        wlr_keyboard_set_keymap(wlr_keyboard, server->keyboard_group->keyboard.keymap);
+    } else {
+        // Fallback: compile a default keymap if group doesn't have one yet
+        struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+        struct xkb_keymap *keymap =
+            xkb_keymap_new_from_names(context, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+        wlr_keyboard_set_keymap(wlr_keyboard, keymap);
+        xkb_keymap_unref(keymap);
+        xkb_context_unref(context);
+    }
 
-    // Create new xkb context and default keymap
-    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    struct xkb_keymap *keymap =
-        xkb_keymap_new_from_names(context, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
-
-    // Assign the keymap to the keyboard and clean up refs
-    wlr_keyboard_set_keymap(wlr_keyboard, keymap);
-    xkb_keymap_unref(keymap);
-    xkb_context_unref(context);
-
-    wlr_keyboard_set_repeat_info(wlr_keyboard, 25, 600);
-
-    // Setup event listeners for modifiers, key events, and destruction
-    keyboard->modifiers.notify = keyboard_handle_modifiers;
-    wl_signal_add(&wlr_keyboard->events.modifiers, &keyboard->modifiers);
-
-    keyboard->key.notify = qw_keyboard_handle_key;
-    wl_signal_add(&wlr_keyboard->events.key, &keyboard->key);
+    if (!wlr_keyboard_group_add_keyboard(server->keyboard_group, wlr_keyboard)) {
+        wlr_log(WLR_ERROR, "Failed to add keyboard to keyboard group");
+        free(keyboard);
+        return;
+    }
 
     keyboard->destroy.notify = qw_keyboard_handle_destroy;
     wl_signal_add(&device->events.destroy, &keyboard->destroy);
-
-    wlr_seat_set_keyboard(server->seat, keyboard->wlr_keyboard);
 
     wl_list_insert(&server->keyboards, &keyboard->link);
 }

--- a/libqtile/backend/wayland/qw/keyboard.h
+++ b/libqtile/backend/wayland/qw/keyboard.h
@@ -12,15 +12,12 @@ struct qw_keyboard {
     struct qw_server *server;
     struct wlr_keyboard *wlr_keyboard;
 
-    struct wl_listener modifiers;
-    struct wl_listener key;
     struct wl_listener destroy;
-
-    // tracking for key repeats
-    bool key_pressed;
-    struct wl_event_source *repeat_source;
-    xkb_keysym_t repeat_keysym;
 };
+
+// Event handlers for keyboard group
+void qw_keyboard_group_handle_modifiers(struct wl_listener *listener, void *data);
+void qw_keyboard_group_handle_key(struct wl_listener *listener, void *data);
 
 // Creates and sets up a new keyboard on the server from the input device
 void qw_server_keyboard_new(struct qw_server *server, struct wlr_input_device *device);

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -84,11 +84,14 @@ void qw_server_finalize(struct qw_server *server) {
     wl_list_remove(&server->new_pointer_constraint.link);
     wl_list_remove(&server->new_idle_inhibitor.link);
     wl_list_remove(&server->set_output_power_mode.link);
+    wl_list_remove(&server->keyboard_group_key.link);
+    wl_list_remove(&server->keyboard_group_modifiers.link);
 #if WLR_HAS_XWAYLAND
     wl_list_remove(&server->new_xwayland_surface.link);
     wl_list_remove(&server->xwayland_ready.link);
     wlr_xwayland_destroy(server->xwayland);
 #endif
+    wlr_keyboard_group_destroy(server->keyboard_group);
     wl_display_destroy_clients(server->display);
     wlr_scene_node_destroy(&server->scene->tree.node);
     qw_cursor_destroy(server->cursor);
@@ -573,10 +576,33 @@ static void qw_handle_activation_request(struct wl_listener *listener, void *dat
 
 void qw_server_set_keymap(struct qw_server *server, const char *layout, const char *options,
                           const char *variant) {
-    struct qw_keyboard *keyboard;
-    wl_list_for_each(keyboard, &server->keyboards, link) {
-        qw_keyboard_set_keymap(keyboard, layout, options, variant);
+    if (!server->keyboard_group) {
+        return;
     }
+
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!context) {
+        wlr_log(WLR_ERROR, "Failed to create XKB context");
+        return;
+    }
+
+    struct xkb_rule_names names = {
+        .layout = layout ? layout : "",
+        .options = options ? options : "",
+        .variant = variant ? variant : "",
+    };
+
+    struct xkb_keymap *keymap =
+        xkb_keymap_new_from_names(context, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    if (keymap) {
+        wlr_keyboard_set_keymap(&server->keyboard_group->keyboard, keymap);
+        xkb_keymap_unref(keymap);
+    } else {
+        wlr_log(WLR_ERROR, "Failed to compile XKB keymap for group");
+    }
+
+    xkb_context_unref(context);
 }
 
 static void qw_server_handle_request_set_selection(struct wl_listener *listener, void *data) {
@@ -817,6 +843,30 @@ struct qw_server *qw_server_create() {
         // already logged in the create if failed
         return NULL;
     }
+
+    // Set up keyboard group
+    server->keyboard_group = wlr_keyboard_group_create();
+
+    server->keyboard_group_key.notify = qw_keyboard_group_handle_key;
+    wl_signal_add(&server->keyboard_group->keyboard.events.key, &server->keyboard_group_key);
+
+    server->keyboard_group_modifiers.notify = qw_keyboard_group_handle_modifiers;
+    wl_signal_add(&server->keyboard_group->keyboard.events.modifiers,
+                  &server->keyboard_group_modifiers);
+
+    // Default keymap for group keyboard
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap =
+        xkb_keymap_new_from_names(context, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    wlr_keyboard_set_keymap(&server->keyboard_group->keyboard, keymap);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+
+    // Set default repeat info
+    wlr_keyboard_set_repeat_info(&server->keyboard_group->keyboard, 25, 600);
+
+    // Assign the group keyboard to the seat
+    wlr_seat_set_keyboard(server->seat, &server->keyboard_group->keyboard);
 
     server->drag_icon = wlr_scene_tree_create(server->scene_windows_layers[LAYER_DRAG_ICON]);
     server->request_start_drag.notify = qw_server_handle_request_start_drag;

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -27,6 +27,7 @@
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -279,6 +280,9 @@ struct qw_server {
     struct wlr_output_power_manager_v1 *output_power_manager;
     struct wl_listener set_output_power_mode;
     struct wl_list idle_timers; // list of qw_idle_timer
+    struct wlr_keyboard_group *keyboard_group;
+    struct wl_listener keyboard_group_key;
+    struct wl_listener keyboard_group_modifiers;
 #if WLR_HAS_XWAYLAND
     struct wlr_xwayland *xwayland;
     struct wl_listener xwayland_ready;


### PR DESCRIPTION
Certain keyboards may represent keys (e.g. media keys) as separate logical devices. Currently, qtile only checks for modifiers on the same keyboard device and so may fail to detect a modifier when it's on a different logical device.

This PR checks for any modifiers on all registered keyboard devices.

Fixes #5977