### PR TITLE
Add ASan tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             - uses: actions/checkout@v6
             - name: Build Docker image
               run: |
-                docker build -t qtile-ci .
+                docker buildx build -t qtile-ci .
             - name: Run tests in container
               run: |
                 mkdir coredumps
@@ -38,6 +38,68 @@ jobs:
                 COVERALLS_FLAG_NAME: ${{ format('{0}-{1}', matrix.python-version, matrix.backend) }}
                 COVERALLS_PARALLEL: true
                 COVERALLS_SERVICE_JOB_ID: ${{ github.run_id }}
+
+    asan-tests:
+        runs-on: ubuntu-24.04
+        name: "ASan wayc (python ${{ matrix.python-version }})"
+        strategy:
+            matrix:
+                python-version: ['3.14']
+        steps:
+            - uses: actions/checkout@v6
+            - name: Build base Docker image
+              run: |
+                docker buildx build -t qtile-ci .
+            - name: Build ASan Docker image
+              run: |
+                docker buildx build -f ./Dockerfile.asan -t qtile-ci .
+            - name: Run tests under ASan
+              run: |
+                make asan-ci-check
+              env:
+                QTILE_CI_PYTHON: ${{ matrix.python-version }}
+                QTILE_CI_BACKEND: wayland
+                ASAN_OPTIONS: log_path=/workspace/asan.log
+            - name: List and filter ASan log files
+              if: always()
+              run: |
+                asan_failed=0
+                lsan_failed=0
+                echo "=== AddressSanitizer errors ==="
+                if ls -1 asan.log.* 2>/dev/null; then
+                  asan_failed=1
+                else
+                  echo "  none"
+                fi
+                echo ""
+                echo "=== Leaks referencing libwayc ==="
+                PATTERN="libqtile/backend/wayland/qw"
+                matches=$(grep -lE "$PATTERN" lsan.log.* 2>/dev/null) || true
+                if [ -n "$matches" ]; then
+                  echo "$matches"
+                  lsan_failed=1
+                else
+                  echo "  none"
+                fi
+                echo ""
+                echo "=== Other LeakSanitizer errors ==="
+                other_matches=$(grep -LE "$PATTERN" lsan.log.* 2>/dev/null) || true
+                if [ -n "$other_matches" ]; then
+                  echo "$other_matches"
+                else
+                  echo "  none"
+                fi
+                exit $(($asan_failed || $lsan_failed))
+            - name: Upload ASan log files
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                name: asan-log
+                path: |
+                  asan.log*
+                  lsan.log*
+                if-no-files-found: warn
+                retention-days: 10
 
     coverage:
         name: Finalize Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
                   echo "  none"
                 fi
                 echo ""
-                echo "=== Leaks referencing libwayc ==="
-                PATTERN="libqtile/backend/wayland/qw"
+                echo "=== Leaks referencing libwayc and wayland clients ==="
+                PATTERN="libqtile/backend/wayland/qw|test/wayland_clients/bin"
                 matches=$(grep -lE "$PATTERN" lsan.log.* 2>/dev/null) || true
                 if [ -n "$matches" ]; then
                   echo "$matches"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ RUN dnf install -y \
     cairo-devel \
     cairo-gobject-devel \
     dbus-x11 \
-    gcc git make\
+    gcc git make \
     gdb \
     gobject-introspection \
     gtk3 \
     ImageMagick \
+    libasan \
     libnotify \
+    libubsan \
     pango \
     procps \
     pulseaudio-libs \

--- a/Dockerfile.asan
+++ b/Dockerfile.asan
@@ -1,0 +1,5 @@
+FROM qtile-ci
+
+RUN dnf -y install 'dnf-command(copr)' \
+       && dnf -y copr enable richcarni/glycin-2.2 \
+       && dnf -y upgrade glycin-libs glycin-loaders

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,16 @@ check: deps ## Run the test suite on the latest python
 		uv tool run coveralls --service=github || true; \
 	fi
 
+.PHONY: asan-check
+asan-check: deps ## Run the test suite on the latest python
+	uv run ./libqtile/backend/wayland/cffi/build.py --asan
+	LD_PRELOAD=$$(ldconfig -p | awk '/libasan\.so\.[0-9]/ {print $$NF; exit}') \
+	GLYCIN_DISABLE_SANDBOX=i-know-the-risks \
+	ASAN_OPTIONS=log_exe_name=1:leak_check_at_exit=0:$$ASAN_OPTIONS \
+	QTILE_LSAN_ENABLE=1 \
+	PYTHONMALLOC=malloc \
+	uv run $(UV_PYTHON_ARG) python3 -m pytest test/backend/wayland test/widgets $(PYTEST_BACKEND_ARG)
+
 TTY := $(shell [ -t 0 ] && echo "-t")
 DOCKER_RUN = docker run --rm --init -i $(TTY) \
 	-v $(PWD):/workspace:z \
