### PR TITLE
[Wayland] Add missing allocation-failure checks

### DIFF
--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -428,7 +428,12 @@ static void qw_server_handle_new_xdg_toplevel(struct wl_listener *listener, void
 static void qw_server_handle_new_decoration(struct wl_listener *listener, void *data) {
     UNUSED(listener);
     struct wlr_xdg_toplevel_decoration_v1 *decoration = data;
-    qw_xdg_view_decoration_new(decoration->toplevel->base->data, decoration);
+    struct qw_xdg_view *xdg_view = decoration->toplevel->base->data;
+    if (xdg_view == NULL) {
+        wlr_log(WLR_ERROR, "received decoration for a toplevel with no associated view");
+        return;
+    }
+    qw_xdg_view_decoration_new(xdg_view, decoration);
 }
 
 static void qw_server_handle_new_layer_surface(struct wl_listener *listener, void *data) {

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -649,8 +649,19 @@ static void qw_server_handle_start_drag(struct wl_listener *listener, void *data
     }
 
     struct qw_drag_icon *drag_icon = calloc(1, sizeof(*drag_icon));
+    if (drag_icon == NULL) {
+        wlr_log(WLR_ERROR, "failed to allocate qw_drag_icon");
+        return;
+    }
+
     drag_icon->server = server;
     drag_icon->scene_icon = wlr_scene_drag_icon_create(server->drag_icon, drag->icon);
+    if (drag_icon->scene_icon == NULL) {
+        wlr_log(WLR_ERROR, "failed to create scene drag icon");
+        free(drag_icon);
+        return;
+    }
+
     drag_icon->destroy.notify = qw_server_handle_drag_icon_destroy;
     wl_signal_add(&drag->events.destroy, &drag_icon->destroy);
 }

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -1002,7 +1002,9 @@ bool qw_server_init(struct qw_server *server) {
                   &server->virtual_pointer_new);
 
     // Session lock setup
-    qw_session_lock_init(server);
+    if (!qw_session_lock_init(server)) {
+        return false;
+    }
 
     server->ftl_mgr = wlr_foreign_toplevel_manager_v1_create(server->display);
     if (server->ftl_mgr == NULL) {

--- a/libqtile/backend/wayland/qw/server.c
+++ b/libqtile/backend/wayland/qw/server.c
@@ -663,7 +663,9 @@ void qw_server_handle_new_pointer_constraint(struct wl_listener *listener, void 
 }
 
 void qw_server_set_inhibited(struct qw_server *server, bool inhibited) {
-    wlr_idle_notifier_v1_set_inhibited(server->idle_notifier, inhibited);
+    if (server->idle_notifier != NULL) {
+        wlr_idle_notifier_v1_set_inhibited(server->idle_notifier, inhibited);
+    }
 }
 
 static void qw_server_handle_idle_inhibitor_destroy(struct wl_listener *listener, void *data) {
@@ -686,6 +688,10 @@ static void qw_server_handle_new_idle_inhibitor(struct wl_listener *listener, vo
     struct wlr_idle_inhibitor_v1 *wlr_inhibitor = data;
 
     struct qw_idle_inhibitor *inhibitor = calloc(1, sizeof(struct qw_idle_inhibitor));
+    if (inhibitor == NULL) {
+        wlr_log(WLR_ERROR, "failed to allocate qw_idle_inhibitor");
+        return;
+    }
 
     inhibitor->server = server;
     inhibitor->wlr_inhibitor = wlr_inhibitor;
@@ -1251,7 +1257,7 @@ struct wlr_output *qw_server_get_current_output(struct qw_server *server) {
 }
 
 void qw_server_idle_notify_activity(struct qw_server *server) {
-    if (server->idle_inhibit_manager != NULL) {
+    if (server->idle_notifier != NULL) {
         wlr_idle_notifier_v1_notify_activity(server->idle_notifier, server->seat);
     }
     // Fire resume for each timer that is currently idle
@@ -1299,11 +1305,22 @@ void qw_server_add_idle_timer(struct qw_server *server, int seconds) {
     }
 
     struct qw_idle_timer *timer = calloc(1, sizeof(*timer));
+    if (timer == NULL) {
+        wlr_log(WLR_ERROR, "failed to allocate qw_idle_timer");
+        return;
+    }
+
     timer->server = server;
     timer->seconds = seconds;
     timer->is_idle = false;
     timer->event_source =
         wl_event_loop_add_timer(server->event_loop, qw_server_idle_timer_cb, timer);
+    if (timer->event_source == NULL) {
+        wlr_log(WLR_ERROR, "failed to create idle timer event source");
+        free(timer);
+        return;
+    }
+
     wl_list_insert(&server->idle_timers, &timer->link);
 
     wl_event_source_timer_update(timer->event_source, seconds * 1000);

--- a/libqtile/backend/wayland/qw/session-lock.c
+++ b/libqtile/backend/wayland/qw/session-lock.c
@@ -23,6 +23,10 @@ void qw_session_lock_restore_focus(struct qw_server *server) {
 // Useful if one lock surface disappears (e.g. output disconnect)
 // but others remain.
 void qw_session_lock_focus_first_lock_surface(struct qw_server *server) {
+    if (wl_list_empty(&server->lock->lock->surfaces)) {
+        return;
+    }
+
     struct wlr_seat *seat = server->seat;
     struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
     struct wlr_session_lock_surface_v1 *surface;
@@ -51,6 +55,12 @@ void qw_session_lock_output_create_blanking_rects(struct qw_output *output) {
     wlr_output_effective_resolution(output->wlr_output, &o_width, &o_height);
     struct wlr_scene_rect *blanking_rect = wlr_scene_rect_create(
         server->scene_windows_layers[LAYER_LOCK], o_width, o_height, rect_color);
+
+    if (blanking_rect == NULL) {
+        wlr_log(WLR_ERROR, "failed to create blanking rect for session lock");
+        return;
+    }
+
     wlr_scene_node_set_position(&blanking_rect->node, output->x, output->y);
 
     // Make sure blanking rects are below any lock surfaces
@@ -102,10 +112,17 @@ void qw_session_lock_crashed_update_rects(struct qw_server *server) {
         struct wlr_scene_rect *blanking_rect =
             wlr_scene_rect_create(server->scene_windows_layers[LAYER_LOCK], width, height,
                                   QW_SESSION_LOCK_BLANKING_RECT_CRASHED);
+
+        if (blanking_rect == NULL) {
+            wlr_log(WLR_ERROR, "failed to create blanking rect for session lock");
+            continue;
+        }
+
         wlr_scene_node_set_position(&blanking_rect->node, o->x, o->y);
         o->blanking_rect = blanking_rect;
         if (old_rect != NULL) {
             wlr_scene_node_destroy(&old_rect->node);
+            old_rect = NULL;
         }
     }
 }
@@ -127,8 +144,7 @@ void qw_session_lock_surface_handle_destroy(struct wl_listener *listener, void *
         }
     }
 
-    if (server->lock != NULL && server->lock->lock != NULL &&
-        !wl_list_empty(&server->lock->lock->surfaces)) {
+    if (server->lock != NULL && server->lock->lock != NULL) {
         qw_session_lock_focus_first_lock_surface(server);
     }
 
@@ -196,6 +212,24 @@ void qw_session_lock_handle_new_surface(struct wl_listener *listener, void *data
 
     struct wlr_scene_tree *scene_tree = lock_surface->surface->data =
         wlr_scene_subsurface_tree_create(lock->scene, lock_surface->surface);
+
+    if (scene_tree == NULL) {
+        wlr_log(WLR_ERROR, "failed to create scene tree");
+        return;
+    }
+
+    struct qw_session_lock_surface *sls = calloc(1, sizeof(*sls));
+    if (sls == NULL) {
+        wlr_log(WLR_ERROR, "failed to allocate qw_session_lock_surface");
+        wlr_scene_node_destroy(&scene_tree->node);
+        return;
+    }
+
+    sls->server = lock->server;
+    sls->lock_surface = lock_surface;
+    sls->surface_destroy.notify = qw_session_lock_surface_handle_destroy;
+    wl_signal_add(&lock_surface->surface->events.destroy, &sls->surface_destroy);
+
     output->lock_surface = lock_surface;
 
     // Make sure lock surface is at the top.
@@ -213,19 +247,12 @@ void qw_session_lock_handle_new_surface(struct wl_listener *listener, void *data
     // surface if a keyboard appears after the lock surface.
     struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(lock->server->seat);
     struct wlr_output *current_output = qw_server_get_current_output(lock->server);
-    if (keyboard && output->wlr_output == current_output) {
+    if (keyboard != NULL && output->wlr_output == current_output) {
         wlr_seat_keyboard_notify_enter(lock->server->seat, lock_surface->surface,
                                        keyboard->keycodes, keyboard->num_keycodes,
                                        &keyboard->modifiers);
         wlr_seat_pointer_notify_enter(lock->server->seat, lock_surface->surface, 0, 0);
     }
-
-    struct qw_session_lock_surface *sls = calloc(1, sizeof(*sls));
-    sls->server = lock->server;
-    sls->lock_surface = lock_surface;
-
-    sls->surface_destroy.notify = qw_session_lock_surface_handle_destroy;
-    wl_signal_add(&lock_surface->surface->events.destroy, &sls->surface_destroy);
 }
 
 void qw_session_lock_handle_new(struct wl_listener *listener, void *data) {
@@ -250,6 +277,13 @@ void qw_session_lock_handle_new(struct wl_listener *listener, void *data) {
     }
 
     lock->scene = wlr_scene_tree_create(server->scene_windows_layers[LAYER_LOCK]);
+    if (lock->scene == NULL) {
+        wlr_log(WLR_ERROR, "failed to create scene tree");
+        wlr_session_lock_v1_destroy(session_lock);
+        free(lock);
+        return;
+    }
+
     lock->server = server;
     lock->lock = session_lock;
     server->lock = lock;
@@ -270,10 +304,17 @@ void qw_session_lock_handle_new(struct wl_listener *listener, void *data) {
     server->on_session_lock_cb(true, server->cb_data);
 }
 
-void qw_session_lock_init(struct qw_server *server) {
+bool qw_session_lock_init(struct qw_server *server) {
     server->lock_state = QW_SESSION_LOCK_UNLOCKED;
     server->lock_manager = wlr_session_lock_manager_v1_create(server->display);
+    if (server->lock_manager == NULL) {
+        wlr_log(WLR_ERROR, "failed to create session lock manager");
+        return false;
+    }
+
     server->new_session_lock.notify = qw_session_lock_handle_new;
     wl_signal_add(&server->lock_manager->events.new_lock, &server->new_session_lock);
     wlr_scene_node_set_enabled(&server->scene_windows_layers[LAYER_LOCK]->node, false);
+
+    return true;
 }

--- a/libqtile/backend/wayland/qw/session-lock.h
+++ b/libqtile/backend/wayland/qw/session-lock.h
@@ -39,7 +39,7 @@ struct qw_session_lock {
     struct wl_listener destroy;
 };
 
-void qw_session_lock_init(struct qw_server *server);
+bool qw_session_lock_init(struct qw_server *server);
 void qw_session_lock_output_create_blanking_rects(struct qw_output *output);
 void qw_session_lock_output_change(struct qw_output *output);
 void qw_session_lock_focus_first_lock_surface(struct qw_server *server);

--- a/libqtile/backend/wayland/qw/xwayland-view.c
+++ b/libqtile/backend/wayland/qw/xwayland-view.c
@@ -219,6 +219,11 @@ static void static_view_handle_override_redirect(struct wl_listener *listener, v
 
     qw_server_xwayland_view_new(server, xwayland_surface);
     struct qw_xwayland_view *xwayland_view = xwayland_surface->data;
+    if (xwayland_view == NULL) {
+        wlr_log(WLR_ERROR, "failed to convert override-redirect view");
+        return;
+    }
+
     if (associated) {
         qw_xwayland_view_handle_associate(&xwayland_view->associate, NULL);
     }
@@ -844,6 +849,11 @@ static void qw_xwayland_view_handle_request_override_redirect(struct wl_listener
 
     qw_server_xwayland_static_view_new(server, xwayland_surface);
     struct qw_xwayland_view *static_view = xwayland_surface->data;
+    if (static_view == NULL) {
+        wlr_log(WLR_ERROR, "failed to convert managed view to override-redirect");
+        return;
+    }
+
     if (associated) {
         static_view_handle_associate(&static_view->associate, NULL);
     }
@@ -894,7 +904,7 @@ static void qw_xwayland_view_update_maximized(void *self, bool maximized) {
 void qw_server_xwayland_view_new(struct qw_server *server,
                                  struct wlr_xwayland_surface *xwayland_surface) {
     struct qw_xwayland_view *xwayland_view = calloc(1, sizeof(*xwayland_view));
-    if (!xwayland_view) {
+    if (xwayland_view == NULL) {
         wlr_log(WLR_ERROR, "failed to create qw_xwayland_view struct");
         return;
     }


### PR DESCRIPTION
## Addresses the "Misc" item from #6012:
> add missing allocation-failure checks (session lock surface, idle
> inhibitor/timer, drag icon, decoration for a failed view, xwayland
> override-redirect conversions)

## Changes

- **session lock**: check `wlr_scene_rect_create` and allocation failures in blanking-rect creation and lock-surface setup instead of dereferencing NULL or leaking. `qw_session_lock_init` now returns `bool` so a failed session lock manager creation stops `qw_server_init` instead of continuing silently. The `surface_destroy` listener is now registered before `output->lock_surface` is set, so a later failure can't leave a dangling reference.

- **idle notifier**: `qw_server_idle_notify_activity` was checking `idle_inhibit_manager` before dereferencing `idle_notifier`, a mismatched guard between two independent objects. `qw_server_set_inhibited` had no guard at all. Both now check `idle_notifier` directly.

- **idle inhibitor/timer**: `qw_server_handle_new_idle_inhibitor` and `qw_server_add_idle_timer` used their `calloc` results unconditionally; `qw_server_add_idle_timer` also didn't check `wl_event_loop_add_timer`. Both now check allocation/creation and bail out cleanly on failure.

- **drag icon**: `qw_server_handle_start_drag` didn't check the `qw_drag_icon` allocation or `wlr_scene_drag_icon_create`; the latter now frees `drag_icon` on failure instead of leaking it.

- **decoration for a failed view**: `qw_server_handle_new_decoration` passed `decoration->toplevel->base->data` straight into `qw_xdg_view_decoration_new` without checking it, if the toplevel's `qw_xdg_view` allocation failed earlier, `base->data` is never set and this was a NULL dereference.

- **xwayland override-redirect conversions**: both conversion directions (`static_view_handle_override_redirect` and `qw_xwayland_view_handle_request_override_redirect`) destroy the old view representation, construct the new one, and immediately dereference the result without checking it. Both now check and bail out with a log message on failure.
