### PR TITLE
 Wayland: add ext-workspace-v1 support 

### DIFF
--- a/libqtile/backend/wayland/cffi/build.py
+++ b/libqtile/backend/wayland/cffi/build.py
@@ -144,6 +144,11 @@ PROTOS: list[Protocol] = [
         build_client=True,
         build_server=False,
     ),
+    Protocol(
+        f"{WAYLAND_PROTOCOLS}/staging/ext-workspace/ext-workspace-v1.xml",
+        build_client=True,
+        build_server=False,
+    ),
 ]
 
 TEST_CLIENTS: list[TestClient] = [
@@ -224,6 +229,15 @@ TEST_CLIENTS: list[TestClient] = [
         ],
         includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
     ),
+    TestClient(
+        name="workspace-manager",
+        sources=[
+            TEST_CLIENT_SRC_PATH / "workspace-manager.c",
+            CLIENT_BASE,
+            QW_PROTO_OUT_PATH / "ext-workspace-v1-protocol.c",
+        ],
+        includes=[QW_PROTO_OUT_PATH, TEST_CLIENT_SRC_PATH],
+    ),
 ]
 
 # Build configuration
@@ -239,6 +253,7 @@ CDEF_FILES = [
     "cursor.h",
     "input-device.h",
     "keyboard.h",
+    "workspace-manager.h",
 ]
 XWAYLAND_ONLY_SOURCES = ["xwayland-view.c"]
 
@@ -378,6 +393,7 @@ extern "Python" bool remove_idle_inhibitor_cb(void *userdata, void *inhibitor);
 extern "Python" bool check_inhibited_cb(void *userdata);
 extern "Python" struct qw_qtile_config *get_qtile_config_cb(void *userdata);
 extern "Python" void idle_state_change_cb(void *userdata, int seconds, bool is_idle);
+extern "Python" void workspace_manager_group_action_cb(void *userdata, const char *group, int action);
 
 extern "Python" int request_focus_cb(void *userdata);
 extern "Python" int request_close_cb(void *userdata);

--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -56,6 +56,7 @@ from libqtile.backend.wayland.idle_notify import IdleNotifier
 from libqtile.backend.wayland.window import Base, Internal, Static, Window
 from libqtile.command.base import allow_when_locked, expose_command
 from libqtile.config import Output, Screen, ScreenRect
+from libqtile.group import _Group
 from libqtile.images import Img
 from libqtile.log_utils import logger
 from libqtile.utils import ColorType, QtileError, reap_zombies, rgb
@@ -228,6 +229,22 @@ def idle_state_change_cb(userdata: ffi.CData, seconds: int, is_idle: bool) -> No
     core.handle_idle_state_change(seconds, is_idle)
 
 
+@ffi.def_extern()
+def workspace_manager_group_action_cb(userdata: ffi.CData, groupname: str, action: int) -> None:
+    group = ffi.string(groupname).decode()
+    if not group:
+        return
+
+    core = ffi.from_handle(userdata)
+
+    if action == lib.WORKSPACE_GROUP_ACTIVATE:
+        core.handle_workspace_manager_group_activate(group)
+    elif action == lib.WORKSPACE_GROUP_REMOVE:
+        core.handle_workspace_manager_group_remove(group)
+    elif action == lib.WORKSPACE_GROUP_CREATE_WORKSPACE:
+        core.handle_workspace_manager_group_create_workspace(group)
+
+
 def get_wlr_log_level() -> int:
     if logger.level <= logging.DEBUG:
         return lib.WLR_DEBUG
@@ -280,6 +297,7 @@ class Core(base.Core):
         self.qw.check_inhibited_cb = lib.check_inhibited_cb
         self.qw.get_qtile_config_cb = lib.get_qtile_config_cb
         self.qw.idle_state_change_cb = lib.idle_state_change_cb
+        self.qw.workspace_manager_group_action_cb = lib.workspace_manager_group_action_cb
         if not lib.qw_server_start(self.qw):
             sys.exit(1)
         os.environ["WAYLAND_DISPLAY"] = self.display_name
@@ -289,6 +307,13 @@ class Core(base.Core):
         self._locked = False
         self.idle_inhibitor_manager = IdleInhibitorManager(self)
         self.idle_notifier = IdleNotifier(self)
+
+        # Hooks to group events for the workspace manager protocol
+        hook.subscribe.addgroup(self.handle_addgroup)
+        hook.subscribe.delgroup(self.handle_delgroup)
+        hook.subscribe.client_urgent_hint_changed(self.handle_urgency)
+        hook.subscribe.changegroup(self.handle_group_changes)
+        hook.subscribe.setgroup(self.handle_group_changes)
 
     def update_backend_log_level(self) -> None:
         """Update the wlr log level based on Qtile's log level."""
@@ -956,6 +981,55 @@ class Core(base.Core):
     def test_destroy_output(self, index: int) -> None:
         """Destroy the nth output at runtime. Only available in an active test."""
         lib.qw_server_test_destroy_output(self.qw, index)
+
+    def _update_workspace_state(self, group: _Group) -> None:
+        # Group is active if it's allocated to a screen
+        active = group.screen is not None
+
+        # Groups with an empty label or scratchpads should be marked as hidden
+        # This is same behaviour as GroupBox widget
+        hidden = group.label == "" or hasattr(group, "dropdowns")
+
+        # Check if any window in the group is flagged as urgent
+        urgent = any(win.urgent for win in group.windows)
+
+        label = group.label if group.label is not None else ""
+
+        lib.qw_workspace_set_state(
+            self.qw, group.name.encode(), label.encode(), active, hidden, urgent
+        )
+
+    def handle_addgroup(self, groupname: str) -> None:
+        group = self.qtile.groups_map[groupname]
+        group_id = group.name
+        group_name = group.label or groupname
+
+        lib.qw_workspace_manager_create_workspace(self.qw, group_id.encode(), group_name.encode())
+
+    def handle_delgroup(self, groupname: str) -> None:
+        lib.qw_workspace_manager_delete_workspace(self.qw, groupname.encode())
+
+    def handle_urgency(self, client: Window) -> None:
+        if not client.group:
+            return
+
+        self._update_workspace_state(client.group)
+
+    def handle_group_changes(self) -> None:
+        for group in self.qtile.groups_map.values():
+            self._update_workspace_state(group)
+
+    def handle_workspace_manager_group_activate(self, groupname: str) -> None:
+        group = self.qtile.groups_map.get(groupname)
+        if group is None:
+            return
+        group.toscreen()
+
+    def handle_workspace_manager_group_remove(self, groupname: str) -> None:
+        self.qtile.delete_group(groupname)
+
+    def handle_workspace_manager_group_create_workspace(self, groupname: str) -> None:
+        self.qtile.add_group(groupname, label=groupname)
 
 
 class Painter:

