### PR TITLE
Fix dynamic screen generation 

### DIFF
--- a/libqtile/backend/wayland/core.py
+++ b/libqtile/backend/wayland/core.py
@@ -586,6 +586,7 @@ class Core(base.Core):
         view = self.qw_cursor.view
 
         if view == ffi.NULL:
+            self.qtile.hovered_window = None
             return
 
         win = self.qtile.windows_map.get(view.wid)

--- a/libqtile/config.py
+++ b/libqtile/config.py
@@ -582,7 +582,13 @@ class Screen(CommandObject):
         if new_group is None:
             return
 
+        if new_group.screen is self:
+            return
+
         if new_group.screen == self:
+            # Same logical screen. Update reference without peforming a
+            # screen change
+            new_group.screen = self
             return
 
         if save_prev and new_group is not self.group:

--- a/libqtile/core/manager.py
+++ b/libqtile/core/manager.py
@@ -451,6 +451,11 @@ class Qtile(CommandObject):
         config_screens = self.get_screens_from_config(output_info)
         new_screens: list[Screen] = []
 
+        # Clear current_screen if there's no matching Screen in config
+        if hasattr(self, "current_screen"):
+            if self.current_screen not in config_screens:
+                del self.current_screen
+
         for i, info in enumerate(output_info):
             if i < len(config_screens):
                 scr = config_screens[i]
@@ -507,8 +512,16 @@ class Qtile(CommandObject):
             new_screens.append(Screen())
 
         for screen in self.screens:
-            if screen not in new_screens:
+            # Finalize_gaps for screen instances that are not in new_screens
+            if not any(screen is ns for ns in new_screens):
                 screen.finalize_gaps()
+
+        # With dynamically generated screens we need to update current_screen
+        # to a matching new Screen, or set a sensible default
+        if self.current_screen in new_screens:
+            self.current_screen = new_screens[new_screens.index(self.current_screen)]
+        else:
+            self.current_screen = new_screens[0]
 
         self.screens = new_screens
 

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -145,7 +145,11 @@ class _Group(CommandObject):
 
     def set_screen(self, screen, warp=True):
         """Set this group's screen to screen"""
+        if screen is self.screen:
+            return
         if screen == self.screen:
+            # Same logical screen. Just update reference
+            self.screen = screen
             return
         self.screen = screen
         if self.screen:


### PR DESCRIPTION
Problem: When using generate_screens, dynamically generated screens'
groups are holding a stale reference to the previous screen instance.
See issue https://github.com/qtile/qtile/issues/6048

Fix: When configuring screens, set_group should update its screen
reference if the screen is the same (by equality). Same for set_screen

Additionally call finalise_gap for all old screens

There is also a potential issue with updating current_screen if we don't
account for dynamically generated screens, which has been addressed

Fixes https://github.com/qtile/qtile/issues/6048

(Also fixes a small bug with hovered window, which can affect screen focus)