@@ -57,6 +67,10 @@ DOCKER_RUN = docker run --rm --init -i $(TTY) \
 .PHONY: ci-check
 ci-check: ## Run the test suite in the docker ci container
 	$(DOCKER_RUN) make check
+
+.PHONY: asan-ci-check
+asan-ci-check: ## Run the test suite in the docker ci container
+	$(DOCKER_RUN) make asan-check
 
 .PHONY: ci-bash
 ci-bash: ## Run the test suite in the docker ci container

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -432,6 +432,8 @@ def build_c_objects(config: BuildConfig, *, debug: bool = False, asan: bool = Fa
 
         preargs = ["-g3", "-Og"] if (debug or asan) else ["-O2"]
         preargs += ["-fPIC", "-Wall", "-Wextra"]
+        if asan:
+            preargs += ["-fsanitize=address,leak,undefined", "-fno-omit-frame-pointer"]
 
         cmd.shlib_compiler.compile(
             [os.path.basename(p) for p in config.source_files],

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -444,13 +444,13 @@ def build_c_objects(config: BuildConfig, *, debug: bool = False, asan: bool = Fa
         )
 
 
-def build_test_clients() -> None:
+def build_test_clients(asan: bool = False) -> None:
     TEST_CLIENT_OUT_PATH.mkdir(parents=True, exist_ok=True)
     for client in TEST_CLIENTS:
-        _build_test_client(client)
+        _build_test_client(client, asan)
 
 
-def _build_test_client(client: TestClient) -> None:
+def _build_test_client(client: TestClient, asan: bool) -> None:
     def to_str(v: str | Path) -> str:
         return v.resolve().as_posix() if isinstance(v, Path) else v
 
@@ -460,10 +460,16 @@ def _build_test_client(client: TestClient) -> None:
     libs = (
         subprocess.check_output(["pkg-config", "--libs", *client.all_packages]).decode().split()
     )
+    asan_flags = (
+        ["-fsanitize=address,leak,undefined", "-fno-omit-frame-pointer", "-g3", "-Og"]
+        if asan
+        else []
+    )
 
     cmd = [
         "cc",
         *cflags,
+        *asan_flags,
         *(to_str(s) for s in client.sources),
         *(arg for inc in client.includes for arg in ("-I", to_str(inc))),
         *client.extra_args,
@@ -513,7 +519,7 @@ def ffi_compile(*, verbose: bool = False, debug: bool = False, asan: bool = Fals
     generate_protocols()
     build_c_objects(config, debug=debug, asan=asan)
     compile_ffi(config, verbose=verbose, debug=debug, asan=asan)
-    build_test_clients()
+    build_test_clients(asan=asan)
 
 
 if __name__ == "__main__":

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -19,6 +19,9 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
     wl_list_remove(&cursor->request_set_cursor_shape.link);
 
     wlr_xcursor_manager_destroy(cursor->mgr);
+#if WLR_HAS_XWAYLAND
+    wlr_xcursor_manager_destroy(cursor->xwayland_mgr);
+#endif
     wlr_cursor_destroy(cursor->cursor);
 
     free(cursor);

--- a/libqtile/backend/wayland/qw/cursor.c
+++ b/libqtile/backend/wayland/qw/cursor.c
@@ -19,6 +19,7 @@ void qw_cursor_destroy(struct qw_cursor *cursor) {
     wl_list_remove(&cursor->request_set_cursor_shape.link);
 
     wlr_xcursor_manager_destroy(cursor->mgr);
+    wlr_cursor_destroy(cursor->cursor);
 
     free(cursor);
 }

--- a/test/backend/wayland/test_session_lock.py
+++ b/test/backend/wayland/test_session_lock.py
@@ -163,6 +163,7 @@ def test_crashed(lock_manager, test_client):
     test_client.assert_error("unlock", "no active lock")
 
 
+@pytest.mark.skipif(asan_enabled, reason="crash test intentionally leaks")
 def test_crashed_ipc_disabled(lock_manager, test_client):
     """Confirm IPC is still locked when in crashed state."""
     test_client.assert_ok("lock")

--- a/test/backend/wayland/test_session_lock.py
+++ b/test/backend/wayland/test_session_lock.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from types import MethodType
 
@@ -143,6 +144,10 @@ def test_ipc_disabled(lock_manager, test_client):
     lock_manager.assert_unlocked()
 
 
+asan_enabled = os.environ.get("ASAN_OPTIONS") is not None
+
+
+@pytest.mark.skipif(asan_enabled, reason="crash test intentionally leaks")
 @enable_ipc
 def test_crashed(lock_manager, test_client):
     """Confirm crashed state is still locked."""

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,6 +5,7 @@ Defining them here rather than in conftest.py avoids issues with circular import
 between test/conftest.py and test/backend/<backend>/conftest.py files.
 """
 
+import ctypes
 import faulthandler
 import functools
 import logging
@@ -255,6 +256,15 @@ class TestManager:
             except Exception:
                 wpipe.send(traceback.format_exc())
             finally:
+                if os.environ.get("QTILE_LSAN_ENABLE"):
+                    try:
+                        # libasan must be loaded via LD_PRELOAD
+                        lib = ctypes.CDLL(None)
+                        getattr(lib, "__sanitizer_set_report_path")(b"lsan.log")
+                        getattr(lib, "__lsan_do_recoverable_leak_check")()
+                    except (OSError, AttributeError) as e:
+                        print(f"error: {type(e).__name__}: {e}")
+                        traceback.print_exc()
                 wpipe.close()
 
         self.proc = multiprocessing.Process(target=run_qtile)

--- a/test/wayland_clients/src/client-base.c
+++ b/test/wayland_clients/src/client-base.c
@@ -13,6 +13,11 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#if __SANITIZE_ADDRESS__
+#include <sanitizer/lsan_interface.h>
+#define HAVE_LSAN 1
+#endif
+
 static const struct client_ops *ops_ptr;
 
 void test_ok(void) {
@@ -245,6 +250,13 @@ int client_run(struct client_state *state, const struct client_ops *ops) {
     }
 
     client_state_cleanup(state);
+
+#if HAVE_LSAN
+    if (getenv("QTILE_LSAN_ENABLE") != NULL) {
+        __sanitizer_set_report_path("lsan.log");
+        __lsan_do_recoverable_leak_check();
+    }
+#endif
 
     return 0;
 }

--- a/test/wayland_clients/src/cursor-shape.c
+++ b/test/wayland_clients/src/cursor-shape.c
@@ -268,8 +268,30 @@ void setup(struct client_state *base) {
 
 void cleanup(struct client_state *base) {
     struct test_state *state = (struct test_state *)base;
+    if (state->buffer) {
+        wl_buffer_destroy(state->buffer->wl_buffer);
+        free(state->buffer);
+    }
+    if (state->toplevel) {
+        xdg_toplevel_destroy(state->toplevel);
+    }
+    if (state->xdg_surface) {
+        xdg_surface_destroy(state->xdg_surface);
+    }
     if (state->surface) {
         wl_surface_destroy(state->surface);
+    }
+    if (state->cursor_device) {
+        wp_cursor_shape_device_v1_destroy(state->cursor_device);
+    }
+    if (state->cursor_manager) {
+        wp_cursor_shape_manager_v1_destroy(state->cursor_manager);
+    }
+    if (state->pointer) {
+        wl_pointer_destroy(state->pointer);
+    }
+    if (state->xdg_wm_base) {
+        xdg_wm_base_destroy(state->xdg_wm_base);
     }
 }
 

--- a/test/wayland_clients/src/ftl-manager.c
+++ b/test/wayland_clients/src/ftl-manager.c
@@ -135,6 +135,10 @@ toplevel_closed(void *data,
 
     wl_list_remove(&te->link);
     te->test_state->pending_close = false;
+    free(te->title);
+    free(te->app_id);
+    free(te->output_enter);
+    free(te->output_leave);
     free(te);
 }
 
@@ -411,7 +415,7 @@ static bool dispatch_command(struct client_state *base, const char *cmd, const c
         cmd_check_state(state, arg, STATE_ACTIVATED);
     else if (strcmp(cmd, "check_maximized") == 0)
         cmd_check_state(state, arg, STATE_MAXIMIZED);
-    else if (strcmp(cmd, "check_maximized") == 0)
+    else if (strcmp(cmd, "check_minimized") == 0)
         cmd_check_state(state, arg, STATE_MINIMIZED);
     else if (strcmp(cmd, "check_fullscreen") == 0)
         cmd_check_state(state, arg, STATE_FULLSCREEN);
@@ -436,7 +440,26 @@ static bool dispatch_command(struct client_state *base, const char *cmd, const c
     return true;
 }
 
-void cleanup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    struct toplevel_entry *te, *te_tmp;
+    wl_list_for_each_safe(te, te_tmp, &state->toplevels, link) {
+        toplevel_closed(te, te->ftl_handle);
+    }
+
+    struct output_entry *oe, *oe_tmp;
+    wl_list_for_each_safe(oe, oe_tmp, &state->outputs, link) {
+        wl_list_remove(&oe->link);
+        wl_output_destroy(oe->wl_output);
+        free(oe->name);
+        free(oe);
+    }
+
+    if (state->ftl_manager) {
+        zwlr_foreign_toplevel_manager_v1_destroy(state->ftl_manager);
+    }
+}
 
 void setup(struct client_state *base) {
     struct test_state *state = (struct test_state *)base;

--- a/test/wayland_clients/src/layer-shell.c
+++ b/test/wayland_clients/src/layer-shell.c
@@ -411,11 +411,20 @@ void setup(struct client_state *base) {
 void cleanup(struct client_state *base) {
     struct test_state *state = (struct test_state *)base;
 
+    if (state->buffer) {
+        destroy_buffer(state->buffer);
+    }
     if (state->layer_surface) {
         zwlr_layer_surface_v1_destroy(state->layer_surface);
     }
     if (state->surface) {
         wl_surface_destroy(state->surface);
+    }
+    if (state->keyboard) {
+        wl_keyboard_release(state->keyboard);
+    }
+    if (state->layer_shell) {
+        zwlr_layer_shell_v1_destroy(state->layer_shell);
     }
 }
 

--- a/test/wayland_clients/src/output-power-management.c
+++ b/test/wayland_clients/src/output-power-management.c
@@ -215,7 +215,22 @@ static bool dispatch_command(struct client_state *base, const char *cmd, const c
     return true;
 }
 
-void cleanup(struct client_state *base) { struct test_state *state = (struct test_state *)base; }
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    struct output_entry *oe, *tmp;
+    wl_list_for_each_safe(oe, tmp, &state->outputs, link) {
+        wl_list_remove(&oe->link);
+        zwlr_output_power_v1_destroy(oe->power);
+        wl_output_destroy(oe->wl_output);
+        free(oe->name);
+        free(oe);
+    }
+
+    if (state->power_manager) {
+        zwlr_output_power_manager_v1_destroy(state->power_manager);
+    }
+}
 
 void setup(struct client_state *base) {
     struct test_state *state = (struct test_state *)base;

--- a/test/wayland_clients/src/session-lock.c
+++ b/test/wayland_clients/src/session-lock.c
@@ -267,6 +267,9 @@ static void cmd_destroy_surface(struct test_state *state) {
 
     struct surface_entry *se, *tmp;
     wl_list_for_each_safe(se, tmp, &state->surfaces, link) {
+        if (se->buffer) {
+            destroy_buffer(se->buffer);
+        }
         ext_session_lock_surface_v1_destroy(se->lock_surface);
         wl_surface_destroy(se->wl_surface);
         wl_list_remove(&se->link);
@@ -349,12 +352,24 @@ void cleanup(struct client_state *base) {
     if (!state->do_crash) {
         struct surface_entry *se, *stmp;
         wl_list_for_each_safe(se, stmp, &state->surfaces, link) {
+            if (se->buffer) {
+                destroy_buffer(se->buffer);
+            }
             ext_session_lock_surface_v1_destroy(se->lock_surface);
             wl_surface_destroy(se->wl_surface);
             free(se);
         }
+        struct output_entry *oe, *otmp;
+        wl_list_for_each_safe(oe, otmp, &state->outputs, link) {
+            wl_output_destroy(oe->wl_output);
+            wl_list_remove(&oe->link);
+            free(oe);
+        }
         if (state->lock) {
             ext_session_lock_v1_destroy(state->lock);
+        }
+        if (state->lock_manager) {
+            ext_session_lock_manager_v1_destroy(state->lock_manager);
         }
     }
 }


### PR DESCRIPTION
~Thinking I should just ditch the docker caching! It does shave a few minutes off but not sure that warrants this crime against yaml~ Caching is removed

---

I've started by running the subset of wayland tests with Address Sanitization enabled

Regular tests are commented out for testing/demo purposes

For the ASan tests I've swapped in a version of glycin (0.22.beta) that I built and put up on fedora copr (https://copr.fedorainfracloud.org/coprs/richcarni/glycin-2.2/), and with which I can disable sandboxing, since that doesn't seem to work with ASan

My thinking was to live with this until fedora gets glycin 0.22, and then a lot of unfortunate complexity here can be removed

As for the actual results :\ Haven't looked into the results in great depth yet but I think they are all leaks. Posted the list of log files at end (can be downloaded from CI). I think quite a few are from the wayland test clients not cleaning up after themselves on exit (so probably nothing serious). Some appear outside the scope of wayc. Some are maybe false positives? 

`test_crashed` from `test_session_lock` is the only test where the test failed - I guess that makes senses, I think it leaks by design, so I've just skipped it for now

todos:
- [x] Check latest LSan changes still picks up leaks in wayland clients
- [x] Fix any identified leaks in wayc