### PR TITLE
[wayland] Tidy up on output destroy

### DIFF
--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -35,6 +35,15 @@ static void qw_output_handle_destroy(struct wl_listener *listener, void *data) {
     wl_list_remove(&output->destroy.link);
     wl_list_remove(&output->link);
 
+    /* Clean up non-scene dynamic memory if present */
+    if (output->background.type == QW_BACKGROUND_WALLPAPER && output->background.wallpaper) {
+        if (output->background.wallpaper->surface) {
+            cairo_surface_destroy(output->background.wallpaper->surface);
+        }
+        free(output->background.wallpaper);
+        output->background.wallpaper = NULL;
+    }
+
     /*
     null out the output pointer on all layer views that belong to this output
     before freeing it. Layer surfaces may be unmapped after output removal (e.g.
@@ -45,6 +54,12 @@ static void qw_output_handle_destroy(struct wl_listener *listener, void *data) {
         struct qw_layer_view *layer_view;
         wl_list_for_each(layer_view, &output->layers[i], link) { layer_view->output = NULL; }
     }
+
+    /* wlroots automatically destroys wlr_scene_output and attached scene nodes
+     * when wlr_output is destroyed. Simply clear the pointer. */
+    output->scene = NULL;
+    output->fullscreen_background = NULL;
+
     free(output);
 }
 

--- a/libqtile/backend/wayland/qw/session-lock.c
+++ b/libqtile/backend/wayland/qw/session-lock.c
@@ -63,16 +63,22 @@ void qw_session_lock_output_create_blanking_rects(struct qw_output *output) {
 // blanking rect attached to that output.
 // Ensures lock surfaces always cover the full output geometry.
 void qw_session_lock_output_change(struct qw_output *output) {
+    if (output == NULL) {
+        return;
+    }
     int x, y, w, h;
     x = output->full_area.x;
     y = output->full_area.y;
     w = output->full_area.width;
     h = output->full_area.height;
 
-    if (output->lock_surface != NULL) {
+    /* Safely check that the lock_surface and its underlying scene tree exist */
+    if (output->lock_surface && output->lock_surface->surface) {
         struct wlr_scene_tree *scene_tree = output->lock_surface->surface->data;
-        wlr_scene_node_set_position(&scene_tree->node, x, y);
-        wlr_session_lock_surface_v1_configure(output->lock_surface, w, h);
+        if (scene_tree != NULL) {
+            wlr_scene_node_set_position(&scene_tree->node, x, y);
+            wlr_session_lock_surface_v1_configure(output->lock_surface, w, h);
+        }
     }
 
     if (output->blanking_rect != NULL) {


### PR DESCRIPTION
Destroys any wallpaper surface and sets scene and fullscreen background pointers to NULL.