### PR TITLE
output: add missing `return` in `qw_output_paint_background_color`

### DIFF
--- a/libqtile/backend/wayland/qw/output.c
+++ b/libqtile/backend/wayland/qw/output.c
@@ -390,6 +390,7 @@ void qw_output_paint_background_color(struct qw_output *output, float color[4]) 
         wlr_scene_rect_create(output->server->scene_wallpaper_tree, o_width, o_height, color);
     if (rect == NULL) {
         wlr_log(WLR_ERROR, "Failed to create scene_rect for background.");
+        return;
     }
 
     // Save reference to scene rect so we can destroy it later


### PR DESCRIPTION
If `wlr_scene_rect_create` returns NULL, the function logged the error but fell through anyway, dereferencing the NULL rect on the next line via `wlr_scene_node_set_position(&rect->node, ...)`.

Add the missing `return` so allocation failure is handled instead of crashing.

Addresses part of #6012.