### PR TITLE
xdg-view: set `popup->base.server` in `qw_server_xdg_popup_new`

### DIFF
--- a/libqtile/backend/wayland/qw/xdg-view.c
+++ b/libqtile/backend/wayland/qw/xdg-view.c
@@ -633,6 +633,7 @@ static struct qw_xdg_popup *qw_server_xdg_popup_new(struct wlr_xdg_popup *wlr_po
 
     popup->wlr_popup = wlr_popup;
     popup->xdg_view = xdg_view;
+    popup->base.server = xdg_view->base.server;
     popup->base.view_type = QW_VIEW_XDG_POPUP;
 
     popup->scene_tree = wlr_scene_tree_create(parent);


### PR DESCRIPTION
`qw_xdg_popup_handle_destroy` dereferences `popup->base.server` via `qw_cursor_update_pointer_focus`, but the popup constructor never set it, so it was always NULL, guaranteed segfault on every xdg popup destroy.

Introduced by `aae88c6`.

Fixes #6052