### PR TITLE
fix(nix): replace /usr/bin/qtile in service file

### DIFF
--- a/nix/qtile.nix
+++ b/nix/qtile.nix
@@ -51,7 +51,7 @@ let
           $out/share/systemd/user/qtile-session.target
 
         substituteInPlace $out/share/systemd/user/qtile.service \
-          --replace-fail '%h/.local/bin/qtile' '${placeholder "out"}/bin/qtile' \
+          --replace-fail '/usr/bin/qtile' '${placeholder "out"}/bin/qtile' \
           --replace-fail '/usr/bin/systemctl' '${pkgs.systemd}/bin/systemctl'
       '';
     };


### PR DESCRIPTION
Fixes an issue introduced by 7f0f60b, where the qtile executable path was changed without changing the nix replacer command.

(`--replace-fail` did not fail because the line with the old path was kept around, just commented out.)