### PR TITLE
Wayland: implement keyboard shortcuts inhibit protocol

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -134,6 +134,11 @@ PROTOS: list[Protocol] = [
     Protocol(
         f"{WAYLAND_PROTOCOLS}/stable/tablet/tablet-v2.xml", build_client=True, build_server=False
     ),
+    Protocol(
+        f"{QW_PROTO_IN_PATH}/virtual-keyboard-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -192,6 +197,15 @@ TEST_CLIENTS: list[TestClient] = [
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "wlr-layer-shell-unstable-v1-protocol.c",
             QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="virtual-keyboard",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "virtual-keyboard.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "virtual-keyboard-unstable-v1-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),

--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -139,6 +139,11 @@ PROTOS: list[Protocol] = [
         build_client=True,
         build_server=False,
     ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -206,6 +211,16 @@ TEST_CLIENTS: list[TestClient] = [
             TEST_CLIENT_SRC_PATH / "virtual-keyboard.c",
             CLIENT_BASE,
             QW_PROTO_OUT_PATH / "virtual-keyboard-unstable-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
+    TestClient(
+        name="shortcut-inhibitor",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "shortcut-inhibitor.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "keyboard-shortcuts-inhibit-unstable-v1-protocol.c",
+            QW_PROTO_OUT_PATH / "xdg-shell-protocol.c",
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),

--- a/libqtile/backend/wayland/proto/virtual-keyboard-unstable-v1.xml
+++ b/libqtile/backend/wayland/proto/virtual-keyboard-unstable-v1.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="virtual_keyboard_unstable_v1">
+  <copyright>
+    Copyright © 2008-2011  Kristian Høgsberg
+    Copyright © 2010-2013  Intel Corporation
+    Copyright © 2012-2013  Collabora, Ltd.
+    Copyright © 2018       Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwp_virtual_keyboard_v1" version="1">
+    <description summary="virtual keyboard">
+      The virtual keyboard provides an application with requests which emulate
+      the behaviour of a physical keyboard.
+
+      This interface can be used by clients on its own to provide raw input
+      events, or it can accompany the input method protocol.
+    </description>
+
+    <request name="keymap">
+      <description summary="keyboard mapping">
+        Provide a file descriptor to the compositor which can be
+        memory-mapped to provide a keyboard mapping description.
+
+        Format carries a value from the keymap_format enumeration.
+      </description>
+      <arg name="format" type="uint" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </request>
+
+    <enum name="error">
+      <entry name="no_keymap" value="0" summary="No keymap was set"/>
+    </enum>
+
+    <request name="key">
+      <description summary="key event">
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond granularity, with an
+        undefined base. All requests regarding a single object must share the
+        same clock.
+
+        Keymap must be set before issuing this request.
+
+        State carries a value from the key_state enumeration.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" summary="physical state of the key"/>
+    </request>
+
+    <request name="modifiers">
+      <description summary="modifier and group state">
+        Notifies the compositor that the modifier and/or group state has
+        changed, and it should update state.
+
+        The client should use wl_keyboard.modifiers event to synchronize its
+        internal state with seat state.
+
+        Keymap must be set before issuing this request.
+      </description>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual keyboard keyboard object"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_virtual_keyboard_manager_v1" version="1">
+    <description summary="virtual keyboard manager">
+      A virtual keyboard manager allows an application to provide keyboard
+      input events as if they came from a physical keyboard.
+    </description>
+
+    <enum name="error">
+      <entry name="unauthorized" value="0" summary="client not authorized to use the interface"/>
+    </enum>
+
+    <request name="create_virtual_keyboard">
+      <description summary="Create a new virtual keyboard">
+        Creates a new virtual keyboard associated to a seat.
+
+        If the compositor enables a keyboard to perform arbitrary actions, it
+        should present an error when an untrusted client requests a new
+        keyboard.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+      <arg name="id" type="new_id" interface="zwp_virtual_keyboard_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/libqtile/backend/wayland/qw/keyboard.c
+++ b/libqtile/backend/wayland/qw/keyboard.c
@@ -6,6 +6,23 @@
 #include <wlr/util/log.h>
 #include <xkbcommon/xkbcommon.h>
 
+static bool qw_is_keyboard_inhibited(struct qw_server *server,
+                                     struct wlr_surface *focused_surface) {
+    if (focused_surface == NULL) {
+        return false;
+    }
+
+    struct qw_keyboard_shortcut_inhibitor *inhibitor;
+    wl_list_for_each(inhibitor, &server->shortcut_inhibitors, link) {
+        if (inhibitor->wlr_inhibitor->surface == focused_surface &&
+            inhibitor->wlr_inhibitor->active) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Called when the keyboard device is destroyed
 static void qw_keyboard_handle_destroy(struct wl_listener *listener, void *data) {
     UNUSED(data);
@@ -103,13 +120,16 @@ static void qw_keyboard_handle_key(struct wl_listener *listener, void *data) {
     // Get current keyboard modifiers (shift, ctrl, alt, etc.)
     uint32_t modifiers = wlr_keyboard_get_modifiers(keyboard->wlr_keyboard);
 
+    // Check if keyboard is inhibited
+    bool inhibited = qw_is_keyboard_inhibited(server, seat->keyboard_state.focused_surface);
+
     // If key is pressed...
     if (event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
         // Track key for repeat
         keyboard->key_pressed = true;
 
         // Don't handle presses if an exclusive layer has focus
-        if (server->exclusive_layer == NULL) {
+        if (server->exclusive_layer == NULL && !inhibited) {
             // Call user callback for each symbol to check if handled
             for (int i = 0; i < nsyms; ++i) {
                 // TODO: for efficiency maybe let c take control of the key list?

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -59,6 +59,8 @@ static void qw_server_destroy_dummy_input_devices(struct qw_server *server) {
     }
 }
 
+static void qw_remove_shortcut_inhibitors(struct qw_server *server);
+
 // Cleanup routine to destroy the compositor and free resources.
 void qw_server_finalize(struct qw_server *server) {
     // TODO: what else to finalize?
@@ -85,6 +87,7 @@ void qw_server_finalize(struct qw_server *server) {
     wl_list_remove(&server->new_pointer_constraint.link);
     wl_list_remove(&server->new_idle_inhibitor.link);
     wl_list_remove(&server->set_output_power_mode.link);
+    wl_list_remove(&server->new_shortcut_inhibitor.link);
 
 #if WLR_HAS_XWAYLAND
     wl_list_remove(&server->new_xwayland_surface.link);
@@ -95,6 +98,7 @@ void qw_server_finalize(struct qw_server *server) {
     wl_display_destroy_clients(server->display);
     wlr_scene_node_destroy(&server->scene->tree.node);
     qw_cursor_destroy(server->cursor);
+    qw_remove_shortcut_inhibitors(server);
     wlr_allocator_destroy(server->allocator);
     wlr_renderer_destroy(server->renderer);
     wlr_backend_destroy(server->backend);
@@ -756,6 +760,49 @@ static void qw_server_handle_output_power_set_mode(struct wl_listener *listener,
     }
 }
 
+static void qw_shortcut_inhibitor_destroy(struct qw_keyboard_shortcut_inhibitor *inhibitor) {
+    if (inhibitor == NULL) {
+        return;
+    }
+    wl_list_remove(&inhibitor->link);
+    wl_list_remove(&inhibitor->destroy.link);
+    free(inhibitor);
+}
+
+static void qw_remove_shortcut_inhibitors(struct qw_server *server) {
+    struct qw_keyboard_shortcut_inhibitor *inhibitor, *tmp_inhibitor;
+    wl_list_for_each_safe(inhibitor, tmp_inhibitor, &server->shortcut_inhibitors, link) {
+        qw_shortcut_inhibitor_destroy(inhibitor);
+    }
+}
+
+static void qw_handle_shortcut_inhibitor_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct qw_keyboard_shortcut_inhibitor *inhibitor =
+        wl_container_of(listener, inhibitor, destroy);
+    qw_shortcut_inhibitor_destroy(inhibitor);
+}
+
+static void qw_handle_shortcut_new_inhibitor(struct wl_listener *listener, void *data) {
+    struct qw_server *server = wl_container_of(listener, server, new_shortcut_inhibitor);
+    struct wlr_keyboard_shortcuts_inhibitor_v1 *wlr_inhibitor = data;
+
+    struct qw_keyboard_shortcut_inhibitor *inhibitor = calloc(1, sizeof(*inhibitor));
+    if (inhibitor == NULL) {
+        wlr_log(WLR_ERROR, "Could not create qw_keyboard_shortcut_inhibitor.\n");
+        return;
+    }
+
+    inhibitor->server = server;
+    inhibitor->wlr_inhibitor = wlr_inhibitor;
+    wl_list_insert(&server->shortcut_inhibitors, &inhibitor->link);
+
+    inhibitor->destroy.notify = qw_handle_shortcut_inhibitor_destroy;
+    wl_signal_add(&wlr_inhibitor->events.destroy, &inhibitor->destroy);
+
+    wlr_keyboard_shortcuts_inhibitor_v1_activate(wlr_inhibitor);
+}
+
 // Initialize the server object with all components and listeners.
 bool qw_server_init(struct qw_server *server) {
     server->display = wl_display_create();
@@ -1027,6 +1074,17 @@ bool qw_server_init(struct qw_server *server) {
 
     // Initialize idle timers list
     wl_list_init(&server->idle_timers);
+
+    // Keyboard shortcut inhibitors
+    wl_list_init(&server->shortcut_inhibitors);
+    server->shortcut_inhibitor_manager = wlr_keyboard_shortcuts_inhibit_v1_create(server->display);
+    if (server->shortcut_inhibitor_manager == NULL) {
+        wlr_log(WLR_ERROR, "failed to create keyboard shortcut inhibitor manager");
+        return false;
+    }
+    server->new_shortcut_inhibitor.notify = qw_handle_shortcut_new_inhibitor;
+    wl_signal_add(&server->shortcut_inhibitor_manager->events.new_inhibitor,
+                  &server->new_shortcut_inhibitor);
 
 #if WLR_HAS_XWAYLAND
     server->xwayland = wlr_xwayland_create(server->display, server->compositor, true);

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -27,6 +27,7 @@
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
+#include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
@@ -279,6 +280,9 @@ struct qw_server {
     struct wlr_output_power_manager_v1 *output_power_manager;
     struct wl_listener set_output_power_mode;
     struct wl_list idle_timers; // list of qw_idle_timer
+    struct wlr_keyboard_shortcuts_inhibit_manager_v1 *shortcut_inhibitor_manager;
+    struct wl_list shortcut_inhibitors; // list of qw_keyboard_shortcut_inhibitor
+    struct wl_listener new_shortcut_inhibitor;
 #if WLR_HAS_XWAYLAND
     struct wlr_xwayland *xwayland;
     struct wl_listener xwayland_ready;
@@ -315,6 +319,15 @@ struct qw_idle_timer {
     // Private data
     struct wl_event_source *event_source;
     struct wl_list link; // server->idle_timers
+};
+
+struct qw_keyboard_shortcut_inhibitor {
+    struct qw_server *server;
+
+    // Private data
+    struct wlr_keyboard_shortcuts_inhibitor_v1 *wlr_inhibitor;
+    struct wl_listener destroy;
+    struct wl_list link; // Link for server->inhibitors list
 };
 
 // Utility functions exposed by the server API

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -328,3 +328,9 @@ def test_client(wmanager, request):
 
     with ClientHandler(script, wmanager) as client:
         yield client
+
+
+@pytest.fixture
+def virtual_keyboard(wmanager):
+    with ClientHandler("virtual-keyboard", wmanager) as keyboard:
+        yield keyboard

--- a/test/backend/wayland/test_shortcut_inhibitor.py
+++ b/test/backend/wayland/test_shortcut_inhibitor.py
@@ -1,0 +1,89 @@
+import pytest
+
+from libqtile.config import Key
+from libqtile.lazy import lazy
+from test.helpers import BareConfig, Retry
+
+
+class ShorcutInhibitorConfig(BareConfig):
+    keys = [Key(["control"], key, lazy.group[key].toscreen()) for key in "abcd"]
+
+
+KEY_A = 30
+KEY_B = 48
+MOD_CONTROL = 4
+
+
+pytestmark = [
+    pytest.mark.parametrize("test_client", ["shortcut-inhibitor"], indirect=True),
+    pytest.mark.parametrize("wmanager", [ShorcutInhibitorConfig], indirect=True),
+]
+
+
+def test_shortcut_inhibitor(test_client, wmanager, virtual_keyboard):
+    """Test that a wayland client can grab all keypresses"""
+
+    def assert_group(name):
+        assert wmanager.c.group.info()["name"] == name
+
+    @Retry(ignore_exceptions=(AssertionError,))
+    def wait_for_windows(count):
+        assert len(wmanager.c.windows()) == count
+
+    assert_group("a")
+
+    # Verify that keyboard events work
+    virtual_keyboard.assert_ok("set_modifier control")
+    virtual_keyboard.assert_ok(f"tap {KEY_B}")
+    virtual_keyboard.assert_ok("clear_modifiers")
+    assert_group("b")
+
+    # Check that a client receives key presses
+    test_client.assert_ok("show")
+    wait_for_windows(1)
+    virtual_keyboard.assert_ok(f"tap {KEY_A}")
+    lines = test_client.send_read_until("get_keypress", "OK")
+    assert lines
+    assert lines[0] == f"key: {KEY_A} mods: 0"
+    test_client.assert_ok("clear_keypress")
+
+    # Check that a client does not receive bound keys
+    virtual_keyboard.assert_ok("set_modifier control")
+    virtual_keyboard.assert_ok(f"tap {KEY_A}")
+    virtual_keyboard.assert_ok("clear_modifiers")
+    lines = test_client.send_read_until("get_keypress", "OK")
+    assert lines
+    assert lines[0] == "key: 0 mods: 0"
+    test_client.assert_ok("clear_keypress")
+
+    # Confirm qtile handles the key binding
+    assert_group("a")
+
+    # Have client create a shortcut inhibitor
+    test_client.assert_ok("inhibit")
+
+    # Check that a client now receives bound keys
+    wmanager.c.group["b"].toscreen()  # Window needs to be focused
+    virtual_keyboard.assert_ok("set_modifier control")
+    virtual_keyboard.assert_ok(f"tap {KEY_A}")
+    virtual_keyboard.assert_ok("clear_modifiers")
+    lines = test_client.send_read_until("get_keypress", "OK")
+    assert lines
+    assert lines[0] == f"key: {KEY_A} mods: {MOD_CONTROL}"
+    test_client.assert_ok("clear_keypress")
+
+    # Verify that qtile did not change groups
+    assert_group("b")
+
+    # Release the inhibitor and confirm that qtile swallows keys again
+    test_client.assert_ok("uninhibit")
+    virtual_keyboard.assert_ok("set_modifier control")
+    virtual_keyboard.assert_ok(f"tap {KEY_A}")
+    virtual_keyboard.assert_ok("clear_modifiers")
+    lines = test_client.send_read_until("get_keypress", "OK")
+    assert lines
+    assert lines[0] == "key: 0 mods: 0"
+    test_client.assert_ok("clear_keypress")
+
+    # Qtile should swallow key press and switch group
+    assert_group("a")

--- a/test/wayland_clients/src/client-base.c
+++ b/test/wayland_clients/src/client-base.c
@@ -54,6 +54,26 @@ void test_false(void) {
 
 void do_roundtrip(struct client_state *state) { wl_display_roundtrip(state->display); }
 
+// Wraps compositor error messages in our test script error function.
+static void custom_wl_log_handler(const char *fmt, va_list args) {
+    char buf[512];
+    vsnprintf(buf, sizeof(buf), fmt, args);
+
+    size_t len = strlen(buf);
+    if (len > 0 && buf[len - 1] == '\n') {
+        buf[len - 1] = '\0';
+    }
+
+    test_error(buf);
+}
+
+bool compositor_raised_error(struct client_state *state) {
+    if (wl_display_get_error(state->display) != 0) {
+        return true;
+    }
+    return false;
+}
+
 static void registry_global(void *data, struct wl_registry *registry, uint32_t name,
                             const char *interface, uint32_t version) {
     struct client_state *state = data;
@@ -141,6 +161,8 @@ static void client_state_cleanup(struct client_state *state) {
 int client_run(struct client_state *state, const struct client_ops *ops) {
     ops_ptr = ops;
 
+    wl_log_set_handler_client(custom_wl_log_handler);
+
     state->display = wl_display_connect(NULL);
     if (!state->display) {
         fprintf(stderr, "ERROR: failed to connect to display: %s\n", strerror(errno));
@@ -196,6 +218,10 @@ int client_run(struct client_state *state, const struct client_ops *ops) {
 
         if (fds[1].revents & POLLIN) {
             wl_display_dispatch(state->display);
+            if (compositor_raised_error(state)) {
+                running = false;
+                break;
+            }
         }
 
         if (fds[0].revents & POLLIN) {

--- a/test/wayland_clients/src/client-base.h
+++ b/test/wayland_clients/src/client-base.h
@@ -42,6 +42,8 @@ void test_message(const char *fmt, ...);
 void test_true(void);
 void test_false(void);
 
+bool compositor_raised_error(struct client_state *state);
+
 struct buffer *create_buffer(struct client_state *state, uint32_t width, uint32_t height,
                              uint32_t colour);
 void destroy_buffer(struct buffer *buf);

--- a/test/wayland_clients/src/shortcut-inhibitor.c
+++ b/test/wayland_clients/src/shortcut-inhibitor.c
@@ -1,0 +1,247 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "client-base.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+    struct zwp_keyboard_shortcuts_inhibit_manager_v1 *inhibit_mgr;
+    struct zwp_keyboard_shortcuts_inhibitor_v1 *inhibitor;
+    bool inhibitor_active;
+    struct xdg_wm_base *xdg_wm_base;
+    struct wl_surface *surface;
+    struct xdg_surface *xdg_surface;
+    struct xdg_toplevel *toplevel;
+    struct buffer *buffer;
+    struct wl_keyboard *keyboard;
+
+    uint32_t mods_depressed;
+    struct {
+        uint32_t key;
+        uint32_t mods;
+    } keypress;
+};
+
+static void shortcut_inhibitor_active(
+    void *data, struct zwp_keyboard_shortcuts_inhibitor_v1 *zwp_keyboard_shortcuts_inhibitor_v1) {
+    struct test_state *state = data;
+    state->inhibitor_active = true;
+}
+
+static void shortcut_inhibitor_inactive(
+    void *data, struct zwp_keyboard_shortcuts_inhibitor_v1 *zwp_keyboard_shortcuts_inhibitor_v1) {
+    struct test_state *state = data;
+    state->inhibitor_active = false;
+}
+
+struct zwp_keyboard_shortcuts_inhibitor_v1_listener inhibitor_listener = {
+    .active = shortcut_inhibitor_active, .inactive = shortcut_inhibitor_inactive};
+
+static void toplevel_close(void *data, struct xdg_toplevel *t) { exit(0); }
+
+static void toplevel_configure(void *data, struct xdg_toplevel *t, int32_t w, int32_t h,
+                               struct wl_array *states) {
+    (void)data;
+    (void)t;
+    (void)w;
+    (void)h;
+    (void)states;
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+};
+
+static void xdg_surface_configure(void *data, struct xdg_surface *surf, uint32_t serial) {
+    struct test_state *state = data;
+    xdg_surface_ack_configure(surf, serial);
+    wl_surface_commit(state->surface);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void wm_ping(void *data, struct xdg_wm_base *wm, uint32_t serial) {
+    xdg_wm_base_pong(wm, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_listener = {
+    .ping = wm_ping,
+};
+
+static void keyboard_keymap(void *data, struct wl_keyboard *keyboard, uint32_t format, int fd,
+                            uint32_t size) {
+    close(fd); // Ignore the keymap
+}
+
+static void keyboard_enter(void *data, struct wl_keyboard *keyboard, uint32_t serial,
+                           struct wl_surface *surface, struct wl_array *keys) {}
+
+static void keyboard_leave(void *data, struct wl_keyboard *keyboard, uint32_t serial,
+                           struct wl_surface *surface) {}
+
+static void keyboard_key(void *data, struct wl_keyboard *keyboard, uint32_t serial, uint32_t time,
+                         uint32_t key, uint32_t pressed_state) {
+    struct test_state *state = data;
+    if (pressed_state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+        state->keypress.key = key;
+        state->keypress.mods = state->mods_depressed;
+    }
+}
+
+static void keyboard_modifiers(void *data, struct wl_keyboard *keyboard, uint32_t serial,
+                               uint32_t depressed, uint32_t latched, uint32_t locked,
+                               uint32_t group) {
+    struct test_state *state = data;
+    state->mods_depressed = depressed;
+}
+
+static void keyboard_repeat_info(void *data, struct wl_keyboard *keyboard, int32_t rate,
+                                 int32_t delay) {}
+
+static const struct wl_keyboard_listener keyboard_listener = {
+    .keymap = keyboard_keymap,
+    .enter = keyboard_enter,
+    .leave = keyboard_leave,
+    .key = keyboard_key,
+    .modifiers = keyboard_modifiers,
+    .repeat_info = keyboard_repeat_info,
+};
+
+static void seat_capabilities(void *data, struct wl_seat *seat, uint32_t capabilities) {
+    struct test_state *state = data;
+
+    if ((capabilities & WL_SEAT_CAPABILITY_KEYBOARD) && !state->keyboard) {
+        state->keyboard = wl_seat_get_keyboard(seat);
+        wl_keyboard_add_listener(state->keyboard, &keyboard_listener, state);
+    } else if (!(capabilities & WL_SEAT_CAPABILITY_KEYBOARD) && state->keyboard) {
+        wl_keyboard_destroy(state->keyboard);
+        state->keyboard = NULL;
+    }
+}
+
+static void seat_name(void *data, struct wl_seat *seat, const char *name) {}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_capabilities,
+    .name = seat_name,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        state->xdg_wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(state->xdg_wm_base, &xdg_wm_listener, state);
+    } else if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+        state->inhibit_mgr = wl_registry_bind(
+            registry, name, &zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
+    } else if (strcmp(interface, wl_seat_interface.name) == 0) {
+        // The seat is already bound but we want a listener for keyboard events
+        wl_seat_add_listener(state->base.seat, &seat_listener, state);
+    }
+}
+
+void cmd_create_window(struct test_state *state) {
+    state->surface = wl_compositor_create_surface(state->base.compositor);
+
+    state->xdg_surface = xdg_wm_base_get_xdg_surface(state->xdg_wm_base, state->surface);
+    state->toplevel = xdg_surface_get_toplevel(state->xdg_surface);
+
+    xdg_surface_add_listener(state->xdg_surface, &xdg_surface_listener, state);
+    xdg_toplevel_add_listener(state->toplevel, &xdg_toplevel_listener, state);
+
+    // Set fixed size so qtile will float window
+    xdg_toplevel_set_min_size(state->toplevel, 300, 300);
+    xdg_toplevel_set_max_size(state->toplevel, 300, 300);
+
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    // Create contents of window
+    state->buffer = create_buffer(&state->base, 300, 300, 0xFF606060);
+
+    wl_surface_attach(state->surface, state->buffer->wl_buffer, 0, 0);
+    wl_surface_damage_buffer(state->surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(state->surface);
+    do_roundtrip(&state->base);
+
+    test_ok();
+}
+
+static void cmd_inhibit(struct test_state *state) {
+    if (state->surface == NULL) {
+        test_error("inhibitor requires a surface.");
+        return;
+    }
+
+    state->inhibitor = zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+        state->inhibit_mgr, state->surface, state->base.seat);
+    zwp_keyboard_shortcuts_inhibitor_v1_add_listener(state->inhibitor, &inhibitor_listener, state);
+    do_roundtrip(&state->base);
+
+    // Compositor will raise an error if we request an inhibitor more than once for the same
+    // surface.
+    if (!compositor_raised_error(&state->base)) {
+        test_ok();
+    }
+}
+
+static void cmd_uninhibit(struct test_state *state) {
+    zwp_keyboard_shortcuts_inhibitor_v1_destroy(state->inhibitor);
+    state->inhibitor == NULL;
+    state->inhibitor_active = false;
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "show") == 0) {
+        cmd_create_window(state);
+    } else if (strcmp(cmd, "get_keypress") == 0) {
+        test_message("key: %u mods: %u", state->keypress.key, state->keypress.mods);
+        test_ok();
+    } else if (strcmp(cmd, "clear_keypress") == 0) {
+        state->keypress.key = 0;
+        state->keypress.mods = 0;
+        test_ok();
+    } else if (strcmp(cmd, "inhibit") == 0) {
+        cmd_inhibit(state);
+    } else if (strcmp(cmd, "uninhibit") == 0) {
+        cmd_uninhibit(state);
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    return true;
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (state->surface) {
+        wl_surface_destroy(state->surface);
+    }
+
+    if (state->inhibitor != NULL) {
+        zwp_keyboard_shortcuts_inhibitor_v1_destroy(state->inhibitor);
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}

--- a/test/wayland_clients/src/virtual-keyboard.c
+++ b/test/wayland_clients/src/virtual-keyboard.c
@@ -1,0 +1,189 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <xkbcommon/xkbcommon.h>
+
+#include "client-base.h"
+#include "virtual-keyboard-unstable-v1-client-protocol.h"
+
+// Standard XKB modifier bitmasks for US QWERTY keymap
+#define MOD_SHIFT (1U << 0)   // 0x01
+#define MOD_CONTROL (1U << 2) // 0x04
+#define MOD_ALT (1U << 3)     // 0x08
+#define MOD_SUPER (1U << 6)   // 0x40
+
+struct test_state {
+    struct client_state base;
+    struct zwp_virtual_keyboard_manager_v1 *vkeyboard_mgr;
+    struct zwp_virtual_keyboard_v1 *vkeyboard;
+    uint32_t active_mods;
+};
+
+// Standard US QWERTY keymap in XKB v1 format
+static const char *default_xkb_keymap = "xkb_keymap {\n"
+                                        "   xkb_keycodes  { include \"evdev+aliases(qwerty)\" };\n"
+                                        "   xkb_types     { include \"complete\" };\n"
+                                        "   xkb_compat    { include \"complete\" };\n"
+                                        "   xkb_symbols   { include \"pc+us+inet(evdev)\" };\n"
+                                        "   xkb_geometry  { include \"pc(pc105)\" };\n"
+                                        "};\n";
+
+static int create_memfd_with_data(const char *data, size_t size) {
+    int fd = memfd_create("test-virtual-keyboard-keymap", MFD_CLOEXEC);
+    if (fd < 0) {
+        return -1;
+    }
+
+    // Expand memory size
+    if (ftruncate(fd, size) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    // Memory map and write the keymap string into the fd
+    void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        close(fd);
+        return -1;
+    }
+
+    memcpy(ptr, data, size);
+    munmap(ptr, size);
+
+    return fd;
+}
+
+int send_virtual_keyboard_keymap(struct zwp_virtual_keyboard_v1 *vkeyboard) {
+    size_t keymap_size = strlen(default_xkb_keymap) + 1; // Include null terminator
+
+    int fd = create_memfd_with_data(default_xkb_keymap, keymap_size);
+    if (fd < 0) {
+        return -1;
+    }
+
+    zwp_virtual_keyboard_v1_keymap(vkeyboard, WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, fd,
+                                   (uint32_t)keymap_size);
+
+    // Compositor duplicates/maps the fd upon receiving the request; we close our local fd
+    close(fd);
+    return 0;
+}
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, zwp_virtual_keyboard_manager_v1_interface.name) == 0) {
+        state->vkeyboard_mgr =
+            wl_registry_bind(registry, name, &zwp_virtual_keyboard_manager_v1_interface, 1);
+    }
+
+    if (state->vkeyboard == NULL && state->vkeyboard_mgr != NULL && state->base.seat != NULL) {
+        state->vkeyboard = zwp_virtual_keyboard_manager_v1_create_virtual_keyboard(
+            state->vkeyboard_mgr, state->base.seat);
+        send_virtual_keyboard_keymap(state->vkeyboard);
+    }
+}
+
+static void send_modifiers(struct test_state *state) {
+    if (state->vkeyboard == NULL) {
+        test_error("no virtual keyboard.");
+        return;
+    }
+
+    // Send updated depressed modifiers mask to compositor
+    zwp_virtual_keyboard_v1_modifiers(state->vkeyboard, state->active_mods, 0, 0, 0);
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static void send_key(struct test_state *state, uint32_t keycode, uint32_t key_state) {
+    if (state->vkeyboard == NULL) {
+        test_error("no virtual keyboard.");
+        return;
+    }
+
+    // Ensure compositor has active modifier state before sending keypress
+    send_modifiers(state);
+
+    uint32_t time_ms = 0;
+    zwp_virtual_keyboard_v1_key(state->vkeyboard, time_ms, keycode, key_state);
+    // wl_display_flush(client->display);
+    do_roundtrip(&state->base);
+    test_ok();
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(cmd, "press") == 0) {
+        if (arg == NULL) {
+            test_error("press requires a keycode.");
+        } else {
+            send_key(state, atoi(arg), WL_KEYBOARD_KEY_STATE_PRESSED);
+        }
+    } else if (strcmp(cmd, "release") == 0) {
+        if (arg == NULL) {
+            test_error("release requires a keycode.");
+        } else {
+            send_key(state, atoi(arg), WL_KEYBOARD_KEY_STATE_RELEASED);
+        }
+    } else if (strcmp(cmd, "tap") == 0) {
+        if (arg == NULL) {
+            test_error("tap requires a keycode.");
+        } else {
+            send_key(state, atoi(arg), WL_KEYBOARD_KEY_STATE_PRESSED);
+            send_key(state, atoi(arg), WL_KEYBOARD_KEY_STATE_RELEASED);
+        }
+    } else if (strcmp(cmd, "set_modifier") == 0) {
+        if (arg == NULL) {
+            test_error("set_modifier requires a modifier name.");
+        } else if (strcmp(arg, "shift") == 0) {
+            state->active_mods |= MOD_SHIFT;
+            send_modifiers(state);
+        } else if (strcmp(arg, "control") == 0) {
+            state->active_mods |= MOD_CONTROL;
+            send_modifiers(state);
+        } else if (strcmp(arg, "alt") == 0) {
+            state->active_mods |= MOD_ALT;
+            send_modifiers(state);
+        } else if (strcmp(arg, "super") == 0) {
+            state->active_mods |= MOD_SUPER;
+            send_modifiers(state);
+        } else {
+            test_error("Unknown modifier: %s", arg);
+        }
+    } else if (strcmp(cmd, "clear_modifiers") == 0) {
+        state->active_mods = 0;
+        send_modifiers(state);
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    return true;
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (state->vkeyboard) {
+        zwp_virtual_keyboard_v1_destroy(state->vkeyboard);
+    }
+    if (state->vkeyboard_mgr) {
+        zwp_virtual_keyboard_manager_v1_destroy(state->vkeyboard_mgr);
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}


### PR DESCRIPTION
This protocol allows clients to grab all keyboard presses. When an inhibitor is active, qtile's keybindings are not triggered and all events pass to the client.

This is useful for remote desktop/VNC clients where users want to run shortcuts on the remote machine.