--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -8,6 +8,7 @@
 #include "util.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <wlr/types/wlr_ext_workspace_v1.h>
 
 static void qw_output_handle_frame(struct wl_listener *listener, void *data) {
     UNUSED(data);
@@ -209,6 +210,8 @@ void qw_server_output_new(struct qw_server *server, struct wlr_output *wlr_outpu
     struct wlr_output_layout_output *l_output =
         wlr_output_layout_add_auto(server->output_layout, wlr_output);
     wlr_scene_output_layout_add_output(server->scene_layout, l_output, output->scene);
+
+    wlr_ext_workspace_group_handle_v1_output_enter(server->workspace_group, wlr_output);
 }
 
 void qw_output_background_destroy(struct qw_output *output) {

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -27,6 +27,7 @@
 #include "wayland-server-protocol.h"
 #include "wayland-util.h"
 #include "wlr/util/log.h"
+#include "workspace-manager.h"
 #include "xdg-view.h"
 #if WLR_HAS_XWAYLAND
 #include "xwayland-view.h"
@@ -65,6 +66,7 @@ static void qw_remove_shortcut_inhibitors(struct qw_server *server);
 void qw_server_finalize(struct qw_server *server) {
     // TODO: what else to finalize?
     qw_server_destroy_dummy_input_devices(server);
+    qw_workspace_manager_finish(server);
 
     wl_list_remove(&server->new_input.link);
     wl_list_remove(&server->new_output.link);
@@ -1140,6 +1142,11 @@ bool qw_server_init(struct qw_server *server) {
     }
     server->set_output_power_mode.notify = qw_server_handle_output_power_set_mode;
     wl_signal_add(&server->output_power_manager->events.set_mode, &server->set_output_power_mode);
+
+    // Workspace manager
+    if (!qw_workspace_manager_init(server)) {
+        wlr_log(WLR_ERROR, "Unable to create workspace manager.\n");
+    }
 
     // TODO: setup listeners
     return true;

--- a/libqtile/backend/wayland/qw/server.h
+++ b/libqtile/backend/wayland/qw/server.h
@@ -158,6 +158,9 @@ typedef struct qw_qtile_config *(*get_qtile_config_cb_t)(void *userdata);
 // Callback for idle state change
 typedef void (*idle_state_change_cb_t)(void *userdata, int seconds, bool is_idle);
 
+// Callbacks for workspace manager
+typedef void (*workspace_manager_group_action_cb_t)(void *userdata, const char *group, int action);
+
 enum {
     LAYER_BACKGROUND,   // background, layer shell
     LAYER_BOTTOM,       // bottom, layer shell
@@ -220,6 +223,7 @@ struct qw_server {
     check_inhibited_cb_t check_inhibited_cb;
     get_qtile_config_cb_t get_qtile_config_cb;
     idle_state_change_cb_t idle_state_change_cb;
+    workspace_manager_group_action_cb_t workspace_manager_group_action_cb;
     void *view_activation_cb_data;
     void *cb_data;
     struct qw_layer_view *exclusive_layer;
@@ -295,6 +299,9 @@ struct qw_server {
     struct wlr_pointer_constraints_v1 *pointer_constraints;
     struct wl_listener new_pointer_constraint;
     struct wlr_keyboard *dummy_keyboard;
+    struct wlr_ext_workspace_manager_v1 *workspace_manager;
+    struct wlr_ext_workspace_group_handle_v1 *workspace_group;
+    struct wl_listener workspace_commit;
 };
 
 struct qw_drag_icon {

--- a/libqtile/backend/wayland/qw/workspace-manager.c
+++ b/libqtile/backend/wayland/qw/workspace-manager.c
@@ -1,0 +1,169 @@
+#include <stdlib.h>
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_ext_workspace_v1.h>
+
+#include "output.h"
+#include "server.h"
+#include "workspace-manager.h"
+
+static struct wlr_ext_workspace_handle_v1 *find_workspace_by_id(struct qw_server *server,
+                                                                const char *id) {
+    if (server == NULL || server->workspace_manager == NULL || id == NULL)
+        return NULL;
+
+    struct wlr_ext_workspace_handle_v1 *ws;
+    wl_list_for_each(ws, &server->workspace_manager->workspaces, link) {
+        if (ws->id != NULL && strcmp(ws->id, id) == 0) {
+            return ws;
+        }
+    }
+    return NULL;
+}
+
+static void handle_workspace_commit(struct wl_listener *listener, void *data) {
+    struct qw_server *server = wl_container_of(listener, server, workspace_commit);
+    struct wlr_ext_workspace_v1_commit_event *event = data;
+    struct wlr_ext_workspace_v1_request *req;
+
+    wl_list_for_each(req, event->requests, link) {
+        switch (req->type) {
+        case WLR_EXT_WORKSPACE_V1_REQUEST_ACTIVATE:
+            if (req->activate.workspace != NULL && req->activate.workspace->id != NULL) {
+                server->workspace_manager_group_action_cb(
+                    server->cb_data, req->activate.workspace->id, WORKSPACE_GROUP_ACTIVATE);
+            }
+            break;
+
+        // Deactivating a group should only be done by qtile
+        case WLR_EXT_WORKSPACE_V1_REQUEST_DEACTIVATE:
+            break;
+
+        case WLR_EXT_WORKSPACE_V1_REQUEST_CREATE_WORKSPACE:
+            if (req->create_workspace.name != NULL) {
+                server->workspace_manager_group_action_cb(
+                    server->cb_data, req->create_workspace.name, WORKSPACE_GROUP_CREATE_WORKSPACE);
+            }
+            break;
+
+        case WLR_EXT_WORKSPACE_V1_REQUEST_REMOVE:
+            if (req->remove.workspace != NULL && req->remove.workspace->id != NULL) {
+                server->workspace_manager_group_action_cb(
+                    server->cb_data, req->remove.workspace->id, WORKSPACE_GROUP_REMOVE);
+            }
+            break;
+
+        // Assigning a workspace to a workspace group has no meaning in qtile
+        // as we use a single, global workspace group.
+        case WLR_EXT_WORKSPACE_V1_REQUEST_ASSIGN:
+            break;
+        }
+    }
+}
+
+bool qw_workspace_manager_init(struct qw_server *server) {
+    if (server == NULL || server->display == NULL) {
+        return false;
+    }
+
+    server->workspace_manager =
+        wlr_ext_workspace_manager_v1_create(server->display, 1); // Version 1
+    if (server->workspace_manager == NULL) {
+        return false;
+    }
+
+    // Create a global workspace group with creation capabilities
+    uint32_t group_caps = EXT_WORKSPACE_GROUP_HANDLE_V1_GROUP_CAPABILITIES_CREATE_WORKSPACE;
+    server->workspace_group =
+        wlr_ext_workspace_group_handle_v1_create(server->workspace_manager, group_caps);
+    if (server->workspace_group == NULL) {
+        return false;
+    }
+
+    server->workspace_commit.notify = handle_workspace_commit;
+    wl_signal_add(&server->workspace_manager->events.commit, &server->workspace_commit);
+
+    return true;
+}
+
+void qw_workspace_manager_finish(struct qw_server *server) {
+    if (server == NULL || server->workspace_manager == NULL) {
+        return;
+    }
+
+    wl_list_remove(&server->workspace_commit.link);
+
+    if (server->workspace_group != NULL) {
+        wlr_ext_workspace_group_handle_v1_destroy(server->workspace_group);
+        server->workspace_group = NULL;
+    }
+
+    struct wlr_ext_workspace_handle_v1 *ws, *tmp_ws;
+    wl_list_for_each_safe(ws, tmp_ws, &server->workspace_manager->workspaces, link) {
+        wlr_ext_workspace_handle_v1_destroy(ws);
+    }
+
+    server->workspace_manager = NULL;
+}
+
+void qw_workspace_manager_create_workspace(struct qw_server *server, const char *id,
+                                           const char *name) {
+    if (server == NULL || server->workspace_manager == NULL || server->workspace_group == NULL ||
+        id == NULL) {
+        return;
+    }
+
+    uint32_t caps = EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_ACTIVATE |
+                    EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_REMOVE;
+
+    struct wlr_ext_workspace_handle_v1 *ws =
+        wlr_ext_workspace_handle_v1_create(server->workspace_manager, id, caps);
+
+    if (ws == NULL) {
+        wlr_log(WLR_ERROR, "Could not create workspace handle for %s", id);
+        return;
+    }
+
+    wlr_ext_workspace_handle_v1_set_name(ws, name);
+    wlr_ext_workspace_handle_v1_set_group(ws, server->workspace_group);
+}
+
+void qw_workspace_manager_delete_workspace(struct qw_server *server, const char *id) {
+    struct wlr_ext_workspace_handle_v1 *ws = find_workspace_by_id(server, id);
+    if (ws != NULL) {
+        wlr_ext_workspace_handle_v1_destroy(ws);
+    }
+}
+
+void qw_workspace_set_state(struct qw_server *server, const char *id, const char *name, bool active,
+                            bool hidden, bool urgent) {
+    if (id == NULL) {
+        return;
+    }
+
+    struct wlr_ext_workspace_handle_v1 *ws = find_workspace_by_id(server, id);
+    if (ws == NULL) {
+        return;
+    }
+
+    uint32_t current_state = ws->state;
+
+    bool current_active = (current_state & EXT_WORKSPACE_HANDLE_V1_STATE_ACTIVE) != 0;
+    bool current_hidden = (current_state & EXT_WORKSPACE_HANDLE_V1_STATE_HIDDEN) != 0;
+    bool current_urgent = (current_state & EXT_WORKSPACE_HANDLE_V1_STATE_URGENT) != 0;
+
+    if (name != NULL && strcmp(ws->name, name) != 0) {
+        wlr_ext_workspace_handle_v1_set_name(ws, name);
+    }
+
+    if (current_active != active) {
+        wlr_ext_workspace_handle_v1_set_active(ws, active);
+    }
+
+    if (current_hidden != hidden) {
+        wlr_ext_workspace_handle_v1_set_hidden(ws, hidden);
+    }
+
+    if (current_urgent != urgent) {
+        wlr_ext_workspace_handle_v1_set_urgent(ws, urgent);
+    }
+}

--- a/libqtile/backend/wayland/qw/workspace-manager.h
+++ b/libqtile/backend/wayland/qw/workspace-manager.h
@@ -1,0 +1,22 @@
+#ifndef WORKSPACE_MANAGER_H
+#define WORKSPACE_MANAGER_H
+
+#include <stdbool.h>
+#include <wlr/types/wlr_ext_workspace_v1.h>
+
+struct qw_server;
+
+enum { WORKSPACE_GROUP_ACTIVATE, WORKSPACE_GROUP_REMOVE, WORKSPACE_GROUP_CREATE_WORKSPACE };
+
+// Functions for workspace manager lifecycle
+bool qw_workspace_manager_init(struct qw_server *server);
+void qw_workspace_manager_finish(struct qw_server *server);
+
+// Functions called from the python backend
+void qw_workspace_manager_create_workspace(struct qw_server *server, const char *id,
+                                           const char *name);
+void qw_workspace_manager_delete_workspace(struct qw_server *server, const char *id);
+void qw_workspace_set_state(struct qw_server *server, const char *id, const char *name, bool active,
+                            bool hidden, bool urgent);
+
+#endif /* WORKSPACE_MANAGER_H */

--- a/libqtile/backend/wayland/window.py
+++ b/libqtile/backend/wayland/window.py
@@ -162,7 +162,10 @@ class Base(base._Window):
 
     @urgent.setter
     def urgent(self, urgent: bool) -> None:
+        needs_hook = self._ptr.urgent != urgent
         self._ptr.urgent = urgent
+        if needs_hook:
+            hook.fire("client_urgent_hint_changed", self)
 
     def kill(self) -> None:
         self._ptr.kill(self._ptr)
@@ -276,6 +279,7 @@ class Base(base._Window):
 
         if self.urgent:
             self.urgent = False
+            hook.fire("client_urgent_hint_changed", self)
 
         if self.group and self.group.current_window is not self:
             self.group.focus(self)

--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -270,7 +270,7 @@ class ClientHandler:
         """Verify that the client outputs an error message."""
         assert self.send(command) == f"ERROR: {error}"
 
-    def send_read_until(self, command, expected, timeout_ms=2000):
+    def send_read_until(self, command, expected, timeout_ms=2000, exclude_expected=True):
         """
         Send command and read stdout until `expected` is seen.
 
@@ -303,7 +303,17 @@ class ClientHandler:
             lines.extend(raw_lines)
 
             if expected in lines:
+                if exclude_expected:
+                    return lines[:-1]
                 return lines
+
+    def send_read_ok(self, command):
+        """
+        Sends a command and reads until OK is received.
+
+        Returns output excluding "OK".
+        """
+        return self.send_read_until(command, "OK")
 
     def restart(self):
         self._run()

--- a/test/backend/wayland/test_foreign_toplevel_management.py
+++ b/test/backend/wayland/test_foreign_toplevel_management.py
@@ -29,31 +29,31 @@ def test_ftl_state(wmanager, test_client):
     """Test that client is notified about client state."""
     wmanager.test_window("window1")
     win1 = get_window("window1", wmanager)
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
 
     # Test maximize
     win1.toggle_maximize()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True, maximized=True) in lines
     win1.toggle_maximize()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
 
     # Test minimize (NB window is not focused when minimized)
     win1.toggle_minimize()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=False, minimized=True) in lines
     win1.toggle_minimize()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
 
     # Test fullscreen
     win1.toggle_fullscreen()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True, fullscreen=True) in lines
     win1.toggle_fullscreen()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
 
 
@@ -63,17 +63,17 @@ def test_focus_state(wmanager, test_client):
     win1 = get_window("window1", wmanager)
     win2 = get_window("window2", wmanager)
 
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1") in lines
     assert make_line("window2", activated=True) in lines
 
     win1.focus()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
     assert make_line("window2") in lines
 
     win2.focus()
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1") in lines
     assert make_line("window2", activated=True) in lines
 
@@ -81,7 +81,7 @@ def test_focus_state(wmanager, test_client):
 def test_client_set_state(wmanager, test_client):
     wmanager.test_window("window1")
     win1 = get_window("window1", wmanager)
-    lines = test_client.send_read_until("list", "OK")
+    lines = test_client.send_read_ok("list")
     assert make_line("window1", activated=True) in lines
 
     test_client.assert_ok("fullscreen window1")
@@ -124,9 +124,9 @@ def test_output_enter_leave(wmanager, test_client):
     test_client.assert_ok("output_reset window1")
     win1.set_size_floating(200, 200)
     win1.set_position_floating(700, 100)
-    lines = test_client.send_read_until("output_enter window1", "OK")
+    lines = test_client.send_read_ok("output_enter window1")
     assert "output_enter: HEADLESS-1" in lines
     test_client.assert_error("output_leave window1", "output_leave message not received")
     win1.set_position(900, 100)
-    lines = test_client.send_read_until("output_leave window1", "OK")
+    lines = test_client.send_read_ok("output_leave window1")
     assert "output_leave: HEADLESS-2" in lines

--- a/test/backend/wayland/test_output_power.py
+++ b/test/backend/wayland/test_output_power.py
@@ -45,7 +45,7 @@ def test_opm_dual_monitor(wmanager, test_client):
     """Check each output can be powered individually."""
 
     def get_output_state():
-        return test_client.send_read_until("identify", "OK")
+        return test_client.send_read_ok("identify")
 
     # Check client is notified about two outputs
     wait_for_outputs(test_client, 2)

--- a/test/backend/wayland/test_workspace_manager.py
+++ b/test/backend/wayland/test_workspace_manager.py
@@ -1,0 +1,230 @@
+import pytest
+
+from libqtile.config import Group, ScratchPad
+from test.conftest import dualmonitor
+from test.helpers import BareConfig
+
+
+class WorkspaceManagerConfig(BareConfig):
+    groups = [Group(name) for name in "abcd"]
+    groups.extend(
+        [
+            Group("e", label=""),  # Empty label means group is hidden
+            ScratchPad("f"),  # scratchpads are also hidden
+        ]
+    )
+
+
+pytestmark = [
+    pytest.mark.parametrize("test_client", ["workspace-manager"], indirect=True),
+    pytest.mark.parametrize("wmanager", [WorkspaceManagerConfig], indirect=True),
+]
+
+
+def make_line(name, label=None, active=False, hidden=False, urgent=False):
+    def yn(value):
+        return "YES" if value else "no"
+
+    return (
+        f"""Workspace [{name}] "{name if label is None else label}" """
+        f"(active={yn(active)}, hidden={yn(hidden)}, urgent={yn(urgent)})"
+    )
+
+
+def get_window(title, wmanager):
+    wins = wmanager.c.windows()
+    for w in wins:
+        if w["name"] == title:
+            return wmanager.c.window[w["id"]]
+
+    assert False
+
+
+# Test server side code
+
+
+def test_workspace_group_capabilities(wmanager, test_client):
+    """Test that qtile advertises ability for clients to create workspaces."""
+    lines = test_client.send_read_ok("workspace_group_capabilities 0")  # index of workspace group
+    assert len(lines) == 1
+    assert lines[0] == "create_workspace"
+
+
+def test_workspace_capabilities(wmanager, test_client):
+    """Test that workspaces advertise ability to activate and remove them."""
+    lines = test_client.send_read_ok("workspace_capabilities a")  # workspace name
+    assert len(lines) == 2
+    assert "activate" in lines
+    assert "remove" in lines
+
+
+def test_workspaces_active_state(wmanager, test_client):
+    """Tests that all groups are passed to clients and display active state."""
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5  # Scratchpads are not added
+    assert make_line("a", active=True) in lines
+    for group in "bcd":
+        assert make_line(group) in lines
+
+    # Change group and check that workspaces are updated
+    wmanager.c.group["b"].toscreen()
+    lines = test_client.send_read_ok("list")
+    assert make_line("b", active=True) in lines
+    for group in "acd":
+        assert make_line(group) in lines
+
+
+@dualmonitor
+def test_workspaces_multimonitor_active_state(wmanager, test_client):
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5  # Scratchpads are not added
+    for group in "ab":
+        assert make_line(group, active=True) in lines
+    for group in "cd":
+        assert make_line(group) in lines
+
+    # Change group and check that workspaces are updated
+    wmanager.c.group["c"].toscreen(0)
+    wmanager.c.group["d"].toscreen(1)
+    lines = test_client.send_read_ok("list")
+    for group in "ab":
+        assert make_line(group) in lines
+    for group in "cd":
+        assert make_line(group, active=True) in lines
+
+
+def test_workspaces_hidden_state(wmanager, test_client):
+    """Test that a group with an empty label is hidden."""
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5  # Scratchpads are not added
+    assert make_line("e", label="", hidden=True) in lines
+
+
+def test_workspaces_urgent_state(wmanager, test_client):
+    """Test that a group with an urgent window is marked accordingly."""
+
+    # Create a window on a different group
+    wmanager.c.group["b"].toscreen()
+    wmanager.test_window("urgent_window")
+    wmanager.c.group["a"].toscreen()
+
+    # Check state is showing as not urgent
+    lines = test_client.send_read_ok("list")
+    assert make_line("b") in lines
+
+    # Set window as urgent and verify state is updated
+    win = get_window("urgent_window", wmanager)
+    win.eval("self.urgent=True")
+    lines = test_client.send_read_ok("list")
+    assert make_line("b", urgent=True) in lines
+
+    # Change group (tp focus urgent window) and check urgent state is removed
+    wmanager.c.group["b"].toscreen()
+    wmanager.c.group["a"].toscreen()
+    lines = test_client.send_read_ok("list")
+    assert make_line("b") in lines
+
+
+@dualmonitor
+def test_workspaces_outputs(wmanager, test_client):
+    """Tests that qtile's workspace group is advertised on all outputs."""
+    lines = test_client.send_read_ok("workspace_group_outputs 0")
+    assert lines
+    assert lines[0] == "outputs: 2"
+
+    # Remove an output and confirm client is notified
+    wmanager.c.core.test_destroy_output(1)
+    lines = test_client.send_read_ok("workspace_group_outputs 0")
+    assert lines
+    assert lines[0] == "outputs: 1"
+
+
+def test_workspaces_outputs_label_change(wmanager, test_client):
+    """Tests whether label changes are sent to clients."""
+    lines = test_client.send_read_ok("list")
+    assert make_line("a", active=True) in lines
+    assert make_line("b") in lines
+
+    # Change label for group a
+    wmanager.c.group["a"].set_label("test_group_a")
+    lines = test_client.send_read_ok("list")
+    assert make_line("a", label="test_group_a", active=True) in lines
+
+    # Change label to empty string which causes group to be hidden
+    wmanager.c.group["b"].set_label("")
+    lines = test_client.send_read_ok("list")
+    assert make_line("b", label="", hidden=True) in lines
+
+
+def test_workspace_add_remove_workspace(wmanager, test_client):
+    """Tests whether groups added/removed by qtile are sent to clients."""
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5
+
+    # Add a new group
+    wmanager.c.addgroup("new_group", label="new_label")
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 6
+    assert make_line("new_group", label="new_label") in lines
+
+    # Delete a group
+    assert make_line("b") in lines
+    wmanager.c.delgroup("b")
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5
+    assert make_line("b") not in lines
+
+
+# Test commands sent by clients
+
+
+def test_workspace_client_activate_workspace(wmanager, test_client):
+    """Test clients can activate workspaces."""
+    assert wmanager.c.group.info()["name"] == "a"
+
+    # Client requests group b
+    test_client.assert_ok("activate b")
+    assert wmanager.c.group.info()["name"] == "b"
+
+    # Check status is also updated
+    lines = test_client.send_read_ok("list")
+    assert make_line("a") in lines
+    assert make_line("b", active=True) in lines
+
+
+@dualmonitor
+def test_workspace_client_activate_workspace_multimonitor(wmanager, test_client):
+    """Test clients can activate workspaces."""
+    assert wmanager.c.screen[0].group.info()["name"] == "a"
+    assert wmanager.c.screen[1].group.info()["name"] == "b"
+
+    # Client requests group b
+    test_client.assert_ok("activate c")
+    assert wmanager.c.screen[0].group.info()["name"] == "c"
+
+    wmanager.c.to_screen(1)
+    test_client.assert_ok("activate d")
+    assert wmanager.c.screen[1].group.info()["name"] == "d"
+
+    # Check status is also updated
+    lines = test_client.send_read_ok("list")
+    for group in "ab":
+        assert make_line(group) in lines
+    for group in "cd":
+        assert make_line(group, active=True) in lines
+
+
+def test_workspace_client_add_remove_workspace(wmanager, test_client):
+    """Test clients can create and remove workspaces."""
+    test_client.assert_ok("create_workspace client_group")
+    lines = test_client.send_read_ok("list")
+    assert "client_group" in wmanager.c.get_groups()
+    assert len(lines) == 6
+    assert make_line("client_group") in lines
+
+    assert "c" in wmanager.c.get_groups()
+    test_client.assert_ok("remove c")
+    assert "c" not in wmanager.c.get_groups()
+    lines = test_client.send_read_ok("list")
+    assert len(lines) == 5
+    assert make_line("c") not in lines

--- a/test/wayland_clients/src/workspace-manager.c
+++ b/test/wayland_clients/src/workspace-manager.c
@@ -1,0 +1,467 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "client-base.h"
+#include "ext-workspace-v1-client-protocol.h"
+
+struct test_state {
+    struct client_state base;
+    struct ext_workspace_manager_v1 *manager;
+    struct wl_list groups;     // group_node::link
+    struct wl_list workspaces; // workspace_node::global_link
+};
+
+struct group_node {
+    struct ext_workspace_group_handle_v1 *handle;
+    struct test_state *state;
+    struct wl_list workspaces; // workspace_node::group_link
+    struct wl_list link;
+    uint32_t capabilities;
+    uint8_t output_count;
+};
+
+struct workspace_node {
+    struct ext_workspace_handle_v1 *handle;
+    struct test_state *state;
+    struct group_node *group;
+    char *id;
+    char *name;
+    bool active;
+    bool hidden;
+    bool urgent;
+    struct wl_list global_link;
+    struct wl_list group_link;
+    uint32_t capabilities;
+};
+
+enum { WORKSPACE_ACTION_ACTIVATE, WORKSPACE_ACTION_REMOVE, WORKSPACE_ACTION_CREATE };
+
+static struct group_node *find_workspace_group_by_index(struct test_state *state, int index) {
+    if (index < 0) {
+        test_error("invalid index.");
+        return NULL;
+    }
+
+    if (wl_list_empty(&state->groups)) {
+        test_error("no workspace groups.");
+        return NULL;
+    }
+
+    int i = 0;
+    struct group_node *group = NULL;
+    struct group_node *entry;
+
+    wl_list_for_each(entry, &state->groups, link) {
+        if (i == index) {
+            group = entry;
+            return group;
+        }
+        i++;
+    }
+
+    test_error("index out of bounds.");
+    return NULL;
+}
+
+static struct workspace_node *find_workspace_by_id(struct test_state *state, const char *id) {
+
+    struct workspace_node *workspace;
+
+    if (id == NULL) {
+        return NULL;
+    }
+
+    wl_list_for_each(workspace, &state->workspaces, global_link) {
+        if (workspace->id != NULL && strcmp(workspace->id, id) == 0) {
+            return workspace;
+        }
+    }
+    return NULL;
+}
+
+static void ws_handle_id(void *data, struct ext_workspace_handle_v1 *handle, const char *id) {
+    struct workspace_node *ws = data;
+
+    if (id == NULL) {
+        return;
+    }
+
+    char *new_id = strdup(id);
+    if (id != NULL && new_id == NULL) {
+        test_error("out of memory duplicating workspace id.");
+        return;
+    }
+
+    free(ws->id);
+    ws->id = new_id;
+}
+
+static void ws_handle_name(void *data, struct ext_workspace_handle_v1 *handle, const char *name) {
+    struct workspace_node *ws = data;
+    if (name == NULL) {
+        return;
+    }
+
+    char *new_name = strdup(name);
+    if (name != NULL && new_name == NULL) {
+        test_error("out of memory duplicating workspace name.");
+        return;
+    }
+
+    free(ws->name);
+    ws->name = new_name;
+}
+
+static void ws_handle_coordinates(void *data, struct ext_workspace_handle_v1 *handle,
+                                  struct wl_array *coordinates) {}
+
+static void ws_handle_state(void *data, struct ext_workspace_handle_v1 *handle,
+                            uint32_t state_flags) {
+    struct workspace_node *ws = data;
+
+    ws->active = (state_flags & EXT_WORKSPACE_HANDLE_V1_STATE_ACTIVE) != 0;
+    ws->hidden = (state_flags & EXT_WORKSPACE_HANDLE_V1_STATE_HIDDEN) != 0;
+    ws->urgent = (state_flags & EXT_WORKSPACE_HANDLE_V1_STATE_URGENT) != 0;
+}
+
+static void ws_handle_capabilities(void *data, struct ext_workspace_handle_v1 *handle,
+                                   uint32_t caps) {
+    struct workspace_node *ws = data;
+    ws->capabilities = caps;
+}
+
+static void ws_handle_removed(void *data, struct ext_workspace_handle_v1 *handle) {
+    struct workspace_node *ws = data;
+    if (ws->group_link.next != NULL) {
+        wl_list_remove(&ws->group_link);
+    }
+    wl_list_remove(&ws->global_link);
+
+    ext_workspace_handle_v1_destroy(handle);
+    if (ws->id != NULL) {
+        free(ws->id);
+    }
+    if (ws->name != NULL) {
+        free(ws->name);
+    }
+    free(ws);
+}
+
+static const struct ext_workspace_handle_v1_listener workspace_listener = {
+    .id = ws_handle_id,
+    .name = ws_handle_name,
+    .coordinates = ws_handle_coordinates,
+    .state = ws_handle_state,
+    .capabilities = ws_handle_capabilities,
+    .removed = ws_handle_removed,
+};
+
+static void group_handle_capabilities(void *data,
+                                      struct ext_workspace_group_handle_v1 *group_handle,
+                                      uint32_t caps) {
+    struct group_node *group = data;
+    group->capabilities = caps;
+}
+
+static void group_handle_output_enter(void *data,
+                                      struct ext_workspace_group_handle_v1 *group_handle,
+                                      struct wl_output *output) {
+    struct group_node *group = data;
+    group->output_count++;
+}
+
+static void group_handle_output_leave(void *data,
+                                      struct ext_workspace_group_handle_v1 *group_handle,
+                                      struct wl_output *output) {
+    struct group_node *group = data;
+    group->output_count--;
+}
+
+static void group_handle_workspace_enter(void *data,
+                                         struct ext_workspace_group_handle_v1 *group_handle,
+                                         struct ext_workspace_handle_v1 *ws_handle) {
+    struct group_node *group = data;
+
+    // Look up workspace handle in the manager's workspace list
+    struct workspace_node *ws, *target_ws = NULL;
+    wl_list_for_each(ws, &group->state->workspaces, global_link) {
+        if (ws->handle == ws_handle) {
+            target_ws = ws;
+            break;
+        }
+    }
+
+    if (target_ws == NULL) {
+        return;
+    }
+
+    target_ws->group = group;
+
+    // Add to group's workspace list if not already present
+    struct workspace_node *gws;
+    wl_list_for_each(gws, &group->workspaces, group_link) {
+        if (gws == target_ws)
+            return;
+    }
+
+    wl_list_insert(&group->workspaces, &target_ws->group_link);
+}
+
+static void group_handle_workspace_leave(void *data,
+                                         struct ext_workspace_group_handle_v1 *group_handle,
+                                         struct ext_workspace_handle_v1 *ws_handle) {
+    struct group_node *group = data;
+    struct workspace_node *ws, *tmp;
+    wl_list_for_each_safe(ws, tmp, &group->workspaces, group_link) {
+        if (ws->handle == ws_handle) {
+            wl_list_remove(&ws->group_link);
+            ws->group = NULL;
+            break;
+        }
+    }
+}
+
+static void group_handle_removed(void *data, struct ext_workspace_group_handle_v1 *group_handle) {
+    struct group_node *group = data;
+    wl_list_remove(&group->link);
+    ext_workspace_group_handle_v1_destroy(group_handle);
+    struct test_state *state = group->state;
+    free(group);
+}
+
+static const struct ext_workspace_group_handle_v1_listener group_listener = {
+    .capabilities = group_handle_capabilities,
+    .output_enter = group_handle_output_enter,
+    .output_leave = group_handle_output_leave,
+    .workspace_enter = group_handle_workspace_enter,
+    .workspace_leave = group_handle_workspace_leave,
+    .removed = group_handle_removed,
+};
+
+static void manager_handle_workspace_group(void *data, struct ext_workspace_manager_v1 *mgr,
+                                           struct ext_workspace_group_handle_v1 *group_handle) {
+    struct test_state *state = data;
+
+    struct group_node *group = calloc(1, sizeof(*group));
+    group->handle = group_handle;
+    group->state = state;
+    wl_list_init(&group->workspaces);
+
+    wl_list_insert(&state->groups, &group->link);
+    ext_workspace_group_handle_v1_add_listener(group_handle, &group_listener, group);
+}
+
+static void manager_handle_workspace(void *data, struct ext_workspace_manager_v1 *mgr,
+                                     struct ext_workspace_handle_v1 *ws_handle) {
+    struct test_state *state = data;
+
+    struct workspace_node *ws = calloc(1, sizeof(*ws));
+    ws->handle = ws_handle;
+    ws->state = state;
+
+    wl_list_insert(&state->workspaces, &ws->global_link);
+
+    ext_workspace_handle_v1_add_listener(ws_handle, &workspace_listener, ws);
+}
+
+static void manager_handle_done(void *data, struct ext_workspace_manager_v1 *mgr) {}
+
+static void manager_handle_finished(void *data, struct ext_workspace_manager_v1 *mgr) {}
+
+static const struct ext_workspace_manager_v1_listener manager_listener = {
+    .workspace_group = manager_handle_workspace_group,
+    .workspace = manager_handle_workspace,
+    .done = manager_handle_done,
+    .finished = manager_handle_finished,
+};
+
+static void registry_handler(struct client_state *base, struct wl_registry *registry, uint32_t name,
+                             const char *interface, uint32_t version) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (strcmp(interface, ext_workspace_manager_v1_interface.name) == 0) {
+        state->manager = wl_registry_bind(registry, name, &ext_workspace_manager_v1_interface, 1);
+        ext_workspace_manager_v1_add_listener(state->manager, &manager_listener, state);
+    } else if (strcmp(interface, wl_output_interface.name) == 0) {
+        // We need to bind to the output interface to get output enter/leave events
+        wl_registry_bind(registry, name, &wl_output_interface, 1);
+    }
+}
+
+static void cmd_list(struct test_state *state) {
+    int group_idx = 0;
+    struct group_node *group;
+    wl_list_for_each(group, &state->groups, link) {
+        struct workspace_node *ws;
+        wl_list_for_each(ws, &group->workspaces, group_link) {
+            test_message("Workspace [%s] \"%s\" (active=%s, hidden=%s, urgent=%s)",
+                         ws->id ? ws->id : "no-id", ws->name ? ws->name : "no-name",
+                         ws->active ? "YES" : "no", ws->hidden ? "YES" : "no",
+                         ws->urgent ? "YES" : "no");
+        }
+    }
+    test_ok();
+}
+
+static void cmd_action(struct test_state *state, const char *id, int action) {
+    struct workspace_node *workspace = find_workspace_by_id(state, id);
+
+    if (workspace == NULL && action != WORKSPACE_ACTION_CREATE) {
+        test_error("unknown workspace id: %s", id);
+        return;
+    } else if (workspace != NULL && action == WORKSPACE_ACTION_CREATE) {
+        test_error("can't create workspace with existing id.");
+        return;
+    }
+
+    if (action == WORKSPACE_ACTION_ACTIVATE) {
+        ext_workspace_handle_v1_activate(workspace->handle);
+    } else if (action == WORKSPACE_ACTION_REMOVE) {
+        ext_workspace_handle_v1_remove(workspace->handle);
+    } else if (action == WORKSPACE_ACTION_CREATE) {
+        if (wl_list_empty(&state->groups)) {
+            test_error("no workspace groups found.");
+            return;
+        }
+        struct group_node *group = wl_container_of(state->groups.next, group, link);
+        ext_workspace_group_handle_v1_create_workspace(group->handle, id);
+    }
+
+    ext_workspace_manager_v1_commit(state->manager);
+    test_ok();
+}
+
+static void cmd_workspace_group_capabilities(struct test_state *state, int index) {
+    struct group_node *group = find_workspace_group_by_index(state, index);
+
+    if (group == NULL) {
+        return;
+    }
+
+    if (group->capabilities & EXT_WORKSPACE_GROUP_HANDLE_V1_GROUP_CAPABILITIES_CREATE_WORKSPACE) {
+        test_message("create_workspace");
+    }
+    test_ok();
+}
+
+static void cmd_workspace_group_outputs(struct test_state *state, int index) {
+    struct group_node *group = find_workspace_group_by_index(state, index);
+
+    if (group == NULL) {
+        return;
+    }
+
+    test_message("outputs: %d", group->output_count);
+    test_ok();
+}
+
+static void cmd_workspace_capabilities(struct test_state *state, const char *id) {
+    struct workspace_node *workspace = find_workspace_by_id(state, id);
+
+    if (workspace == NULL) {
+        test_error("unknown workspace id: %s.", id);
+        return;
+    }
+
+    if (workspace->capabilities & EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_ACTIVATE) {
+        test_message("activate");
+    }
+    if (workspace->capabilities & EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_DEACTIVATE) {
+        test_message("deactivate");
+    }
+    if (workspace->capabilities & EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_REMOVE) {
+        test_message("remove");
+    }
+    if (workspace->capabilities & EXT_WORKSPACE_HANDLE_V1_WORKSPACE_CAPABILITIES_ASSIGN) {
+        test_message("assign");
+    }
+    test_ok();
+}
+
+static bool dispatch_command(struct client_state *base, const char *cmd, const char *arg) {
+    struct test_state *state = (struct test_state *)base;
+
+    if (state == NULL) {
+        return false;
+    }
+
+    if (strcmp(cmd, "list") == 0) {
+        cmd_list(state);
+    } else if (strcmp(cmd, "activate") == 0) {
+        cmd_action(state, arg, WORKSPACE_ACTION_ACTIVATE);
+    } else if (strcmp(cmd, "remove") == 0) {
+        cmd_action(state, arg, WORKSPACE_ACTION_REMOVE);
+    } else if (strcmp(cmd, "create_workspace") == 0) {
+        cmd_action(state, arg, WORKSPACE_ACTION_CREATE);
+    } else if (strcmp(cmd, "workspace_group_capabilities") == 0) {
+        cmd_workspace_group_capabilities(state, atoi(arg));
+    } else if (strcmp(cmd, "workspace_capabilities") == 0) {
+        cmd_workspace_capabilities(state, arg);
+    } else if (strcmp(cmd, "workspace_group_outputs") == 0) {
+        cmd_workspace_group_outputs(state, atoi(arg));
+    } else if (strcmp(cmd, "quit") == 0) {
+        return false;
+    }
+    return true;
+}
+
+void setup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+
+    wl_list_init(&state->groups);
+    wl_list_init(&state->workspaces);
+}
+
+void cleanup(struct client_state *base) {
+    struct test_state *state = (struct test_state *)base;
+    if (state == NULL) {
+        return;
+    }
+
+    struct workspace_node *ws, *tmp_ws;
+    wl_list_for_each_safe(ws, tmp_ws, &state->workspaces, global_link) {
+        wl_list_remove(&ws->global_link);
+
+        if (ws->group_link.next != NULL && ws->group_link.prev != NULL) {
+            wl_list_remove(&ws->group_link);
+        }
+
+        if (ws->handle != NULL) {
+            ext_workspace_handle_v1_destroy(ws->handle);
+            ws->handle = NULL;
+        }
+
+        free(ws->id);
+        free(ws->name);
+        free(ws);
+    }
+
+    struct group_node *group, *tmp_group;
+    wl_list_for_each_safe(group, tmp_group, &state->groups, link) {
+        wl_list_remove(&group->link);
+
+        if (group->handle != NULL) {
+            ext_workspace_group_handle_v1_destroy(group->handle);
+            group->handle = NULL;
+        }
+
+        free(group);
+    }
+
+    if (state->manager != NULL) {
+        ext_workspace_manager_v1_destroy(state->manager);
+        state->manager = NULL;
+    }
+}
+
+int main(void) {
+    struct test_state state = {0};
+
+    const struct client_ops ops = {.setup = setup,
+                                   .registry_global = registry_handler,
+                                   .dispatch_command = dispatch_command,
+                                   .cleanup = cleanup};
+
+    return client_run(&state.base, &ops);
+}


### PR DESCRIPTION
Implement server-side support for the ext-workspace-v1 Wayland protocol, allowing external panels, taskbars (like Waybar), and IPC utilities to monitor and control Qtile workspaces.

The ext-workspace-v1 specification introduces two core entities:

1. Workspace Groups (ext_workspace_group_handle_v1):

Represents a collection of workspaces tied to one or more outputs. Because Qtile allows any group to be displayed on any screen/output interchangeably, Qtile maps this as a single global workspace group associated with all active outputs (via output_enter/leave events).

2. Workspaces (ext_workspace_handle_v1):
   
Represents individual workspace objects within a group. These map 1:1 Qtile's internal `Group` objects, exposing workspace IDs, names, states (active, hidden, urgent), and capabilities.

This PR provides the following implementation:

- Initialize the `wlr_ext_workspace_manager_v1` global and create a single workspace group upon server startup.
- Dynamically create/destroy workspace handles as Qtile groups are added or removed.
- Update workspace flags (active, hidden, urgent) and synchronise names during Qtile state changes.
- Handle client-initiated transaction commits to process requests such as workspace activation, creation, and removal.
- Properly bind `wlr_output` instances to the workspace group to ensure clients receive `output_enter` events regardless of setup timing.

Closes https://github.com/qtile/qtile/issues/5614