### PR TITLE
wayland: Fix cursor configure use after free

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -305,13 +305,17 @@ class Core(base.Core):
     # Callback to fetch qtile config parameters from wayc
     # Add additional parameters as needed (server.h: struct qw_qtile_config)
     def get_config(self) -> ffi.CData:
-        config = ffi.new("struct qw_qtile_config *")
         theme = self.qtile.config.wl_xcursor_theme
-        config.wl_xcursor_theme = (
-            ffi.new("char[]", theme.encode()) if theme is not None else ffi.NULL
+        theme_buf = ffi.new("char[]", theme.encode()) if theme is not None else ffi.NULL
+        config = ffi.new(
+            "struct qw_qtile_config *",
+            {
+                "wl_xcursor_theme": theme_buf,
+                "wl_xcursor_size": self.qtile.config.wl_xcursor_size,
+            },
         )
-        config.wl_xcursor_size = self.qtile.config.wl_xcursor_size
-        self._config = config  # Reference to keep config alive
+        # References to keep alive for c caller
+        self._config_keepalive = [theme_buf, config]
         return config
 
     def on_config_load(self, initial: bool) -> None:


### PR DESCRIPTION
As well as holding a reference to config, we also need to hold one to
the config string: wl_xcursor_theme, to keep it alive

Picked this up with asan testing

asan error:
```
=================================================================
==3511==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c243a22d2f0 at pc 0x7fb43c12501d bp 0x7ffd6f4aae90 sp 0x7ffd6f4aa638
READ of size 18 at 0x7c243a22d2f0 thread T0
    #0 0x7fb43c12501c in strdup (/usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../lib/libasan.so+0x12501c) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7bb43050e82c in wlr_xcursor_manager_create (/usr/lib/libwlroots-0.20.so+0xb782c) (BuildId: 5d79c389f2b9aa0fc253c289695a92dbd7f9d1fc)
    #2 0x7bb4305fbec4 in qw_cursor_configure_xcursor libqtile/backend/wayland/qw/cursor.c:657
    #3 0x7bb4305da823 in _cffi_f_qw_cursor_configure_xcursor libqtile/backend/wayland/_ffi.c:1948
    #4 0x7fb43b85dacd  (/usr/lib/libpython3.14.so.1.0+0x5dacd) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #5 0x7fb43ba16d3f  (/usr/lib/libpython3.14.so.1.0+0x216d3f) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #6 0x7bb43a0092c1  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x72c1) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #7 0x7bb43a009fc5  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x7fc5) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #8 0x7fb43b9a48c8 in _PyObject_MakeTpCall (/usr/lib/libpython3.14.so.1.0+0x1a48c8) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #9 0x7fb43b8e0a94  (/usr/lib/libpython3.14.so.1.0+0xe0a94) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #10 0x7fb43b8650fc  (/usr/lib/libpython3.14.so.1.0+0x650fc) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #11 0x7fb43b9b6d71  (/usr/lib/libpython3.14.so.1.0+0x1b6d71) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #12 0x7fb43baba2c3 in PyEval_EvalCode (/usr/lib/libpython3.14.so.1.0+0x2ba2c3) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #13 0x7fb43bb0398e  (/usr/lib/libpython3.14.so.1.0+0x30398e) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #14 0x7fb43bb04476  (/usr/lib/libpython3.14.so.1.0+0x304476) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #15 0x7fb43bb03852  (/usr/lib/libpython3.14.so.1.0+0x303852) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #16 0x7fb43bb03656  (/usr/lib/libpython3.14.so.1.0+0x303656) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #17 0x7fb43baa78cf in Py_RunMain (/usr/lib/libpython3.14.so.1.0+0x2a78cf) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #18 0x7fb43baa167b in Py_BytesMain (/usr/lib/libpython3.14.so.1.0+0x2a167b) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #19 0x7fb43b427740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #20 0x7fb43b427878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #21 0x5648c118d044 in _start (/usr/bin/python3.14+0x1044) (BuildId: 7d28bb88eb2d929bf00b0f7e80bb83480668eae9)

0x7c243a22d2f0 is located 48 bytes inside of 66-byte region [0x7c243a22d2c0,0x7c243a22d302)
freed by thread T0 here:
    #0 0x7fb43c12af31  (/usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../lib/libasan.so+0x12af31) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7bb43392076a in cdata_dealloc (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0xf76a) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #2 0x7bb433920818 in cdataowning_dealloc (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0xf818) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #3 0x7fb43b987507 in _Py_Dealloc (/usr/lib/libpython3.14.so.1.0+0x187507) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #4 0x7fb43b8592e7  (/usr/lib/libpython3.14.so.1.0+0x592e7) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #5 0x7fb43b9e24ea  (/usr/lib/libpython3.14.so.1.0+0x1e24ea) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #6 0x7bb43392ae99 in general_invoke_callback (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x19e99) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #7 0x7bb43393a409 in cffi_call_python (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x29409) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #8 0x7bb4305d0702 in get_qtile_config_cb libqtile/backend/wayland/_ffi.c:1685
    #9 0x7bb4305fbdec in qw_cursor_configure_xcursor libqtile/backend/wayland/qw/cursor.c:639
    #10 0x7bb4305da823 in _cffi_f_qw_cursor_configure_xcursor libqtile/backend/wayland/_ffi.c:1948
    #11 0x7fb43b85dacd  (/usr/lib/libpython3.14.so.1.0+0x5dacd) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #12 0x7fb43ba16d3f  (/usr/lib/libpython3.14.so.1.0+0x216d3f) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #13 0x7bb43a0092c1  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x72c1) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #14 0x7bb43a009fc5  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x7fc5) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #15 0x7fb43b9a48c8 in _PyObject_MakeTpCall (/usr/lib/libpython3.14.so.1.0+0x1a48c8) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #16 0x7fb43b8e0a94  (/usr/lib/libpython3.14.so.1.0+0xe0a94) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #17 0x7fb43b8650fc  (/usr/lib/libpython3.14.so.1.0+0x650fc) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #18 0x7fb43b9b6d71  (/usr/lib/libpython3.14.so.1.0+0x1b6d71) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #19 0x7fb43baba2c3 in PyEval_EvalCode (/usr/lib/libpython3.14.so.1.0+0x2ba2c3) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #20 0x7fb43bb0398e  (/usr/lib/libpython3.14.so.1.0+0x30398e) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #21 0x7fb43bb04476  (/usr/lib/libpython3.14.so.1.0+0x304476) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #22 0x7fb43bb03852  (/usr/lib/libpython3.14.so.1.0+0x303852) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #23 0x7fb43bb03656  (/usr/lib/libpython3.14.so.1.0+0x303656) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #24 0x7fb43baa78cf in Py_RunMain (/usr/lib/libpython3.14.so.1.0+0x2a78cf) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #25 0x7fb43baa167b in Py_BytesMain (/usr/lib/libpython3.14.so.1.0+0x2a167b) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #26 0x7fb43b427740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #27 0x7fb43b427878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #28 0x5648c118d044 in _start (/usr/bin/python3.14+0x1044) (BuildId: 7d28bb88eb2d929bf00b0f7e80bb83480668eae9)

previously allocated by thread T0 here:
    #0 0x7fb43c12bf49 in calloc (/usr/lib/gcc/x86_64-pc-linux-gnu/16.1.1/../../../../lib/libasan.so+0x12bf49) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x7bb433924be5 in allocate_owning_object (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x13be5) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #2 0x7bb433924e5b in allocate_with_allocator (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x13e5b) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #3 0x7bb4339254f8 in direct_newp (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x144f8) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #4 0x7bb433934951 in _ffi_new (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x23951) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #5 0x7bb433934982 in ffi_new (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x23982) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #6 0x7fb43b9d50ea  (/usr/lib/libpython3.14.so.1.0+0x1d50ea) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #7 0x7fb43b9a4569  (/usr/lib/libpython3.14.so.1.0+0x1a4569) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #8 0x7fb43b85e2a0  (/usr/lib/libpython3.14.so.1.0+0x5e2a0) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #9 0x7fb43b9e24ea  (/usr/lib/libpython3.14.so.1.0+0x1e24ea) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #10 0x7bb43392ae99 in general_invoke_callback (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x19e99) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #11 0x7bb43393a409 in cffi_call_python (/home/rich/venv/lib/python3.14/site-packages/_cffi_backend.cpython-314-x86_64-linux-gnu.so+0x29409) (BuildId: a0b04f7fb39282b5fb2ac0fcd69f14c200e8ae5e)
    #12 0x7bb4305d0702 in get_qtile_config_cb libqtile/backend/wayland/_ffi.c:1685
    #13 0x7bb4305fbdec in qw_cursor_configure_xcursor libqtile/backend/wayland/qw/cursor.c:639
    #14 0x7bb4305da823 in _cffi_f_qw_cursor_configure_xcursor libqtile/backend/wayland/_ffi.c:1948
    #15 0x7fb43b85dacd  (/usr/lib/libpython3.14.so.1.0+0x5dacd) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #16 0x7fb43ba16d3f  (/usr/lib/libpython3.14.so.1.0+0x216d3f) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #17 0x7bb43a0092c1  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x72c1) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #18 0x7bb43a009fc5  (/usr/lib/python3.14/lib-dynload/_asyncio.cpython-314-x86_64-linux-gnu.so+0x7fc5) (BuildId: 306d36b0f7db1bd551ccb0fc1b3533f26ebcda28)
    #19 0x7fb43b9a48c8 in _PyObject_MakeTpCall (/usr/lib/libpython3.14.so.1.0+0x1a48c8) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #20 0x7fb43b8e0a94  (/usr/lib/libpython3.14.so.1.0+0xe0a94) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #21 0x7fb43b8650fc  (/usr/lib/libpython3.14.so.1.0+0x650fc) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #22 0x7fb43b9b6d71  (/usr/lib/libpython3.14.so.1.0+0x1b6d71) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #23 0x7fb43baba2c3 in PyEval_EvalCode (/usr/lib/libpython3.14.so.1.0+0x2ba2c3) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #24 0x7fb43bb0398e  (/usr/lib/libpython3.14.so.1.0+0x30398e) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #25 0x7fb43bb04476  (/usr/lib/libpython3.14.so.1.0+0x304476) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #26 0x7fb43bb03852  (/usr/lib/libpython3.14.so.1.0+0x303852) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #27 0x7fb43bb03656  (/usr/lib/libpython3.14.so.1.0+0x303656) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #28 0x7fb43baa78cf in Py_RunMain (/usr/lib/libpython3.14.so.1.0+0x2a78cf) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)
    #29 0x7fb43baa167b in Py_BytesMain (/usr/lib/libpython3.14.so.1.0+0x2a167b) (BuildId: 0391d8effc4dbc774e13929f071ff1435e8904e6)

SUMMARY: AddressSanitizer: heap-use-after-free (/usr/lib/libwlroots-0.20.so+0xb782c) (BuildId: 5d79c389f2b9aa0fc253c289695a92dbd7f9d1fc) in wlr_xcursor_manager_create
Shadow bytes around the buggy address:
  0x7c243a22d000: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fa fa
  0x7c243a22d080: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x7c243a22d100: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
  0x7c243a22d180: fd fd fd fd fd fd fd fd fa fa fa fa 00 00 00 00
  0x7c243a22d200: 00 00 00 00 00 00 fa fa fa fa 00 00 00 00 00 00
=>0x7c243a22d280: 00 00 00 00 fa fa fa fa fd fd fd fd fd fd[fd]fd
  0x7c243a22d300: fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c243a22d380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c243a22d400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c243a22d480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c243a22d500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==3511==ABORTING
```