### PR TITLE
pangocffi: free the buffers transferred by pango_parse_markup() and g_markup_escape_text()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Qtile x.xx.x, released xxxx-xx-xx:
     * features
     * bugfixes
+      - Free the buffers handed over by pango_parse_markup() and
+        g_markup_escape_text(). Both transfer ownership to the caller, so every
+        update of a widget with markup enabled leaked the rendered text and its
+        attribute list
 
 Qtile 0.37.0, released 2026-08-07:
     * features

--- a/libqtile/pango_ffi.py
+++ b/libqtile/pango_ffi.py
@@ -56,6 +56,11 @@ pango_ffi.cdef(
     // https://developer.gnome.org/pango/stable/pango-Layout-Objects.html
     PangoLayout *pango_cairo_create_layout (cairo_t *cr);
     void g_object_unref(gpointer object);
+    void g_free(gpointer mem);
+    void g_error_free(GError *error);
+
+    void
+    pango_attr_list_unref (PangoAttrList *list);
 
     void
     pango_layout_set_font_description (PangoLayout *layout,

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -136,9 +136,20 @@ def parse_markup(value, accel_marker=0):
     )
 
     if ret == 0:
+        if error[0] != ffi.NULL:
+            gobject.g_error_free(error[0])
         raise BadMarkup(f"parse_markup() failed for: {value}")
 
-    return attr_list[0], ffi.string(text[0]), chr(accel_marker)
+    # pango_parse_markup() transfers ownership of both out-parameters to the
+    # caller: the text is a freshly allocated buffer, and the attribute list
+    # carries a reference that pango_layout_set_attributes() does not take
+    # over. Copy the text out and free it, and tie the list's reference to the
+    # lifetime of the cdata we hand back.
+    parsed_text = ffi.string(text[0])
+    gobject.g_free(text[0])
+    attrs = ffi.gc(attr_list[0], pango.pango_attr_list_unref)
+
+    return attrs, parsed_text, chr(accel_marker)
 
 
 def markup_escape_text(text):

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -154,4 +154,6 @@ def parse_markup(value, accel_marker=0):
 
 def markup_escape_text(text):
     ret = gobject.g_markup_escape_text(text.encode("utf-8"), -1)
-    return ffi.string(ret).decode()
+    escaped = ffi.string(ret).decode()
+    gobject.g_free(ret)
+    return escaped


### PR DESCRIPTION
Fixes #6034.

`pangocffi` never releases the buffers that Pango and GLib hand it, so every widget update with markup enabled leaks permanently. Both call sites take ownership from APIs that transfer it:

- `pango_parse_markup()` returns a freshly allocated `text` buffer and a `PangoAttrList` reference. `parse_markup()` copied the text into a Python object and returned the raw list pointer, freeing neither, and `pango_layout_set_attributes()` takes its *own* reference rather than adopting ours. The `GError` on the failure path was leaked too.
- `g_markup_escape_text()` returns a newly allocated string that `markup_escape_text()` decoded and then dropped.

Neither `g_free()` nor `pango_attr_list_unref()` was declared in `libqtile/pango_ffi.py`.

`TextLayout.text` calls `parse_markup()` on every assignment and `markup=True` is the default for `_TextBox`, so this scales with how often widget contents change. `markup_escape_text()` is called on each update by `windowname`, `tasklist`, `notify`, `prompt`, `clipboard`, `mpris2widget`, `widgetbox`, `wlaniw` and `windowtabs`. `pangocffi` is shared by both backends, so the leak is backend-independent.

This turned up on a qtile with 7 days uptime sitting at 5.2 GB RSS, 4.83 GB of it in the glibc `brk` heap and invisible to Python — `gc.get_objects()` returned 116k objects while the heap held 65.2M live chunks, 23.5M of them 144-byte buffers still containing the bar's clock string and window titles. The full analysis is in #6034.

### Changes

- `pango_ffi.py`: declare `g_free()`, `g_error_free()` and `pango_attr_list_unref()`.
- `parse_markup()`: free the text once it has been copied out, wrap the attribute list in `ffi.gc(attr_list[0], pango.pango_attr_list_unref)` so our reference is dropped after `pango_layout_set_attributes()` has taken its own, and free the `GError` on the failure path.
- `markup_escape_text()`: free the escaped string after decoding it.

### Verification

Measuring `mallinfo2().uordblks` around 20 000 calls of each, on the same interpreter, before and after:

| | before | after |
|---|---|---|
| `parse_markup()` | +288.0 B/call | **+0.0 B/call** |
| `markup_escape_text()` | +144.0 B/call | **+0.0 B/call** |
| full draw (`create_layout` → `parse_markup` → `set_attributes` → `set_text` → `show_layout`) | +651.7 B/draw | **+0.0 B/draw** |

The full draw path shows ~366 B/draw on the first round of 2000 and exactly 0 on every round after, i.e. one-off Pango cache warmup rather than accumulation.

Behaviour is unchanged: text still comes back with markup stripped, the accel-marker path still returns the marker and stripped text, escaping output is identical, `BadMarkup` is still raised for malformed input (20 000 failing parses in a row leak nothing), and colour attributes still render after our reference is dropped — verified by rasterising to an `ImageSurface` and counting red pixels.

`ruff check`, `ruff format --check` and `mypy` (the pinned pre-commit versions) pass on both changed files.

---
*Prepared with LM assistance — Claude Code*
