### PR TITLE
resources: switch to /usr/bin/qtile

### DIFF
--- a/resources/qtile.service
+++ b/resources/qtile.service
@@ -6,7 +6,9 @@ After=qtile-session.target graphical-session-pre.target
 
 [Service]
 Type=exec
-ExecStart=%h/.local/bin/qtile start
+# If you have installed from source, you should probably use this line:
+# ExecStart=%h/.local/bin/qtile start
+ExecStart=/usr/bin/qtile start
 ExecStopPost=/usr/bin/systemctl --user stop graphical-session.target
 Restart=on-failure
 TimeoutStopSec=10s


### PR DESCRIPTION
This means that most (with the exception of Nix) packagers can just install the file directly, and hopefully the comment will help users installing from source.