### PR TITLE
Fix repl send after client disconnected

### DIFF
--- a/libqtile/interactive/repl.py
+++ b/libqtile/interactive/repl.py
@@ -120,8 +120,11 @@ class QtileREPLServer:
         async def send(message, end=True):
             """Wrapper to send data to client."""
             suffix = TERMINATOR if end else ""
-            writer.write(f"{message}{suffix}\n".encode())
-            await writer.drain()
+            try:
+                writer.write(f"{message}{suffix}\n".encode())
+                await writer.drain()
+            except ConnectionResetError:
+                return
 
         await send("Connected to Qtile REPL\nPress Ctrl+C to exit.\n")
 


### PR DESCRIPTION
Handle ConnectionResetError exception when the handle_client loop calls send after the connection has disconnected but before at_eof has been re-evaluated at the start of the loop

Fixes test_repl_server_executes_code test failures